### PR TITLE
Add doc id to oldDoc for ease-of-use in sync function

### DIFF
--- a/src/github.com/couchbaselabs/sync_gateway/channels/sync_runner.go
+++ b/src/github.com/couchbaselabs/sync_gateway/channels/sync_runner.go
@@ -22,7 +22,12 @@ import (
 
 const funcWrapper = `
 	function(newDoc, oldDoc, realUserCtx) {
+
 		var v = %s;
+
+		if (oldDoc) {
+			oldDoc._id = newDoc._id;
+		}
 
 		function makeArray(maybeArray) {
 			if (Array.isArray(maybeArray)) {

--- a/src/github.com/couchbaselabs/sync_gateway/db/crud.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/crud.go
@@ -691,7 +691,6 @@ func (db *Database) getChannelsAndAccess(doc *document, body Body, revID string)
 	if oldJsonBytes, err = db.getAncestorJSON(doc, revID); err != nil {
 		return
 	}
-
 	oldJson := string(oldJsonBytes)
 
 	if db.ChannelMapper != nil {

--- a/src/github.com/couchbaselabs/sync_gateway/db/crud.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/crud.go
@@ -10,7 +10,6 @@
 package db
 
 import (
-	"bytes"
 	"encoding/json"
 	"github.com/couchbaselabs/walrus"
 	"net/http"
@@ -691,16 +690,6 @@ func (db *Database) getChannelsAndAccess(doc *document, body Body, revID string)
 	var oldJsonBytes []byte
 	if oldJsonBytes, err = db.getAncestorJSON(doc, revID); err != nil {
 		return
-	}
-
-	// inject the _id property into oldJsonBytes if it's non-empty
-	if len(oldJsonBytes) > 0 {
-
-		// strip the leading {
-		oldJsonBytes = oldJsonBytes[1:len(oldJsonBytes)]
-
-		// rebuild as `{"_id":"` + doc.ID + `",` + oldJsonBytes
-		oldJsonBytes, err = bytes.Join([][]byte{[]byte(`{"_id":"`), []byte(doc.ID), []byte(`",`), oldJsonBytes}, []byte("")), nil
 	}
 
 	oldJson := string(oldJsonBytes)

--- a/src/github.com/couchbaselabs/sync_gateway/db/crud.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/crud.go
@@ -10,6 +10,7 @@
 package db
 
 import (
+	"bytes"
 	"encoding/json"
 	"github.com/couchbaselabs/walrus"
 	"net/http"
@@ -691,6 +692,17 @@ func (db *Database) getChannelsAndAccess(doc *document, body Body, revID string)
 	if oldJsonBytes, err = db.getAncestorJSON(doc, revID); err != nil {
 		return
 	}
+
+	// inject the _id property into oldJsonBytes if it's non-empty
+	if len(oldJsonBytes) > 0 {
+
+		// strip the leading {
+		oldJsonBytes = oldJsonBytes[1:len(oldJsonBytes)]
+
+		// rebuild as `{"_id":"` + doc.ID + `",` + oldJsonBytes
+		oldJsonBytes, err = bytes.Join([][]byte{[]byte(`{"_id":"`), []byte(doc.ID), []byte(`",`), oldJsonBytes}, []byte("")), nil
+	}
+
 	oldJson := string(oldJsonBytes)
 
 	if db.ChannelMapper != nil {


### PR DESCRIPTION
Add the doc id to oldDoc by prepending id property to incoming oldJson byte array.
