### PR TITLE
Fix go version number extraction

### DIFF
--- a/go.sh
+++ b/go.sh
@@ -2,8 +2,8 @@
 
 # This script runs the given Go subcommand with GOPATH set up correctly for sync_gateway.
 
-GO_VERSION=`go version | awk '{ gsub(/go/, "", $3); print $3 }'`
-if [[ $(echo "$GO_VERSION >= 1.2" | bc) -eq 0 ]]; then
+GO_MAJOR_MINOR_VERSION=`go version | sed -E 's/.*go([0-9]\.[0-9]+).*/\1/'`
+if [[ $(echo "$GO_MAJOR_MINOR_VERSION >= 1.2" | bc) -eq 0 ]]; then
   echo "*** Go 1.2 or higher is required to build Sync Gateway; you have" `go version`
   echo "Please visit http://golang.org/doc/install or use your package manager to upgrade."
   exit 1


### PR DESCRIPTION
We really need to check to major.minor so 1.2.1 should be considered
1.2. while 1.32 should be considered 1.32 even though their aren't
double digit minor versions today I think it makes sense to consider
them.

This has been tested against the version strings

go version go1.3 darwin/amd64
go version go1.2.1 darwin/amd64
go version go1.2 darwin/amd64
go version go1.31 darwin/amd64

This version uses sed as default installed on OSX (afaik) @snej can you test on
your machine?

fixes #343 
