### PR TITLE
CBG-1650 - added runtime config and database configs to sgcollect

### DIFF
--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -440,7 +440,7 @@ def make_config_tasks(zip_dir, sg_config_path, sg_url, should_redact):
                                  log_file="sync_gateway.log",
                                  content_postprocessors=server_config_postprocessors)
     collect_config_tasks.append(runtime_config_task)
-
+# Get persisted dbconfigs
     dbs = get_db_list(sg_url)
     for db in dbs:
         db_config_url = "{0}/{1}/_config".format(sg_url, db)

--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -423,7 +423,7 @@ def make_config_tasks(zip_dir, sg_config_path, sg_url, should_redact):
 
     # Get server config
     server_config_url = "{0}/_config".format(sg_url)
-    config_task = make_curl_task(name="Running server config",
+    config_task = make_curl_task(name="Collect server config",
                                  user="",
                                  password="",
                                  url=server_config_url,
@@ -431,6 +431,27 @@ def make_config_tasks(zip_dir, sg_config_path, sg_url, should_redact):
                                  content_postprocessors=server_config_postprocessors)
     collect_config_tasks.append(config_task)
 
+    # Get server config with runtime defaults
+    server_runtime_config_url = "{0}/_config?include_runtime=true".format(sg_url)
+    runtime_config_task = make_curl_task(name="Collect runtime config",
+                                 user="",
+                                 password="",
+                                 url=server_runtime_config_url,
+                                 log_file="sync_gateway.log",
+                                 content_postprocessors=server_config_postprocessors)
+    collect_config_tasks.append(runtime_config_task)
+
+    dbs = get_db_list(sg_url)
+    for db in dbs:
+        db_config_url = "{0}/{1}/_config".format(sg_url, db)
+        db_config_task = make_curl_task(name="Collect {0} database config".format(db),
+                                 user="",
+                                 password="",
+                                 url=db_config_url,
+                                 log_file="sync_gateway.log",
+                                 content_postprocessors=db_config_postprocessors)
+        collect_config_tasks.append(db_config_task)
+    
     return collect_config_tasks
 
 

--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -440,7 +440,8 @@ def make_config_tasks(zip_dir, sg_config_path, sg_url, should_redact):
                                  log_file="sync_gateway.log",
                                  content_postprocessors=server_config_postprocessors)
     collect_config_tasks.append(runtime_config_task)
-# Get persisted dbconfigs
+    
+    # Get persisted dbconfigs
     dbs = get_db_list(sg_url)
     for db in dbs:
         db_config_url = "{0}/{1}/_config".format(sg_url, db)

--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -431,7 +431,7 @@ def make_config_tasks(zip_dir, sg_config_path, sg_url, should_redact):
                                  content_postprocessors=server_config_postprocessors)
     collect_config_tasks.append(config_task)
 
-    # Get server config with runtime defaults
+    # Get server config with runtime defaults and runtime dbconfigs
     server_runtime_config_url = "{0}/_config?include_runtime=true".format(sg_url)
     runtime_config_task = make_curl_task(name="Collect runtime config",
                                  user="",


### PR DESCRIPTION
CBG-1650

- Renamed "Running server config" to "Collect server config"
- Added task to collect runtime config
- Added task to loop over database configs and collect them

Tested with single DB and multiple, as well as partial redaction. Partial redaction caused UD tags to be replaced with hashes as intended. This was verified through the username config option for both the server configs, and the database configs. These are not hashed when redaction is "none" or default.