### PR TITLE
CBG-1719: Fixed flakey integration test for TestUnprocessibleDelta

### DIFF
--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -5747,10 +5747,10 @@ func TestReplicatorDoNotSendDeltaWhenSrcIsTombstone(t *testing.T) {
 	activeRT.waitForReplicationStatus(ar.ID, db.ReplicationStateStopped)
 }
 
-// CBG-1672 - Return 422 status for unprocessible deltas instead of 404 to use non-delta retry handling
+// CBG-1672 - Return 422 status for unprocessable deltas instead of 404 to use non-delta retry handling
 // Should log "422 Unable to unmarshal mutable body for doc test deltaSrc=1-dbc7919edc9ec2576d527880186f8e8a"
 // then fall back to full body replication
-func TestUnprocessibleDeltas(t *testing.T) {
+func TestUnprocessableDeltas(t *testing.T) {
 	if !base.IsEnterpriseEdition() {
 		t.Skipf("Requires EE for some delta sync")
 	}

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -5809,23 +5809,15 @@ func TestUnprocessableDeltas(t *testing.T) {
 			DatabaseContext: activeRT.GetDatabase(),
 		},
 		Continuous:          true,
-		ChangesBatchSize:    1,
+		ChangesBatchSize:    200,
 		DeltasEnabled:       true,
 		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), true, false, false).DBReplicatorStats(t.Name()),
 	})
 	assert.Equal(t, "", ar.GetStatus().LastSeqPush)
 	assert.NoError(t, ar.Start())
+	defer func() { assert.NoError(t, ar.Stop()) }()
 
 	err = passiveRT.waitForRev("test", revID)
-	require.NoError(t, err)
-
-	assert.NoError(t, ar.Stop())
-
-	// Make 2nd revision
-	resp = activeRT.SendAdminRequest(http.MethodPut, "/db/test?rev="+revID, `{"field1":"f1_2","field2":"f2_2"}`)
-	assertStatus(t, resp, http.StatusCreated)
-	revID = respRevID(t, resp)
-	err = activeRT.WaitForPendingChanges()
 	require.NoError(t, err)
 
 	rev, err := passiveRT.GetDatabase().GetRevisionCacheForTest().GetActive("test", true)
@@ -5835,13 +5827,16 @@ func TestUnprocessableDeltas(t *testing.T) {
 	rev.BodyBytes = []byte("{invalid}")
 	passiveRT.GetDatabase().GetRevisionCacheForTest().Upsert(rev)
 
-	assert.NoError(t, ar.Start())
+	// Make 2nd revision
+	resp = activeRT.SendAdminRequest(http.MethodPut, "/db/test?rev="+revID, `{"field1":"f1_2","field2":"f2_2"}`)
+	assertStatus(t, resp, http.StatusCreated)
+	revID = respRevID(t, resp)
+	err = activeRT.WaitForPendingChanges()
+	require.NoError(t, err)
 
 	// Check if it replicated
 	err = passiveRT.waitForRev("test", revID)
 	assert.NoError(t, err)
-
-	assert.NoError(t, ar.Stop())
 }
 
 // CBG-1428 - check for regression of ISGR not ignoring _removed:true bodies when purgeOnRemoval is disabled


### PR DESCRIPTION
CBG-1719

Replication is used continuously instead of one shots, along with using a defer to stop the replicator at the end of the function. 

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [ ] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1266/