### PR TITLE
CBG-1714: Unsupported and logger config is hidden if not used from config endpoint and migrated startup config

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -281,7 +281,9 @@ func (h *handler) handleGetConfig() error {
 			}
 		}
 
-		cfg.Logging = *base.BuildLoggingConfigFromLoggers(h.server.config.Logging.RedactionLevel, h.server.config.Logging.LogFilePath)
+		if h.server.config.Logging != nil {
+			cfg.Logging = base.BuildLoggingConfigFromLoggers(h.server.config.Logging.RedactionLevel, h.server.config.Logging.LogFilePath)
+		}
 		cfg.Databases = databaseMap
 
 		h.writeJSON(cfg)
@@ -1072,7 +1074,10 @@ func (h *handler) handleSGCollect() error {
 
 	zipFilename := sgcollectFilename()
 
-	logFilePath := h.server.config.Logging.LogFilePath
+	logFilePath := ""
+	if h.server.config.Logging != nil {
+		logFilePath = h.server.config.Logging.LogFilePath
+	}
 
 	if err := sgcollectInstance.Start(logFilePath, h.serialNumber, zipFilename, params); err != nil {
 		return base.HTTPErrorf(http.StatusInternalServerError, "Error running sgcollect_info: %v", err)

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -3314,9 +3314,11 @@ func TestIncludeRuntimeStartupConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check that db revs limit is there now and error logging config
+	require.NotNil(t, runtimeServerConfigResponse.Databases)
 	assert.Contains(t, runtimeServerConfigResponse.Databases, "db")
 	assert.Equal(t, base.Uint32Ptr(100), runtimeServerConfigResponse.Databases["db"].RevsLimit)
 
+	require.NotNil(t, runtimeServerConfigResponse.Logging)
 	assert.NotNil(t, runtimeServerConfigResponse.Logging.Error)
 	assert.Equal(t, "debug", runtimeServerConfigResponse.Logging.Console.LogLevel.String())
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -848,6 +848,9 @@ func envDefaultExpansion(key string, getEnvFn func(string) string) (value string
 
 // SetupAndValidateLogging validates logging config and initializes all logging.
 func (sc *StartupConfig) SetupAndValidateLogging() (err error) {
+	if sc.Logging == nil {
+		sc.Logging = &base.LoggingConfig{}
+	}
 
 	base.SetRedaction(sc.Logging.RedactionLevel)
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -882,7 +882,7 @@ func SetMaxFileDescriptors(maxP *uint64) error {
 
 func (sc *ServerContext) Serve(config *StartupConfig, addr string, handler http.Handler) error {
 	http2Enabled := false
-	if config.Unsupported.HTTP2 != nil && config.Unsupported.HTTP2.Enabled != nil {
+	if config.Unsupported != nil && config.Unsupported.HTTP2 != nil && config.Unsupported.HTTP2.Enabled != nil {
 		http2Enabled = *config.Unsupported.HTTP2.Enabled
 	}
 

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -155,7 +155,6 @@ func (lc *LegacyServerConfig) ToStartupConfig() (*StartupConfig, DbConfigMap, er
 			MetricsInterfaceAuthentication:            lc.MetricsInterfaceAuthentication,
 			EnableAdminAuthenticationPermissionsCheck: lc.EnableAdminAuthenticationPermissionsCheck,
 		},
-		Logging: base.LoggingConfig{},
 		Auth: AuthConfig{
 			BcryptCost: lc.BcryptCost,
 		},
@@ -184,6 +183,8 @@ func (lc *LegacyServerConfig) ToStartupConfig() (*StartupConfig, DbConfigMap, er
 	}
 
 	if lc.Logging != nil {
+		sc.Logging = &base.LoggingConfig{}
+
 		sc.Logging.LogFilePath = lc.Logging.LogFilePath
 		sc.Logging.RedactionLevel = lc.Logging.RedactionLevel
 		sc.Logging.Console = &lc.Logging.Console

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -179,14 +179,6 @@ func (lc *LegacyServerConfig) ToStartupConfig() (*StartupConfig, DbConfigMap, er
 		}
 	}
 
-	if lc.Unsupported != nil {
-		if lc.Unsupported.Http2Config != nil {
-			sc.Unsupported.HTTP2 = &HTTP2Config{
-				Enabled: lc.Unsupported.Http2Config.Enabled,
-			}
-		}
-	}
-
 	if lc.MaxHeartbeat != nil {
 		sc.Replicator.MaxHeartbeat = base.NewConfigDuration(time.Second * time.Duration(*lc.MaxHeartbeat))
 	}
@@ -249,11 +241,17 @@ func (lc *LegacyServerConfig) ToStartupConfig() (*StartupConfig, DbConfigMap, er
 		sc.API.HTTPS.TLSKeyPath = *lc.SSLKey
 	}
 	if lc.Unsupported != nil {
+		sc.Unsupported = &UnsupportedConfig{}
 		if lc.Unsupported.StatsLogFrequencySecs != nil {
 			sc.Unsupported.StatsLogFrequency = base.NewConfigDuration(time.Second * time.Duration(*lc.Unsupported.StatsLogFrequencySecs))
 		}
 		if lc.Unsupported.UseStdlibJSON != nil {
 			sc.Unsupported.UseStdlibJSON = lc.Unsupported.UseStdlibJSON
+		}
+		if lc.Unsupported.Http2Config != nil {
+			sc.Unsupported.HTTP2 = &HTTP2Config{
+				Enabled: lc.Unsupported.Http2Config.Enabled,
+			}
 		}
 	}
 	if lc.MaxFileDescriptors != nil {

--- a/rest/config_legacy_test.go
+++ b/rest/config_legacy_test.go
@@ -26,9 +26,9 @@ func TestLegacyConfigToStartupConfig(t *testing.T) {
 		},
 		{
 			name:     "Override *duration for StatsLogFrequency",
-			base:     StartupConfig{Unsupported: UnsupportedConfig{StatsLogFrequency: base.NewConfigDuration(time.Minute)}},
+			base:     StartupConfig{Unsupported: &UnsupportedConfig{StatsLogFrequency: base.NewConfigDuration(time.Minute)}},
 			input:    LegacyServerConfig{Unsupported: &UnsupportedServerConfigLegacy{StatsLogFrequencySecs: base.UintPtr(10)}},
-			expected: StartupConfig{Unsupported: UnsupportedConfig{StatsLogFrequency: base.NewConfigDuration(time.Second * 10)}},
+			expected: StartupConfig{Unsupported: &UnsupportedConfig{StatsLogFrequency: base.NewConfigDuration(time.Second * 10)}},
 		},
 		{
 			name:     "Override duration zero ServerReadTimeout",
@@ -64,7 +64,7 @@ func TestLegacyConfigToStartupConfig(t *testing.T) {
 			name:     "Override nil *bool HTTP2Enable",
 			base:     StartupConfig{},
 			input:    LegacyServerConfig{Unsupported: &UnsupportedServerConfigLegacy{Http2Config: &HTTP2Config{Enabled: base.BoolPtr(false)}}},
-			expected: StartupConfig{Unsupported: UnsupportedConfig{HTTP2: &HTTP2Config{Enabled: base.BoolPtr(false)}}},
+			expected: StartupConfig{Unsupported: &UnsupportedConfig{HTTP2: &HTTP2Config{Enabled: base.BoolPtr(false)}}},
 		},
 		{
 			name:     "Absent property AdminInterfaceAuthentication",

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -41,7 +41,7 @@ func DefaultStartupConfig(defaultLogFilePath string) StartupConfig {
 			// Post-DP this should be set to base.IsEnterpriseEdition as default
 			EnableAdminAuthenticationPermissionsCheck: base.BoolPtr(false),
 		},
-		Logging: base.LoggingConfig{
+		Logging: &base.LoggingConfig{
 			LogFilePath:    defaultLogFilePath,
 			RedactionLevel: base.DefaultRedactionLevel,
 			Console: &base.ConsoleLoggerConfig{
@@ -60,12 +60,12 @@ func DefaultStartupConfig(defaultLogFilePath string) StartupConfig {
 
 // StartupConfig is the config file used by Sync Gateway in 3.0+ to start up with node-specific settings, and then bootstrap databases via Couchbase Server.
 type StartupConfig struct {
-	Bootstrap   BootstrapConfig    `json:"bootstrap,omitempty"`
-	API         APIConfig          `json:"api,omitempty"`
-	Logging     base.LoggingConfig `json:"logging,omitempty"`
-	Auth        AuthConfig         `json:"auth,omitempty"`
-	Replicator  ReplicatorConfig   `json:"replicator,omitempty"`
-	Unsupported *UnsupportedConfig `json:"unsupported,omitempty"`
+	Bootstrap   BootstrapConfig     `json:"bootstrap,omitempty"`
+	API         APIConfig           `json:"api,omitempty"`
+	Logging     *base.LoggingConfig `json:"logging,omitempty"`
+	Auth        AuthConfig          `json:"auth,omitempty"`
+	Replicator  ReplicatorConfig    `json:"replicator,omitempty"`
+	Unsupported *UnsupportedConfig  `json:"unsupported,omitempty"`
 
 	DatabaseCredentials PerDatabaseCredentialsConfig `json:"database_credentials,omitempty" help:"A map of database name to credentials, that can be used instead of the bootstrap ones."`
 
@@ -199,7 +199,7 @@ func NewEmptyStartupConfig() StartupConfig {
 		API: APIConfig{
 			CORS: &CORSConfig{},
 		},
-		Logging: base.LoggingConfig{
+		Logging: &base.LoggingConfig{
 			Console: &base.ConsoleLoggerConfig{},
 			Error:   &base.FileLoggerConfig{},
 			Warn:    &base.FileLoggerConfig{},

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -51,7 +51,7 @@ func DefaultStartupConfig(defaultLogFilePath string) StartupConfig {
 		Auth: AuthConfig{
 			BcryptCost: auth.DefaultBcryptCost,
 		},
-		Unsupported: UnsupportedConfig{
+		Unsupported: &UnsupportedConfig{
 			StatsLogFrequency: base.NewConfigDuration(time.Minute),
 		},
 		MaxFileDescriptors: DefaultMaxFileDescriptors,
@@ -65,7 +65,7 @@ type StartupConfig struct {
 	Logging     base.LoggingConfig `json:"logging,omitempty"`
 	Auth        AuthConfig         `json:"auth,omitempty"`
 	Replicator  ReplicatorConfig   `json:"replicator,omitempty"`
-	Unsupported UnsupportedConfig  `json:"unsupported,omitempty"`
+	Unsupported *UnsupportedConfig `json:"unsupported,omitempty"`
 
 	DatabaseCredentials PerDatabaseCredentialsConfig `json:"database_credentials,omitempty" help:"A map of database name to credentials, that can be used instead of the bootstrap ones."`
 
@@ -208,7 +208,7 @@ func NewEmptyStartupConfig() StartupConfig {
 			Trace:   &base.FileLoggerConfig{},
 			Stats:   &base.FileLoggerConfig{},
 		},
-		Unsupported: UnsupportedConfig{
+		Unsupported: &UnsupportedConfig{
 			HTTP2: &HTTP2Config{},
 		},
 	}
@@ -232,7 +232,7 @@ func setGlobalConfig(sc *StartupConfig) error {
 	}
 
 	// Given unscoped usage of base.JSON functions, this can't be scoped.
-	if base.BoolDefault(sc.Unsupported.UseStdlibJSON, false) {
+	if sc.Unsupported != nil && base.BoolDefault(sc.Unsupported.UseStdlibJSON, false) {
 		base.Infof(base.KeyAll, "Using the stdlib JSON package")
 		base.UseStdlibJSON = true
 	}

--- a/rest/config_startup_test.go
+++ b/rest/config_startup_test.go
@@ -73,14 +73,14 @@ func TestStartupConfigMerge(t *testing.T) {
 		},
 		{
 			name:     "Keep original *ConsoleLoggerConfig",
-			config:   StartupConfig{Logging: base.LoggingConfig{Console: &base.ConsoleLoggerConfig{LogKeys: []string{"HTTP", "Config", "CRUD", "DCP", "Sync"}}}},
-			override: StartupConfig{Logging: base.LoggingConfig{Console: &base.ConsoleLoggerConfig{}}},
-			expected: StartupConfig{Logging: base.LoggingConfig{Console: &base.ConsoleLoggerConfig{LogKeys: []string{"HTTP", "Config", "CRUD", "DCP", "Sync"}}}},
+			config:   StartupConfig{Logging: &base.LoggingConfig{Console: &base.ConsoleLoggerConfig{LogKeys: []string{"HTTP", "Config", "CRUD", "DCP", "Sync"}}}},
+			override: StartupConfig{Logging: &base.LoggingConfig{Console: &base.ConsoleLoggerConfig{}}},
+			expected: StartupConfig{Logging: &base.LoggingConfig{Console: &base.ConsoleLoggerConfig{LogKeys: []string{"HTTP", "Config", "CRUD", "DCP", "Sync"}}}},
 		}, {
 			name:     "Override empty logging",
-			config:   StartupConfig{Logging: base.LoggingConfig{Trace: &base.FileLoggerConfig{}}},
-			override: StartupConfig{Logging: base.LoggingConfig{Trace: &base.FileLoggerConfig{Enabled: base.BoolPtr(true)}}},
-			expected: StartupConfig{Logging: base.LoggingConfig{Trace: &base.FileLoggerConfig{Enabled: base.BoolPtr(true)}}},
+			config:   StartupConfig{Logging: &base.LoggingConfig{Trace: &base.FileLoggerConfig{}}},
+			override: StartupConfig{Logging: &base.LoggingConfig{Trace: &base.FileLoggerConfig{Enabled: base.BoolPtr(true)}}},
+			expected: StartupConfig{Logging: &base.LoggingConfig{Trace: &base.FileLoggerConfig{Enabled: base.BoolPtr(true)}}},
 		},
 		{
 			name:     "Keep original *CORSconfig",

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -557,7 +557,7 @@ func TestSetupAndValidateLoggingWithLoggingConfig(t *testing.T) {
 	t.Skip("Skipping TestSetupAndValidateLoggingWithLoggingConfig")
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
 	logFilePath := "/var/log/sync_gateway"
-	sc := &StartupConfig{Logging: base.LoggingConfig{LogFilePath: logFilePath, RedactionLevel: base.RedactFull}}
+	sc := &StartupConfig{Logging: &base.LoggingConfig{LogFilePath: logFilePath, RedactionLevel: base.RedactFull}}
 	err := sc.SetupAndValidateLogging()
 	assert.NoError(t, err, "Setup and validate logging should be successful")
 	assert.Equal(t, base.RedactFull, sc.Logging.RedactionLevel)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1044,7 +1044,7 @@ type statsWrapper struct {
 
 func (sc *ServerContext) startStatsLogger() {
 
-	if sc.config.Unsupported.StatsLogFrequency == nil || sc.config.Unsupported.StatsLogFrequency.Value() == 0 {
+	if sc.config.Unsupported == nil || sc.config.Unsupported.StatsLogFrequency == nil || sc.config.Unsupported.StatsLogFrequency.Value() == 0 {
 		// don't start the stats logger when explicitly zero
 		return
 	}


### PR DESCRIPTION
CBG-1714

Unsupported and logger configs in startup config are now pointers and nil checked around the code. 

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [ ] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1258/
