### PR TITLE
Updating version (and commit hash) on each build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.walrus
 *~
 .#*
+build_info.go
 /bin
 /pkg
 /vendor/pkg

--- a/build.sh
+++ b/build.sh
@@ -8,10 +8,10 @@
 # populate version info before each build
 CURRENT_BRANCH=`git status -b -s | sed q | sed 's/## //'`
 CURRENT_COMMIT=`cat .git/refs/heads/$CURRENT_BRANCH | sed 's/\n//'`
-sed -i -e 's/CurrentBranch.*=.*/CurrentBranch     = "'$CURRENT_BRANCH'"/' ./src/github.com/couchbaselabs/sync_gateway/rest/config.go
-sed -i -e 's/CurrentCommit.*=.*/CurrentCommit     = "'$CURRENT_COMMIT'"/' ./src/github.com/couchbaselabs/sync_gateway/rest/config.go
+sed -i '' -e 's/CurrentBranch.*=.*/CurrentBranch     = "'$CURRENT_BRANCH'"/' ./src/github.com/couchbaselabs/sync_gateway/rest/config.go
+sed -i '' -e 's/CurrentCommit.*=.*/CurrentCommit     = "'$CURRENT_COMMIT'"/' ./src/github.com/couchbaselabs/sync_gateway/rest/config.go
 
-# build
-export GOBIN="`pwd`/bin"
-./go.sh install -v github.com/couchbaselabs/sync_gateway
-echo "Success! Output is bin/sync_gateway"
+# # build
+# export GOBIN="`pwd`/bin"
+# ./go.sh install -v github.com/couchbaselabs/sync_gateway
+# echo "Success! Output is bin/sync_gateway"

--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,13 @@
 # dependent packages (in vendor) and the gateway source code (in src)
 # by setting $GOPATH.
 
+# populate version info before each build
+CURRENT_BRANCH=`git status -b -s | sed q | sed 's/## //'`
+CURRENT_COMMIT=`cat .git/refs/heads/$CURRENT_BRANCH | sed 's/\n//'`
+sed -i -e 's/CurrentBranch.*=.*/CurrentBranch     = "'$CURRENT_BRANCH'"/' ./src/github.com/couchbaselabs/sync_gateway/rest/config.go
+sed -i -e 's/CurrentCommit.*=.*/CurrentCommit     = "'$CURRENT_COMMIT'"/' ./src/github.com/couchbaselabs/sync_gateway/rest/config.go
+
+# build
 export GOBIN="`pwd`/bin"
 ./go.sh install -v github.com/couchbaselabs/sync_gateway
 echo "Success! Output is bin/sync_gateway"

--- a/build.sh
+++ b/build.sh
@@ -6,12 +6,13 @@
 # by setting $GOPATH.
 
 # populate version info before each build
+BUILD_INFO="./src/github.com/couchbaselabs/sync_gateway/rest/build_info.go"
 CURRENT_BRANCH=`git status -b -s | sed q | sed 's/## //'`
 CURRENT_COMMIT=`cat .git/refs/heads/$CURRENT_BRANCH | sed 's/\n//'`
-sed -i '' -e 's/CurrentBranch.*=.*/CurrentBranch     = "'$CURRENT_BRANCH'"/' ./src/github.com/couchbaselabs/sync_gateway/rest/config.go
-sed -i '' -e 's/CurrentCommit.*=.*/CurrentCommit     = "'$CURRENT_COMMIT'"/' ./src/github.com/couchbaselabs/sync_gateway/rest/config.go
+sed -i '' -e 's/CurrentBranch.*=.*/CurrentBranch     = "'$CURRENT_BRANCH'"/' $BUILD_INFO
+sed -i '' -e 's/CurrentCommit.*=.*/CurrentCommit     = "'$CURRENT_COMMIT'"/' $BUILD_INFO
 
-# # build
-# export GOBIN="`pwd`/bin"
-# ./go.sh install -v github.com/couchbaselabs/sync_gateway
-# echo "Success! Output is bin/sync_gateway"
+# build
+export GOBIN="`pwd`/bin"
+./go.sh install -v github.com/couchbaselabs/sync_gateway
+echo "Success! Output is bin/sync_gateway"

--- a/src/github.com/couchbaselabs/sync_gateway/rest/build_info.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/build_info.go
@@ -1,0 +1,16 @@
+//  Copyright (c) 2012 Couchbase, Inc.
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+package rest
+
+const (
+	CurrentBranch     = ""
+	CurrentCommit     = ""
+	FullVersionString = VersionString + " (" + CurrentBranch + " - " + CurrentCommit + ")"
+)

--- a/src/github.com/couchbaselabs/sync_gateway/rest/config.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/config.go
@@ -29,8 +29,8 @@ var DefaultServer = "walrus:"
 var DefaultPool = "default"
 
 const (
-	CurrentBranch     = ""
-	CurrentCommit     = ""
+	CurrentBranch     = "myFork"
+	CurrentCommit     = "0b4e3dafc8726bf44d1d47a5d86b5714cc1cb559"
 	FullVersionString = VersionString + " (" + CurrentBranch + " - " + CurrentCommit + ")"
 )
 

--- a/src/github.com/couchbaselabs/sync_gateway/rest/config.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/config.go
@@ -28,12 +28,6 @@ var DefaultAdminInterface = ":4985"
 var DefaultServer = "walrus:"
 var DefaultPool = "default"
 
-const (
-	CurrentBranch     = "myFork"
-	CurrentCommit     = "0b4e3dafc8726bf44d1d47a5d86b5714cc1cb559"
-	FullVersionString = VersionString + " (" + CurrentBranch + " - " + CurrentCommit + ")"
-)
-
 // JSON object that defines the server configuration.
 type ServerConfig struct {
 	Interface      *string // Interface to bind REST API to, default ":4984"

--- a/src/github.com/couchbaselabs/sync_gateway/rest/config.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/config.go
@@ -28,6 +28,12 @@ var DefaultAdminInterface = ":4985"
 var DefaultServer = "walrus:"
 var DefaultPool = "default"
 
+const (
+	CurrentBranch     = ""
+	CurrentCommit     = ""
+	FullVersionString = VersionString + " (" + CurrentBranch + " - " + CurrentCommit + ")"
+)
+
 // JSON object that defines the server configuration.
 type ServerConfig struct {
 	Interface      *string // Interface to bind REST API to, default ":4984"
@@ -351,5 +357,6 @@ func RunServer(config *ServerConfig) {
 // Main entry point for a simple server; you can have your main() function just call this.
 // It parses command-line flags, reads the optional configuration file, then starts the server.
 func ServerMain() {
+	fmt.Println(FullVersionString)
 	RunServer(ParseCommandLine())
 }


### PR DESCRIPTION
With binaries, it can be hard to keep track of which version or specific commit you may be running (especially when trying to switch between versions a lot, using multiple machines, etc). The enhancements to build.sh grab branch and commit info, and then they're displayed alongside the VersionString to keep you up-to-date.
