### PR TITLE
Updated sync gateway version strings in stdout and HTTP Headers, fixes issue #383

### DIFF
--- a/src/github.com/couchbaselabs/sync_gateway/rest/api.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/api.go
@@ -36,13 +36,16 @@ var VersionString string
 var LongVersionString string
 
 func init() {
-	VersionString = fmt.Sprintf("%s/%.2f", ServerName, VersionNumber)
+	VersionString = ServerName
 
 	if VersionBuildNumberString[0] != '@' {
-		LongVersionString = fmt.Sprintf("%s (%s; commit %.8s)",
+		LongVersionString = fmt.Sprintf("%s/%s(commit %.8s)",
 			VersionString, VersionBuildNumberString, VersionCommitSHA)
+
+		VersionString = fmt.Sprintf("%s/%.2f", ServerName, VersionNumber)
 	} else {
-		LongVersionString = VersionString + " (unofficial)"
+		LongVersionString = fmt.Sprintf("%s/(unofficial)", VersionString)
+		VersionString = LongVersionString
 	}
 }
 


### PR DESCRIPTION
This patch fixes the initial requirements for #383, for the complete set of features, the build will need to be updated to inject git info into the api.go file prior to compilation.

A new ticket will be created for the build.sh changes
