### PR TITLE
sync_gateway now returns a 204 status for OPTIONS method calls

### DIFF
--- a/src/github.com/couchbaselabs/sync_gateway/rest/api_test.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/api_test.go
@@ -178,7 +178,7 @@ func TestRoot(t *testing.T) {
 	response = rt.sendRequest("HEAD", "/", "")
 	assertStatus(t, response, 200)
 	response = rt.sendRequest("OPTIONS", "/", "")
-	assertStatus(t, response, 200)
+	assertStatus(t, response, 204)
 	assert.Equals(t, response.Header().Get("Allow"), "GET, HEAD")
 	response = rt.sendRequest("PUT", "/", "")
 	assertStatus(t, response, 405)

--- a/src/github.com/couchbaselabs/sync_gateway/rest/routing.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/routing.go
@@ -197,6 +197,8 @@ func wrapRouter(sc *ServerContext, privs handlerPrivs, router *mux.Router) http.
 				response.Header().Add("Allow", strings.Join(options, ", "))
 				if rq.Method != "OPTIONS" {
 					h.writeStatus(http.StatusMethodNotAllowed, "")
+				} else {
+					h.writeStatus(http.StatusNoContent, "")
 				}
 			}
 		}


### PR DESCRIPTION
This is ...in alignment with CouchDB

Updated test case to assert 204 response

fixes issue #284 
