### PR TITLE
Add descriptive error for Facebook auth when email is missing

### DIFF
--- a/src/github.com/couchbaselabs/sync_gateway/rest/session_api.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/session_api.go
@@ -107,6 +107,11 @@ func (h *handler) makeSessionFromEmail(email string, createUserIfNeeded bool) er
 		if !createUserIfNeeded {
 			return base.HTTPErrorf(http.StatusUnauthorized, "No such user")
 		}
+		
+		if len(email) < 1 {
+			return base.HTTPErrorf(http.StatusBadRequest, "Cannot register new user: email is missing")
+		}
+		
 		// Create a User with the given email address as username and a random password.
 		user, err = h.registerNewUser(email)
 		if err != nil {


### PR DESCRIPTION
A user can configure their privacy settings in Facebook to hide their email address, in which case an email is not returned from a call to /me.  When automatic provisioning is turned on, this causes user creation to fail.  I've added a check to rest.makeSessionFromEmail which will log a specific error message in this case.  No functional changes were made to the gateway.

In the long term, I think it would be a better idea to use the Facebook UID instead of the email address for the username.
