### PR TITLE
Increase Tap sequence give-up timeout from 5 to 60 sec

### DIFF
--- a/src/github.com/couchbaselabs/sync_gateway/db/change_cache.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/change_cache.go
@@ -13,8 +13,8 @@ import (
 	"github.com/couchbaselabs/sync_gateway/channels"
 )
 
-var MaxChannelLogPendingCount = 10000              // Max number of waiting sequences
-var MaxChannelLogPendingWaitTime = 5 * time.Second // Max time we'll wait for a missing sequence
+var MaxChannelLogPendingCount = 10000               // Max number of waiting sequences
+var MaxChannelLogPendingWaitTime = 60 * time.Second // Max time we'll wait for a missing sequence
 
 // Enable keeping a channel-log for the "*" channel (channel.UserStarChannel). The only time this channel is needed is if
 // someone has access to "*" (e.g. admin-party) and tracks its changes feed.


### PR DESCRIPTION
Fixes #517
As discussed here: https://groups.google.com/d/msg/mobile-couchbase/BF6FzbFzR5E/V2MuaN0t5K0J
