### PR TITLE
Fix for issue #332

### DIFF
--- a/src/github.com/couchbaselabs/sync_gateway/base/bucket.go
+++ b/src/github.com/couchbaselabs/sync_gateway/base/bucket.go
@@ -111,12 +111,13 @@ func (bucket couchbaseBucket) Dump() {
 
 // Creates a Bucket that talks to a real live Couchbase server.
 func GetCouchbaseBucket(spec BucketSpec) (bucket Bucket, err error) {
-        cbbucket, err := couchbase.GetBucket(spec.Server, spec.PoolName, spec.BucketName)
-        if err == nil {
-                bucket = couchbaseBucket{cbbucket}
-        }
-        return
+	cbbucket, err := couchbase.GetBucket(spec.Server, spec.PoolName, spec.BucketName)
+	if err == nil {
+		bucket = couchbaseBucket{cbbucket}
+	}
+	return
 }
+
 func GetBucket(spec BucketSpec) (bucket Bucket, err error) {
 	if isWalrus, _ := regexp.MatchString(`^(walrus:|file:|/|\.)`, spec.Server); isWalrus {
 		Log("Opening Walrus database %s on <%s>", spec.BucketName, spec.Server)

--- a/src/github.com/couchbaselabs/sync_gateway/base/bucket.go
+++ b/src/github.com/couchbaselabs/sync_gateway/base/bucket.go
@@ -111,25 +111,12 @@ func (bucket couchbaseBucket) Dump() {
 
 // Creates a Bucket that talks to a real live Couchbase server.
 func GetCouchbaseBucket(spec BucketSpec) (bucket Bucket, err error) {
-	client, err := couchbase.ConnectWithAuth(spec.Server, spec.Auth)
-	if err != nil {
-		return
-	}
-	poolName := spec.PoolName
-	if poolName == "" {
-		poolName = "default"
-	}
-	pool, err := client.GetPool(poolName)
-	if err != nil {
-		return
-	}
-	cbbucket, err := pool.GetBucket(spec.BucketName)
-	if err == nil {
-		bucket = couchbaseBucket{cbbucket}
-	}
-	return
+        cbbucket, err := couchbase.GetBucket(spec.Server, spec.PoolName, spec.BucketName)
+        if err == nil {
+                bucket = couchbaseBucket{cbbucket}
+        }
+        return
 }
-
 func GetBucket(spec BucketSpec) (bucket Bucket, err error) {
 	if isWalrus, _ := regexp.MatchString(`^(walrus:|file:|/|\.)`, spec.Server); isWalrus {
 		Log("Opening Walrus database %s on <%s>", spec.BucketName, spec.Server)

--- a/src/github.com/couchbaselabs/sync_gateway/rest/server_context.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/server_context.go
@@ -278,11 +278,11 @@ func (sc *ServerContext) startShadowing(dbcontext *db.DatabaseContext, shadow *S
 	}
 	dbcontext.Shadower = shadower
 
-        //Remove credentials from server URL before logging
-        url, err := couchbase.ParseURL(spec.Server)
-        if err == nil {
-	    base.Log("Database %q shadowing remote bucket %q, pool %q, server <%s:%s/%s>", dbcontext.Name, spec.BucketName, spec.PoolName, url.Scheme, url.Host, url.Path)
-        }
+	//Remove credentials from server URL before logging
+	url, err := couchbase.ParseURL(spec.Server)
+	if err == nil {
+		base.Log("Database %q shadowing remote bucket %q, pool %q, server <%s:%s/%s>", dbcontext.Name, spec.BucketName, spec.PoolName, url.Scheme, url.Host, url.Path)
+	}
 	return nil
 }
 

--- a/src/github.com/couchbaselabs/sync_gateway/rest/server_context.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/server_context.go
@@ -277,7 +277,12 @@ func (sc *ServerContext) startShadowing(dbcontext *db.DatabaseContext, shadow *S
 		return err
 	}
 	dbcontext.Shadower = shadower
-	base.Log("Database %q shadowing remote bucket %q, pool %q, server <%s>", dbcontext.Name, spec.BucketName, spec.PoolName, spec.Server)
+
+        //Remove credentials from server URL before logging
+        url, err := couchbase.ParseURL(spec.Server)
+        if err == nil {
+	    base.Log("Database %q shadowing remote bucket %q, pool %q, server <%s:%s/%s>", dbcontext.Name, spec.BucketName, spec.PoolName, url.Scheme, url.Host, url.Path)
+        }
 	return nil
 }
 


### PR DESCRIPTION
Now Opens shadow bucket with full server URL including user credentials if present, this allows password protected buckets to be opened.

A user must define a URL for the shadow bucket that includes credentials, e.g. in the sgconfig.json the following snippet creates a sync_gateway DB that shadows a password protected CouchbaseServer bucket. 

Note: The credentials username must match the shadow bucket name.

```
"databases": {
    "db": {
        "server":"http://localhost:8091",
        "bucket":"db",
        "shadow": {
            "server": "http://shadow:passw0rd@localhost:8091",
            "bucket": "shadow"
    },
```
