### PR TITLE
CBG-1660: Strip out credentials obtained through GET db config

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -199,6 +199,13 @@ func (h *handler) handleGetDbConfig() error {
 		}
 	}
 
+	// Strip out credentials that are stamped into the config
+	responseConfig.Username = ""
+	responseConfig.Password = ""
+	responseConfig.CACertPath = ""
+	responseConfig.KeyPath = ""
+	responseConfig.CertPath = ""
+
 	h.writeJSON(responseConfig)
 	return nil
 }


### PR DESCRIPTION
CBG-1660

Strip out credentials from db config during the GET db config operation. 
Tested with a unit test.