### PR TITLE
Updated build.sh to extract current Git branch,commit 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.sublime-workspace
 *.walrus
+**/git_info.go
 \#*
 *~
 .#*

--- a/build.sh
+++ b/build.sh
@@ -13,8 +13,6 @@ GIT_BRANCH=`git status -b -s | sed q | sed 's/## //' | sed 's/\.\.\..*$//' | sed
 GIT_COMMIT=`git rev-parse HEAD`
 GIT_DIRTY=$(test -n "`git status --porcelain`" && echo "+CHANGES" || true)
 
-echo ${GIT_BRANCH}
-
 sed -i '' -e 's/GitCommit.*=.*/GitCommit = "'$GIT_COMMIT'"/' $BUILD_INFO
 sed -i '' -e 's/GitBranch.*=.*/GitBranch = "'$GIT_BRANCH'"/' $BUILD_INFO
 sed -i '' -e 's/GitDirty.*=.*/GitDirty = "'$GIT_DIRTY'"/' $BUILD_INFO

--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,20 @@
 # dependent packages (in vendor) and the gateway source code (in src)
 # by setting $GOPATH.
 
+# Set the git commit info before the build
+BUILD_INFO="./src/github.com/couchbaselabs/sync_gateway/rest/git_info.go"
+# Escape forward slash's so sed command does not get confused
+# We use thses in feature branches e.g. feature/issue_nnn
+GIT_BRANCH=`git status -b -s | sed q | sed 's/## //' | sed 's/\\//\\\\\//g'`
+GIT_COMMIT=`git rev-parse HEAD`
+GIT_DIRTY=$(test -n "`git status --porcelain`" && echo "+CHANGES" || true)
+
+echo ${GIT_BRANCH}
+
+sed -i '' -e 's/GitCommit.*=.*/GitCommit = "'$GIT_COMMIT'"/' $BUILD_INFO
+sed -i '' -e 's/GitBranch.*=.*/GitBranch = "'$GIT_BRANCH'"/' $BUILD_INFO
+sed -i '' -e 's/GitDirty.*=.*/GitDirty = "'$GIT_DIRTY'"/' $BUILD_INFO
+
 export GOBIN="`pwd`/bin"
 ./go.sh install -v github.com/couchbaselabs/sync_gateway
 echo "Success! Output is bin/sync_gateway"

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@
 BUILD_INFO="./src/github.com/couchbaselabs/sync_gateway/rest/git_info.go"
 # Escape forward slash's so sed command does not get confused
 # We use thses in feature branches e.g. feature/issue_nnn
-GIT_BRANCH=`git status -b -s | sed q | sed 's/## //' | sed 's/\\//\\\\\//g'`
+GIT_BRANCH=`git status -b -s | sed q | sed 's/## //' | sed 's/\.\.\..*$//' | sed 's/\\//\\\\\//g'`
 GIT_COMMIT=`git rev-parse HEAD`
 GIT_DIRTY=$(test -n "`git status --porcelain`" && echo "+CHANGES" || true)
 

--- a/src/github.com/couchbaselabs/sync_gateway/rest/api.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/api.go
@@ -36,13 +36,14 @@ var VersionString string
 var LongVersionString string
 
 func init() {
-	VersionString = fmt.Sprintf("%s/%.2f", ServerName, VersionNumber)
-
 	if VersionBuildNumberString[0] != '@' {
-		LongVersionString = fmt.Sprintf("%s (%s; commit %.8s)",
-			VersionString, VersionBuildNumberString, VersionCommitSHA)
+		LongVersionString = fmt.Sprintf("%s/%s(commit %.7s)",
+			ServerName, VersionBuildNumberString, VersionCommitSHA)
+
+		VersionString = fmt.Sprintf("%s/%.2f", ServerName, VersionNumber)
 	} else {
-		LongVersionString = VersionString + " (unofficial)"
+		LongVersionString = fmt.Sprintf("%s/%s(commit %.7s%s)", ServerName, GitBranch, GitCommit, GitDirty)
+		VersionString = fmt.Sprintf("%s/(unofficial)", ServerName)
 	}
 }
 

--- a/src/github.com/couchbaselabs/sync_gateway/rest/api.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/api.go
@@ -19,6 +19,7 @@ import (
 	"runtime"
 	"runtime/pprof"
 	"strconv"
+	"strings"
 
 	"github.com/couchbaselabs/sync_gateway/base"
 	"github.com/couchbaselabs/sync_gateway/db"
@@ -37,12 +38,19 @@ var LongVersionString string
 
 func init() {
 	if VersionBuildNumberString[0] != '@' {
-		LongVersionString = fmt.Sprintf("%s/%s(commit %.7s)",
-			ServerName, VersionBuildNumberString, VersionCommitSHA)
+		//Split version number and build number (optional)
+		versionTokens := strings.Split(VersionBuildNumberString, "-")
+		BuildVersionString := versionTokens[0]
+		var BuildNumberString string
+		if len(versionTokens) > 1 {
+			BuildNumberString = fmt.Sprintf("%s;", versionTokens[1])
+		}
+		LongVersionString = fmt.Sprintf("%s/%s(%s%.7s)",
+			ServerName, BuildVersionString, BuildNumberString, VersionCommitSHA)
 
 		VersionString = fmt.Sprintf("%s/%.2f", ServerName, VersionNumber)
 	} else {
-		LongVersionString = fmt.Sprintf("%s/%s(commit %.7s%s)", ServerName, GitBranch, GitCommit, GitDirty)
+		LongVersionString = fmt.Sprintf("%s/%s(%.7s%s)", ServerName, GitBranch, GitCommit, GitDirty)
 		VersionString = fmt.Sprintf("%s/unofficial", ServerName)
 	}
 }

--- a/src/github.com/couchbaselabs/sync_gateway/rest/api.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/api.go
@@ -43,7 +43,7 @@ func init() {
 		VersionString = fmt.Sprintf("%s/%.2f", ServerName, VersionNumber)
 	} else {
 		LongVersionString = fmt.Sprintf("%s/%s(commit %.7s%s)", ServerName, GitBranch, GitCommit, GitDirty)
-		VersionString = fmt.Sprintf("%s/(unofficial)", ServerName)
+		VersionString = fmt.Sprintf("%s/unofficial", ServerName)
 	}
 }
 

--- a/src/github.com/couchbaselabs/sync_gateway/rest/git_info.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/git_info.go
@@ -1,0 +1,6 @@
+package rest
+
+// The git commit that was compiled. This will be filled in by the compiler.
+const GitCommit = "@GIT_COMMIT@"
+const GitBranch = "@GIT_BRANCH@"
+const GitDirty = "@GIT_DIRTY@"

--- a/src/github.com/couchbaselabs/sync_gateway/rest/git_info.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/git_info.go
@@ -1,6 +1,0 @@
-package rest
-
-// The git commit that was compiled. This will be filled in by the compiler.
-const GitCommit = "@GIT_COMMIT@"
-const GitBranch = "@GIT_BRANCH@"
-const GitDirty = "@GIT_DIRTY@"


### PR DESCRIPTION
Updated build.sh to extract current Git branch,commit and if any loca…
…l files have been changed, these values are then used in the server startup message to make it clear what release of sync_gateway is being run. fixes issue #391
