### PR TITLE
Update sync_gateway_service_install.sh

### DIFF
--- a/service/sync_gateway_service_install.sh
+++ b/service/sync_gateway_service_install.sh
@@ -127,7 +127,7 @@ if  ["$OS" = ""] && ["$VER" = ""] ; then
 fi
 
 # Check that runtime user account exists
-if [ "$OS" != "Darwin" && -z `id -u $RUNAS_TEMPLATE_VAR 2>/dev/null` ]; then
+if [ "$OS" != "Darwin" ] && [ -z `id -u $RUNAS_TEMPLATE_VAR 2>/dev/null` ]; then
     echo "The sync_gateway runtime user account does not exist \"$RUNAS_TEMPLATE_VAR\"." > /dev/stderr
     exit 1
 fi


### PR DESCRIPTION
I couldn't get this script to run on a default install of Ubuntu 14.04.1 LTS. The error I received was:

```
./sync_gateway_service_install.sh: 130: [: missing ]
```

Making this small tweak fixed things.
