### PR TITLE
disallow star is breaking admin access

### DIFF
--- a/db/changes.go
+++ b/db/changes.go
@@ -65,7 +65,7 @@ const kChangesPageSize = 200
 
 // Returns a list of all the changes made on a channel.
 func (db *Database) ChangesFeed(channel string, options ChangesOptions) (<-chan *ChangeEntry, error) {
-	if channel == "*" || !channels.IsValidChannel(channel) {
+	if !channels.IsValidChannel(channel) {
 		return nil, &base.HTTPError{400, fmt.Sprintf("%q is not a valid channel", channel)}
 	}
 	lastSequence := options.Since


### PR DESCRIPTION
I have a user with the channels list ["*"] in their auth document (an admin user), and this change makes it so they can sync again. I'm not sure if this is the best way to fix the bug though...
