### PR TITLE
Added config support for setting custom read/write timeouts on HTTP(S) server

### DIFF
--- a/examples/custom_read-write_timeouts.json
+++ b/examples/custom_read-write_timeouts.json
@@ -1,0 +1,13 @@
+{
+	"ServerReadTimeout": 200,
+	"ServerWriteTimeout": 200,
+	"log": ["HTTP+"],
+	"databases": {
+		"db": {
+			"server": "walrus:",
+			"users": {
+				"GUEST": {"disabled": false, "admin_channels": ["*"] }
+			}
+		}
+	}
+}

--- a/src/github.com/couchbaselabs/sync_gateway/base/http_listener.go
+++ b/src/github.com/couchbaselabs/sync_gateway/base/http_listener.go
@@ -20,7 +20,7 @@ func init() {
 
 // This is like a combination of http.ListenAndServe and http.ListenAndServeTLS, which also
 // uses ThrottledListen to limit the number of open HTTP connections.
-func ListenAndServeHTTP(addr string, connLimit int, certFile *string, keyFile *string, handler http.Handler) error {
+func ListenAndServeHTTP(addr string, connLimit int, certFile *string, keyFile *string, handler http.Handler, readTimeout *int, writeTimeout *int) error {
 	var config *tls.Config
 	if certFile != nil {
 		config = &tls.Config{}
@@ -41,6 +41,13 @@ func ListenAndServeHTTP(addr string, connLimit int, certFile *string, keyFile *s
 	}
 	defer listener.Close()
 	server := &http.Server{Addr: addr, Handler: handler}
+	if readTimeout != nil {
+		server.ReadTimeout = time.Duration(*readTimeout) * time.Second
+	}
+	if writeTimeout != nil {
+		server.WriteTimeout = time.Duration(*writeTimeout) * time.Second
+	}
+
 	return server.Serve(listener)
 }
 

--- a/src/github.com/couchbaselabs/sync_gateway/rest/config.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/config.go
@@ -46,6 +46,8 @@ type ServerConfig struct {
 	Interface                      *string         // Interface to bind REST API to, default ":4984"
 	SSLCert                        *string         // Path to SSL cert file, or nil
 	SSLKey                         *string         // Path to SSL private key file, or nil
+	ServerReadTimeout              *int            // maximum duration.Second before timing out read of the HTTP(S) request
+	ServerWriteTimeout             *int            // maximum duration.Second before timing out write of the HTTP(S) response
 	AdminInterface                 *string         // Interface to bind admin API to, default ":4985"
 	AdminUI                        *string         // Path to Admin HTML page, if omitted uses bundled HTML
 	ProfileInterface               *string         // Interface to bind Go profile API to (no default)
@@ -384,7 +386,8 @@ func (config *ServerConfig) serve(addr string, handler http.Handler) {
 	if config.MaxIncomingConnections != nil {
 		maxConns = *config.MaxIncomingConnections
 	}
-	err := base.ListenAndServeHTTP(addr, maxConns, config.SSLCert, config.SSLKey, handler)
+
+	err := base.ListenAndServeHTTP(addr, maxConns, config.SSLCert, config.SSLKey, handler, config.ServerReadTimeout, config.ServerWriteTimeout)
 	if err != nil {
 		base.LogFatal("Failed to start HTTP server on %s: %v", addr, err)
 	}


### PR DESCRIPTION
fixes issue #362 

ServerReadTimeout   // maximum duration.Second before timing out read of the HTTP(S) request
ServerWriteTimeout    // maximum duration.Second before timing out write of the HTTP(S) response
