### PR TITLE
Escape '+' chars in PathVar, fixes issue #367

### DIFF
--- a/src/github.com/couchbaselabs/sync_gateway/rest/api_test.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/api_test.go
@@ -213,6 +213,37 @@ func TestFunkyDocIDs(t *testing.T) {
 
 	response := rt.sendRequest("GET", "/db/AC%2FDC", "")
 	assertStatus(t, response, 200)
+
+	rt.createDoc(t, "AC+DC")
+	response = rt.sendRequest("GET", "/db/AC+DC", "")
+	assertStatus(t, response, 200)
+
+	rt.createDoc(t, "AC+DC+GC")
+	response = rt.sendRequest("GET", "/db/AC+DC+GC", "")
+	assertStatus(t, response, 200)
+
+	response = rt.sendRequest("PUT", "/db/foo+bar+moo+car", `{"prop":true}`)
+	assertStatus(t, response, 201)
+	response = rt.sendRequest("GET", "/db/foo+bar+moo+car", "")
+	assertStatus(t, response, 200)
+
+	rt.createDoc(t, "AC%2BDC2")
+	response = rt.sendRequest("GET", "/db/AC%2BDC2", "")
+	assertStatus(t, response, 200)
+
+	rt.createDoc(t, "AC%2BDC%2BGC2")
+	response = rt.sendRequest("GET", "/db/AC%2BDC%2BGC2", "")
+	assertStatus(t, response, 200)
+
+	response = rt.sendRequest("PUT", "/db/foo%2Bbar%2Bmoo%2Bcar2", `{"prop":true}`)
+	assertStatus(t, response, 201)
+	response = rt.sendRequest("GET", "/db/foo%2Bbar%2Bmoo%2Bcar2", "")
+	assertStatus(t, response, 200)
+
+	response = rt.sendRequest("PUT", "/db/foo%2Bbar+moo%2Bcar3", `{"prop":true}`)
+	assertStatus(t, response, 201)
+	response = rt.sendRequest("GET", "/db/foo+bar%2Bmoo+car3", "")
+	assertStatus(t, response, 200)
 }
 
 func TestDesignDocs(t *testing.T) {

--- a/src/github.com/couchbaselabs/sync_gateway/rest/handler.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/handler.go
@@ -246,6 +246,10 @@ func (h *handler) assertAdminOnly() {
 
 func (h *handler) PathVar(name string) string {
 	v := mux.Vars(h.rq)[name]
+
+	//Escape special chars i.e. '+' otherwise they are removed by QueryUnescape()
+	v = fixUnescapedSpecialChars(v)
+
 	// Before routing the URL we explicitly disabled expansion of %-escapes in the path
 	// (see function fixQuotedSlashes). So we have to unescape them now.
 	v, _ = url.QueryUnescape(v)
@@ -512,4 +516,13 @@ func (h *handler) writeStatus(status int, message string) {
 	h.setStatus(status, message)
 	jsonOut, _ := json.Marshal(db.Body{"error": errorStr, "reason": message})
 	h.response.Write(jsonOut)
+}
+
+func fixUnescapedSpecialChars(path string) string {
+
+	if strings.Contains(path, "+") {
+		newpath := strings.Replace(path, "+", "%2B", 1)
+		return newpath
+	}
+	return path
 }

--- a/src/github.com/couchbaselabs/sync_gateway/rest/handler.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/handler.go
@@ -248,7 +248,7 @@ func (h *handler) PathVar(name string) string {
 	v := mux.Vars(h.rq)[name]
 
 	//Escape special chars i.e. '+' otherwise they are removed by QueryUnescape()
-	v = fixUnescapedSpecialChars(v)
+	v = strings.Replace(v, "+", "%2B", -1)
 
 	// Before routing the URL we explicitly disabled expansion of %-escapes in the path
 	// (see function fixQuotedSlashes). So we have to unescape them now.
@@ -516,13 +516,4 @@ func (h *handler) writeStatus(status int, message string) {
 	h.setStatus(status, message)
 	jsonOut, _ := json.Marshal(db.Body{"error": errorStr, "reason": message})
 	h.response.Write(jsonOut)
-}
-
-func fixUnescapedSpecialChars(path string) string {
-
-	if strings.Contains(path, "+") {
-		newpath := strings.Replace(path, "+", "%2B", 1)
-		return newpath
-	}
-	return path
 }


### PR DESCRIPTION
By escaping '+' chars before call to url.QueryUnescape
