### PR TITLE
CBG-1717: Backport CBG-1716: norev uses "sequence" property name except for ISGR which uses "seq" (#5280)

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -591,7 +591,11 @@ func (bh *blipHandler) handleNoRev(rq *blip.Message) error {
 		rq.String(), base.UD(rq.Properties[NorevMessageId]), rq.Properties[NorevMessageRev], rq.Properties[NorevMessageError], rq.Properties[NorevMessageReason])
 
 	if bh.sgr2PullProcessedSeqCallback != nil {
-		bh.sgr2PullProcessedSeqCallback(rq.Properties[NorevMessageSeq], IDAndRev{DocID: rq.Properties[NorevMessageId], RevID: rq.Properties[NorevMessageRev]})
+		if bh.blipContext.ActiveSubprotocol() == BlipCBMobileReplicationV2 && bh.clientType == BLIPClientTypeSGR2 {
+			bh.sgr2PullProcessedSeqCallback(rq.Properties[NorevMessageSeq], IDAndRev{DocID: rq.Properties[NorevMessageId], RevID: rq.Properties[NorevMessageRev]})
+		} else {
+			bh.sgr2PullProcessedSeqCallback(rq.Properties[NorevMessageSequence], IDAndRev{DocID: rq.Properties[NorevMessageId], RevID: rq.Properties[NorevMessageRev]})
+		}
 	}
 
 	// Couchbase Lite always sends noreply=true for norev profiles

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -591,7 +591,7 @@ func (bh *blipHandler) handleNoRev(rq *blip.Message) error {
 		rq.String(), base.UD(rq.Properties[NorevMessageId]), rq.Properties[NorevMessageRev], rq.Properties[NorevMessageError], rq.Properties[NorevMessageReason])
 
 	if bh.sgr2PullProcessedSeqCallback != nil {
-		if bh.blipContext.ActiveSubprotocol() == BlipCBMobileReplicationV2 && bh.clientType == BLIPClientTypeSGR2 {
+		if bh.clientType == BLIPClientTypeSGR2 {
 			bh.sgr2PullProcessedSeqCallback(rq.Properties[NorevMessageSeq], IDAndRev{DocID: rq.Properties[NorevMessageId], RevID: rq.Properties[NorevMessageRev]})
 		} else {
 			bh.sgr2PullProcessedSeqCallback(rq.Properties[NorevMessageSequence], IDAndRev{DocID: rq.Properties[NorevMessageId], RevID: rq.Properties[NorevMessageRev]})

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -496,7 +496,7 @@ func (bsc *BlipSyncContext) sendNoRev(sender *blip.Sender, docID, revID string, 
 	noRevRq := NewNoRevMessage()
 	noRevRq.SetId(docID)
 	noRevRq.SetRev(revID)
-	if bsc.blipContext.ActiveSubprotocol() == BlipCBMobileReplicationV2 && bsc.clientType == BLIPClientTypeSGR2 {
+	if bsc.clientType == BLIPClientTypeSGR2 {
 		noRevRq.SetSeq(seq)
 	} else {
 		noRevRq.SetSequence(seq)

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -491,13 +491,16 @@ func (bsc *BlipSyncContext) sendBLIPMessage(sender *blip.Sender, msg *blip.Messa
 }
 
 func (bsc *BlipSyncContext) sendNoRev(sender *blip.Sender, docID, revID string, seq SequenceID, err error) error {
-
 	base.DebugfCtx(bsc.loggingCtx, base.KeySync, "Sending norev %q %s due to unavailable revision: %v", base.UD(docID), revID, err)
 
 	noRevRq := NewNoRevMessage()
 	noRevRq.SetId(docID)
 	noRevRq.SetRev(revID)
-	noRevRq.SetSeq(seq)
+	if bsc.blipContext.ActiveSubprotocol() == BlipCBMobileReplicationV2 && bsc.clientType == BLIPClientTypeSGR2 {
+		noRevRq.SetSeq(seq)
+	} else {
+		noRevRq.SetSequence(seq)
+	}
 
 	status, reason := base.ErrorAsHTTPStatus(err)
 	noRevRq.SetError(strconv.Itoa(status))

--- a/db/blip_sync_messages.go
+++ b/db/blip_sync_messages.go
@@ -60,11 +60,12 @@ const (
 	RevMessageDeltaSrc    = "deltaSrc"
 
 	// norev message properties
-	NorevMessageId     = "id"
-	NorevMessageRev    = "rev"
-	NorevMessageSeq    = "seq"
-	NorevMessageError  = "error"
-	NorevMessageReason = "reason"
+	NorevMessageId       = "id"
+	NorevMessageRev      = "rev"
+	NorevMessageSeq      = "seq" // Use when protocol version 2 with client type ISGR
+	NorevMessageSequence = "sequence"
+	NorevMessageError    = "error"
+	NorevMessageReason   = "reason"
 
 	// changes message properties
 	ChangesMessageIgnoreNoConflicts = "ignoreNoConflicts"
@@ -399,6 +400,10 @@ func (nrm *noRevMessage) SetRev(rev string) {
 
 func (nrm *noRevMessage) SetSeq(seq SequenceID) {
 	nrm.Properties[NorevMessageSeq] = seq.String()
+}
+
+func (nrm *noRevMessage) SetSequence(sequence SequenceID) {
+	nrm.Properties[NorevMessageSequence] = sequence.String()
 }
 
 func (nrm *noRevMessage) SetReason(reason string) {

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -2797,6 +2797,7 @@ func TestBlipNorev(t *testing.T) {
 	norevMsg := db.NewNoRevMessage()
 	norevMsg.SetId("docid")
 	norevMsg.SetRev("1-a")
+	norevMsg.SetSequence(db.SequenceID{Seq: 50})
 	norevMsg.SetError("404")
 	norevMsg.SetReason("couldn't send xyz")
 
@@ -2813,6 +2814,20 @@ func TestBlipNorev(t *testing.T) {
 	resp := norevMsg.Response()
 	assert.NotNil(t, resp)
 	assert.Equal(t, "handleNoRev", resp.Properties[db.SGHandler])
+}
+
+// TestNoRevSetSeq makes sure the correct string is used with the corresponding function
+func TestNoRevSetSeq(t *testing.T) {
+	norevMsg := db.NewNoRevMessage()
+	assert.Equal(t, "", norevMsg.Properties[db.NorevMessageSeq])
+	assert.Equal(t, "", norevMsg.Properties[db.NorevMessageSequence])
+
+	norevMsg.SetSequence(db.SequenceID{Seq: 50})
+	assert.Equal(t, "50", norevMsg.Properties[db.NorevMessageSequence])
+
+	norevMsg.SetSeq(db.SequenceID{Seq: 60})
+	assert.Equal(t, "60", norevMsg.Properties[db.NorevMessageSeq])
+
 }
 
 // TestBlipDeltaSyncPushAttachment tests updating a doc that has an attachment with a delta that doesn't modify the attachment.


### PR DESCRIPTION
CBG-1717

Backport of CBG-1716 without the sub-protocol check