### PR TITLE
CBG-1642 - Added removal logging for SG Replicate

### DIFF
--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -57,6 +57,7 @@ type LegacyServerConfig struct {
 	AdminInterfaceAuthentication              *bool                          `json:"admin_interface_authentication,omitempty" help:"Whether the admin API requires authentication"`
 	MetricsInterfaceAuthentication            *bool                          `json:"metrics_interface_authentication,omitempty" help:"Whether the metrics API requires authentication"`
 	EnableAdminAuthenticationPermissionsCheck *bool                          `json:"enable_advanced_auth_dp,omitempty" help:"Whether to enable the permissions check feature of admin auth"`
+	Replications                              interface{}                    `json:"replications,omitempty"` // Functionality removed. Used to log message to user to switch to ISGR
 }
 
 type FacebookConfigLegacy struct {
@@ -318,6 +319,15 @@ func LoadServerConfig(path string) (config *LegacyServerConfig, err error) {
 // readServerConfig returns a validated LegacyServerConfig from an io.Reader
 func readServerConfig(r io.Reader) (config *LegacyServerConfig, err error) {
 	err = decodeAndSanitiseConfig(r, &config)
+	if err != nil {
+		return nil, err
+	}
+
+	err = config.validate()
+	if err != nil {
+		return nil, err
+	}
+
 	return config, err
 }
 
@@ -380,6 +390,11 @@ func (config *LegacyServerConfig) validate() (errorMessages error) {
 				"unsupported.stats_log_freq_secs", 10))
 		}
 	}
+
+	if config.Replications != nil {
+		errorMessages = multierror.Append(errorMessages, fmt.Errorf("cannot use SG replicate as it has been removed. Please use Inter-Sync Gateway Replication instead"))
+	}
+
 	return errorMessages
 }
 

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -320,14 +320,10 @@ func LoadServerConfig(path string) (config *LegacyServerConfig, err error) {
 func readServerConfig(r io.Reader) (config *LegacyServerConfig, err error) {
 	err = decodeAndSanitiseConfig(r, &config)
 	if err != nil {
-		return nil, err
+		return config, err
 	}
 
 	err = config.validate()
-	if err != nil {
-		return nil, err
-	}
-
 	return config, err
 }
 

--- a/rest/config_legacy_test.go
+++ b/rest/config_legacy_test.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -249,4 +250,21 @@ func TestLegacyConfigXattrsDefault(t *testing.T) {
 			assert.Equal(t, test.expectedXattrs, *dbc.EnableXattrs)
 		})
 	}
+}
+
+func TestSGReplicateValidation(t *testing.T) {
+	errText := "cannot use SG replicate as it has been removed. Please use Inter-Sync Gateway Replication instead"
+	configReader := strings.NewReader(`{
+			"replications": [
+				{
+					"source": "db",
+					"target": "db-copy"
+				}
+			]
+		}`)
+
+	config, err := readServerConfig(configReader)
+	assert.Nil(t, config)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), errText)
 }

--- a/rest/config_legacy_test.go
+++ b/rest/config_legacy_test.go
@@ -263,7 +263,7 @@ func TestSGReplicateValidation(t *testing.T) {
 			]
 		}`)
 
-	_, err := readServerConfig(configReader)
+	_, err := readLegacyServerConfig(configReader)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), errText)
 }

--- a/rest/config_legacy_test.go
+++ b/rest/config_legacy_test.go
@@ -263,8 +263,7 @@ func TestSGReplicateValidation(t *testing.T) {
 			]
 		}`)
 
-	config, err := readServerConfig(configReader)
-	assert.Nil(t, config)
+	_, err := readServerConfig(configReader)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), errText)
 }

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -82,7 +82,7 @@ func TestReadServerConfig(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
 			buf := bytes.NewBufferString(test.config)
-			_, err := readServerConfig(buf)
+			_, err := readLegacyServerConfig(buf)
 
 			// stdlib/CE specific error checking
 			expectedErr := test.errStdlib
@@ -128,7 +128,7 @@ func TestConfigValidation(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			buf := bytes.NewBufferString(test.config)
-			config, err := readServerConfig(buf)
+			config, err := readLegacyServerConfig(buf)
 			assert.NoError(t, err)
 			errorMessages := config.setupAndValidateDatabases()
 			if test.err != "" {
@@ -148,7 +148,7 @@ func TestConfigValidationDeltaSync(t *testing.T) {
 	jsonConfig := `{"databases": {"db": {"delta_sync": {"enabled": true}}}}`
 
 	buf := bytes.NewBufferString(jsonConfig)
-	config, err := readServerConfig(buf)
+	config, err := readLegacyServerConfig(buf)
 	assert.NoError(t, err)
 
 	errorMessages := config.setupAndValidateDatabases()
@@ -169,7 +169,7 @@ func TestConfigValidationCache(t *testing.T) {
 	jsonConfig := `{"databases": {"db": {"cache": {"rev_cache": {"size": 0}, "channel_cache": {"max_number": 100, "compact_high_watermark_pct": 95, "compact_low_watermark_pct": 25}}}}}`
 
 	buf := bytes.NewBufferString(jsonConfig)
-	config, err := readServerConfig(buf)
+	config, err := readLegacyServerConfig(buf)
 	assert.NoError(t, err)
 
 	errorMessages := config.setupAndValidateDatabases()
@@ -217,7 +217,7 @@ func TestConfigValidationImport(t *testing.T) {
 	jsonConfig := `{"databases": {"db": {"enable_shared_bucket_access":true, "import_docs": true, "import_partitions": 32}}}`
 
 	buf := bytes.NewBufferString(jsonConfig)
-	config, err := readServerConfig(buf)
+	config, err := readLegacyServerConfig(buf)
 	assert.NoError(t, err)
 
 	errorMessages := config.setupAndValidateDatabases()
@@ -282,7 +282,7 @@ func TestConfigValidationImportPartitions(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			buf := bytes.NewBufferString(test.config)
-			config, err := readServerConfig(buf)
+			config, err := readLegacyServerConfig(buf)
 			assert.NoError(t, err)
 			errorMessages := config.setupAndValidateDatabases()
 			if test.err != "" {
@@ -298,7 +298,7 @@ func TestConfigValidationImportPartitions(t *testing.T) {
 	}
 }
 
-// TestLoadServerConfigExamples will run LoadServerConfig for configs found under the legacy examples directory.
+// TestLoadServerConfigExamples will run LoadLegacyServerConfig for configs found under the legacy examples directory.
 func TestLoadServerConfigExamples(t *testing.T) {
 	const exampleLogDirectory = "../examples/legacy_config"
 	const configSuffix = ".json"
@@ -319,7 +319,7 @@ func TestLoadServerConfigExamples(t *testing.T) {
 		}
 
 		t.Run(configPath, func(tt *testing.T) {
-			_, err := LoadServerConfig(configPath)
+			_, err := LoadLegacyServerConfig(configPath)
 			assert.NoError(tt, err, "unexpected error validating example config")
 		})
 

--- a/rest/main.go
+++ b/rest/main.go
@@ -193,7 +193,7 @@ func getInitialStartupConfig(fileStartupConfig *StartupConfig, flagStartupConfig
 // update it to a 3.x config
 // Returns the new startup config, a bool of whether to fallback to legacy config and an error
 func automaticConfigUpgrade(configPath string) (sc *StartupConfig, disablePersistentConfig bool, err error) {
-	legacyServerConfig, err := LoadServerConfig(configPath)
+	legacyServerConfig, err := LoadLegacyServerConfig(configPath)
 	if err != nil {
 		return nil, false, err
 	}


### PR DESCRIPTION
CBG-1642

- Added "replication" legacy config option which returns error if used with what it's replaced with
- Added legacy config validation to `readServerConfig` so automatic migration validates legacy config before upgrading

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1051

## Merge post-beta
- [ ] Merge post-beta