### PR TITLE
Improved session management (delete, get) via Admin API

### DIFF
--- a/src/github.com/couchbaselabs/sync_gateway/db/database.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/database.go
@@ -403,7 +403,7 @@ func (db *Database) DeleteAllDocs(docType string) error {
 }
 
 // Deletes all session documents for a user
-func (db *Database) DeleteUserSessions(userName string) error {
+func (db *DatabaseContext) DeleteUserSessions(userName string) error {
 	opts := Body{"stale": false}
 	opts["startkey"] = userName
 	opts["endkey"] = userName

--- a/src/github.com/couchbaselabs/sync_gateway/rest/admin_api.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/admin_api.go
@@ -155,6 +155,13 @@ func (h *handler) updatePrincipal(name string, isUser bool) error {
 	if err != nil {
 		return err
 	} else if replaced {
+		// on update with a new password, remove previous user sessions
+		if newInfo.Password != nil {
+			err = h.db.DeleteUserSessions(*newInfo.Name)
+			if err != nil {
+				return err
+			}
+		}
 		h.writeStatus(http.StatusOK, "OK")
 	} else {
 		h.writeStatus(http.StatusCreated, "Created")

--- a/src/github.com/couchbaselabs/sync_gateway/rest/admin_api_test.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/admin_api_test.go
@@ -255,24 +255,14 @@ func TestSessionAPI(t *testing.T) {
 
 	// 3. DELETE a session not belonging to the user (should fail)
 	response = rt.sendAdminRequest("DELETE", fmt.Sprintf("/db/_user/%s/_session/%s", "user1", user2sessions[0]), "")
-	assertStatus(t, response, 200)
+	assertStatus(t, response, 404)
 
 	// GET the session and make sure it still exists
 	response = rt.sendAdminRequest("GET", fmt.Sprintf("/db/_session/%s", user2sessions[0]), "")
 	assertStatus(t, response, 200)
 
-	// 4. DELETE multiple sessions for a user
-	response = rt.sendAdminRequest("DELETE", "/db/_user/user1/_session", fmt.Sprintf(`{"keys":[%q,%q]}`, user1sessions[2], user1sessions[3]))
-	assertStatus(t, response, 200)
-
-	// Validate that multiple sessions were deleted
-	response = rt.sendAdminRequest("GET", fmt.Sprintf("/db/_session/%s", user1sessions[2]), "")
-	assertStatus(t, response, 404)
-	response = rt.sendAdminRequest("GET", fmt.Sprintf("/db/_session/%s", user1sessions[3]), "")
-	assertStatus(t, response, 404)
-
-	// 5. DELETE all sessions for a user
-	response = rt.sendAdminRequest("DELETE", "/db/_user/user2/_session", `{"keys":["*"]}`)
+	// 4. DELETE all sessions for a user
+	response = rt.sendAdminRequest("DELETE", "/db/_user/user2/_session", "")
 	assertStatus(t, response, 200)
 
 	// Validate that all sessions were deleted
@@ -281,7 +271,7 @@ func TestSessionAPI(t *testing.T) {
 		assertStatus(t, response, 404)
 	}
 
-	// 6. DELETE sessions when password is changed
+	// 5. DELETE sessions when password is changed
 	// Change password for user3
 	response = rt.sendAdminRequest("PUT", "/db/_user/user3", `{"password":"5678"}`)
 

--- a/src/github.com/couchbaselabs/sync_gateway/rest/routing.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/routing.go
@@ -112,6 +112,12 @@ func CreateAdminHandler(sc *ServerContext) http.Handler {
 	dbr.Handle("/_session",
 		makeHandler(sc, adminPrivs, (*handler).createUserSession)).Methods("POST")
 
+	dbr.Handle("/_session/{sessionid}",
+		makeHandler(sc, adminPrivs, (*handler).getUserSession)).Methods("GET")
+
+	dbr.Handle("/_session/{sessionid}",
+		makeHandler(sc, adminPrivs, (*handler).deleteUserSession)).Methods("DELETE")
+
 	dbr.Handle("/_raw/{docid:"+docRegex+"}",
 		makeHandler(sc, adminPrivs, (*handler).handleGetRawDoc)).Methods("GET", "HEAD")
 
@@ -125,6 +131,11 @@ func CreateAdminHandler(sc *ServerContext) http.Handler {
 		makeHandler(sc, adminPrivs, (*handler).putUser)).Methods("PUT")
 	dbr.Handle("/_user/{name}",
 		makeHandler(sc, adminPrivs, (*handler).deleteUser)).Methods("DELETE")
+
+	dbr.Handle("/_user/{name}/_session",
+		makeHandler(sc, adminPrivs, (*handler).deleteUserSessions)).Methods("DELETE")
+	dbr.Handle("/_user/{name}/_session/{sessionid}",
+		makeHandler(sc, adminPrivs, (*handler).deleteUserSession)).Methods("DELETE")
 
 	dbr.Handle("/_role/",
 		makeHandler(sc, adminPrivs, (*handler).getRoles)).Methods("GET", "HEAD")

--- a/src/github.com/couchbaselabs/sync_gateway/rest/session_api.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/session_api.go
@@ -13,6 +13,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/gorilla/mux"
+
 	"github.com/couchbaselabs/sync_gateway/auth"
 	"github.com/couchbaselabs/sync_gateway/base"
 	"github.com/couchbaselabs/sync_gateway/channels"
@@ -23,22 +25,9 @@ const kDefaultSessionTTL = 24 * time.Hour
 
 // Respond with a JSON struct containing info about the current login session
 func (h *handler) respondWithSessionInfo() error {
-	var name *string
-	allChannels := channels.TimedSet{}
-	if h.user != nil {
-		userName := h.user.Name()
-		if userName != "" {
-			name = &userName
-		}
-		allChannels = h.user.Channels()
-	}
-	// Return a JSON struct similar to what CouchDB returns:
-	userCtx := db.Body{"name": name, "channels": allChannels}
-	handlers := []string{"default", "cookie"}
-	if h.PersonaEnabled() {
-		handlers = append(handlers, "persona")
-	}
-	response := db.Body{"ok": true, "userCtx": userCtx, "authentication_handlers": handlers}
+
+	response := h.formatSessionResponse(h.user)
+
 	h.writeJSON(response)
 	return nil
 }
@@ -63,6 +52,7 @@ func (h *handler) handleSessionPOST() error {
 	if err != nil {
 		return err
 	}
+
 	if !user.Authenticate(params.Password) {
 		user = nil
 	}
@@ -107,11 +97,11 @@ func (h *handler) makeSessionFromEmail(email string, createUserIfNeeded bool) er
 		if !createUserIfNeeded {
 			return base.HTTPErrorf(http.StatusUnauthorized, "No such user")
 		}
-		
+
 		if len(email) < 1 {
 			return base.HTTPErrorf(http.StatusBadRequest, "Cannot register new user: email is missing")
 		}
-		
+
 		// Create a User with the given email address as username and a random password.
 		user, err = h.registerNewUser(email)
 		if err != nil {
@@ -160,4 +150,139 @@ func (h *handler) createUserSession() error {
 	response.CookieName = auth.CookieName
 	h.writeJSON(response)
 	return nil
+}
+
+func (h *handler) getUserSession() error {
+
+	h.assertAdminOnly()
+	session, err := h.db.Authenticator().GetSession(mux.Vars(h.rq)["sessionid"])
+
+	if session == nil {
+		if err == nil {
+			err = kNotFoundError
+		}
+		return err
+	}
+
+	return h.respondWithSessionInfoForSession(session)
+}
+
+// ADMIN API: Deletes a specified session.  If username is present on the request, validates
+// that the session being deleted is associated with the user.
+func (h *handler) deleteUserSession() error {
+	h.assertAdminOnly()
+	userName := mux.Vars(h.rq)["name"]
+	if userName != "" {
+		return h.deleteUserSessionWithValidation(mux.Vars(h.rq)["sessionid"], userName)
+	} else {
+		return h.db.Authenticator().DeleteSession(mux.Vars(h.rq)["sessionid"])
+	}
+}
+
+// ADMIN API: Deletes a collection of sessions for a user.  If "*" is included as a
+// key, removes all session for the user.
+func (h *handler) deleteUserSessions() error {
+	h.assertAdminOnly()
+
+	var sessionIds []string
+	deleteAll := false
+	input, err := h.readJSON()
+	if err == nil {
+		keys, ok := input["keys"].([]interface{})
+		sessionIds = make([]string, len(keys))
+
+		for i := 0; i < len(keys); i++ {
+			if sessionIds[i], ok = keys[i].(string); !ok {
+				break
+			}
+			// if * is passed in as a session id, we want to delete all sessions for the user
+			if sessionIds[i] == "*" {
+				deleteAll = true
+			}
+		}
+		if !ok {
+			err = base.HTTPErrorf(http.StatusBadRequest, "Bad/missing keys")
+		}
+	}
+
+	userName := mux.Vars(h.rq)["name"]
+	if deleteAll {
+		err = h.db.DeleteUserSessions(userName)
+		if err != nil {
+			return err
+		}
+	} else {
+		for _, sessionId := range sessionIds {
+			err = h.deleteUserSessionWithValidation(sessionId, userName)
+			if err != nil {
+				// fail silently for failed delete
+			}
+		}
+	}
+
+	return err
+}
+
+// Delete a session if associated with the user provided
+func (h *handler) deleteUserSessionWithValidation(sessionId string, userName string) error {
+
+	// Validate that the session being deleted belongs to the user.  This adds some
+	// overhead - for user-agnostic session deletion should use deleteSession
+	session, getErr := h.db.Authenticator().GetSession(sessionId)
+	if getErr == nil {
+		if session.Username == userName {
+			delErr := h.db.Authenticator().DeleteSession(sessionId)
+			if delErr != nil {
+				return delErr
+			}
+		}
+	}
+	return nil
+}
+
+// Respond with a JSON struct containing info about the current login session
+func (h *handler) respondWithSessionInfoForSession(session *auth.LoginSession) error {
+
+	var userName string
+	if session != nil {
+		userName = session.Username
+	}
+
+	user, err := h.db.Authenticator().GetUser(userName)
+
+	// let the empty user case succeed
+	if err != nil {
+		return err
+	}
+
+	response := h.formatSessionResponse(user)
+	if response != nil {
+		h.writeJSON(response)
+	}
+	return nil
+}
+
+// Formats session response similar to what is returned by CouchDB
+func (h *handler) formatSessionResponse(user auth.User) db.Body {
+
+	var name *string
+	allChannels := channels.TimedSet{}
+
+	if user != nil {
+		userName := user.Name()
+		if userName != "" {
+			name = &userName
+		}
+		allChannels = user.Channels()
+	}
+
+	// Return a JSON struct similar to what CouchDB returns:
+	userCtx := db.Body{"name": name, "channels": allChannels}
+	handlers := []string{"default", "cookie"}
+	if h.PersonaEnabled() {
+		handlers = append(handlers, "persona")
+	}
+	response := db.Body{"ok": true, "userCtx": userCtx, "authentication_handlers": handlers}
+	return response
+
 }


### PR DESCRIPTION
Added support for session management/cleanup via the Admin API:

GET /_session/{sessionid}
- retrieves session information for the specified session

DELETE /$DB/_session/$sessionid
- deletes the specified session, with no additional validation

DELETE /_user/$name/_session/$sessionid
- deletes the specified session.  Validates that the session is associated with username=$name

DELETE /_user/$name/_session
- request body is a JSON object with a 'keys' property in the format "keys":["sessionid1","sessionid2",...]
- deletes all sessions in the keys array that are associated with username=$name
- if "*" is passed as a value in the keys array, all sessions associated with the user are deleted

Password change logic was also updated to delete existing user sessions when that user's password is changed.
