### PR TITLE
CBG-1643: Add additional context for unknown authority

### DIFF
--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -11,6 +11,7 @@ package rest
 import (
 	"bytes"
 	"context"
+	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1158,6 +1159,10 @@ func initClusterAgent(clusterAddress, clusterUser, clusterPass, certPath, keyPat
 	}
 
 	if err := <-agentReadyErr; err != nil {
+		if _, ok := err.(x509.UnknownAuthorityError); ok {
+			err = fmt.Errorf("%w - Provide a CA cert, or set tls_skip_verify to true in config", err)
+		}
+
 		return nil, err
 	}
 


### PR DESCRIPTION
CBG-1643

Wraps the error returned from the initial gocb / Couchbase connection with additional direction for users if the error is `UnknownAuthorityError`.

```
x509: certificate signed by unknown authority - Provide a CA cert, or set tls_skip_verify to true in config
```

Tested locally with X509 unit test.

## Merge post-beta or review priority
- [ ] Merge post-beta or review priority