### PR TITLE
Closes #344

### DIFF
--- a/src/github.com/couchbaselabs/sync_gateway/rest/config.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/config.go
@@ -168,6 +168,7 @@ func ReadServerConfigFromData(data []byte) (*ServerConfig, error) {
 	return config, nil
 }
 
+// Reads a ServerConfig from a URL.
 func ReadServerConfigFromUrl(url string) (*ServerConfig, error) {
 
 	resp, err := http.Get(url)

--- a/src/github.com/couchbaselabs/sync_gateway/rest/config.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/config.go
@@ -185,7 +185,7 @@ func ReadServerConfigFromUrl(url string) (*ServerConfig, error) {
 
 // Reads a ServerConfig from either a JSON file or from a URL.
 func ReadServerConfig(path string) (*ServerConfig, error) {
-	if strings.HasPrefix(path, "http") {
+	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
 		return ReadServerConfigFromUrl(path)
 	} else {
 		return ReadServerConfigFromFile(path)


### PR DESCRIPTION
Read the config from a URL rather than a local file if the name of the config file starts with "http"
