### PR TITLE
Fix infinite loops in changes feed by reordering new channels' items

### DIFF
--- a/src/github.com/couchbaselabs/sync_gateway/db/changes_view.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/changes_view.go
@@ -31,7 +31,7 @@ func (dbc *DatabaseContext) getChangesInChannelFromView(
 	start := time.Now()
 	// Query the view:
 	optMap := changesViewOptions(channelName, endSeq, options)
-	base.LogTo("Cache", "  Querying 'channels' view for %q (start=#%d, end=#%d, limit=%d)", channelName, options.Since+1, endSeq, options.Limit)
+	base.LogTo("Cache", "  Querying 'channels' view for %q (start=#%d, end=#%d, limit=%d)", channelName, options.Since.Seq+1, endSeq, options.Limit)
 	vres := channelsViewResult{}
 	err := dbc.Bucket.ViewCustom("sync_gateway", "channels", optMap, &vres)
 	if err != nil {
@@ -73,7 +73,7 @@ func changesViewOptions(channelName string, endSeq uint64, options ChangesOption
 	}
 	optMap := Body{
 		"stale":    false,
-		"startkey": []interface{}{channelName, options.Since + 1},
+		"startkey": []interface{}{channelName, options.Since.Seq + 1},
 		"endkey":   endKey,
 	}
 	if options.Limit > 0 {

--- a/src/github.com/couchbaselabs/sync_gateway/db/channel_cache.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/channel_cache.go
@@ -78,7 +78,7 @@ func (c *channelCache) _getCachedChanges(options ChangesOptions) (validFrom uint
 		return // Return nil if nothing is cached
 	}
 	var start int
-	for start = len(log) - 1; start >= 0 && log[start].Sequence > options.Since; start-- {
+	for start = len(log) - 1; start >= 0 && log[start].Sequence > options.Since.Seq; start-- {
 	}
 	start++
 
@@ -114,7 +114,8 @@ func (c *channelCache) GetChanges(options ChangesOptions) ([]*LogEntry, error) {
 		base.LogTo("Cache", "getCachedChanges(%q, %d) --> nothing cached",
 			c.channelName, options.Since)
 	}
-	if cacheValidFrom <= options.Since+1 {
+	startSeq := options.Since.Seq + 1
+	if cacheValidFrom <= startSeq {
 		return resultFromCache, nil
 	}
 
@@ -130,7 +131,7 @@ func (c *channelCache) GetChanges(options ChangesOptions) ([]*LogEntry, error) {
 		base.LogTo("Cache", "2nd getCachedChanges(%q, %d) got %d more, valid from #%d!",
 			c.channelName, options.Since, len(resultFromCache)-numFromCache, cacheValidFrom)
 	}
-	if cacheValidFrom <= options.Since+1 {
+	if cacheValidFrom <= startSeq {
 		return resultFromCache, nil
 	}
 
@@ -144,7 +145,7 @@ func (c *channelCache) GetChanges(options ChangesOptions) ([]*LogEntry, error) {
 
 	// Cache some of the view results, if there's room in the cache:
 	if len(resultFromCache) < ChannelCacheMaxLength {
-		c.prependChanges(resultFromView, options.Since+1, options.Limit == 0)
+		c.prependChanges(resultFromView, startSeq, options.Limit == 0)
 	}
 
 	result := resultFromView

--- a/src/github.com/couchbaselabs/sync_gateway/db/sequence_id.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/sequence_id.go
@@ -1,0 +1,87 @@
+package db
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/couchbaselabs/sync_gateway/base"
+)
+
+// A change sequence as reported externally in a _changes feed.
+// Most of the time the TriggerSeq is 0, but if a revision is being sent retroactively because
+// the user got access to a channel, the TriggerSeq will be equal to the sequence of the change
+// that gave the user access.
+type SequenceID struct {
+	TriggeredBy uint64 // The sequence # that triggered this (0 if none)
+	Seq         uint64 // The actual internal sequence
+}
+
+var MaxSequenceID = SequenceID{Seq: math.MaxUint64}
+
+func (s SequenceID) String() string {
+	if s.TriggeredBy > 0 {
+		return fmt.Sprintf("%d:%d", s.TriggeredBy, s.Seq)
+	} else {
+		return strconv.FormatUint(s.Seq, 10)
+	}
+}
+
+func ParseSequenceID(str string) (s SequenceID, err error) {
+	if str == "" {
+		return SequenceID{}, nil
+	}
+	components := strings.Split(str, ":")
+	if len(components) == 1 {
+		s.Seq, err = strconv.ParseUint(str, 10, 64)
+	} else if len(components) != 2 {
+		err = base.HTTPErrorf(400, "Invalid sequence")
+	} else {
+		s.TriggeredBy, err = strconv.ParseUint(components[0], 10, 64)
+		if err == nil {
+			s.Seq, err = strconv.ParseUint(components[1], 10, 64)
+		}
+	}
+	if err != nil {
+		err = base.HTTPErrorf(400, "Invalid sequence")
+	}
+	return
+}
+
+func (s SequenceID) MarshalJSON() ([]byte, error) {
+	if s.TriggeredBy > 0 {
+		return []byte(fmt.Sprintf("\"%d:%d\"", s.TriggeredBy, s.Seq)), nil
+	} else {
+		return []byte(strconv.FormatUint(s.Seq, 10)), nil
+	}
+}
+
+func (s *SequenceID) UnmarshalJSON(data []byte) error {
+	if len(data) > 0 && data[0] == '"' {
+		var raw string
+		err := json.Unmarshal(data, &raw)
+		if err == nil {
+			*s, err = ParseSequenceID(string(raw))
+		}
+		return err
+	} else {
+		s.TriggeredBy = 0
+		return json.Unmarshal(data, &s.Seq)
+	}
+}
+
+// The most significant value is TriggeredBy, unless it's zero, in which case use Seq.
+// The tricky part is that "n" sorts after "n:m" for any nonzero m
+func (s SequenceID) Before(s2 SequenceID) bool {
+	if s.TriggeredBy == s2.TriggeredBy {
+		return s.Seq < s2.Seq // the simple case: untriggered, or triggered by same sequence
+	} else if s.TriggeredBy == 0 {
+		return s.Seq < s2.TriggeredBy // s2 triggered but not s
+	} else if s2.TriggeredBy == 0 {
+		return s.TriggeredBy <= s2.Seq // s triggered but not s2
+	} else {
+		return s.TriggeredBy < s2.TriggeredBy // both triggered, but by different sequences
+	}
+}

--- a/src/github.com/couchbaselabs/sync_gateway/db/sequence_id_test.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/sequence_id_test.go
@@ -1,0 +1,77 @@
+package db
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/couchbaselabs/go.assert"
+)
+
+func TestParseSequenceID(t *testing.T) {
+	s, err := ParseSequenceID("1234")
+	assertNoError(t, err, "ParseSequenceID")
+	assert.Equals(t, s, SequenceID{Seq: 1234})
+
+	s, err = ParseSequenceID("5678:1234")
+	assertNoError(t, err, "ParseSequenceID")
+	assert.Equals(t, s, SequenceID{Seq: 1234, TriggeredBy: 5678})
+
+	s, err = ParseSequenceID("")
+	assertNoError(t, err, "ParseSequenceID")
+	assert.Equals(t, s, SequenceID{Seq: 0, TriggeredBy: 0})
+
+	s, err = ParseSequenceID("foo")
+	assert.True(t, err != nil)
+	s, err = ParseSequenceID(":")
+	assert.True(t, err != nil)
+	s, err = ParseSequenceID("123:456:789")
+	assert.True(t, err != nil)
+	s, err = ParseSequenceID(":1")
+	assert.True(t, err != nil)
+	s, err = ParseSequenceID("123:ggg")
+	assert.True(t, err != nil)
+}
+
+func TestMarshalSequenceID(t *testing.T) {
+	s := SequenceID{Seq: 1234}
+	assert.Equals(t, s.String(), "1234")
+	asJson, err := json.Marshal(s)
+	assertNoError(t, err, "Marshal failed")
+	assert.Equals(t, string(asJson), "1234")
+
+	var s2 SequenceID
+	err = json.Unmarshal(asJson, &s2)
+	assertNoError(t, err, "Unmarshal failed")
+	assert.Equals(t, s2, s)
+}
+
+func TestMarshalTriggeredSequenceID(t *testing.T) {
+	s := SequenceID{TriggeredBy: 5678, Seq: 1234}
+	assert.Equals(t, s.String(), "5678:1234")
+	asJson, err := json.Marshal(s)
+	assertNoError(t, err, "Marshal failed")
+	assert.Equals(t, string(asJson), "\"5678:1234\"")
+
+	var s2 SequenceID
+	err = json.Unmarshal(asJson, &s2)
+	assertNoError(t, err, "Unmarshal failed")
+	assert.Equals(t, s2, s)
+}
+
+func TestCompareSequenceIDs(t *testing.T) {
+	orderedSeqs := []SequenceID{
+		SequenceID{Seq: 1234},
+		SequenceID{Seq: 5677},
+		SequenceID{TriggeredBy: 5678, Seq: 1234},
+		SequenceID{TriggeredBy: 5678, Seq: 2222},
+		SequenceID{Seq: 5678}, // 5678 comes after the sequences it triggered
+		SequenceID{TriggeredBy: 6666, Seq: 5678},
+		SequenceID{Seq: 6666},
+	}
+
+	for i := 0; i < len(orderedSeqs); i++ {
+		for j := 0; j < len(orderedSeqs); j++ {
+			assert.Equals(t, orderedSeqs[i].Before(orderedSeqs[j]), i < j)
+		}
+	}
+}


### PR DESCRIPTION
When a user gets access to a channel at sequence m, the pre-existing
items in that channel now appear in the feed right before sequence m,
with sequence IDs of the form "m:n" where n is the actual sequence # of
the item. This allows the changes feed to pick up where it left off,
avoiding infinite loops.
It does mean that public sequence IDs can now be strings, not just
numbers. But clients should not mind, since the IDs are opaque to them.
Fixes #314 (again!)
