### PR TITLE
out of bounds error fixed

### DIFF
--- a/db/changes.go
+++ b/db/changes.go
@@ -184,10 +184,11 @@ func (db *Database) MultiChangesFeed(channels channels.Set, options ChangesOptio
 			i := 0
 			for name, _ := range channels {
 				var err error
-				feeds[i], err = db.ChangesFeed(name, options)
+				feed, err := db.ChangesFeed(name, options)
 				if err != nil {
 					return
 				}
+        feeds = append(feeds,feed)
 				i++
 			}
 


### PR DESCRIPTION
Using CouchChat-IOS demo (great by the way) got a out of bounds error after pulling latest revision of sync_gateway. This fixes it.
