### PR TITLE
CBG-1731 Forward-port fix for go-couchbase TLS handling to Lithium

### DIFF
--- a/base/dcp_receiver.go
+++ b/base/dcp_receiver.go
@@ -278,13 +278,12 @@ func StartDCPFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArguments, c
 	auth := spec.Auth
 
 	// If using client certificate for authentication, configure go-couchbase for cbdatasource's initial
-	// connection to retrieve cluster configuration.
+	// connection to retrieve cluster configuration.  go-couchbase doesn't support handling
+	// x509 auth and root ca verification as separate concerns.
 	if spec.Certpath != "" && spec.Keypath != "" {
 		couchbase.SetCertFile(spec.Certpath)
 		couchbase.SetKeyFile(spec.Keypath)
 		auth = NoPasswordAuthHandler{Handler: spec.Auth}
-	}
-	if spec.CACertPath != "" {
 		couchbase.SetRootFile(spec.CACertPath)
 		couchbase.SetSkipVerify(false)
 	}

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -118,12 +118,11 @@ func createCBGTIndex(c *CbgtContext, dbName string, bucket Bucket, spec BucketSp
 	//       how this can be optimized if we're not actually using it in the indexImpl
 	indexParams := `{"name": "` + dbName + `"}`
 
-	// Required for initial pools request, before BucketDataSourceOptions kick in
+	// Required for initial pools request, before BucketDataSourceOptions kick in.
+	// go-couchbase doesn't support handling x509 auth and root ca verification as separate concerns.
 	if spec.Certpath != "" && spec.Keypath != "" {
 		couchbase.SetCertFile(spec.Certpath)
 		couchbase.SetKeyFile(spec.Keypath)
-	}
-	if spec.CACertPath != "" {
 		couchbase.SetRootFile(spec.CACertPath)
 		couchbase.SetSkipVerify(false)
 	}


### PR DESCRIPTION
go-couchbase requires that x509 auth and cacert validation be handled together.  Required until we completely move off go-couchbase DCP client.

CBG-1731


## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/view/Build/job/sync-gateway-integration/1280/
  - filed CBG-1743
