### PR TITLE
Add support for public document channel

### DIFF
--- a/src/github.com/couchbaselabs/sync_gateway/auth/auth.go
+++ b/src/github.com/couchbaselabs/sync_gateway/auth/auth.go
@@ -143,6 +143,9 @@ func (auth *Authenticator) rebuildChannels(princ Principal) error {
 		}
 		channels.Add(set)
 	}
+	// always grant access to the public document channel
+	channels.AddChannel(ch.DocumentStarChannel, 1)
+
 	base.LogTo("Access", "Computed channels for %q: %s", princ.Name(), channels)
 	princ.setChannels(channels)
 	return nil

--- a/src/github.com/couchbaselabs/sync_gateway/auth/auth_test.go
+++ b/src/github.com/couchbaselabs/sync_gateway/auth/auth_test.go
@@ -170,7 +170,7 @@ func TestUserAccess(t *testing.T) {
 	// User with no access:
 	auth := NewAuthenticator(gTestBucket, nil)
 	user, _ := auth.NewUser("foo", "password", nil)
-	assert.DeepEquals(t, user.ExpandWildCardChannel(ch.SetOf("*")), ch.SetOf())
+	assert.DeepEquals(t, user.ExpandWildCardChannel(ch.SetOf("*")), ch.SetOf("!"))
 	assert.False(t, user.CanSeeChannel("x"))
 	assert.True(t, canSeeAllChannels(user, ch.SetOf()))
 	assert.False(t, canSeeAllChannels(user, ch.SetOf("x")))
@@ -307,7 +307,7 @@ func TestRebuildUserChannels(t *testing.T) {
 	user2, err := auth.GetUser("testUser")
 	assert.Equals(t, err, nil)
 	log.Printf("Channels = %s", user2.Channels())
-	assert.DeepEquals(t, user2.Channels(), ch.AtSequence(ch.SetOf("explicit1", "derived1", "derived2"), 1))
+	assert.DeepEquals(t, user2.Channels(), ch.AtSequence(ch.SetOf("explicit1", "derived1", "derived2", "!"), 1))
 }
 
 func TestRebuildRoleChannels(t *testing.T) {
@@ -319,7 +319,7 @@ func TestRebuildRoleChannels(t *testing.T) {
 
 	role2, err := auth.GetRole("testRole")
 	assert.Equals(t, err, nil)
-	assert.DeepEquals(t, role2.Channels(), ch.AtSequence(ch.SetOf("explicit1", "derived1", "derived2"), 1))
+	assert.DeepEquals(t, role2.Channels(), ch.AtSequence(ch.SetOf("explicit1", "derived1", "derived2", "!"), 1))
 }
 
 func TestRebuildChannelsError(t *testing.T) {
@@ -367,9 +367,9 @@ func TestRoleInheritance(t *testing.T) {
 	user2, err := auth.GetUser("arthur")
 	assert.Equals(t, err, nil)
 	log.Printf("Channels = %s", user2.Channels())
-	assert.DeepEquals(t, user2.Channels(), ch.AtSequence(ch.SetOf("britain"), 1))
+	assert.DeepEquals(t, user2.Channels(), ch.AtSequence(ch.SetOf("!", "britain"), 1))
 	assert.DeepEquals(t, user2.InheritedChannels(),
-		ch.TimedSet{"britain": 0x1, "dull": 0x3, "duller": 0x3, "dullest": 0x3, "hoopy": 0x4, "hoopier": 0x4, "hoopiest": 0x4})
+		ch.TimedSet{"!": 0x1, "britain": 0x1, "dull": 0x3, "duller": 0x3, "dullest": 0x3, "hoopy": 0x4, "hoopier": 0x4, "hoopiest": 0x4})
 	assert.True(t, user2.CanSeeChannel("britain"))
 	assert.True(t, user2.CanSeeChannel("duller"))
 	assert.True(t, user2.CanSeeChannel("hoopy"))

--- a/src/github.com/couchbaselabs/sync_gateway/auth/role.go
+++ b/src/github.com/couchbaselabs/sync_gateway/auth/role.go
@@ -146,14 +146,14 @@ func (role *roleImpl) UnauthError(message string) error {
 // Returns true if the Role is allowed to access the channel.
 // A nil Role means access control is disabled, so the function will return true.
 func (role *roleImpl) CanSeeChannel(channel string) bool {
-	return role == nil || role.Channels_.Contains(channel) || role.Channels_.Contains("*")
+	return role == nil || role.Channels_.Contains(channel) || role.Channels_.Contains(ch.UserStarChannel)
 }
 
 // Returns the sequence number since which the Role has been able to access the channel, else zero.
 func (role *roleImpl) CanSeeChannelSince(channel string) uint64 {
 	seq := role.Channels_[channel]
 	if seq == 0 {
-		seq = role.Channels_["*"]
+		seq = role.Channels_[ch.UserStarChannel]
 	}
 	return seq
 }
@@ -193,7 +193,7 @@ func authorizeAnyChannel(princ Principal, channels base.Set) error {
 				return nil
 			}
 		}
-	} else if princ.Channels().Contains("*") {
+	} else if princ.Channels().Contains(ch.UserStarChannel) {
 		return nil
 	}
 	return princ.UnauthError("You are not allowed to see this")

--- a/src/github.com/couchbaselabs/sync_gateway/auth/user.go
+++ b/src/github.com/couchbaselabs/sync_gateway/auth/user.go
@@ -275,9 +275,9 @@ func (user *userImpl) InheritedChannels() ch.TimedSet {
 	return channels
 }
 
-// If a channel list contains a wildcard ("*"), replace it with all the user's accessible channels.
+// If a channel list contains the all-channel wildcard, replace it with all the user's accessible channels.
 func (user *userImpl) ExpandWildCardChannel(channels base.Set) base.Set {
-	if channels.Contains("*") {
+	if channels.Contains(ch.AllChannelWildcard) {
 		channels = user.InheritedChannels().AsSet()
 	}
 	return channels
@@ -286,7 +286,7 @@ func (user *userImpl) ExpandWildCardChannel(channels base.Set) base.Set {
 func (user *userImpl) FilterToAvailableChannels(channels base.Set) ch.TimedSet {
 	output := ch.TimedSet{}
 	for channel, _ := range channels {
-		if channel == "*" {
+		if channel == ch.AllChannelWildcard {
 			return user.InheritedChannels().Copy()
 		}
 		output.AddChannel(channel, user.CanSeeChannelSince(channel))

--- a/src/github.com/couchbaselabs/sync_gateway/channels/set.go
+++ b/src/github.com/couchbaselabs/sync_gateway/channels/set.go
@@ -24,11 +24,16 @@ const (
 	ExpandStar
 )
 
+// Constants for the * channel variations
+const UserStarChannel = "*"     // user channel for "can access all docs"
+const DocumentStarChannel = "!" // doc channel for "visible to all users"
+const AllChannelWildcard = "*"  // wildcard for 'all channels'
+
 var kValidChannelRegexp *regexp.Regexp
 
 func init() {
 	var err error
-	kValidChannelRegexp, err = regexp.Compile(`^([-+=/_.@\p{L}\p{Nd}]+|\*)$`)
+	kValidChannelRegexp, err = regexp.Compile(`^([-+=/_.@\p{L}\p{Nd}]+|[\*\!])$`)
 	if err != nil {
 		panic("Bad IsValidChannel regexp")
 	}
@@ -52,10 +57,10 @@ func SetFromArray(names []string, mode StarMode) (base.Set, error) {
 	result := base.SetFromArray(names)
 	switch mode {
 	case RemoveStar:
-		result = result.Removing("*")
+		result = result.Removing(UserStarChannel)
 	case ExpandStar:
-		if result.Contains("*") {
-			result = base.SetOf("*")
+		if result.Contains(UserStarChannel) {
+			result = base.SetOf(UserStarChannel)
 		}
 	}
 	return result, nil
@@ -83,13 +88,13 @@ func SetOf(names ...string) base.Set {
 
 // If the set contains "*", returns a set of only "*". Else returns the original set.
 func ExpandingStar(set base.Set) base.Set {
-	if _, exists := set["*"]; exists {
-		return base.SetOf("*")
+	if _, exists := set[UserStarChannel]; exists {
+		return base.SetOf(UserStarChannel)
 	}
 	return set
 }
 
 // Returns a set with any "*" channel removed.
 func IgnoringStar(set base.Set) base.Set {
-	return set.Removing("*")
+	return set.Removing(UserStarChannel)
 }

--- a/src/github.com/couchbaselabs/sync_gateway/channels/set_test.go
+++ b/src/github.com/couchbaselabs/sync_gateway/channels/set_test.go
@@ -16,13 +16,13 @@ import (
 )
 
 func TestIsValidChannel(t *testing.T) {
-	valid := []string{"*", "a", "FOO", "123", "-z", "foo_bar", "Éclær", "z7_"}
+	valid := []string{"*", "a", "FOO", "123", "-z", "foo_bar", "Éclær", "z7_", "!"}
 	for _, ch := range valid {
 		if !IsValidChannel(ch) {
 			t.Errorf("IsValidChannel(%q) should be true", ch)
 		}
 	}
-	invalid := []string{"", "**", "a*", "a ", "b?", ",", "Z∫•"}
+	invalid := []string{"", "**", "a*", "a ", "b?", ",", "Z∫•", "*!"}
 	for _, ch := range invalid {
 		if IsValidChannel(ch) {
 			t.Errorf("IsValidChannel(%q) should be false", ch)

--- a/src/github.com/couchbaselabs/sync_gateway/db/change_cache.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/change_cache.go
@@ -16,7 +16,7 @@ import (
 var MaxChannelLogPendingCount = 10000              // Max number of waiting sequences
 var MaxChannelLogPendingWaitTime = 5 * time.Second // Max time we'll wait for a missing sequence
 
-// Enable keeping a channel-log for the "*" channel. The only time this channel is needed is if
+// Enable keeping a channel-log for the "*" channel (channel.UserStarChannel). The only time this channel is needed is if
 // someone has access to "*" (e.g. admin-party) and tracks its changes feed.
 var EnableStarChannelLog = true
 
@@ -290,8 +290,8 @@ func (c *changeCache) _addToCache(change *LogEntry) base.Set {
 	}
 
 	if EnableStarChannelLog {
-		c._getChannelCache("*").addToCache(change, false)
-		addedTo = append(addedTo, "*")
+		c._getChannelCache(channels.UserStarChannel).addToCache(change, false)
+		addedTo = append(addedTo, channels.UserStarChannel)
 	}
 
 	// Record a histogram of the overall lag from the time the doc was saved:

--- a/src/github.com/couchbaselabs/sync_gateway/db/database_test.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/database_test.go
@@ -568,7 +568,7 @@ func TestAccessFunction(t *testing.T) {
 
 	user, err = authenticator.GetUser("naomi")
 	assertNoError(t, err, "GetUser")
-	expected := channels.AtSequence(channels.SetOf("Hulu", "Netflix"), 1)
+	expected := channels.AtSequence(channels.SetOf("Hulu", "Netflix", "!"), 1)
 	assert.DeepEquals(t, user.Channels(), expected)
 
 	expected.AddChannel("CrunchyRoll", 2)

--- a/src/github.com/couchbaselabs/sync_gateway/rest/admin_api_test.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/admin_api_test.go
@@ -37,7 +37,7 @@ func TestUserAPI(t *testing.T) {
 	assert.Equals(t, body["name"], "snej")
 	assert.Equals(t, body["email"], "jens@couchbase.com")
 	assert.DeepEquals(t, body["admin_channels"], []interface{}{"bar", "foo"})
-	assert.DeepEquals(t, body["all_channels"], []interface{}{"bar", "foo"})
+	assert.DeepEquals(t, body["all_channels"], []interface{}{"!", "bar", "foo"})
 	assert.Equals(t, body["password"], nil)
 
 	// Check the list of all users:
@@ -89,7 +89,7 @@ func TestUserAPI(t *testing.T) {
 	body = nil
 	json.Unmarshal(response.Body.Bytes(), &body)
 	assert.DeepEquals(t, body["admin_roles"], []interface{}{"hipster"})
-	assert.DeepEquals(t, body["all_channels"], []interface{}{"bar", "fedoras", "fixies", "foo"})
+	assert.DeepEquals(t, body["all_channels"], []interface{}{"!", "bar", "fedoras", "fixies", "foo"})
 
 	// DELETE the user
 	assertStatus(t, rt.sendAdminRequest("DELETE", "/db/_user/snej", ""), 200)

--- a/src/github.com/couchbaselabs/sync_gateway/rest/bulk_api.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/bulk_api.go
@@ -49,14 +49,14 @@ func (h *handler) handleAllDocs() error {
 		}
 	}
 
-	// Get the set of channels the user has access to; nil if user is admin or has access to "*"
+	// Get the set of channels the user has access to; nil if user is admin or has access to user "*"
 	var availableChannels channels.TimedSet
 	if h.user != nil {
 		availableChannels = h.user.InheritedChannels()
 		if availableChannels == nil {
 			panic("no channels for user?")
 		}
-		if availableChannels.Contains("*") {
+		if availableChannels.Contains(channels.UserStarChannel) {
 			availableChannels = nil
 		}
 	}

--- a/src/github.com/couchbaselabs/sync_gateway/rest/changes_api.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/changes_api.go
@@ -102,7 +102,7 @@ func (h *handler) handleChanges() error {
 
 	// Get the channels as parameters to an imaginary "bychannel" filter.
 	// The default is all channels the user can access.
-	userChannels := channels.SetOf("*")
+	userChannels := channels.SetOf(channels.AllChannelWildcard)
 	if filter != "" {
 		if filter != "sync_gateway/bychannel" {
 			return base.HTTPErrorf(http.StatusBadRequest, "Unknown filter; try sync_gateway/bychannel")


### PR DESCRIPTION
Resolves conflict between user `*` channel (meaning access to all documents) and the document `*` channel (meaning available to all users).  Previously only the user `*` channel was enabled - documents added to the `*` channel would only be available to users who also had the `*` channel.

Changed the naming of the document \* channel from `*` to `!` for simplicity and clarity.  Access to the `!` channel is being granted to all users by default in auth.rebuildChannels.

Switched to using named constants instead of `*` and `!` where possible, to more easily distinguish between intended usage.
