### PR TITLE
CBG-1514 DCP client with one-shot feed support

### DIFF
--- a/base/bootstrap.go
+++ b/base/bootstrap.go
@@ -40,7 +40,7 @@ func NewCouchbaseCluster(server, username, password,
 		return nil, err
 	}
 
-	authenticatorConfig, _, err := GoCBv2AuthenticatorConfig(
+	authenticatorConfig, err := GoCBv2Authenticator(
 		username, password,
 		x509CertPath, x509KeyPath,
 	)

--- a/base/dcp_client.go
+++ b/base/dcp_client.go
@@ -122,15 +122,17 @@ func (dc *DCPClient) close() {
 
 	// set dc.closing to true, avoid retriggering close if it's already in progress
 	if !dc.closing.CompareAndSwap(false, true) {
+		Infof(KeyDCP, "DCP Client close called - client is already closing")
 		return
 	}
 
 	// Stop workers
 	close(dc.terminator)
 	if dc.agent != nil {
+
 		agentErr := dc.agent.Close()
 		if agentErr != nil {
-			Infof(KeyDCP, "Error closing DCP agent in client close: %v", agentErr)
+			Warnf("Error closing DCP agent in client close: %v", agentErr)
 		}
 	}
 	closeErr := dc.getCloseError()

--- a/base/dcp_client.go
+++ b/base/dcp_client.go
@@ -147,7 +147,10 @@ func (dc *DCPClient) initAgent(spec BucketSpec) error {
 	}
 
 	agentConfig := gocbcore.DCPAgentConfig{}
-	agentConfig.FromConnStr(connStr)
+	connStrError := agentConfig.FromConnStr(connStr)
+	if connStrError != nil {
+		return fmt.Errorf("Unable to start DCP Client - error building conn str: %v", connStrError)
+	}
 
 	auth, authErr := spec.GocbcoreAuthProvider()
 	if authErr != nil {

--- a/base/dcp_client.go
+++ b/base/dcp_client.go
@@ -1,0 +1,364 @@
+package base
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/couchbase/gocbcore/v10"
+	"github.com/couchbase/gocbcore/v10/memd"
+	sgbucket "github.com/couchbase/sg-bucket"
+)
+
+//
+
+const openStreamTimeout = 30 * time.Second
+const openRetryCount = 10
+const defaultNumWorkers = 8
+
+type endStreamCallbackFunc func(e endStreamEvent)
+
+type DCPClient struct {
+	ID                string                         // unique ID for DCPClient - used for DCP stream name, must be unique
+	agent             *gocbcore.DCPAgent             // SDK DCP agent, manages connections and calls back to DCPClient stream observer implementation
+	callback          sgbucket.FeedEventCallbackFunc // Callback invoked on DCP mutations/deletions
+	workers           []*DCPWorker                   // Workers for concurrent processing of incoming mutations and callback.  vbuckets are partitioned across workers
+	spec              BucketSpec                     // Bucket spec for the target data store
+	numVbuckets       uint16                         // number of vbuckets on target data store
+	terminator        chan bool                      // Used to close worker goroutines spawned by the DCPClient
+	doneChannel       chan error                     // Returns nil on successful completion of one-shot feed or external close of feed, error otherwise
+	metadata          DCPMetadataStore               // Implementation of DCPMetadataStore for metadata persistence
+	activeVbuckets    map[uint16]struct{}            // vbuckets that have an open stream
+	activeVbucketLock sync.Mutex                     // Synchronization for activeVbuckets
+	oneShot           bool                           // Whether DCP feed should be one-shot
+	endSeqNos         []uint64                       // endSeqNos for one-shot DCP feeds
+	closing           AtomicBool                     // Set when the client is closing (either due to internal or external request)
+	closeError        error                          // Will be set to a non-nil value for unexpected error
+	closeErrorLock    sync.Mutex                     // Synchronization on close error
+}
+
+type DCPClientOptions struct {
+	NumWorkers  int
+	OneShot     bool
+	OneShotDone chan struct{}
+}
+
+func NewDCPClient(ID string, callback sgbucket.FeedEventCallbackFunc, options DCPClientOptions, store CouchbaseStore) (*DCPClient, error) {
+
+	numWorkers := defaultNumWorkers
+	if options.NumWorkers > 0 {
+		numWorkers = options.NumWorkers
+	}
+	numVbuckets, err := store.GetMaxVbno()
+	if err != nil {
+		return nil, fmt.Errorf("Unable to determine maxVbNo when creating DCP client: %w", err)
+	}
+
+	client := &DCPClient{
+		workers:     make([]*DCPWorker, numWorkers),
+		numVbuckets: numVbuckets,
+		callback:    callback,
+		ID:          ID,
+		spec:        store.GetSpec(),
+		terminator:  make(chan bool),
+		doneChannel: make(chan error),
+	}
+
+	// Initialize active vbuckets
+	client.activeVbuckets = make(map[uint16]struct{})
+	for vbNo := uint16(0); vbNo < numVbuckets; vbNo++ {
+		client.activeVbuckets[vbNo] = struct{}{}
+	}
+
+	// TODO: option to specify metadata implementation in DCPClientOptions
+	client.metadata = NewDCPMetadataMem(numVbuckets)
+
+	if options.OneShot {
+		_, highSeqnos, statsErr := store.GetStatsVbSeqno(numVbuckets, true)
+		if statsErr != nil {
+			return nil, fmt.Errorf("Unable to obtain high seqnos for one-shot DCP feed: %w", statsErr)
+		}
+
+		// Set endSeqNos on client for use by stream observer
+		client.endSeqNos = make([]uint64, client.numVbuckets)
+		for i := uint16(0); i < client.numVbuckets; i++ {
+			client.endSeqNos[i] = highSeqnos[i]
+		}
+
+		// Set endSeqNos on client metadata for use when opening streams
+		client.metadata.SetEndSeqNos(highSeqnos)
+	}
+
+	return client, nil
+}
+
+func (dc *DCPClient) Start() (doneChan chan error, err error) {
+
+	err = dc.initAgent(dc.spec)
+	if err != nil {
+		return nil, err
+	}
+	dc.startWorkers()
+
+	for i := uint16(0); i < dc.numVbuckets; i++ {
+		openErr := dc.openStream(i)
+		if err != nil {
+			return nil, fmt.Errorf("Unable to start DCP client, error opening stream for vb %d: %w", i, openErr)
+		}
+	}
+	return dc.doneChannel, nil
+}
+
+// Close is used externally to stop the DCP client. If the client was already closed due to error, returns that error
+func (dc *DCPClient) Close() error {
+	dc.close()
+	return dc.getCloseError()
+}
+
+// close is used internally to stop the DCP client.  Sends any fatal errors to the client's done channel, and
+// closes that channel.
+func (dc *DCPClient) close() {
+
+	// set dc.closing to true, avoid retriggering close if it's already in progress
+	if !dc.closing.CompareAndSwap(false, true) {
+		return
+	}
+
+	// Stop workers
+	close(dc.terminator)
+	if dc.agent != nil {
+		agentErr := dc.agent.Close()
+		if agentErr != nil {
+			Infof(KeyDCP, "Error closing DCP agent in client close: %v", agentErr)
+		}
+	}
+	closeErr := dc.getCloseError()
+	if closeErr != nil {
+		dc.doneChannel <- closeErr
+	}
+	close(dc.doneChannel)
+}
+
+func (dc *DCPClient) initAgent(spec BucketSpec) error {
+	connStr, err := spec.GetGoCBConnString()
+	if err != nil {
+		return err
+	}
+
+	agentConfig := gocbcore.DCPAgentConfig{}
+	agentConfig.FromConnStr(connStr)
+
+	auth, authErr := spec.GocbcoreAuthProvider()
+	if authErr != nil {
+		return fmt.Errorf("Unable to start DCP Client - error creating authenticator: %w", authErr)
+	}
+
+	// Force poolsize to 1, multiple clients results in DCP naming collision
+	agentConfig.KVConfig.PoolSize = 1
+	agentConfig.BucketName = spec.BucketName
+	agentConfig.DCPConfig.AgentPriority = gocbcore.DcpAgentPriorityLow
+	agentConfig.SecurityConfig.Auth = auth
+	agentConfig.UserAgent = "SyncGatewayDCP"
+
+	flags := memd.DcpOpenFlagProducer
+	flags |= memd.DcpOpenFlagIncludeXattrs
+	var agentErr error
+	dc.agent, agentErr = gocbcore.CreateDcpAgent(&agentConfig, dc.ID, flags)
+	if agentErr != nil {
+		return fmt.Errorf("Unable to start DCP client - error creating agent: %w", agentErr)
+	}
+
+	// Wait for agent to be ready
+	var waitError error
+	for i := 0; i < 10; i++ {
+		waitError = nil
+		agentReadyErr := make(chan error)
+		_, err = dc.agent.WaitUntilReady(
+			time.Now().Add(30*time.Second),
+			gocbcore.WaitUntilReadyOptions{},
+			func(_ *gocbcore.WaitUntilReadyResult, err error) {
+				agentReadyErr <- err
+			})
+		if err != nil {
+			waitError = fmt.Errorf("WaitUntilReady for dcp agent returned error (%d): %w", i, err)
+			continue
+		}
+		err = <-agentReadyErr
+		if err != nil {
+			waitError = fmt.Errorf("WaitUntilReady error channel for dcp agent returned error (%d): %w", i, err)
+			continue
+		}
+		if waitError == nil {
+			break
+		}
+
+	}
+	if waitError != nil {
+		return waitError
+	}
+
+	return nil
+}
+
+func (dc *DCPClient) workerForVbno(vbNo uint16) *DCPWorker {
+	workerIndex := int(vbNo % uint16(len(dc.workers)))
+	return dc.workers[workerIndex]
+}
+
+// startWorkers initializes the DCP workers to receive stream events from eventFeed
+func (dc *DCPClient) startWorkers() {
+
+	// vbuckets are assigned to workers as vbNo % NumWorkers.  Create set of assigned vbuckets
+	assignedVbs := make(map[int][]uint16)
+	for workerIndex, _ := range dc.workers {
+		assignedVbs[workerIndex] = make([]uint16, 0)
+	}
+
+	for vbNo := uint16(0); vbNo < dc.numVbuckets; vbNo++ {
+		workerIndex := int(vbNo % uint16(len(dc.workers)))
+		assignedVbs[workerIndex] = append(assignedVbs[workerIndex], vbNo)
+	}
+
+	//
+	for index, _ := range dc.workers {
+		dc.workers[index] = NewDCPWorker(dc.metadata, dc.callback, dc.onStreamEnd, dc.terminator, nil, nil)
+		dc.workers[index].Start()
+	}
+}
+
+func (dc *DCPClient) openStream(vbID uint16) (err error) {
+
+	for i := 0; i < openRetryCount; i++ {
+		// Cancel open for stopped client
+		select {
+		case <-dc.terminator:
+			return nil
+		default:
+		}
+
+		err = dc.openStreamRequest(vbID)
+		if err == nil {
+			return nil
+		}
+
+		switch {
+		case errors.Is(err, gocbcore.ErrMemdRollback):
+			Infof(KeyDCP, "Open stream for vbID %d failed due to rollback since last open, will rollback metadata and retry", vbID)
+			err := dc.rollback(vbID)
+			if err != nil {
+				return fmt.Errorf("metadata rollback failed for vb %d: %v", vbID, err)
+			}
+		case errors.Is(err, gocbcore.ErrShutdown):
+			Warnf("Closing stream for vbID %d, agent has been shut down", vbID)
+			return err
+		case errors.Is(err, ErrTimeout):
+			Debugf(KeyDCP, "Timeout attempting to open stream for vb %d, will retry", vbID)
+		default:
+			Warnf("Unexpected error opening stream for vbID %d: %v", vbID, err)
+			return err
+		}
+	}
+
+	return fmt.Errorf("openStream failed to complete after %d attempts, last error: %w", openRetryCount, err)
+}
+
+func (dc *DCPClient) rollback(vbID uint16) (err error) {
+	// retrieve new vbuuid
+	// reset meta
+	return nil
+}
+
+// openStreamRequest issues the OpenStream request, but doesn't perform any error handling.  Callers
+// should generally use openStream() for error and retry handling
+func (dc *DCPClient) openStreamRequest(vbID uint16) error {
+
+	vbMeta := dc.metadata.GetMeta(vbID)
+
+	// filter options are only scope + collection selection
+	options := gocbcore.OpenStreamOptions{}
+
+	openStreamError := make(chan error)
+	openStreamCallback := func(f []gocbcore.FailoverEntry, err error) {
+		if err == nil {
+			dc.metadata.SetFailoverEntries(vbID, f)
+		}
+		openStreamError <- err
+	}
+	_, openErr := dc.agent.OpenStream(vbID,
+		memd.DcpStreamAddFlagActiveOnly,
+		vbMeta.vbUUID,
+		vbMeta.startSeqNo,
+		vbMeta.endSeqNo,
+		vbMeta.snapStartSeqNo,
+		vbMeta.snapEndSeqNo,
+		dc,
+		options,
+		openStreamCallback)
+
+	if openErr != nil {
+		return openErr
+	}
+
+	select {
+	case err := <-openStreamError:
+		return err
+	case <-time.After(openStreamTimeout):
+		return ErrTimeout
+	}
+}
+
+func (dc *DCPClient) deactivateVbucket(vbID uint16) {
+	dc.activeVbucketLock.Lock()
+	delete(dc.activeVbuckets, vbID)
+	activeCount := len(dc.activeVbuckets)
+	dc.activeVbucketLock.Unlock()
+	if activeCount == 0 {
+		dc.close()
+	}
+}
+
+func (dc *DCPClient) onStreamEnd(e endStreamEvent) {
+
+	if e.err == nil {
+		Debugf(KeyDCP, "Stream (vb:%d) closed, all items streamed", e.vbID)
+		dc.deactivateVbucket(e.vbID)
+		return
+	}
+
+	if errors.Is(e.err, gocbcore.ErrDCPStreamClosed) {
+		Debugf(KeyDCP, "Stream (vb:%d) closed by DCPClient", e.vbID)
+	}
+
+	if errors.Is(e.err, gocbcore.ErrDCPStreamStateChanged) || errors.Is(e.err, gocbcore.ErrDCPStreamTooSlow) ||
+		errors.Is(e.err, gocbcore.ErrDCPStreamDisconnected) {
+		Infof(KeyDCP, "Stream (vb:%d) closed by server, will reconnect.  Reason: %v", e.vbID, e.err)
+		err := dc.openStream(e.vbID)
+		if err != nil {
+			dc.fatalError(fmt.Errorf("Stream (vb:%d) failed to reopen: %w", e.vbID, err))
+		}
+		return
+	}
+
+	dc.fatalError(fmt.Errorf("Stream (vb:%d) ended with unknown error: %w", e.vbID, e.err))
+}
+
+func (dc *DCPClient) fatalError(err error) {
+	Errorf("DCP client failed with error, closing: %v", err)
+	dc.setCloseError(err)
+	dc.close()
+}
+
+func (dc *DCPClient) setCloseError(err error) {
+	dc.closeErrorLock.Lock()
+	defer dc.closeErrorLock.Unlock()
+	if dc.closeError == nil {
+		dc.closeError = err
+	}
+}
+
+func (dc *DCPClient) getCloseError() error {
+	dc.closeErrorLock.Lock()
+	defer dc.closeErrorLock.Unlock()
+	return dc.closeError
+}

--- a/base/dcp_client_metadata.go
+++ b/base/dcp_client_metadata.go
@@ -1,0 +1,81 @@
+package base
+
+import (
+	"math"
+
+	"github.com/couchbase/gocbcore/v10"
+)
+
+type DCPMetadata struct {
+	vbUUID          gocbcore.VbUUID
+	startSeqNo      gocbcore.SeqNo
+	endSeqNo        gocbcore.SeqNo
+	snapStartSeqNo  gocbcore.SeqNo
+	snapEndSeqNo    gocbcore.SeqNo
+	failoverEntries []gocbcore.FailoverEntry
+}
+
+type DCPMetadataStore interface {
+	Rollback(vbID uint16)
+	GetMeta(vbID uint16) DCPMetadata
+	SetEndSeqNos(map[uint16]uint64)
+	SetSnapshot(e snapshotEvent)
+	UpdateSeq(vbNo uint16, seq uint64)
+	SetFailoverEntries(vbNo uint16, entries []gocbcore.FailoverEntry)
+}
+
+type DCPMetadataMem struct {
+	metadata  []DCPMetadata
+	endSeqNos []gocbcore.SeqNo
+}
+
+func NewDCPMetadataMem(numVbuckets uint16) *DCPMetadataMem {
+	m := &DCPMetadataMem{
+		metadata:  make([]DCPMetadata, numVbuckets),
+		endSeqNos: make([]gocbcore.SeqNo, numVbuckets),
+	}
+	for vbNo := uint16(0); vbNo < numVbuckets; vbNo++ {
+		m.metadata[vbNo] = DCPMetadata{
+			failoverEntries: make([]gocbcore.FailoverEntry, 0),
+			endSeqNo:        math.MaxUint64,
+		}
+	}
+	return m
+}
+
+func (m *DCPMetadataMem) Rollback(vbID uint16) {
+	m.metadata[vbID] = DCPMetadata{
+		vbUUID:          0,
+		startSeqNo:      0,
+		endSeqNo:        m.endSeqNos[vbID],
+		snapStartSeqNo:  0,
+		snapEndSeqNo:    0,
+		failoverEntries: make([]gocbcore.FailoverEntry, 0),
+	}
+}
+
+func (m *DCPMetadataMem) GetMeta(vbNo uint16) DCPMetadata {
+	return m.metadata[vbNo]
+}
+
+func (m *DCPMetadataMem) SetSnapshot(e snapshotEvent) {
+	m.metadata[e.vbID].snapStartSeqNo = gocbcore.SeqNo(e.startSeq)
+	m.metadata[e.vbID].snapEndSeqNo = gocbcore.SeqNo(e.endSeq)
+}
+
+func (m *DCPMetadataMem) UpdateSeq(vbNo uint16, seq uint64) {
+	m.metadata[vbNo].startSeqNo = gocbcore.SeqNo(seq)
+}
+
+func (m *DCPMetadataMem) SetFailoverEntries(vbNo uint16, fe []gocbcore.FailoverEntry) {
+	m.metadata[vbNo].failoverEntries = fe
+}
+
+// SetEndSeqNos will update the metadata endSeqNos to the values provided.  Vbuckets not
+// present in the endSeqNos map will have their endSeqNo set to zero.
+func (m *DCPMetadataMem) SetEndSeqNos(endSeqNos map[uint16]uint64) {
+	for i := 0; i < len(m.metadata); i++ {
+		endSeqNo, _ := endSeqNos[uint16(i)]
+		m.metadata[i].endSeqNo = gocbcore.SeqNo(endSeqNo)
+	}
+}

--- a/base/dcp_client_stream_event.go
+++ b/base/dcp_client_stream_event.go
@@ -1,0 +1,75 @@
+package base
+
+import (
+	"github.com/couchbase/gocbcore/v10"
+	sgbucket "github.com/couchbase/sg-bucket"
+)
+
+type streamEvent interface {
+	VbID() uint16
+}
+
+type streamEventCommon struct {
+	vbID     uint16
+	streamID uint16
+}
+
+func (sec streamEventCommon) VbID() uint16 {
+	return sec.vbID
+}
+
+type snapshotEvent struct {
+	streamEventCommon
+	startSeq     uint64
+	endSeq       uint64
+	snapshotType gocbcore.SnapshotState
+}
+
+type mutationEvent struct {
+	streamEventCommon
+	seq      uint64
+	flags    uint32
+	expiry   uint32
+	cas      uint64
+	datatype uint8
+	key      []byte
+	value    []byte
+}
+
+func (e mutationEvent) asFeedEvent() sgbucket.FeedEvent {
+	return sgbucket.FeedEvent{
+		Opcode:   sgbucket.FeedOpMutation,
+		Flags:    e.flags,
+		Expiry:   e.expiry,
+		Key:      e.key,
+		Value:    e.value,
+		DataType: e.datatype,
+		Cas:      e.cas,
+		VbNo:     e.vbID,
+	}
+}
+
+type deletionEvent struct {
+	streamEventCommon
+	seq      uint64
+	cas      uint64
+	datatype uint8
+	key      []byte
+	value    []byte
+}
+
+func (e deletionEvent) asFeedEvent() sgbucket.FeedEvent {
+	return sgbucket.FeedEvent{
+		Opcode:   sgbucket.FeedOpDeletion,
+		Key:      e.key,
+		Value:    e.value,
+		DataType: e.datatype,
+		Cas:      e.cas,
+		VbNo:     e.vbID,
+	}
+}
+
+type endStreamEvent struct {
+	streamEventCommon
+	err error
+}

--- a/base/dcp_client_stream_observer.go
+++ b/base/dcp_client_stream_observer.go
@@ -1,0 +1,135 @@
+package base
+
+import (
+	"github.com/couchbase/gocbcore/v10"
+)
+
+// DCPClient implementation of the gocbcore.StreamObserver interface.  Primarily routes events
+// to the DCPClient's workers to be processed, but performs the following additional functionality:
+//   - key-based filtering for document-based events (Deletion, Expiration, Mutation)
+//   - stream End handling, including restart on error
+func (dc *DCPClient) SnapshotMarker(snapshotMarker gocbcore.DcpSnapshotMarker) {
+
+	e := snapshotEvent{
+		streamEventCommon: streamEventCommon{
+			vbID:     snapshotMarker.VbID,
+			streamID: snapshotMarker.StreamID,
+		},
+		startSeq:     snapshotMarker.StartSeqNo,
+		endSeq:       snapshotMarker.EndSeqNo,
+		snapshotType: snapshotMarker.SnapshotType,
+	}
+	dc.workerForVbno(snapshotMarker.VbID).Send(e)
+}
+
+func (dc *DCPClient) Mutation(mutation gocbcore.DcpMutation) {
+	if dc.afterEndSeq(mutation.VbID, mutation.SeqNo) {
+		return
+	}
+
+	if dc.filteredKey(mutation.Key) {
+		return
+	}
+
+	e := mutationEvent{
+		streamEventCommon: streamEventCommon{
+			vbID:     mutation.VbID,
+			streamID: mutation.StreamID,
+		},
+		seq:      mutation.SeqNo,
+		flags:    mutation.Flags,
+		expiry:   mutation.Expiry,
+		cas:      mutation.Cas,
+		datatype: mutation.Datatype,
+		key:      mutation.Key,
+		value:    mutation.Value,
+	}
+	dc.workerForVbno(mutation.VbID).Send(e)
+}
+
+func (dc *DCPClient) Deletion(deletion gocbcore.DcpDeletion) {
+	if dc.afterEndSeq(deletion.VbID, deletion.SeqNo) {
+		return
+	}
+
+	if dc.filteredKey(deletion.Key) {
+		return
+	}
+
+	e := deletionEvent{
+		streamEventCommon: streamEventCommon{
+			vbID:     deletion.VbID,
+			streamID: deletion.StreamID,
+		},
+		seq:      deletion.SeqNo,
+		cas:      deletion.Cas,
+		datatype: deletion.Datatype,
+		key:      deletion.Key,
+		value:    deletion.Value,
+	}
+	dc.workerForVbno(deletion.VbID).Send(e)
+
+}
+
+//
+func (dc *DCPClient) End(end gocbcore.DcpStreamEnd, err error) {
+
+	e := endStreamEvent{
+		streamEventCommon: streamEventCommon{
+			vbID:     end.VbID,
+			streamID: end.StreamID,
+		},
+		err: err}
+	dc.workerForVbno(end.VbID).Send(e)
+
+}
+
+func (dc *DCPClient) Expiration(expiration gocbcore.DcpExpiration) {
+	// Not used by SG at this time
+}
+
+func (dc *DCPClient) CreateCollection(creation gocbcore.DcpCollectionCreation) {
+	// Not used by SG at this time
+}
+
+func (dc *DCPClient) DeleteCollection(deletion gocbcore.DcpCollectionDeletion) {
+	// Not used by SG at this time
+}
+
+func (dc *DCPClient) FlushCollection(flush gocbcore.DcpCollectionFlush) {
+	// Not used by SG at this time
+}
+
+func (dc *DCPClient) CreateScope(creation gocbcore.DcpScopeCreation) {
+	// Not used by SG at this time
+}
+
+func (dc *DCPClient) DeleteScope(deletion gocbcore.DcpScopeDeletion) {
+	// Not used by SG at this time
+}
+
+func (dc *DCPClient) ModifyCollection(modification gocbcore.DcpCollectionModification) {
+	// Not used by SG at this time
+}
+
+func (dc *DCPClient) OSOSnapshot(snapshot gocbcore.DcpOSOSnapshot) {
+	// Not used by SG at this time
+}
+
+func (dc *DCPClient) SeqNoAdvanced(seqNoAdvanced gocbcore.DcpSeqNoAdvanced) {
+	// Not used by SG at this time
+}
+
+// A one-shot DCP feed specifies the endSeq when opening the stream, but Couchbase Server only ends the DCP stream
+// when it reaches the end of a snapshot that is greater than or equal to the endSeq value.  DCPClient should not
+// process any sequences in that final snapshot that are greater than endSeq - afterEndSeq provides that additional check.
+func (dc *DCPClient) afterEndSeq(vbID uint16, seq uint64) bool {
+	if len(dc.endSeqNos) > 0 && dc.endSeqNos[vbID] < seq {
+		return true
+	}
+	return false
+}
+
+func (dc *DCPClient) filteredKey(key []byte) bool {
+	return false
+}

--- a/base/dcp_client_test.go
+++ b/base/dcp_client_test.go
@@ -1,0 +1,136 @@
+package base
+
+import (
+	"fmt"
+	"log"
+	"sync"
+	"testing"
+	"time"
+
+	sgbucket "github.com/couchbase/sg-bucket"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOneShotDCP(t *testing.T) {
+
+	bucket := GetTestBucket(t)
+	defer bucket.Close()
+
+	num_docs := 1000
+	// write documents to bucket
+	body := map[string]interface{}{"foo": "bar"}
+	for i := 0; i < num_docs; i++ {
+		key := fmt.Sprintf("%s_%d", t.Name(), i)
+		err := bucket.Set(key, 0, body)
+		assert.NoError(t, err)
+	}
+
+	// create callback
+	mutationCount := 0
+	counterCallback := func(event sgbucket.FeedEvent) bool {
+		mutationCount++
+		return false
+	}
+
+	// start one shot feed
+	store, ok := AsCouchbaseStore(bucket)
+	assert.True(t, ok)
+	feedID := t.Name()
+	clientOptions := DCPClientOptions{
+		OneShot: true,
+	}
+
+	dcpClient, err := NewDCPClient(feedID, counterCallback, clientOptions, store)
+	assert.NoError(t, err)
+
+	// Add additional documents in a separate goroutine, to verify afterEndSeq handling
+	var additionalDocsWg sync.WaitGroup
+	additionalDocsWg.Add(1)
+	go func() {
+		updatedBody := map[string]interface{}{"foo": "bar"}
+		for i := num_docs; i < num_docs*2; i++ {
+			key := fmt.Sprintf("%s_%d", t.Name(), i)
+			err := bucket.Set(key, 0, updatedBody)
+			assert.NoError(t, err)
+		}
+		additionalDocsWg.Done()
+	}()
+
+	doneChan, startErr := dcpClient.Start()
+	assert.NoError(t, startErr)
+
+	defer func() {
+		_ = dcpClient.Close()
+	}()
+
+	// wait for done
+	timeout := time.After(3 * time.Second)
+	select {
+	case err := <-doneChan:
+		assert.Equal(t, num_docs, mutationCount)
+		assert.NoError(t, err)
+	case <-timeout:
+		t.Errorf("timeout waiting for one-shot feed to complete")
+	}
+
+	additionalDocsWg.Wait()
+}
+
+func TestTerminateDCPFeed(t *testing.T) {
+
+	bucket := GetTestBucket(t)
+	defer bucket.Close()
+
+	// create callback
+	mutationCount := 0
+	counterCallback := func(event sgbucket.FeedEvent) bool {
+		log.Printf("got mutation for: %s (vb: %d)", event.Key, event.VbNo)
+		mutationCount++
+		return false
+	}
+
+	// start continuous feed with terminator
+	store, ok := AsCouchbaseStore(bucket)
+	assert.True(t, ok)
+	feedID := t.Name()
+
+	dcpClient, err := NewDCPClient(feedID, counterCallback, DCPClientOptions{}, store)
+	assert.NoError(t, err)
+
+	// Add documents in a separate goroutine
+	feedClosed := false
+	var additionalDocsWg sync.WaitGroup
+	additionalDocsWg.Add(1)
+	go func() {
+		updatedBody := map[string]interface{}{"foo": "bar"}
+		for i := 0; i < 10000; i++ {
+			if feedClosed {
+				break
+			}
+			key := fmt.Sprintf("%s_%d", t.Name(), i)
+			err := bucket.Set(key, 0, updatedBody)
+			assert.NoError(t, err)
+		}
+		additionalDocsWg.Done()
+	}()
+
+	doneChan, startErr := dcpClient.Start()
+	assert.NoError(t, startErr)
+
+	// Wait for some processing to complete, then close the feed
+	time.Sleep(10 * time.Millisecond)
+	err = dcpClient.Close()
+	assert.NoError(t, err)
+
+	// wait for done
+	timeout := time.After(3 * time.Second)
+	select {
+	case <-doneChan:
+		feedClosed = true
+	case <-timeout:
+		t.Errorf("timeout waiting for one-shot feed to complete")
+	}
+
+	additionalDocsWg.Wait()
+}

--- a/base/dcp_client_test.go
+++ b/base/dcp_client_test.go
@@ -14,6 +14,10 @@ import (
 
 func TestOneShotDCP(t *testing.T) {
 
+	if UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+
 	bucket := GetTestBucket(t)
 	defer bucket.Close()
 
@@ -78,6 +82,10 @@ func TestOneShotDCP(t *testing.T) {
 }
 
 func TestTerminateDCPFeed(t *testing.T) {
+
+	if UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
 
 	bucket := GetTestBucket(t)
 	defer bucket.Close()

--- a/base/dcp_client_worker.go
+++ b/base/dcp_client_worker.go
@@ -1,0 +1,121 @@
+package base
+
+import (
+	"bytes"
+
+	sgbucket "github.com/couchbase/sg-bucket"
+)
+
+// DCP Worker manages checkpoint persistence and adds a configurable level of concurrency when
+// processing a feed.  gocb's DCPAgent opens one pipeline per server node (by default, can be increased
+// via kvPoolSize).  Increasing the number of workers allows SG to increase the level of concurrent processing without
+// adding additional load on the server.
+// DCPWorker are also single-threaded and guarantee ordered processing of DCP events within a given vbucket.
+//
+// DCPWorker queues incoming mutations in a buffered channel (eventFeed).  The main worker goroutine
+// works this channel and synchronously invokes the mutationCallback for mutations or deletions.
+type DCPWorker struct {
+	endSeqNos             []uint64
+	eventFeed             chan streamEvent
+	terminator            chan bool
+	checkpointPrefixBytes []byte
+	mutationCallback      sgbucket.FeedEventCallbackFunc
+	endStreamCallback     endStreamCallbackFunc
+	ignoreDeletes         bool
+	metadata              DCPMetadataStore
+	pendingSnapshot       map[uint16]snapshotEvent
+}
+
+const defaultQueueLength = 10
+
+type DCPWorkerOptions struct {
+	eventQueueLength int
+	ignoreDeletes    bool
+}
+
+func NewDCPWorker(metadata DCPMetadataStore, mutationCallback sgbucket.FeedEventCallbackFunc, endCallback endStreamCallbackFunc, terminator chan bool, endSeqNos []uint64, options *DCPWorkerOptions) *DCPWorker {
+
+	// Create a buffered channel for queueing incoming DCP events
+	queueLength := defaultQueueLength
+	if options != nil && options.eventQueueLength > 0 {
+		queueLength = options.eventQueueLength
+	}
+	eventQueue := make(chan streamEvent, queueLength)
+
+	return &DCPWorker{
+		eventFeed:             eventQueue,
+		terminator:            terminator,
+		endSeqNos:             endSeqNos,
+		checkpointPrefixBytes: []byte(DCPCheckpointPrefix),
+		mutationCallback:      mutationCallback,
+		endStreamCallback:     endCallback,
+		ignoreDeletes:         options != nil && options.ignoreDeletes,
+		metadata:              metadata,
+		pendingSnapshot:       make(map[uint16]snapshotEvent),
+	}
+}
+
+// Send accepts incoming events from the DCP client and adds to the worker's buffered feed, to be processed by the main worker goroutine
+func (w *DCPWorker) Send(event streamEvent) {
+	select {
+	case w.eventFeed <- event:
+	case <-w.terminator:
+		Infof(KeyDCP, "Closing DCP worker, DCP Client was closed")
+	}
+}
+
+func (w *DCPWorker) Start() {
+
+	go func() {
+		for {
+			select {
+			case event := <-w.eventFeed:
+				vbID := event.VbID()
+				switch e := event.(type) {
+				case snapshotEvent:
+					// Set pending snapshot - don't persist to meta until we receive first sequence in the snapshot,
+					// to avoid attempting to restart with a new snapshot and old sequence value
+					w.pendingSnapshot[vbID] = e
+				case mutationEvent:
+					if w.mutationCallback != nil {
+						w.mutationCallback(e.asFeedEvent())
+					}
+					w.updateSeq(e.key, vbID, e.seq)
+				case deletionEvent:
+					if w.mutationCallback != nil && !w.ignoreDeletes {
+						w.mutationCallback(e.asFeedEvent())
+					}
+					w.updateSeq(e.key, vbID, e.seq)
+				case endStreamEvent:
+					w.endStreamCallback(e)
+				}
+			case <-w.terminator:
+				w.Close()
+				return
+			}
+		}
+	}()
+}
+
+func (w *DCPWorker) checkPendingSnapshot(vbID uint16) {
+	if snapshot, ok := w.pendingSnapshot[vbID]; ok {
+		w.metadata.SetSnapshot(snapshot)
+		delete(w.pendingSnapshot, vbID)
+	}
+}
+
+func (w *DCPWorker) updateSeq(key []byte, vbID uint16, seq uint64) {
+	// Ignore DCP checkpoint documents
+	if bytes.HasPrefix(key, w.checkpointPrefixBytes) {
+		return
+	}
+
+	// TODO: update snapshot and seq in a single atomic update
+	w.checkPendingSnapshot(vbID)
+	w.metadata.UpdateSeq(vbID, seq)
+
+}
+
+func (w *DCPWorker) Close() {
+	// cleanup persistence
+}

--- a/base/dcp_dest.go
+++ b/base/dcp_dest.go
@@ -54,7 +54,7 @@ func init() {
 
 type SGDest interface {
 	cbgt.Dest
-	initFeed(backfillType uint64) error
+	initFeed(backfillType uint64) (map[uint16]uint64, error)
 }
 
 // DCPDest implements SGDest (superset of cbgt.Dest) interface to manage updates coming from a
@@ -600,6 +600,6 @@ func (d *DCPLoggingDest) Stats(w io.Writer) error {
 	return d.dest.Stats(w)
 }
 
-func (d *DCPLoggingDest) initFeed(backfillType uint64) error {
+func (d *DCPLoggingDest) initFeed(backfillType uint64) (map[uint16]uint64, error) {
 	return d.dest.initFeed(backfillType)
 }

--- a/base/dcp_receiver.go
+++ b/base/dcp_receiver.go
@@ -255,7 +255,7 @@ func StartDCPFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArguments, c
 	}
 
 	// Initialize the feed based on the backfill type
-	feedInitErr := dcpReceiver.initFeed(args.Backfill)
+	_, feedInitErr := dcpReceiver.initFeed(args.Backfill)
 	if feedInitErr != nil {
 		return feedInitErr
 	}

--- a/base/error.go
+++ b/base/error.go
@@ -46,6 +46,7 @@ var (
 	ErrImportCancelledPurged = &sgError{"Import Cancelled Due to Purge"}
 	ErrChannelFeed           = &sgError{"Error while building channel feed"}
 	ErrXattrNotFound         = &sgError{"Xattr Not Found"}
+	ErrTimeout               = &sgError{"Operation timed out"}
 
 	// ErrPartialViewErrors is returned if the view call contains any partial errors.
 	// This is more of a warning, and inspecting ViewResult.Errors is required for detail.

--- a/base/gocb_utils.go
+++ b/base/gocb_utils.go
@@ -26,22 +26,22 @@ func GoCBv2SecurityConfig(tlsSkipVerify *bool, caCertPath string) (sc gocb.Secur
 	return sc, nil
 }
 
-// GoCBv2AuthenticatorConfig returns a gocb.Authenticator to use when connecting given a set of credentials.
-func GoCBv2AuthenticatorConfig(username, password, certPath, keyPath string) (a gocb.Authenticator, isX509 bool, err error) {
+// GoCBv2Authenticator returns a gocb.Authenticator to use when connecting given a set of credentials.
+func GoCBv2Authenticator(username, password, certPath, keyPath string) (a gocb.Authenticator, err error) {
 	if certPath != "" && keyPath != "" {
 		cert, certLoadErr := tls.LoadX509KeyPair(certPath, keyPath)
 		if certLoadErr != nil {
-			return nil, false, err
+			return nil, certLoadErr
 		}
 		return gocb.CertificateAuthenticator{
 			ClientCertificate: &cert,
-		}, true, nil
+		}, nil
 	}
 
 	return gocb.PasswordAuthenticator{
 		Username: username,
 		Password: password,
-	}, false, nil
+	}, nil
 }
 
 // GoCBv2TimeoutsConfig returns a gocb.TimeoutsConfig to use when connecting.

--- a/base/main_test_cluster.go
+++ b/base/main_test_cluster.go
@@ -176,9 +176,9 @@ func getCluster(server string) *gocb.Cluster {
 		Fatalf("Couldn't initialize cluster security config: %v", err)
 	}
 
-	authenticatorConfig, _, err := GoCBv2AuthenticatorConfig(TestClusterUsername(), TestClusterPassword(), spec.Certpath, spec.Keypath)
-	if err != nil {
-		Fatalf("Couldn't initialize cluster authenticator config: %v", err)
+	authenticatorConfig, authErr := GoCBv2Authenticator(TestClusterUsername(), TestClusterPassword(), spec.Certpath, spec.Keypath)
+	if authErr != nil {
+		Fatalf("Couldn't initialize cluster authenticator config: %v", authErr)
 	}
 
 	timeoutsConfig := GoCBv2TimeoutsConfig(spec.BucketOpTimeout, StdlibDurationPtr(spec.GetViewQueryTimeout()))


### PR DESCRIPTION
Adds a new DCP client based on the gocb v2 DCP library, with support for running a one-shot DCP feed.

CBG-1514


