### PR TITLE
Restore retry on GetCollectionFromCluster

### DIFF
--- a/base/collection.go
+++ b/base/collection.go
@@ -94,9 +94,7 @@ func GetCollectionFromCluster(cluster *gocb.Cluster, spec BucketSpec, waitUntilR
 
 	// Connect to bucket
 	bucket := cluster.Bucket(spec.BucketName)
-	err := bucket.WaitUntilReady(time.Duration(waitUntilReadySeconds)*time.Second, &gocb.WaitUntilReadyOptions{
-		RetryStrategy: &goCBv2FailFastRetryStrategy{},
-	})
+	err := bucket.WaitUntilReady(time.Duration(waitUntilReadySeconds)*time.Second, nil)
 	if err != nil {
 		_ = cluster.Close(&gocb.ClusterCloseOptions{})
 		if errors.Is(err, gocb.ErrAuthenticationFailure) {


### PR DESCRIPTION
Restores retry handling on collection open, to handle cases where bucket exists but isn't ready.  

Breaks immediate auth check handling on db creation - may need to revisit the work in CBG-1619 to switch retry policy in a more narrow range of scenarios.