### PR TITLE
check if go version is 1.2 or above

### DIFF
--- a/go.sh
+++ b/go.sh
@@ -2,11 +2,11 @@
 
 # This script runs the given Go subcommand with GOPATH set up correctly for sync_gateway.
 
-if [[ `go version` != *go1.2* ]]
-then
-    echo "*** Go 1.2 is required to build Sync Gateway; you have" `go version`
-    echo "Please visit http://golang.org/doc/install or use your package manager to upgrade."
-    exit 1
+GO_VERSION=`go version | awk '{ match($3, /.*([0-9]+\.[0-9]).*/, res); print res[1] }'`
+if [[ $(echo "$GO_VERSION >= 1.2" | bc) -eq 0 ]]; then
+  echo "*** Go 1.2 or higher is required to build Sync Gateway; you have" `go version`
+  echo "Please visit http://golang.org/doc/install or use your package manager to upgrade."
+  exit 1
 fi
 
 export GOPATH="`pwd`:`pwd`/vendor"


### PR DESCRIPTION
Check if the go version is above 1.2, instead of matching hard against
1.2. Since 1.3 is released and the tests seem to pass I think it should
be possible to build with 1.3 as well. This is needed to build with
homebrew as well since go 1.3 is the default version there, see
https://github.com/Homebrew/homebrew/pull/29736

Fixes #343
