### PR TITLE
Allow empty artifacts without failing the build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -403,7 +403,7 @@ pipeline {
         }
         unstable {
             // archive non-verbose outputs upon failure for inspection (each verbose output is conditionally archived on stage failure)
-            archiveArtifacts excludes: 'verbose_*.out', artifacts: '*.out', fingerprint: false
+            archiveArtifacts excludes: 'verbose_*.out', artifacts: '*.out', fingerprint: false, allowEmptyArchive: true
             script {
                 if ("${env.BRANCH_NAME}" == 'master') {
                     mail to: 'mobile_dev_sg@couchbase.com',
@@ -414,7 +414,7 @@ pipeline {
         }
         failure {
             // archive non-verbose outputs upon failure for inspection (each verbose output is conditionally archived on stage failure)
-            archiveArtifacts excludes: 'verbose_*.out', artifacts: '*.out', fingerprint: false
+            archiveArtifacts excludes: 'verbose_*.out', artifacts: '*.out', fingerprint: false, allowEmptyArchive: true
             script {
                 if ("${env.BRANCH_NAME}" == 'master') {
                     mail to: 'mobile_dev_sg@couchbase.com',


### PR DESCRIPTION
Avoids the build failing for a 2nd reason if we fall into an `unstable` or `failure` case and try to collect artifacts that we've already collected in specific stages (like litecore)

```
Archiving artifacts
‘*.out’ doesn’t match anything
```

Seen here:
http://uberjenkins.sc.couchbase.com:8080/blue/organizations/jenkins/_sync-gateway_github_pipeline%2Fsync_gateway/detail/master/1244/pipeline 