### PR TITLE
Added check for nil body in ImmutableAttachmentsCopy() #454

### DIFF
--- a/src/github.com/couchbaselabs/sync_gateway/db/revision.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/revision.go
@@ -29,6 +29,9 @@ func (body Body) ShallowCopy() Body {
 }
 
 func (body Body) ImmutableAttachmentsCopy() Body {
+	if body == nil {
+		return nil
+	}
 	copied := make(Body, len(body))
 	for k1, v1 := range body {
 		if k1 == "_attachments" {


### PR DESCRIPTION
fixes issue #454 

All existing tests pass if revision_cache.go Get returns a copy of the revision body using ImmutableAttachmentsCopy(), once the check for the input body being null is added.
