### PR TITLE
fixes issue #342

### DIFF
--- a/src/github.com/couchbaselabs/sync_gateway/base/bucket.go
+++ b/src/github.com/couchbaselabs/sync_gateway/base/bucket.go
@@ -21,8 +21,8 @@ import (
 
 func init() {
 	// Increase max memcached request size to 20M bytes, to support large docs (attachments!)
-	// arriving in a tap feed. (see issues #210, #333.)
-	gomemcached.MaxBodyLen = int(20.0e6)
+	// arriving in a tap feed. (see issues #210, #333, #342)
+	gomemcached.MaxBodyLen = int(20 * 1024 * 1024)
 }
 
 type Bucket walrus.Bucket


### PR DESCRIPTION
Sets max doc/attachment size in tap feed to true 20Meg (20 \* 1024 *1024), related to issues #210, #333
