### PR TITLE
CBG-1735: Hook up attachment compaction to REST API

### DIFF
--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -318,9 +318,6 @@ func (a *AttachmentCompactionManager) Run(options map[string]interface{}, termin
 		return err
 	}
 
-	a.lock.Lock()
-	defer a.lock.Unlock()
-
 	return nil
 }
 

--- a/db/database.go
+++ b/db/database.go
@@ -83,37 +83,38 @@ const BGTCompletionMaxWait = 30 * time.Second
 // Basic description of a database. Shared between all Database objects on the same database.
 // This object is thread-safe so it can be shared between HTTP handlers.
 type DatabaseContext struct {
-	Name                       string                  // Database name
-	UUID                       string                  // UUID for this database instance. Used by cbgt and sgr
-	Bucket                     base.Bucket             // Storage
-	BucketSpec                 base.BucketSpec         // The BucketSpec
-	BucketLock                 sync.RWMutex            // Control Access to the underlying bucket object
-	mutationListener           changeListener          // Caching feed listener
-	ImportListener             *importListener         // Import feed listener
-	sequences                  *sequenceAllocator      // Source of new sequence numbers
-	ChannelMapper              *channels.ChannelMapper // Runs JS 'sync' function
-	StartTime                  time.Time               // Timestamp when context was instantiated
-	RevsLimit                  uint32                  // Max depth a document's revision tree can grow to
-	autoImport                 bool                    // Add sync data to new untracked couchbase server docs?  (Xattr mode specific)
-	revisionCache              RevisionCache           // Cache of recently-accessed doc revisions
-	changeCache                *changeCache            // Cache of recently-access channels
-	EventMgr                   *EventManager           // Manages notification events
-	AllowEmptyPassword         bool                    // Allow empty passwords?  Defaults to false
-	Options                    DatabaseContextOptions  // Database Context Options
-	AccessLock                 sync.RWMutex            // Allows DB offline to block until synchronous calls have completed
-	State                      uint32                  // The runtime state of the DB from a service perspective
-	ResyncManager              *BackgroundManager
-	TombstoneCompactionManager *BackgroundManager
-	ExitChanges                chan struct{}            // Active _changes feeds on the DB will close when this channel is closed
-	OIDCProviders              auth.OIDCProviderMap     // OIDC clients
-	PurgeInterval              time.Duration            // Metadata purge interval
-	serverUUID                 string                   // UUID of the server, if available
-	DbStats                    *base.DbStats            // stats that correspond to this database context
-	CompactState               uint32                   // Status of database compaction
-	terminator                 chan bool                // Signal termination of background goroutines
-	backgroundTasks            []BackgroundTask         // List of background tasks that are initiated.
-	activeChannels             *channels.ActiveChannels // Tracks active replications by channel
-	CfgSG                      cbgt.Cfg                 // Sync Gateway cluster shared config
+	Name                        string                  // Database name
+	UUID                        string                  // UUID for this database instance. Used by cbgt and sgr
+	Bucket                      base.Bucket             // Storage
+	BucketSpec                  base.BucketSpec         // The BucketSpec
+	BucketLock                  sync.RWMutex            // Control Access to the underlying bucket object
+	mutationListener            changeListener          // Caching feed listener
+	ImportListener              *importListener         // Import feed listener
+	sequences                   *sequenceAllocator      // Source of new sequence numbers
+	ChannelMapper               *channels.ChannelMapper // Runs JS 'sync' function
+	StartTime                   time.Time               // Timestamp when context was instantiated
+	RevsLimit                   uint32                  // Max depth a document's revision tree can grow to
+	autoImport                  bool                    // Add sync data to new untracked couchbase server docs?  (Xattr mode specific)
+	revisionCache               RevisionCache           // Cache of recently-accessed doc revisions
+	changeCache                 *changeCache            // Cache of recently-access channels
+	EventMgr                    *EventManager           // Manages notification events
+	AllowEmptyPassword          bool                    // Allow empty passwords?  Defaults to false
+	Options                     DatabaseContextOptions  // Database Context Options
+	AccessLock                  sync.RWMutex            // Allows DB offline to block until synchronous calls have completed
+	State                       uint32                  // The runtime state of the DB from a service perspective
+	ResyncManager               *BackgroundManager
+	TombstoneCompactionManager  *BackgroundManager
+	AttachmentCompactionManager *BackgroundManager
+	ExitChanges                 chan struct{}            // Active _changes feeds on the DB will close when this channel is closed
+	OIDCProviders               auth.OIDCProviderMap     // OIDC clients
+	PurgeInterval               time.Duration            // Metadata purge interval
+	serverUUID                  string                   // UUID of the server, if available
+	DbStats                     *base.DbStats            // stats that correspond to this database context
+	CompactState                uint32                   // Status of database compaction
+	terminator                  chan bool                // Signal termination of background goroutines
+	backgroundTasks             []BackgroundTask         // List of background tasks that are initiated.
+	activeChannels              *channels.ActiveChannels // Tracks active replications by channel
+	CfgSG                       cbgt.Cfg                 // Sync Gateway cluster shared config
 	//CfgSG                        *base.CfgSG              // Sync Gateway cluster shared config
 	SGReplicateMgr               *sgReplicateManager // Manages interactions with sg-replicate replications
 	Heartbeater                  base.Heartbeater    // Node heartbeater for SG cluster awareness
@@ -559,6 +560,7 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 
 	dbContext.ResyncManager = NewResyncManager()
 	dbContext.TombstoneCompactionManager = NewTombstoneCompactionManager()
+	dbContext.AttachmentCompactionManager = NewAttachmentCompactionManager()
 
 	return dbContext, nil
 }

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -2457,7 +2457,7 @@ func TestTombstoneCompactionStopWithManager(t *testing.T) {
 	callbackFunc := func() {
 		queryCount++
 		if queryCount == 2 {
-			db.TombstoneCompactionManager.Stop()
+			assert.NoError(t, db.TombstoneCompactionManager.Stop())
 		}
 	}
 
@@ -2471,7 +2471,7 @@ func TestTombstoneCompactionStopWithManager(t *testing.T) {
 		})
 	}
 
-	db.TombstoneCompactionManager.Start(map[string]interface{}{"database": db})
+	assert.NoError(t, db.TombstoneCompactionManager.Start(map[string]interface{}{"database": db}))
 
 	waitAndAssertCondition(t, func() bool {
 		return db.TombstoneCompactionManager.GetRunState() == BackgroundProcessStateStopped

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -9204,7 +9204,7 @@ func TestTombstoneCompactionAPI(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, db.BackgroundProcessStateStopped, tombstoneCompactionStatus.State)
-	assert.Equal(t, nil, tombstoneCompactionStatus.LastError)
+	assert.Empty(t, tombstoneCompactionStatus.LastErrorMessage)
 	assert.Equal(t, 0, int(tombstoneCompactionStatus.DocsPurged))
 
 	resp = rt.SendAdminRequest("POST", "/db/_compact", "")
@@ -9227,7 +9227,7 @@ func TestTombstoneCompactionAPI(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, db.BackgroundProcessStateStopped, tombstoneCompactionStatus.State)
-	assert.Equal(t, nil, tombstoneCompactionStatus.LastError)
+	assert.Empty(t, tombstoneCompactionStatus.LastErrorMessage)
 
 	if base.TestUseXattrs() {
 		assert.Equal(t, 100, int(tombstoneCompactionStatus.DocsPurged))

--- a/rest/attachment_compaction_api_test.go
+++ b/rest/attachment_compaction_api_test.go
@@ -1,0 +1,180 @@
+package rest
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAttachmentCompactionAPI(t *testing.T) {
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+
+	// Perform GET before compact has been ran, ensure it starts in valid 'stopped' state
+	resp := rt.SendAdminRequest("GET", "/db/_compact?type=attachment", "")
+	assertStatus(t, resp, http.StatusOK)
+
+	var response db.AttachmentManagerResponse
+	err := base.JSONUnmarshal(resp.BodyBytes(), &response)
+	assert.NoError(t, err)
+	assert.Equal(t, db.BackgroundProcessStateStopped, response.State)
+	assert.Equal(t, int64(0), response.MarkedAttachments)
+	assert.Equal(t, int64(0), response.PurgedAttachments)
+	assert.Nil(t, response.LastError)
+
+	// Kick off compact
+	resp = rt.SendAdminRequest("POST", "/db/_compact?type=attachment", "")
+	assertStatus(t, resp, http.StatusOK)
+
+	// Attempt to kick off again and validate it correctly errors
+	resp = rt.SendAdminRequest("POST", "/db/_compact?type=attachment", "")
+	assertStatus(t, resp, http.StatusServiceUnavailable)
+
+	// Wait for run to complete
+	err = rt.WaitForCondition(func() bool {
+		time.Sleep(1 * time.Second)
+
+		resp := rt.SendAdminRequest("GET", "/db/_compact?type=attachment", "")
+		assertStatus(t, resp, http.StatusOK)
+
+		var response db.AttachmentManagerResponse
+		err = base.JSONUnmarshal(resp.BodyBytes(), &response)
+		assert.NoError(t, err)
+
+		return response.State == db.BackgroundProcessStateStopped
+	})
+	assert.NoError(t, err)
+
+	// Create some legacy attachments to be marked but not compacted
+	for i := 0; i < 20; i++ {
+		docID := fmt.Sprintf("testDoc-%d", i)
+		attID := fmt.Sprintf("testAtt-%d", i)
+		attBody := map[string]interface{}{"value": strconv.Itoa(i)}
+		attJSONBody, err := base.JSONMarshal(attBody)
+		assert.NoError(t, err)
+		CreateLegacyAttachmentDoc(t, &db.Database{DatabaseContext: rt.GetDatabase()}, docID, []byte("{}"), attID, attJSONBody)
+	}
+
+	// Create some 'unmarked' attachments
+	makeUnmarkedDoc := func(docid string) {
+		err := rt.GetDatabase().Bucket.SetRaw(docid, 0, []byte("{}"))
+		assert.NoError(t, err)
+	}
+
+	for i := 0; i < 5; i++ {
+		docID := fmt.Sprintf("%s%s%d", base.AttPrefix, "unmarked", i)
+		makeUnmarkedDoc(docID)
+	}
+
+	// Start attachment compaction run
+	resp = rt.SendAdminRequest("POST", "/db/_compact?type=attachment", "")
+	assertStatus(t, resp, http.StatusOK)
+
+	// Wait for run to complete
+	err = rt.WaitForCondition(func() bool {
+		time.Sleep(1 * time.Second)
+
+		resp := rt.SendAdminRequest("GET", "/db/_compact?type=attachment", "")
+		assertStatus(t, resp, http.StatusOK)
+
+		var response db.AttachmentManagerResponse
+		err = base.JSONUnmarshal(resp.BodyBytes(), &response)
+		assert.NoError(t, err)
+
+		return response.State == db.BackgroundProcessStateStopped
+	})
+	assert.NoError(t, err)
+
+	// Validate results of GET
+	resp = rt.SendAdminRequest("GET", "/db/_compact?type=attachment", "")
+	assertStatus(t, resp, http.StatusOK)
+
+	err = base.JSONUnmarshal(resp.BodyBytes(), &response)
+	assert.NoError(t, err)
+	assert.Equal(t, db.BackgroundProcessStateStopped, response.State)
+	assert.Equal(t, int64(20), response.MarkedAttachments)
+	assert.Equal(t, int64(5), response.PurgedAttachments)
+	assert.Nil(t, response.LastError)
+
+	// Start another run
+	resp = rt.SendAdminRequest("POST", "/db/_compact?type=attachment", "")
+	assertStatus(t, resp, http.StatusOK)
+
+	// Attempt to terminate that run
+	resp = rt.SendAdminRequest("POST", "/db/_compact?type=attachment&action=stop", "")
+	assertStatus(t, resp, http.StatusOK)
+
+	// Verify it has been marked as 'stopping'
+	resp = rt.SendAdminRequest("GET", "/db/_compact?type=attachment", "")
+	assertStatus(t, resp, http.StatusOK)
+
+	err = base.JSONUnmarshal(resp.BodyBytes(), &response)
+	assert.NoError(t, err)
+	assert.Equal(t, db.BackgroundProcessStateStopping, response.State)
+
+	// Wait for run to complete
+	err = rt.WaitForCondition(func() bool {
+		time.Sleep(1 * time.Second)
+
+		resp := rt.SendAdminRequest("GET", "/db/_compact?type=attachment", "")
+		assertStatus(t, resp, http.StatusOK)
+
+		var response db.AttachmentManagerResponse
+		err = base.JSONUnmarshal(resp.BodyBytes(), &response)
+		assert.NoError(t, err)
+
+		return response.State == db.BackgroundProcessStateStopped
+	})
+	assert.NoError(t, err)
+
+}
+
+func CreateLegacyAttachmentDoc(t *testing.T, testDB *db.Database, docID string, body []byte, attID string, attBody []byte) string {
+	attDigest := db.Sha1DigestKey(attBody)
+
+	attDocID := db.MakeAttachmentKey(db.AttVersion1, docID, attDigest)
+	_, err := testDB.Bucket.AddRaw(attDocID, 0, attBody)
+	require.NoError(t, err)
+
+	var unmarshalledBody db.Body
+	err = base.JSONUnmarshal(body, &unmarshalledBody)
+	require.NoError(t, err)
+
+	_, _, err = testDB.Put(docID, unmarshalledBody)
+	require.NoError(t, err)
+
+	_, err = testDB.Bucket.WriteUpdateWithXattr(docID, base.SyncXattrName, "", 0, nil, func(doc []byte, xattr []byte, userXattr []byte, cas uint64) (updatedDoc []byte, updatedXattr []byte, deletedDoc bool, expiry *uint32, err error) {
+		attachmentSyncData := map[string]interface{}{
+			attID: map[string]interface{}{
+				"content_type": "application/json",
+				"digest":       attDigest,
+				"length":       2,
+				"revpos":       2,
+				"stub":         true,
+			},
+		}
+
+		attachmentSyncDataBytes, err := base.JSONMarshal(attachmentSyncData)
+		require.NoError(t, err)
+
+		xattr, err = base.InjectJSONPropertiesFromBytes(xattr, base.KVPairBytes{
+			Key: "attachments",
+			Val: attachmentSyncDataBytes,
+		})
+		require.NoError(t, err)
+
+		return doc, xattr, false, nil, nil
+	})
+	require.NoError(t, err)
+
+	return attDocID
+}

--- a/rest/attachment_compaction_api_test.go
+++ b/rest/attachment_compaction_api_test.go
@@ -14,7 +14,10 @@ import (
 )
 
 func TestAttachmentCompactionAPI(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
 
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
@@ -29,7 +32,7 @@ func TestAttachmentCompactionAPI(t *testing.T) {
 	assert.Equal(t, db.BackgroundProcessStateStopped, response.State)
 	assert.Equal(t, int64(0), response.MarkedAttachments)
 	assert.Equal(t, int64(0), response.PurgedAttachments)
-	assert.Nil(t, response.LastError)
+	assert.Empty(t, response.LastErrorMessage)
 
 	// Kick off compact
 	resp = rt.SendAdminRequest("POST", "/db/_compact?type=attachment", "")
@@ -103,7 +106,7 @@ func TestAttachmentCompactionAPI(t *testing.T) {
 	assert.Equal(t, db.BackgroundProcessStateStopped, response.State)
 	assert.Equal(t, int64(20), response.MarkedAttachments)
 	assert.Equal(t, int64(5), response.PurgedAttachments)
-	assert.Nil(t, response.LastError)
+	assert.Empty(t, response.LastErrorMessage)
 
 	// Start another run
 	resp = rt.SendAdminRequest("POST", "/db/_compact?type=attachment", "")


### PR DESCRIPTION
CBG-1735
 - Hooks up the attachment compaction work to the REST API
 - Utilizes the new Generic API interface
 - Tweaked the generic interface a little to have start / stop return errors so that it can manage state internally fully and return errors when a function is invalid... Such as requesting that an already running function is started again

## Dependencies
- [x] https://github.com/couchbase/sync_gateway/pull/5290

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [ ] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/???/
- [ ] `xattrs=false` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/???/