### PR TITLE
Ensures that during _bulk_docs, if channel access or roles have been changed

### DIFF
--- a/src/github.com/couchbaselabs/sync_gateway/db/crud.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/crud.go
@@ -576,6 +576,20 @@ func (db *Database) updateDoc(docid string, allowImport bool, callback func(*doc
 				// might not incorporate the effects of this change.
 				writeOpts |= walrus.Indexable
 			}
+
+			if len(access) > 0 && db.user != nil {
+				//invalidate channels current user
+				base.Log("Invalidating channels of current user")
+				db.invalUserChannels(db.user.Name())
+				//db.invalRoleChannels(db.user.Name())
+			}
+
+			if len(roles) > 0 && db.user != nil {
+				//invalidate channels current user
+				base.Log("Invalidating channels of current user")
+				db.invalRoleChannels(db.user.Name())
+			}
+
 		} else {
 			base.LogTo("CRUD+", "updateDoc(%q): Rev %q leaves %q still current",
 				docid, newRevID, prevCurrentRev)

--- a/src/github.com/couchbaselabs/sync_gateway/db/crud.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/crud.go
@@ -623,13 +623,14 @@ func (db *Database) updateDoc(docid string, allowImport bool, callback func(*doc
 		base.LogTo("Access", "Rev %q/%q invalidates channels of %s", docid, newRevID, changedPrincipals)
 		for _, name := range changedPrincipals {
 			db.invalUserOrRoleChannels(name)
-			//If this is the current in memory db.user, reload to generate updated channel
+			//If this is the current in memory db.user, reload to generate updated channels
 			if db.user != nil && db.user.Name() == name {
 				user, err := db.Authenticator().GetUser(db.user.Name())
 				if err != nil {
-					return "", err
+					base.Warn("Error reloading db.user[%s], channels list is out of date: %+v", db.user.Name(), err)
+				} else {
+					db.user = user
 				}
-				db.user = user
 			}
 		}
 	}
@@ -642,9 +643,10 @@ func (db *Database) updateDoc(docid string, allowImport bool, callback func(*doc
 			if db.user != nil && db.user.Name() == name {
 				user, err := db.Authenticator().GetUser(db.user.Name())
 				if err != nil {
-					return "", err
+					base.Warn("Error reloading db.user[%s], roles list is out of date: %+v", db.user.Name(), err)
+				} else {
+					db.user = user
 				}
-				db.user = user
 			}
 		}
 	}

--- a/src/github.com/couchbaselabs/sync_gateway/db/crud.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/crud.go
@@ -627,7 +627,7 @@ func (db *Database) updateDoc(docid string, allowImport bool, callback func(*doc
 			if db.user != nil && db.user.Name() == name {
 				user, err := db.Authenticator().GetUser(db.user.Name())
 				if err != nil {
-					base.Warn("Error reloading db.user[%s], channels list is out of date: %+v", db.user.Name(), err)
+					base.Warn("Error reloading db.user[%s], channels list is out of date --> %+v", db.user.Name(), err)
 				} else {
 					db.user = user
 				}
@@ -643,7 +643,7 @@ func (db *Database) updateDoc(docid string, allowImport bool, callback func(*doc
 			if db.user != nil && db.user.Name() == name {
 				user, err := db.Authenticator().GetUser(db.user.Name())
 				if err != nil {
-					base.Warn("Error reloading db.user[%s], roles list is out of date: %+v", db.user.Name(), err)
+					base.Warn("Error reloading db.user[%s], roles list is out of date --> %+v", db.user.Name(), err)
 				} else {
 					db.user = user
 				}


### PR DESCRIPTION
...the current calling users channel or roles caches are invalidated.
