### PR TITLE
LogLevel and LogKey Stringer implementation

### DIFF
--- a/base/log_keys.go
+++ b/base/log_keys.go
@@ -128,9 +128,8 @@ func (keyMask *LogKey) enabled(logKey LogKey, checkWildcards bool) bool {
 	return flag&uint32(logKey) != 0
 }
 
-// LogKeyName returns the string representation of a single log key.
-func LogKeyName(logKey LogKey) string {
-	// No lock required to read concurrently, as long as nobody writes to logKeyNames.
+// String returns the string representation of a single log key.
+func (logKey LogKey) String() string {
 	return logKeyNames[logKey]
 }
 
@@ -143,7 +142,7 @@ func (keyMask *LogKey) EnabledLogKeys() []string {
 	for i := 0; i < len(logKeyNames); i++ {
 		logKey := LogKey(1) << uint32(i)
 		if keyMask.enabled(logKey, false) {
-			logKeys = append(logKeys, LogKeyName(logKey))
+			logKeys = append(logKeys, logKey.String())
 		}
 	}
 	return logKeys

--- a/base/log_keys.go
+++ b/base/log_keys.go
@@ -1,6 +1,7 @@
 package base
 
 import (
+	"fmt"
 	"strings"
 	"sync/atomic"
 )
@@ -130,7 +131,11 @@ func (keyMask *LogKey) enabled(logKey LogKey, checkWildcards bool) bool {
 
 // String returns the string representation of a single log key.
 func (logKey LogKey) String() string {
-	return logKeyNames[logKey]
+	// No lock required to read concurrently, as long as nobody writes to logKeyNames.
+	if str, ok := logKeyNames[logKey]; ok {
+		return str
+	}
+	return fmt.Sprintf("LogKey(%b)", logKey)
 }
 
 // EnabledLogKeys returns a slice of enabled log key names.

--- a/base/log_keys_test.go
+++ b/base/log_keys_test.go
@@ -39,11 +39,11 @@ func TestLogKey(t *testing.T) {
 }
 
 func TestLogKeyNames(t *testing.T) {
-	name := LogKeyName(KeyDCP)
+	name := KeyDCP.String()
 	assert.Equals(t, name, "DCP")
 
 	// Can't retrieve name of combined log keys.
-	name = LogKeyName(KeyDCP | KeyReplicate)
+	name = LogKey(KeyDCP | KeyReplicate).String()
 	assert.Equals(t, name, "")
 
 	keys := []string{}
@@ -54,23 +54,23 @@ func TestLogKeyNames(t *testing.T) {
 	keys = append(keys, "DCP")
 	logKeys = ToLogKey(keys)
 	assert.Equals(t, logKeys, KeyDCP)
-	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{LogKeyName(KeyDCP)})
+	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{KeyDCP.String()})
 
 	keys = append(keys, "Access")
 	logKeys = ToLogKey(keys)
 	assert.Equals(t, logKeys, KeyAccess|KeyDCP)
-	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{LogKeyName(KeyAccess), LogKeyName(KeyDCP)})
+	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{KeyAccess.String(), KeyDCP.String()})
 
 	keys = []string{"*", "DCP"}
 	logKeys = ToLogKey(keys)
 	assert.Equals(t, logKeys, KeyAll|KeyDCP)
-	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{LogKeyName(KeyAll), LogKeyName(KeyDCP)})
+	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{KeyAll.String(), KeyDCP.String()})
 
 	// Test that invalid log keys are ignored, and "+" suffixes are stripped.
 	keys = []string{"DCP", "HTTP+", "InvalidLogKey"}
 	logKeys = ToLogKey(keys)
 	assert.Equals(t, logKeys, KeyDCP|KeyHTTP)
-	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{LogKeyName(KeyDCP), LogKeyName(KeyHTTP)})
+	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{KeyDCP.String(), KeyHTTP.String()})
 }
 
 // This test has no assertions, but will flag any data races when run under `-race`.
@@ -139,7 +139,7 @@ func BenchmarkToggleLogKeys(b *testing.B) {
 
 func BenchmarkLogKeyName(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		_ = LogKeyName(KeyDCP)
+		_ = KeyDCP.String()
 	}
 }
 

--- a/base/log_keys_test.go
+++ b/base/log_keys_test.go
@@ -1,6 +1,7 @@
 package base
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -42,9 +43,9 @@ func TestLogKeyNames(t *testing.T) {
 	name := KeyDCP.String()
 	assert.Equals(t, name, "DCP")
 
-	// Can't retrieve name of combined log keys.
+	// Combined log keys, or key masks print the binary representation.
 	name = LogKey(KeyDCP | KeyReplicate).String()
-	assert.Equals(t, name, "")
+	assert.Equals(t, name, fmt.Sprintf("LogKey(%b)", KeyDCP|KeyReplicate))
 
 	keys := []string{}
 	logKeys := ToLogKey(keys)

--- a/base/log_level.go
+++ b/base/log_level.go
@@ -29,7 +29,7 @@ var (
 	logLevelNamesPrint = []string{"NON", "ERR", "WRN", "INF", "DBG"}
 )
 
-// Set will replace the current log level with newLevel.
+// Set will override the log level with the given log level.
 func (l *LogLevel) Set(newLevel LogLevel) {
 	atomic.StoreUint32((*uint32)(l), uint32(newLevel))
 }

--- a/base/log_level.go
+++ b/base/log_level.go
@@ -29,6 +29,7 @@ var (
 	logLevelNamesPrint = []string{"NON", "ERR", "WRN", "INF", "DBG"}
 )
 
+// Set will replace the current log level with newLevel.
 func (l *LogLevel) Set(newLevel LogLevel) {
 	atomic.StoreUint32((*uint32)(l), uint32(newLevel))
 }
@@ -43,34 +44,33 @@ func (l *LogLevel) Enabled(logLevel LogLevel) bool {
 
 // String returns the string representation of a log level (e.g. "debug" or "warn")
 func (l LogLevel) String() string {
-	if int(l) >= len(logLevelNames) {
-		return ""
+	if l >= levelCount {
+		return fmt.Sprintf("LogLevel(%d)", l)
+
 	}
 	return logLevelNames[l]
 }
 
 // StringShort returns the short string representation of a log level (e.g. "DBG" or "WRN")
 func (l LogLevel) StringShort() string {
-	if int(l) >= len(logLevelNames) {
-		return ""
+	if l >= levelCount {
+		return fmt.Sprintf("LVL(%d)", l)
 	}
 	return logLevelNamesPrint[l]
 }
 
+// MarshalText implements the TextMarshaler interface.
 func (l *LogLevel) MarshalText() (text []byte, err error) {
-	if l == nil {
-		return nil, errors.New("invalid log level")
+	if l == nil || *l >= levelCount {
+		return nil, fmt.Errorf("unrecognized log level: %v (valid range: %d-%d)", l, 0, levelCount-1)
 	}
-	name := l.String()
-	if name == "" {
-		return nil, fmt.Errorf("unrecognized log level: %v (valid range: %d-%d)", *l, 0, levelCount-1)
-	}
-	return []byte(name), nil
+	return []byte(l.String()), nil
 }
 
+// UnmarshalText implements the TextUnmarshaler interface.
 func (l *LogLevel) UnmarshalText(text []byte) error {
 	if l == nil {
-		return errors.New("invalid log level")
+		return errors.New("nil log level")
 	}
 	for i, name := range logLevelNames {
 		if name == string(text) {

--- a/base/log_level.go
+++ b/base/log_level.go
@@ -41,27 +41,27 @@ func (l *LogLevel) Enabled(logLevel LogLevel) bool {
 	return atomic.LoadUint32((*uint32)(l)) >= uint32(logLevel)
 }
 
-// LogLevelName returns the string representation of a log level (e.g. "debug" or "warn")
-func LogLevelName(logLevel LogLevel) string {
-	if int(logLevel) >= len(logLevelNames) {
+// String returns the string representation of a log level (e.g. "debug" or "warn")
+func (l LogLevel) String() string {
+	if int(l) >= len(logLevelNames) {
 		return ""
 	}
-	return logLevelNames[logLevel]
+	return logLevelNames[l]
 }
 
-// logLevelNamePrint returns the string value to print for a log level (e.g. "DBG" or "WRN")
-func logLevelNamePrint(logLevel LogLevel) string {
-	if int(logLevel) >= len(logLevelNames) {
+// StringShort returns the short string representation of a log level (e.g. "DBG" or "WRN")
+func (l LogLevel) StringShort() string {
+	if int(l) >= len(logLevelNames) {
 		return ""
 	}
-	return logLevelNamesPrint[logLevel]
+	return logLevelNamesPrint[l]
 }
 
 func (l *LogLevel) MarshalText() (text []byte, err error) {
 	if l == nil {
 		return nil, errors.New("invalid log level")
 	}
-	name := LogLevelName(*l)
+	name := l.String()
 	if name == "" {
 		return nil, fmt.Errorf("unrecognized log level: %v (valid range: %d-%d)", *l, 0, levelCount-1)
 	}

--- a/base/log_level_test.go
+++ b/base/log_level_test.go
@@ -60,7 +60,7 @@ func TestLogLevelNames(t *testing.T) {
 	assert.Equals(t, LevelDebug.String(), "debug")
 
 	// Test out of bounds log level
-	assert.Equals(t, LogLevel(math.MaxUint32).String(), "")
+	assert.Equals(t, LogLevel(math.MaxUint32).String(), "LogLevel(4294967295)")
 }
 
 func TestLogLevelText(t *testing.T) {
@@ -80,9 +80,9 @@ func TestLogLevelText(t *testing.T) {
 	// nil pointer recievers
 	var logLevelPtr *LogLevel
 	_, err := logLevelPtr.MarshalText()
-	assert.Equals(t, err.Error(), "invalid log level")
+	assert.StringContains(t, err.Error(), "unrecognized log level")
 	err = logLevelPtr.UnmarshalText([]byte("none"))
-	assert.Equals(t, err.Error(), "invalid log level")
+	assert.Equals(t, err.Error(), "nil log level")
 
 	// Invalid values
 	var logLevel = LogLevel(math.MaxUint32)

--- a/base/log_level_test.go
+++ b/base/log_level_test.go
@@ -53,14 +53,14 @@ func TestLogLevelNames(t *testing.T) {
 	assert.Equals(t, len(logLevelNames), int(levelCount))
 	assert.Equals(t, len(logLevelNamesPrint), int(levelCount))
 
-	assert.Equals(t, LogLevelName(LevelNone), "none")
-	assert.Equals(t, LogLevelName(LevelError), "error")
-	assert.Equals(t, LogLevelName(LevelInfo), "info")
-	assert.Equals(t, LogLevelName(LevelWarn), "warn")
-	assert.Equals(t, LogLevelName(LevelDebug), "debug")
+	assert.Equals(t, LevelNone.String(), "none")
+	assert.Equals(t, LevelError.String(), "error")
+	assert.Equals(t, LevelInfo.String(), "info")
+	assert.Equals(t, LevelWarn.String(), "warn")
+	assert.Equals(t, LevelDebug.String(), "debug")
 
 	// Test out of bounds log level
-	assert.Equals(t, LogLevelName(math.MaxUint32), "")
+	assert.Equals(t, LogLevel(math.MaxUint32).String(), "")
 }
 
 func TestLogLevelText(t *testing.T) {
@@ -68,7 +68,7 @@ func TestLogLevelText(t *testing.T) {
 		t.Run(fmt.Sprintf("LogLevel: %v", i), func(ts *testing.T) {
 			text, err := i.MarshalText()
 			assert.Equals(ts, err, nil)
-			assert.Equals(ts, string(text), LogLevelName(i))
+			assert.Equals(ts, string(text), i.String())
 
 			var logLevel LogLevel
 			err = logLevel.UnmarshalText(text)
@@ -140,7 +140,7 @@ func TestLogLevelConcurrency(t *testing.T) {
 
 func BenchmarkLogLevelName(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		_ = LogLevelName(LevelWarn)
+		_ = LevelWarn.String()
 	}
 }
 

--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -78,14 +78,14 @@ func (lfc *FileLoggerConfig) init(level LogLevel, logFilePath string, minAge int
 	} else if *lfc.Rotation.MaxAge == 0 {
 		// A value of zero disables the age-based log cleanup in Lumberjack.
 	} else if *lfc.Rotation.MaxAge < minAge {
-		return fmt.Errorf("MaxAge for %s was set to %d which is below the minimum of %d", LogLevelName(level), *lfc.Rotation.MaxAge, minAge)
+		return fmt.Errorf("MaxAge for %v was set to %d which is below the minimum of %d", level, *lfc.Rotation.MaxAge, minAge)
 	} else if *lfc.Rotation.MaxAge > maxAgeLimit {
-		return fmt.Errorf("MaxAge for %s was set to %d which is above the maximum of %d", LogLevelName(level), *lfc.Rotation.MaxAge, maxAgeLimit)
+		return fmt.Errorf("MaxAge for %v was set to %d which is above the maximum of %d", level, *lfc.Rotation.MaxAge, maxAgeLimit)
 	}
 
 	if lfc.Output == nil {
 		lfc.Output = newLumberjackOutput(
-			filepath.Join(filepath.FromSlash(logFilePath), "sg_"+LogLevelName(level)+".log"),
+			filepath.Join(filepath.FromSlash(logFilePath), "sg_"+level.String()+".log"),
 			*lfc.Rotation.MaxSize,
 			*lfc.Rotation.MaxAge,
 		)

--- a/base/logging.go
+++ b/base/logging.go
@@ -926,7 +926,7 @@ func addPrefixes(format string, logLevel LogLevel, logKey LogKey) string {
 
 	var logKeyPrefix string
 	if logKey > KeyNone && logKey != KeyAll {
-		logKeyName := LogKeyName(logKey)
+		logKeyName := logKey.String()
 		// Append "+" to logKeys at debug level (for backwards compatibility)
 		if logLevel == LevelDebug {
 			logKeyName += "+"

--- a/base/logging.go
+++ b/base/logging.go
@@ -921,7 +921,7 @@ func addPrefixes(format string, logLevel LogLevel, logKey LogKey) string {
 
 	var logLevelPrefix string
 	if logLevel > LevelNone {
-		logLevelPrefix = "[" + logLevelNamePrint(logLevel) + "] "
+		logLevelPrefix = "[" + logLevel.StringShort() + "] "
 	}
 
 	var logKeyPrefix string

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -364,7 +364,7 @@ func (h *handler) handleSetLogging() error {
 	}
 
 	if newLogLevel != nil {
-		base.Infof(base.KeyAll, "Setting log level to: %v", base.LogLevelName(*newLogLevel))
+		base.Infof(base.KeyAll, "Setting log level to: %v", newLogLevel)
 		base.ConsoleLogLevel().Set(*newLogLevel)
 
 		if len(body) == 0 {

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1373,7 +1373,7 @@ type TestLogger struct {
 
 func (l TestLogger) Logf(logLevel base.LogLevel, logKey base.LogKey, format string, args ...interface{}) {
 	l.T.Logf(
-		base.LogLevelName(logLevel)+" "+
+		logLevel.String()+" "+
 			base.LogKeyName(logKey)+": "+
 			format, args...,
 	)

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1374,7 +1374,7 @@ type TestLogger struct {
 func (l TestLogger) Logf(logLevel base.LogLevel, logKey base.LogKey, format string, args ...interface{}) {
 	l.T.Logf(
 		logLevel.String()+" "+
-			base.LogKeyName(logKey)+": "+
+			logKey.String()+": "+
 			format, args...,
 	)
 }


### PR DESCRIPTION
- Implement the `Stringer` interface for `LogLevel` and `LogKey` types
- Improve code comments and general tidy up

Fixes `2018-04-24T11:51:16.132+01:00 [INF] Console LogLevel: 0xc4200b53d8` message in logs.