### PR TITLE
Add support for incoming _id property during POST /db

### DIFF
--- a/src/github.com/couchbaselabs/sync_gateway/db/crud.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/crud.go
@@ -639,7 +639,13 @@ func (db *Database) Post(body Body) (string, string, error) {
 	if body["_rev"] != nil {
 		return "", "", base.HTTPErrorf(http.StatusNotFound, "No previous revision to replace")
 	}
-	docid := base.CreateUUID()
+
+	// If there's an incoming _id property, use that as the doc ID.
+	docid, idFound := body["_id"].(string)
+	if !idFound {
+		docid = base.CreateUUID()
+	}
+
 	rev, err := db.Put(docid, body)
 	if err != nil {
 		docid = ""

--- a/src/github.com/couchbaselabs/sync_gateway/db/database_test.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/database_test.go
@@ -621,6 +621,39 @@ func TestImport(t *testing.T) {
 	assertNoError(t, err, "can't get doc")
 }
 
+func TestPostWithExistingId(t *testing.T) {
+	db := setupTestDB(t)
+	defer tearDownTestDB(t, db)
+
+	// Test creating a document with existing id property:
+	customDocId := "customIdValue"
+	log.Printf("Create document with existing id...")
+	body := Body{"_id": customDocId, "key1": "value1", "key2": "existing"}
+	docid, rev1id, err := db.Post(body)
+	assert.True(t, rev1id != "")
+	assert.True(t, docid == customDocId)
+	assertNoError(t, err, "Couldn't create document")
+
+	// Test retrieval
+	doc, err := db.GetDoc(customDocId)
+	assert.True(t, doc != nil)
+	assertNoError(t, err, "Unable to retrieve doc using custom id")
+
+	// Test that standard UUID creation still works:
+	log.Printf("Create document with existing id...")
+	body = Body{"_notAnId": customDocId, "key1": "value1", "key2": "existing"}
+	docid, rev1id, err = db.Post(body)
+	assert.True(t, rev1id != "")
+	assert.True(t, docid != customDocId)
+	assertNoError(t, err, "Couldn't create document")
+
+	// Test retrieval
+	doc, err = db.GetDoc(docid)
+	assert.True(t, doc != nil)
+	assertNoError(t, err, "Unable to retrieve doc using generated uuid")
+
+}
+
 //////// BENCHMARKS
 
 func BenchmarkDatabase(b *testing.B) {


### PR DESCRIPTION
If the incoming document for a POST /db includes an _id property, use that value
as the doc id instead of generating a new UUID.
