### PR TITLE
Set expiration time for obsolete revisions to support automatic cleanup

### DIFF
--- a/src/github.com/couchbaselabs/sync_gateway/db/revision.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/revision.go
@@ -44,7 +44,10 @@ func (db *DatabaseContext) getOldRevisionJSON(docid string, revid string) ([]byt
 
 func (db *Database) setOldRevisionJSON(docid string, revid string, body []byte) error {
 	base.LogTo("CRUD+", "Saving old revision %q / %q (%d bytes)", docid, revid, len(body))
-	return db.Bucket.SetRaw(oldRevisionKey(docid, revid), 0, body)
+
+	// Set old revisions to expire after 5 minutes.  Future enhancement to make this a config
+	// setting might be appropriate.
+	return db.Bucket.SetRaw(oldRevisionKey(docid, revid), 300, body)
 }
 
 //////// UTILITY FUNCTIONS:


### PR DESCRIPTION
Set an expiration time of 5 minutes when storing an obsolete revision, so that Couchbase Server
will automatically clean up old document revisions, instead of requiring a manual compact.
