### PR TITLE
GetRev makes an immutable copy of doc revision when processing attachments

### DIFF
--- a/src/github.com/couchbaselabs/sync_gateway/db/attachment.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/attachment.go
@@ -110,7 +110,9 @@ func (db *Database) storeAttachments(doc *document, body Body, generation int, p
 // marshaler will convert that to base64.
 // If minRevpos is > 0, then only attachments that have been changed in a revision of that
 // generation or later are loaded.
-func (db *Database) loadBodyAttachments(body Body, minRevpos int) error {
+func (db *Database) loadBodyAttachments(body Body, minRevpos int) (Body, error) {
+
+	body = body.ImmutableAttachmentsCopy()
 	for _, value := range BodyAttachments(body) {
 		meta := value.(map[string]interface{})
 		revpos, ok := base.ToInt64(meta["revpos"])
@@ -118,13 +120,13 @@ func (db *Database) loadBodyAttachments(body Body, minRevpos int) error {
 			key := AttachmentKey(meta["digest"].(string))
 			data, err := db.GetAttachment(key)
 			if err != nil {
-				return err
+				return nil, err
 			}
 			meta["data"] = data
 			delete(meta, "stub")
 		}
 	}
-	return nil
+	return body, nil
 }
 
 // Retrieves an attachment, base64-encoded, given its key.

--- a/src/github.com/couchbaselabs/sync_gateway/db/crud.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/crud.go
@@ -145,7 +145,6 @@ func (db *Database) GetRev(docid, revid string, listRevisions bool, attachmentsS
 		body["_revisions"] = revisions
 	}
 
-	body = body.ImmutableAttachmentsCopy()
 	// Add attachment bodies:
 	if attachmentsSince != nil && len(BodyAttachments(body)) > 0 {
 		minRevpos := 1
@@ -161,7 +160,7 @@ func (db *Database) GetRev(docid, revid string, listRevisions bool, attachmentsS
 				minRevpos++
 			}
 		}
-		err = db.loadBodyAttachments(body, minRevpos)
+		body, err = db.loadBodyAttachments(body, minRevpos)
 		if err != nil {
 			return nil, err
 		}

--- a/src/github.com/couchbaselabs/sync_gateway/db/crud.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/crud.go
@@ -104,7 +104,6 @@ func (db *Database) GetRev(docid, revid string, listRevisions bool, attachmentsS
 		if body, err = db.getRevision(doc, revid); err != nil {
 			return nil, err
 		}
-		body = body.ImmutableAttachmentsCopy()
 		if doc.hasFlag(channels.Deleted) {
 			body["_deleted"] = true
 		}

--- a/src/github.com/couchbaselabs/sync_gateway/db/crud.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/crud.go
@@ -146,6 +146,7 @@ func (db *Database) GetRev(docid, revid string, listRevisions bool, attachmentsS
 		body["_revisions"] = revisions
 	}
 
+	body = body.ImmutableAttachmentsCopy()
 	// Add attachment bodies:
 	if attachmentsSince != nil && len(BodyAttachments(body)) > 0 {
 		minRevpos := 1

--- a/src/github.com/couchbaselabs/sync_gateway/db/crud.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/crud.go
@@ -104,6 +104,7 @@ func (db *Database) GetRev(docid, revid string, listRevisions bool, attachmentsS
 		if body, err = db.getRevision(doc, revid); err != nil {
 			return nil, err
 		}
+		body = body.ImmutableAttachmentsCopy()
 		if doc.hasFlag(channels.Deleted) {
 			body["_deleted"] = true
 		}

--- a/src/github.com/couchbaselabs/sync_gateway/db/revision.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/revision.go
@@ -28,6 +28,27 @@ func (body Body) ShallowCopy() Body {
 	return copied
 }
 
+func (body Body) ImmutableAttachmentsCopy() Body {
+	copied := make(Body, len(body))
+	for k1, v1 := range body {
+		if k1 == "_attachments" {
+			atts := v1.(map[string]interface{})
+			attscopy := make(map[string]interface{}, len(atts))
+			for k2, v2 := range atts {
+				attachment := v2.(map[string]interface{})
+				attachmentcopy := make(map[string]interface{}, len(attachment))
+				for k3, v3 := range attachment {
+					attachmentcopy[k3] = v3
+				}
+				attscopy[k2] = attachmentcopy
+			}
+			v1 = attscopy
+		}
+		copied[k1] = v1
+	}
+	return copied
+}
+
 // Looks up the raw JSON data of a revision that's been archived to a separate doc.
 // If the revision isn't found (e.g. has been deleted by compaction) returns 404 error.
 func (db *DatabaseContext) getOldRevisionJSON(docid string, revid string) ([]byte, error) {

--- a/src/github.com/couchbaselabs/sync_gateway/rest/api_test.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/api_test.go
@@ -1125,3 +1125,55 @@ func TestDocDeletionFromChannel(t *testing.T) {
 	response = rt.send(requestByUser("GET", "/db/alpha?rev="+rev1, "", "alice"))
 	assert.Equals(t, response.Code, 200)
 }
+
+//Test for regression of issue #447
+func TestAttachmentsNoCrossTalk(t *testing.T) {
+	base.LogKeys["ANDY"] = true
+	var rt restTester
+
+	doc1revId := rt.createDoc(t, "doc1")
+
+	attachmentBody := "this is the body of attachment"
+	attachmentContentType := "content/type"
+	reqHeaders := map[string]string{
+		"Content-Type": attachmentContentType,
+	}
+
+	// attach to existing document with correct rev (should succeed)
+	response := rt.sendRequestWithHeaders("PUT", "/db/doc1/attach1?rev="+doc1revId, attachmentBody, reqHeaders)
+	assertStatus(t, response, 201)
+	var body db.Body
+	json.Unmarshal(response.Body.Bytes(), &body)
+	assert.Equals(t, body["ok"], true)
+	revIdAfterAttachment := body["rev"].(string)
+	if revIdAfterAttachment == "" {
+		t.Fatalf("No revid in response for PUT attachment")
+	}
+	assert.True(t, revIdAfterAttachment != doc1revId)
+
+	reqHeaders = map[string]string{
+		"Accept": "application/json",
+	}
+
+	log.Printf("/db/doc1?rev=%s&revs=true&attachments=true&atts_since=[\"%s\"]", revIdAfterAttachment, doc1revId)
+	response = rt.sendRequestWithHeaders("GET", fmt.Sprintf("/db/doc1?rev=%s&revs=true&attachments=true&atts_since=[\"%s\"]", revIdAfterAttachment, doc1revId), "", reqHeaders)
+	assert.Equals(t, response.Code, 200)
+	//validate attachment has data property
+	json.Unmarshal(response.Body.Bytes(), &body)
+	log.Printf("response body revid1 = %s", body)
+	attachments := body["_attachments"].(map[string]interface{})
+	attach1 := attachments["attach1"].(map[string]interface{})
+	data := attach1["data"]
+	assert.True(t, data != nil)
+
+	log.Printf("/db/doc1?rev=%s&revs=true&attachments=true&atts_since=[\"%s\"]", revIdAfterAttachment, revIdAfterAttachment)
+	response = rt.sendRequestWithHeaders("GET", fmt.Sprintf("/db/doc1?rev=%s&revs=true&attachments=true&atts_since=[\"%s\"]", revIdAfterAttachment, revIdAfterAttachment), "", reqHeaders)
+	assert.Equals(t, response.Code, 200)
+	json.Unmarshal(response.Body.Bytes(), &body)
+	log.Printf("response body revid1 = %s", body)
+	attachments = body["_attachments"].(map[string]interface{})
+	attach1 = attachments["attach1"].(map[string]interface{})
+	data = attach1["data"]
+	assert.True(t, data == nil)
+
+}


### PR DESCRIPTION
The revision cache returns mutable revision bodies, this leads to side effects between calls for the same doc revision.

fixes Feature/issue 447
