### PR TITLE
fixes issue #252

### DIFF
--- a/src/github.com/couchbaselabs/sync_gateway/auth/session.go
+++ b/src/github.com/couchbaselabs/sync_gateway/auth/session.go
@@ -16,6 +16,8 @@ import (
 	"github.com/couchbaselabs/sync_gateway/base"
 )
 
+const kDefaultSessionTTL = 24 * time.Hour
+
 // A user login session (used with cookie-based auth.)
 type LoginSession struct {
 	ID         string        `json:"id"`
@@ -44,11 +46,10 @@ func (auth *Authenticator) AuthenticateCookie(rq *http.Request, response http.Re
 	//update the session Expiration if 10% or more of the current expiration time has elapsed
 	//if the session does not contain a Ttl (probably created prior to upgrading SG), use
 	//default value of 24Hours
-	duration := session.Ttl
-	if duration == 0 {
-		duration, _ = time.ParseDuration("24h")
-		session.Ttl = duration
+	if session.Ttl == 0 {
+		session.Ttl = kDefaultSessionTTL
 	}
+	duration := session.Ttl
 	sessionTimeElapsed := int((time.Now().Add(duration).Sub(session.Expiration)).Seconds())
 	tenPercentOfTtl := int(duration.Seconds()) / 10
 	if sessionTimeElapsed > tenPercentOfTtl {

--- a/src/github.com/couchbaselabs/sync_gateway/auth/session.go
+++ b/src/github.com/couchbaselabs/sync_gateway/auth/session.go
@@ -42,7 +42,7 @@ func (auth *Authenticator) AuthenticateCookie(rq *http.Request, response http.Re
 	}
 	// Don't need to check session.Expiration, because Couchbase will have nuked the document.
         //update the session Expiration if 10% or more of the current expiration time has elapsed
-        sessionPercentElapsed := int((time.Now().Add(session.Ttl).Sub(session.Expiration)).Seconds())
+	sessionPercentElapsed := int((time.Now().Add(session.Ttl).Sub(session.Expiration)).Seconds())
 	tenPercentOfTtl := int(session.Ttl.Seconds())/10
         if(sessionPercentElapsed > tenPercentOfTtl) {
         	session.Expiration = time.Now().Add(session.Ttl)

--- a/src/github.com/couchbaselabs/sync_gateway/auth/session.go
+++ b/src/github.com/couchbaselabs/sync_gateway/auth/session.go
@@ -41,16 +41,16 @@ func (auth *Authenticator) AuthenticateCookie(rq *http.Request, response http.Re
 		return nil, err
 	}
 	// Don't need to check session.Expiration, because Couchbase will have nuked the document.
-        //update the session Expiration if 10% or more of the current expiration time has elapsed
-        duration, _ := time.ParseDuration(session.Ttl)
-	sessionPercentElapsed := int((time.Now().Add(duration).Sub(session.Expiration)).Seconds())
-	tenPercentOfTtl := int(duration.Seconds())/10
-        if(sessionPercentElapsed > tenPercentOfTtl) {
-        	session.Expiration = time.Now().Add(duration)
-        	ttlSec := int(duration.Seconds())
+	//update the session Expiration if 10% or more of the current expiration time has elapsed
+	duration, _ := time.ParseDuration(session.Ttl)
+	sessionTimeElapsed := int((time.Now().Add(duration).Sub(session.Expiration)).Seconds())
+	tenPercentOfTtl := int(duration.Seconds()) / 10
+	if sessionTimeElapsed > tenPercentOfTtl {
+		session.Expiration = time.Now().Add(duration)
+		ttlSec := int(duration.Seconds())
 		if err = auth.bucket.Set(docIDForSession(session.ID), ttlSec, session); err != nil {
-                	return nil, err
-        	}
+			return nil, err
+		}
 
 		cookie.Expires = session.Expiration
 		http.SetCookie(response, cookie)
@@ -71,7 +71,7 @@ func (auth *Authenticator) CreateSession(username string, ttl time.Duration) (*L
 		ID:         base.GenerateRandomSecret(),
 		Username:   username,
 		Expiration: time.Now().Add(ttl),
-		Ttl: ttl.String(),
+		Ttl:        ttl.String(),
 	}
 	if err := auth.bucket.Set(docIDForSession(session.ID), ttlSec, session); err != nil {
 		return nil, err

--- a/src/github.com/couchbaselabs/sync_gateway/auth/session.go
+++ b/src/github.com/couchbaselabs/sync_gateway/auth/session.go
@@ -42,7 +42,9 @@ func (auth *Authenticator) AuthenticateCookie(rq *http.Request, response http.Re
 	}
 	// Don't need to check session.Expiration, because Couchbase will have nuked the document.
         //update the session Expiration if 10% or more of the current expiration time has elapsed
-        if(int((time.Now().Add(session.Ttl).Sub(session.Expiration)).Seconds()) > int(session.Ttl.Seconds())/10) {
+        sessionPercentElapsed := int((time.Now().Add(session.Ttl).Sub(session.Expiration)).Seconds())
+	tenPercentOfTtl := int(session.Ttl.Seconds())/10
+        if(sessionPercentElapsed > tenPercentOfTtl) {
         	session.Expiration = time.Now().Add(session.Ttl)
         	ttlSec := int(session.Ttl.Seconds())
 		if err = auth.bucket.Set(docIDForSession(session.ID), ttlSec, session); err != nil {

--- a/src/github.com/couchbaselabs/sync_gateway/rest/admin_api_test.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/admin_api_test.go
@@ -12,9 +12,11 @@ package rest
 import (
 	"encoding/json"
 	"testing"
+	"log"
+	"time"
 
 	"github.com/couchbaselabs/go.assert"
-
+	"github.com/couchbaselabs/sync_gateway/auth"
 	"github.com/couchbaselabs/sync_gateway/channels"
 	"github.com/couchbaselabs/sync_gateway/db"
 )
@@ -153,4 +155,54 @@ func TestGuestUser(t *testing.T) {
 	assert.Equals(t, user.Name(), "")
 	assert.DeepEquals(t, user.ExplicitChannels(), channels.TimedSet(nil))
 	assert.Equals(t, user.Disabled(), true)
+}
+
+func TestSessionExtension(t *testing.T) {
+        var rt restTester
+        a := auth.NewAuthenticator(rt.bucket(), nil)
+        user, err := a.GetUser("")
+        assert.Equals(t, err, nil)
+        user.SetDisabled(true)
+        err = a.Save(user)
+        assert.Equals(t, err, nil)
+
+        user, err = a.GetUser("")
+        assert.Equals(t, err, nil)
+        assert.True(t, user.Disabled())
+    
+        log.Printf("hello")
+        response := rt.sendRequest("PUT", "/db/doc", `{"hi": "there"}`)
+        assertStatus(t, response, 401)
+
+        user, err = a.NewUser("pupshaw", "letmein", channels.SetOf("*"))
+        a.Save(user)
+
+        assertStatus(t, rt.sendAdminRequest("GET", "/db/_session", ""), 200)
+
+        response = rt.sendAdminRequest("POST", "/db/_session", `{"name":"pupshaw", "ttl":10}`)
+        assertStatus(t, response, 200)
+
+	var body db.Body
+        json.Unmarshal(response.Body.Bytes(), &body)
+        sessionId := body["session_id"].(string)
+        sessionExpiration := body["expires"].(string)
+        assert.True(t, sessionId != "")
+        assert.True(t, sessionExpiration != "")
+        assert.True(t, body["cookie_name"].(string) == "SyncGatewaySession")
+
+	reqHeaders := map[string]string{
+                "Cookie": "SyncGatewaySession="+body["session_id"].(string),
+        }
+        response = rt.sendRequestWithHeaders("PUT", "/db/doc1", `{"hi": "there"}`, reqHeaders)
+        assertStatus(t, response, 201)
+
+        assert.True(t, response.Header().Get("Set-Cookie") == "")
+        
+        //Sleep for 2 seconds, this will ensure 10% of the 100 seconds session ttl has elapsed and
+        //should cause a new Cookie to be sent by the server with the same session ID and an extended expiration date
+        time.Sleep(2 * time.Second) 
+	response = rt.sendRequestWithHeaders("PUT", "/db/doc2", `{"hi": "there"}`, reqHeaders)
+        assertStatus(t, response, 201)
+
+        assert.True(t, response.Header().Get("Set-Cookie") != "")
 }

--- a/src/github.com/couchbaselabs/sync_gateway/rest/handler.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/handler.go
@@ -208,7 +208,7 @@ func (h *handler) checkAuth(context *db.DatabaseContext) error {
 
 	// Check cookie first:
 	var err error
-	h.user, err = context.Authenticator().AuthenticateCookie(h.rq)
+	h.user, err = context.Authenticator().AuthenticateCookie(h.rq, h.response)
 	if err != nil {
 		return err
 	} else if h.user != nil {


### PR DESCRIPTION
A patch to extend a cookie based session, when a user accesses sync gateway after 10% of the session expiration has elapsed, the original session ttl is added to the current system time and the session and cookie are updated and new cookie is returned to the client.

A new test has been added to the admin api
