### PR TITLE
Remove white space from git branch details

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@ BUILD_INFO="./src/github.com/couchbaselabs/sync_gateway/rest/git_info.go"
 git update-index --assume-unchanged ${BUILD_INFO}
 # Escape forward slash's so sed command does not get confused
 # We use thses in feature branches e.g. feature/issue_nnn
-GIT_BRANCH=`git status -b -s | sed q | sed 's/## //' | sed 's/\.\.\..*$//' | sed 's/\\//\\\\\//g'`
+GIT_BRANCH=`git status -b -s | sed q | sed 's/## //' | sed 's/\.\.\..*$//' | sed 's/\\//\\\\\//g' | sed 's/[[:space:]]//g'`
 GIT_COMMIT=`git rev-parse HEAD`
 GIT_DIRTY=$(test -n "`git status --porcelain`" && echo "+CHANGES" || true)
 


### PR DESCRIPTION
this allows a response of 'HEAD (no branch)' to be correctly processed.
