### PR TITLE
CBG-1468: Implement Mark phase of attachment compaction

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -134,6 +134,8 @@ const (
 
 	PersistentConfigPrefix = SyncPrefix + "dbconfig:"
 
+	AttachmentCompactionXattrName = SyncXattrName + "-compact"
+
 	SyncPropertyName = "_sync"
 	SyncXattrName    = "_sync"
 

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -247,6 +247,10 @@ func (b *LeakyBucket) WriteUpdateWithXattr(k string, xattr string, userXattrKey 
 	return b.bucket.WriteUpdateWithXattr(k, xattr, userXattrKey, exp, previous, callback)
 }
 
+func (b *LeakyBucket) SetXattr(k string, xattrKey string, xv []byte) (casOut uint64, err error) {
+	return b.bucket.SetXattr(k, xattrKey, xv)
+}
+
 func (b *LeakyBucket) SubdocInsert(docID string, fieldPath string, cas uint64, value interface{}) error {
 	return b.bucket.SubdocInsert(docID, fieldPath, cas, value)
 }

--- a/base/logging_bucket.go
+++ b/base/logging_bucket.go
@@ -111,6 +111,11 @@ func (b *LoggingBucket) WriteUpdateWithXattr(k string, xattr string, userXattrKe
 	return b.bucket.WriteUpdateWithXattr(k, xattr, userXattrKey, exp, previous, callback)
 }
 
+func (b *LoggingBucket) SetXattr(k string, xattrKey string, xv []byte) (casOut uint64, err error) {
+	defer b.log(time.Now(), k, xattrKey)
+	return b.bucket.SetXattr(k, xattrKey, xv)
+}
+
 func (b *LoggingBucket) SubdocInsert(docID string, fieldPath string, cas uint64, value interface{}) error {
 	defer b.log(time.Now(), docID, fieldPath)
 	return b.bucket.SubdocInsert(docID, fieldPath, cas, value)

--- a/db/attachment_compaction.go
+++ b/db/attachment_compaction.go
@@ -1,0 +1,132 @@
+package db
+
+import (
+	"fmt"
+	"strings"
+
+	sgbucket "github.com/couchbase/sg-bucket"
+	"github.com/couchbase/sync_gateway/base"
+)
+
+const CompactionIDKey = "compactID"
+
+func Mark(db *Database, compactionID string, terminator chan bool) (int, error) {
+	base.InfofCtx(db.Ctx, base.KeyAll, "Starting first phase of attachment compaction (mark phase) with compactionID: %q", compactionID)
+	compactionLoggingID := "compaction: " + compactionID
+
+	var markProcessFailureErr error
+	var attachmentsMarked int
+
+	// failProcess used when a failure is deemed as 'un-recoverable' and we need to abort the compaction process.
+	failProcess := func(err error, format string, args ...interface{}) bool {
+		markProcessFailureErr = err
+		close(terminator)
+		base.WarnfCtx(db.Ctx, format, args)
+		return false
+	}
+
+	callback := func(event sgbucket.FeedEvent) bool {
+		// We've had an error previously so no point doing work for any remaining items
+		if markProcessFailureErr != nil {
+			return false
+		}
+
+		// We only want to process full docs. Not any sync docs.
+		if strings.HasPrefix(string(event.Key), base.SyncPrefix) {
+			return true
+		}
+
+		// Attempt to unmarshal the feed data into a document
+		doc, err := UnmarshalDocumentFromFeed(string(event.Key), event.Cas, event.Value, event.DataType, "")
+		if err != nil {
+			return failProcess(err, "[%s] Failed to unmarshal doc %s from feed. Err: %v", compactionLoggingID, base.UD(string(event.Key)), err)
+		}
+
+		// Any doc written by SGW should have this value set. Not having this means we can skip this doc as it has not
+		// got sync data
+		if doc.Cas == uint64(0) {
+			return true
+		}
+
+		// We need to mark attachments in every leaf revision of the current doc
+		// We will build up a list of attachment names which map to attachment doc IDs. Avoids doing multiple KV ops
+		// when marking if multiple leaves are referencing the same attachment.
+		attachmentKeys := make(map[string]string)
+		for _, leafRevision := range doc.History.GetLeaves() {
+			_, _, attachmentMeta, err := db.getRevision(doc, leafRevision)
+			if err != nil {
+				return failProcess(err, "[%s] Failed to get doc %s revision %s. Err: %v", compactionLoggingID, base.UD(string(event.Key)), base.UD(leafRevision), err)
+			}
+
+			// Iterate over the attachments
+			for attID, attMeta := range attachmentMeta {
+				attMetaMap, ok := attMeta.(map[string]interface{})
+				if !ok {
+					continue
+				}
+
+				attVer, ok := GetAttachmentVersion(attMetaMap)
+				if !ok {
+					continue
+				}
+
+				if attVer != AttVersion1 {
+					continue
+				}
+
+				digest, ok := attMetaMap["digest"]
+				if !ok {
+					continue
+				}
+				attKey := MakeAttachmentKey(AttVersion1, string(event.Key), digest.(string))
+				attachmentKeys[attID] = attKey
+			}
+		}
+
+		for attachmentName, attachmentDocID := range attachmentKeys {
+			// Stamp the current compaction ID into the attachment xattr. This is performing the actual marking
+			xattrValue := []byte(`{"` + CompactionIDKey + `": "` + compactionID + `"}`)
+			_, err = db.Bucket.SetXattr(attachmentDocID, base.SyncXattrName, xattrValue)
+
+			// If an error occurs while stamping in that ID we need to fail this process and then the entire compaction
+			// process. Otherwise an attachment could end up getting erroneously deleted in the later sweep phase.
+			if err != nil {
+				return failProcess(err, "[%s] Failed to mark attachment %s from doc %s with attachment docID %s. Err: %v", compactionLoggingID, base.UD(attachmentName), base.UD(string(event.Key)), base.UD(attachmentDocID), err)
+			}
+
+			base.DebugfCtx(db.Ctx, base.KeyAll, "[%s] Marked attachment %s from doc %s with attachment docID %s", compactionLoggingID, base.UD(attachmentName), base.UD(string(event.Key)), base.UD(attachmentDocID))
+			attachmentsMarked++
+		}
+		return true
+	}
+
+	cbStore, ok := base.AsCouchbaseStore(db.Bucket)
+	if !ok {
+		return 0, fmt.Errorf("bucket is not a Couchbase Store")
+	}
+
+	clientOptions := base.DCPClientOptions{
+		OneShot: true,
+	}
+
+	base.InfofCtx(db.Ctx, base.KeyAll, "[%s] Starting DCP feed for mark phase of attachment compaction", compactionLoggingID)
+	dcpClient, err := base.NewDCPClient(compactionID, callback, clientOptions, cbStore)
+	if err != nil {
+		return 0, err
+	}
+	defer dcpClient.Close()
+
+	doneChan, err := dcpClient.Start()
+	if err != nil {
+		return 0, err
+	}
+
+	select {
+	case <-doneChan:
+		base.InfofCtx(db.Ctx, base.KeyAll, "[%s] Mark phase of attachment compaction completed. Marked %d attachments", compactionLoggingID, attachmentsMarked)
+	case <-terminator:
+		base.InfofCtx(db.Ctx, base.KeyAll, "[%s] Mark phase of attachment compaction was terminated. Marked %d attachments", compactionLoggingID, attachmentsMarked)
+	}
+
+	return attachmentsMarked, markProcessFailureErr
+}

--- a/db/attachment_compaction.go
+++ b/db/attachment_compaction.go
@@ -86,7 +86,7 @@ func Mark(db *Database, compactionID string, terminator chan bool) (int, error) 
 		for attachmentName, attachmentDocID := range attachmentKeys {
 			// Stamp the current compaction ID into the attachment xattr. This is performing the actual marking
 			xattrValue := []byte(`{"` + CompactionIDKey + `": "` + compactionID + `"}`)
-			_, err = db.Bucket.SetXattr(attachmentDocID, base.SyncXattrName, xattrValue)
+			_, err = db.Bucket.SetXattr(attachmentDocID, base.AttachmentCompactionXattrName, xattrValue)
 
 			// If an error occurs while stamping in that ID we need to fail this process and then the entire compaction
 			// process. Otherwise an attachment could end up getting erroneously deleted in the later sweep phase.

--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -49,7 +49,7 @@ func TestAttachmentMark(t *testing.T) {
 
 	for _, attDocKey := range attKeys {
 		var attachmentData Body
-		_, err = testDb.Bucket.GetXattr(attDocKey, base.SyncXattrName, &attachmentData)
+		_, err = testDb.Bucket.GetXattr(attDocKey, base.AttachmentCompactionXattrName, &attachmentData)
 		assert.NoError(t, err)
 
 		compactID, ok := attachmentData[CompactionIDKey]
@@ -72,7 +72,7 @@ func createLegacyAttachmentDoc(t *testing.T, db *Database, docID string, body []
 	_, _, err = db.Put(docID, unmarshalledBody)
 	require.NoError(t, err)
 
-	_, err = db.Bucket.WriteUpdateWithXattr(docID, "_sync", "", 0, nil, func(doc []byte, xattr []byte, userXattr []byte, cas uint64) (updatedDoc []byte, updatedXattr []byte, deletedDoc bool, expiry *uint32, err error) {
+	_, err = db.Bucket.WriteUpdateWithXattr(docID, base.SyncXattrName, "", 0, nil, func(doc []byte, xattr []byte, userXattr []byte, cas uint64) (updatedDoc []byte, updatedXattr []byte, deletedDoc bool, expiry *uint32, err error) {
 		attachmentSyncData := map[string]interface{}{
 			attID: map[string]interface{}{
 				"content_type": "application/json",

--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -1,0 +1,100 @@
+package db
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAttachmentMark(t *testing.T) {
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("Requires CBS")
+	}
+
+	testDb := setupTestDB(t)
+	defer testDb.Close()
+
+	body := map[string]interface{}{"foo": "bar"}
+	for i := 0; i < 10; i++ {
+		key := fmt.Sprintf("%s_%d", t.Name(), i)
+		_, _, err := testDb.Put(key, body)
+		assert.NoError(t, err)
+	}
+
+	attKeys := make([]string, 0, 10)
+	for i := 0; i < 10; i++ {
+		docID := fmt.Sprintf("testDoc-%d", i)
+		attKey := fmt.Sprintf("att-%d", i)
+		attBody := map[string]interface{}{"value": strconv.Itoa(i)}
+		attJSONBody, err := base.JSONMarshal(attBody)
+		assert.NoError(t, err)
+		attKeys = append(attKeys, createLegacyAttachmentDoc(t, testDb, docID, []byte("{}"), attKey, attJSONBody))
+	}
+
+	err := testDb.Bucket.SetRaw("testDocx", 0, []byte("{}"))
+	assert.NoError(t, err)
+
+	time.Sleep(2 * time.Second)
+
+	terminator := make(chan bool)
+	attachmentsMarked, err := Mark(testDb, t.Name(), terminator)
+	assert.NoError(t, err)
+	assert.Equal(t, 10, attachmentsMarked)
+
+	for _, attDocKey := range attKeys {
+		var attachmentData Body
+		_, err = testDb.Bucket.GetXattr(attDocKey, base.SyncXattrName, &attachmentData)
+		assert.NoError(t, err)
+
+		compactID, ok := attachmentData[CompactionIDKey]
+		assert.True(t, ok)
+		assert.Equal(t, t.Name(), compactID)
+	}
+}
+
+func createLegacyAttachmentDoc(t *testing.T, db *Database, docID string, body []byte, attID string, attBody []byte) string {
+	attDigest := Sha1DigestKey(attBody)
+
+	attDocID := MakeAttachmentKey(AttVersion1, docID, attDigest)
+	_, err := db.Bucket.AddRaw(attDocID, 0, attBody)
+	require.NoError(t, err)
+
+	var unmarshalledBody Body
+	err = base.JSONUnmarshal(body, &unmarshalledBody)
+	require.NoError(t, err)
+
+	_, _, err = db.Put(docID, unmarshalledBody)
+	require.NoError(t, err)
+
+	_, err = db.Bucket.WriteUpdateWithXattr(docID, "_sync", "", 0, nil, func(doc []byte, xattr []byte, userXattr []byte, cas uint64) (updatedDoc []byte, updatedXattr []byte, deletedDoc bool, expiry *uint32, err error) {
+		attachmentSyncData := map[string]interface{}{
+			attID: map[string]interface{}{
+				"content_type": "application/json",
+				"digest":       attDigest,
+				"length":       2,
+				"revpos":       2,
+				"stub":         true,
+			},
+		}
+
+		attachmentSyncDataBytes, err := base.JSONMarshal(attachmentSyncData)
+		require.NoError(t, err)
+
+		xattr, err = base.InjectJSONPropertiesFromBytes(xattr, base.KVPairBytes{
+			Key: "attachments",
+			Val: attachmentSyncDataBytes,
+		})
+		require.NoError(t, err)
+
+		return doc, xattr, false, nil, nil
+	})
+	require.NoError(t, err)
+
+	return attDocID
+}

--- a/db/document.go
+++ b/db/document.go
@@ -457,6 +457,22 @@ func UnmarshalDocumentSyncDataFromFeed(data []byte, dataType uint8, userXattrKey
 	return result, body, rawUserXattr, nil, err
 }
 
+func UnmarshalDocumentFromFeed(docid string, cas uint64, data []byte, dataType uint8, userXattrKey string) (doc *Document, err error) {
+	var body []byte
+
+	if dataType&base.MemcachedDataTypeXattr != 0{
+		var syncXattr []byte
+		var userXattr []byte
+		body, syncXattr, userXattr, err = parseXattrStreamData(base.SyncXattrName, userXattrKey, data)
+		if err != nil{
+			return nil, err
+		}
+		return unmarshalDocumentWithXattr(docid, body, syncXattr, userXattr, cas, DocUnmarshalAll)
+	}
+
+	return unmarshalDocument(docid, data)
+}
+
 // parseXattrStreamData returns the raw bytes of the body and the requested xattr (when present) from the raw DCP data bytes.
 // Details on format (taken from https://docs.google.com/document/d/18UVa5j8KyufnLLy29VObbWRtoBn9vs8pcxttuMt6rz8/edit#heading=h.caqiui1pmmmb.):
 /*

--- a/db/document.go
+++ b/db/document.go
@@ -460,11 +460,11 @@ func UnmarshalDocumentSyncDataFromFeed(data []byte, dataType uint8, userXattrKey
 func UnmarshalDocumentFromFeed(docid string, cas uint64, data []byte, dataType uint8, userXattrKey string) (doc *Document, err error) {
 	var body []byte
 
-	if dataType&base.MemcachedDataTypeXattr != 0{
+	if dataType&base.MemcachedDataTypeXattr != 0 {
 		var syncXattr []byte
 		var userXattr []byte
 		body, syncXattr, userXattr, err = parseXattrStreamData(base.SyncXattrName, userXattrKey, data)
-		if err != nil{
+		if err != nil {
 			return nil, err
 		}
 		return unmarshalDocumentWithXattr(docid, body, syncXattr, userXattr, cas, DocUnmarshalAll)

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -40,7 +40,7 @@ licenses/APL2.txt.
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="2594ed1ddc60c95a30b7e3fc76cfeda2cc74b1fd"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="CBG-1468"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="74908f5398d1b5e28a4c8873a7c8931076ad81e3"/>
 
@@ -59,7 +59,7 @@ licenses/APL2.txt.
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="4201f50df22f08f75a0491451fa6507387d41304"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="08f9bc2aa1cb5cb87b9a9bc0f803ddefbc73c5f8"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="CBG-1468"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -40,7 +40,7 @@ licenses/APL2.txt.
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="CBG-1468"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="a5872ff542ba9cf0452528bdbe7ec3f7e90e73d0"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="74908f5398d1b5e28a4c8873a7c8931076ad81e3"/>
 
@@ -59,7 +59,7 @@ licenses/APL2.txt.
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="4201f50df22f08f75a0491451fa6507387d41304"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="CBG-1468"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="1972e5eab603e22c8be5e75cffc6f78de4a8b70c"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 


### PR DESCRIPTION
CBG-1468

- PR for Mark phase of attachment compaction work
- Adds a SetXattr function allowing only an xattr to be updated without the additional work of adding body hash and cas.

## Dependencies
- [x] https://github.com/couchbase/sg-bucket/pull/66
- [x] https://github.com/couchbaselabs/walrus/pull/59
- [ ] https://github.com/couchbase/sync_gateway/pull/5293

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [ ] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/???/
- [ ] `xattrs=false` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/???/