### PR TITLE
Allow people to plugin custom app server into Sync Gateway (issue #430)

### DIFF
--- a/src/github.com/couchbaselabs/sync_gateway/base/util.go
+++ b/src/github.com/couchbaselabs/sync_gateway/base/util.go
@@ -10,12 +10,12 @@
 package base
 
 import (
-	"strconv"
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"io"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 )
@@ -142,4 +142,18 @@ func (v *IntMax) SetIfMax(value int64) {
 	if value > v.i {
 		v.i = value
 	}
+}
+
+// Append a to b, using a single joining slash.
+// Eg, "/foo/" + "/bar" -> "/foo/bar"
+func SingleJoiningSlash(a, b string) string {
+	aslash := strings.HasSuffix(a, "/")
+	bslash := strings.HasPrefix(b, "/")
+	switch {
+	case aslash && bslash:
+		return a + b[1:]
+	case !aslash && !bslash:
+		return a + "/" + b
+	}
+	return a + b
 }

--- a/src/github.com/couchbaselabs/sync_gateway/rest/config.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/config.go
@@ -63,6 +63,7 @@ type ServerConfig struct {
 	MaxFileDescriptors             *uint64         // Max # of open file descriptors (RLIMIT_NOFILE)
 	CompressResponses              *bool           // If false, disables compression of HTTP responses
 	Databases                      DbConfigMap     // Pre-configured databases, mapped by name
+	AppServerProxyTarget           *string         // If non-null, requests to /_appserver will be proxied here
 }
 
 // JSON object that defines a database configuration within the ServerConfig.
@@ -240,6 +241,9 @@ func (self *ServerConfig) MergeWith(other *ServerConfig) error {
 	if self.ConfigServer == nil {
 		self.ConfigServer = other.ConfigServer
 	}
+	if self.AppServerProxyTarget == nil {
+		self.AppServerProxyTarget = other.AppServerProxyTarget
+	}
 	if self.DeploymentID == nil {
 		self.DeploymentID = other.DeploymentID
 	}
@@ -279,6 +283,7 @@ func ParseCommandLine() *ServerConfig {
 	pretty := flag.Bool("pretty", false, "Pretty-print JSON responses")
 	verbose := flag.Bool("verbose", false, "Log more info about requests")
 	logKeys := flag.String("log", "", "Log keywords, comma separated")
+	appServerProxyTarget := flag.String("appServerProxyTarget", "", "URL of AppServer proxy target, if any")
 	flag.Parse()
 
 	var config *ServerConfig
@@ -327,6 +332,9 @@ func ParseCommandLine() *ServerConfig {
 		}
 		if config.AdminInterface == nil {
 			config.AdminInterface = &DefaultAdminInterface
+		}
+		if *appServerProxyTarget != "" {
+			config.AppServerProxyTarget = appServerProxyTarget
 		}
 
 	} else {

--- a/src/github.com/couchbaselabs/sync_gateway/rest/routing.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/routing.go
@@ -40,6 +40,9 @@ func createHandler(sc *ServerContext, privs handlerPrivs) (*mux.Router, *mux.Rou
 	// Global operations:
 	r.Handle("/", makeHandler(sc, privs, (*handler).handleRoot)).Methods("GET", "HEAD")
 
+	// Reverse proxy at /_appserver endpoint (or no-op if nothing configured)
+	r.NewRoute().PathPrefix(kAppServerProxyUrlPrefix).Handler(makeRevProxyHandler(sc, privs))
+
 	// Operations on databases:
 	r.Handle("/{db:"+dbRegex+"}/", makeHandler(sc, privs, (*handler).handleGetDB)).Methods("GET", "HEAD")
 	r.Handle("/{db:"+dbRegex+"}/", makeHandler(sc, privs, (*handler).handlePostDoc)).Methods("POST")


### PR DESCRIPTION
Add configurable target proxy URL for app server.

Any requests to /_appserver endpoint will be proxied to app server.

If nothing configured, returns 500 error for /_appserver endpoint.

https://github.com/couchbase/sync_gateway/issues/430

PS: branch is mis-named, should have been feature/issue_430...
