### PR TITLE
Admin ui included as Go code

### DIFF
--- a/go.sh
+++ b/go.sh
@@ -2,5 +2,5 @@
 
 # This script runs the given Go subcommand with GOPATH set up correctly for sync_gateway.
 
-export GOPATH="`pwd`:`pwd`/vendor"
+export GOPATH="`pwd`:`pwd`/vendor:`pwd`/utils"
 go "$@"

--- a/src/github.com/couchbaselabs/sync_gateway/rest/config.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/config.go
@@ -44,6 +44,7 @@ type ServerConfig struct {
 	SSLCert                 *string         // Path to SSL cert file, or nil
 	SSLKey                  *string         // Path to SSL private key file, or nil
 	AdminInterface          *string         // Interface to bind admin API to, default ":4985"
+	AdminUI                 *string         // Path to Admin HTML page, if omitted uses bundled HTML
 	ProfileInterface        *string         // Interface to bind Go profile API to (no default)
 	ConfigServer            *string         // URL of config server (for dynamic db discovery)
 	Persona                 *PersonaConfig  // Configuration for Mozilla Persona validation

--- a/src/github.com/couchbaselabs/sync_gateway/rest/routing.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/routing.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/couchbaselabs/sync_gateway_admin_ui"
 	"github.com/gorilla/mux"
 )
 
@@ -87,11 +88,12 @@ func CreatePublicHandler(sc *ServerContext) http.Handler {
 func CreateAdminHandler(sc *ServerContext) http.Handler {
 	r, dbr := createHandler(sc, adminPrivs)
 
-	// todo the path should be securely pinned to bin/utils or something
-	r.PathPrefix("/_utils/assets").Handler(http.StripPrefix("/_utils/assets",
-		http.FileServer(http.Dir("./utils/assets")))).Methods("GET", "HEAD")
-	r.PathPrefix("/_utils").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.ServeFile(w, r, "./utils/index.html")
+	r.PathPrefix("/_utils/").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if sc.config.AdminUI != nil {
+			http.ServeFile(w, r, *sc.config.AdminUI)
+		} else {
+			w.Write(sync_gateway_admin_ui.Admin_bundle_html())
+		}
 	})
 
 	dbr.Handle("/_session",


### PR DESCRIPTION
The admin ui is available on the admin port at the `/_utils/` path.
It is delivered as a single HTML asset which is linked from the
`utils/` submodule into the sync_gateway GOPATH in go.sh.

There is a config parameter (adminUI) that tells the server to look on the
filesystem for HTML to serve instead of the packaged version. This
supports both rapid development and customization / independent upgrade.
