### PR TITLE
Added trace logging to TestLocalWinsConflictResolution

### DIFF
--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -4701,7 +4701,7 @@ func TestLocalWinsConflictResolution(t *testing.T) {
 			if base.GTestBucketPool.NumUsableBuckets() < 2 {
 				t.Skipf("test requires at least 2 usable test buckets")
 			}
-			defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD)()
+			defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
 
 			activeRT, remoteRT, remoteURLString, teardown := setupSGRPeers(t)
 			defer teardown()


### PR DESCRIPTION
Part of CBG-1621 to find out more information about what is causing the error when it does happen.

Added trace logging to TestLocalWinsConflictResolution