### PR TITLE
[2.8.3] Backport: Push query ops default selection to lower level

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -98,7 +98,7 @@ type BucketSpec struct {
 	InitialRetrySleepTimeMS                int            // the initial time to sleep in between retry attempts (in millisecond), which will double each retry
 	UseXattrs                              bool           // Whether to use xattrs to store _sync metadata.  Used during view initialization
 	ViewQueryTimeoutSecs                   *uint32        // the view query timeout in seconds (default: 75 seconds)
-	MaxConcurrentQueryOps                  *int            // maximum number of concurrent query operations (default: DefaultMaxConcurrentQueryOps)
+	MaxConcurrentQueryOps                  *int           // maximum number of concurrent query operations (default: DefaultMaxConcurrentQueryOps)
 	BucketOpTimeout                        *time.Duration // How long bucket ops should block returning "operation timed out". If nil, uses GoCB default.  GoCB buckets only.
 	KvPoolSize                             int            // gocb kv_pool_size - number of pipelines per node. Initialized on GetGoCBConnString
 }

--- a/base/bucket.go
+++ b/base/bucket.go
@@ -98,7 +98,7 @@ type BucketSpec struct {
 	InitialRetrySleepTimeMS                int            // the initial time to sleep in between retry attempts (in millisecond), which will double each retry
 	UseXattrs                              bool           // Whether to use xattrs to store _sync metadata.  Used during view initialization
 	ViewQueryTimeoutSecs                   *uint32        // the view query timeout in seconds (default: 75 seconds)
-	MaxConcurrentQueryOps                  int            // maximum number of concurrent query operations (default: DefaultMaxConcurrentQueryOps)
+	MaxConcurrentQueryOps                  *int            // maximum number of concurrent query operations (default: DefaultMaxConcurrentQueryOps)
 	BucketOpTimeout                        *time.Duration // How long bucket ops should block returning "operation timed out". If nil, uses GoCB default.  GoCB buckets only.
 	KvPoolSize                             int            // gocb kv_pool_size - number of pipelines per node. Initialized on GetGoCBConnString
 }

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -172,7 +172,7 @@ func GetCouchbaseBucketGoCBFromAuthenticatedCluster(cluster *gocb.Cluster, spec 
 	bucketOpsQueue := make(chan struct{}, MaxConcurrentBulkOps*nodeCount*numPools)
 
 	maxConcurrentQueryOps := MaxConcurrentQueryOps
-	if spec.MaxConcurrentQueryOps != nil{
+	if spec.MaxConcurrentQueryOps != nil {
 		maxConcurrentQueryOps = *spec.MaxConcurrentQueryOps
 	}
 	viewOpsQueue := make(chan struct{}, maxConcurrentQueryOps)

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -171,7 +171,11 @@ func GetCouchbaseBucketGoCBFromAuthenticatedCluster(cluster *gocb.Cluster, spec 
 	singleOpsQueue := make(chan struct{}, MaxConcurrentSingleOps*nodeCount*numPools)
 	bucketOpsQueue := make(chan struct{}, MaxConcurrentBulkOps*nodeCount*numPools)
 
-	viewOpsQueue := make(chan struct{}, spec.MaxConcurrentQueryOps)
+	maxConcurrentQueryOps := MaxConcurrentQueryOps
+	if spec.MaxConcurrentQueryOps != nil{
+		maxConcurrentQueryOps = *spec.MaxConcurrentQueryOps
+	}
+	viewOpsQueue := make(chan struct{}, maxConcurrentQueryOps)
 
 	bucket = &CouchbaseBucketGoCB{
 		Bucket:                    goCBBucket,

--- a/rest/config.go
+++ b/rest/config.go
@@ -138,11 +138,6 @@ func (bc *BucketConfig) MakeBucketSpec() base.BucketSpec {
 		tlsPort = bc.KvTLSPort
 	}
 
-	maxConcurrentQueryOps := base.MaxConcurrentQueryOps
-	if bc.MaxConcurrentQueryOps != nil {
-		maxConcurrentQueryOps = *bc.MaxConcurrentQueryOps
-	}
-
 	return base.BucketSpec{
 		Server:                server,
 		PoolName:              pool,
@@ -152,7 +147,7 @@ func (bc *BucketConfig) MakeBucketSpec() base.BucketSpec {
 		CACertPath:            bc.CACertPath,
 		KvTLSPort:             tlsPort,
 		Auth:                  bc,
-		MaxConcurrentQueryOps: maxConcurrentQueryOps,
+		MaxConcurrentQueryOps: bc.MaxConcurrentQueryOps,
 	}
 }
 

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -272,32 +272,3 @@ func TestGetOrAddDatabaseFromConfig(t *testing.T) {
 	assert.Equal(t, server, dbContext.BucketSpec.Server)
 	assert.Equal(t, bucketName, dbContext.BucketSpec.BucketName)
 }
-
-func TestViewQueryBucketOptionsOnBucketSpec(t *testing.T) {
-	testCases := []struct {
-		Name              string
-		OperationsPerNode *int
-		ExpectedValue     int
-	}{
-		{
-			Name:              "Set Value",
-			OperationsPerNode: base.IntPtr(10),
-			ExpectedValue:     10,
-		},
-		{
-			Name:              "Set Nil",
-			OperationsPerNode: nil,
-			ExpectedValue:     base.MaxConcurrentQueryOps,
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.Name, func(t *testing.T) {
-			dbConfig := &DbConfig{BucketConfig: BucketConfig{MaxConcurrentQueryOps: testCase.OperationsPerNode}}
-			spec, err := GetBucketSpec(dbConfig)
-			assert.NoError(t, err)
-
-			assert.Equal(t, testCase.ExpectedValue, spec.MaxConcurrentQueryOps)
-		})
-	}
-}


### PR DESCRIPTION
Backport of https://github.com/couchbase/sync_gateway/pull/5142
Fixes integration test issue where MaxConcurrentOps ends up not getting set.
Missed this later fix from original backport.

http://uberjenkins.sc.couchbase.com:8080/view/All/job/sync-gateway-integration/1248/