### PR TITLE
CBG-115: Collect sg_stats.log file

### DIFF
--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -274,6 +274,7 @@ def make_collect_logs_tasks(zip_dir, sg_url):
         "sg_warn.log": "sg_warn.log",
         "sg_info.log": "sg_info.log",
         "sg_debug.log": "sg_debug.log",
+        "sg_stats.log": "sg_stats.log",
         "sync_gateway_access.log": "sync_gateway_access.log",
         "sync_gateway_error.log": "sync_gateway_error.log",
         "sg_accel_access.log": "sg_accel_access.log",


### PR DESCRIPTION
Collects the new sg_stats.log file from: https://github.com/couchbase/sync_gateway/blob/master/base/logging_config.go#L87