### PR TITLE
add ability to create/update attachments using HTTP PUT

### DIFF
--- a/src/github.com/couchbaselabs/sync_gateway/rest/doc_api.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/doc_api.go
@@ -131,6 +131,9 @@ func (h *handler) handlePutAttachment() error {
 		attachmentContentType = "application/octet-stream"
 	}
 	revid := h.getQuery("rev")
+	if revid == "" {
+		revid = h.rq.Header.Get("If-Match")
+	}
 	attachmentData, err := ioutil.ReadAll(h.rq.Body)
 	if err != nil {
 		return err
@@ -141,6 +144,7 @@ func (h *handler) handlePutAttachment() error {
 		// couchdb creates empty body on attachment PUT
 		// for non-existant doc id
 		body = db.Body{}
+		body["_rev"] = revid
 	} else if err != nil {
 		return err
 	} else if body != nil {

--- a/src/github.com/couchbaselabs/sync_gateway/rest/doc_api.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/doc_api.go
@@ -11,6 +11,7 @@ package rest
 
 import (
 	"encoding/json"
+	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 
@@ -118,6 +119,56 @@ func (h *handler) handleGetAttachment() error {
 		h.setHeader("Content-Encoding", encoding)
 	}
 	h.response.Write(data)
+	return nil
+}
+
+// HTTP handler for a PUT of an attachment
+func (h *handler) handlePutAttachment() error {
+	docid := h.PathVar("docid")
+	attachmentName := h.PathVar("attach")
+	attachmentContentType := h.rq.Header.Get("Content-Type")
+	if attachmentContentType == "" {
+		attachmentContentType = "application/octet-stream"
+	}
+	revid := h.getQuery("rev")
+	attachmentData, err := ioutil.ReadAll(h.rq.Body)
+	if err != nil {
+		return err
+	}
+
+	body, err := h.db.GetRev(docid, revid, false, nil)
+	if err != nil && base.IsDocNotFoundError(err) {
+		// couchdb creates empty body on attachment PUT
+		// for non-existant doc id
+		body = db.Body{}
+	} else if err != nil {
+		return err
+	} else if body != nil {
+		body["_rev"] = revid
+	}
+
+	// find attachment (if it existed)
+	attachments := db.BodyAttachments(body)
+	if attachments == nil {
+		attachments = make(map[string]interface{})
+	}
+
+	// create new attachment
+	attachment := make(map[string]interface{})
+	attachment["data"] = attachmentData
+	attachment["content_type"] = attachmentContentType
+
+	//attach it
+	attachments[attachmentName] = attachment
+	body["_attachments"] = attachments
+
+	newRev, err := h.db.Put(docid, body)
+	if err != nil {
+		return err
+	}
+	h.setHeader("Etag", newRev)
+
+	h.writeJSONStatus(http.StatusCreated, db.Body{"ok": true, "id": docid, "rev": newRev})
 	return nil
 }
 

--- a/src/github.com/couchbaselabs/sync_gateway/rest/routing.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/routing.go
@@ -56,6 +56,7 @@ func createHandler(sc *ServerContext, privs handlerPrivs) (*mux.Router, *mux.Rou
 	dbr.Handle("/{docid:"+docRegex+"}", makeHandler(sc, privs, (*handler).handleDeleteDoc)).Methods("DELETE")
 
 	dbr.Handle("/{docid:"+docRegex+"}/{attach}", makeHandler(sc, privs, (*handler).handleGetAttachment)).Methods("GET", "HEAD")
+	dbr.Handle("/{docid:"+docRegex+"}/{attach}", makeHandler(sc, privs, (*handler).handlePutAttachment)).Methods("PUT")
 
 	return r, dbr
 }


### PR DESCRIPTION
Allows for adding/updating attachments using simple curl command:
curl -XPUT .../db/doc_id/attachment_name?rev=document_rev_id --data-binary @attachment_file
