### PR TITLE
CBG-1738: Add fail-fast retry strategy for handleCreateDb

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -76,7 +76,7 @@ func (h *handler) handleCreateDB() error {
 		h.server.lock.Lock()
 		defer h.server.lock.Unlock()
 
-		_, err = h.server._applyConfig(loadedConfig)
+		_, err = h.server._applyConfig(loadedConfig, true)
 		if err != nil {
 			if errors.Is(err, base.ErrAuthError) {
 				return base.HTTPErrorf(http.StatusForbidden, "auth failure accessing provided bucket: %s", bucket)
@@ -525,7 +525,7 @@ func (h *handler) handlePutDbConfig() (err error) {
 	h.server.dbConfigs[dbName] = updatedDbConfig
 
 	// TODO: Dynamic update instead of reload
-	if _, err := h.server._reloadDatabaseFromConfig(dbName); err != nil {
+	if _, err := h.server._reloadDatabaseFromConfig(dbName, false); err != nil {
 		return err
 	}
 
@@ -611,7 +611,7 @@ func (h *handler) handleDeleteDbConfigSync() error {
 	h.server.dbConfigs[dbName] = updatedDbConfig
 
 	// TODO: Dynamic update instead of reload
-	if _, err := h.server._reloadDatabaseFromConfig(dbName); err != nil {
+	if _, err := h.server._reloadDatabaseFromConfig(dbName, false); err != nil {
 		return err
 	}
 
@@ -678,7 +678,7 @@ func (h *handler) handlePutDbConfigSync() error {
 	h.server.dbConfigs[dbName] = updatedDbConfig
 
 	// TODO: Dynamic update instead of reload
-	if _, err := h.server._reloadDatabaseFromConfig(dbName); err != nil {
+	if _, err := h.server._reloadDatabaseFromConfig(dbName, false); err != nil {
 		return err
 	}
 
@@ -762,7 +762,7 @@ func (h *handler) handleDeleteDbConfigImportFilter() error {
 	h.server.dbConfigs[dbName] = updatedDbConfig
 
 	// TODO: Dynamic update instead of reload
-	if _, err := h.server._reloadDatabaseFromConfig(dbName); err != nil {
+	if _, err := h.server._reloadDatabaseFromConfig(dbName, false); err != nil {
 		return err
 	}
 
@@ -829,7 +829,7 @@ func (h *handler) handlePutDbConfigImportFilter() error {
 	h.server.dbConfigs[dbName] = updatedDbConfig
 
 	// TODO: Dynamic update instead of reload
-	if _, err := h.server._reloadDatabaseFromConfig(dbName); err != nil {
+	if _, err := h.server._reloadDatabaseFromConfig(dbName, false); err != nil {
 		return err
 	}
 

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -148,7 +148,7 @@ func TestGetOrAddDatabaseFromConfig(t *testing.T) {
 
 	// Get or add database name from config without valid database name; throws 400 Illegal database name error
 	dbConfig := DbConfig{OldRevExpirySeconds: &oldRevExpirySeconds, LocalDocExpirySecs: &localDocExpirySecs}
-	dbContext, err := serverContext._getOrAddDatabaseFromConfig(DatabaseConfig{DbConfig: dbConfig}, false)
+	dbContext, err := serverContext._getOrAddDatabaseFromConfig(DatabaseConfig{DbConfig: dbConfig}, false, false)
 	assert.Nil(t, dbContext, "Can't create database context without a valid database name")
 	assert.Error(t, err, "It should throw 400 Illegal database name")
 	assert.Contains(t, err.Error(), strconv.Itoa(http.StatusBadRequest))
@@ -167,7 +167,7 @@ func TestGetOrAddDatabaseFromConfig(t *testing.T) {
 		BucketConfig:        BucketConfig{Server: &server, Bucket: &bucketName},
 	}
 
-	dbContext, err = serverContext._getOrAddDatabaseFromConfig(DatabaseConfig{DbConfig: dbConfig}, false)
+	dbContext, err = serverContext._getOrAddDatabaseFromConfig(DatabaseConfig{DbConfig: dbConfig}, false, false)
 	assert.Nil(t, dbContext, "Can't create database context from config with unrecognized value for import_docs")
 	assert.Error(t, err, "It should throw Unrecognized value for import_docs")
 
@@ -185,14 +185,14 @@ func TestGetOrAddDatabaseFromConfig(t *testing.T) {
 		LocalDocExpirySecs:  &localDocExpirySecs,
 		AutoImport:          false}
 
-	dbContext, err = serverContext._getOrAddDatabaseFromConfig(DatabaseConfig{DbConfig: dbConfig}, false)
+	dbContext, err = serverContext._getOrAddDatabaseFromConfig(DatabaseConfig{DbConfig: dbConfig}, false, false)
 	assert.Nil(t, dbContext, "Can't create database context with duplicate database name")
 	assert.Error(t, err, "It should throw 412 Duplicate database names")
 	assert.Contains(t, err.Error(), strconv.Itoa(http.StatusPreconditionFailed))
 
 	// Get or add database from config with duplicate database name and useExisting as true
 	// Existing database context should be returned
-	dbContext, err = serverContext._getOrAddDatabaseFromConfig(DatabaseConfig{DbConfig: dbConfig}, true)
+	dbContext, err = serverContext._getOrAddDatabaseFromConfig(DatabaseConfig{DbConfig: dbConfig}, true, false)
 	assert.NoError(t, err, "No error while trying to get the existing database name")
 	assert.Equal(t, server, dbContext.BucketSpec.Server)
 	assert.Equal(t, bucketName, dbContext.BucketSpec.BucketName)


### PR DESCRIPTION
CBG-1738

Add fail-fast retry strategy for `handleCreateDb`.

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1284/
  - `TestAttachmentCompactionAPI` CBG-1743
  - `TestLogFlush` unknown but opened #5303 to gather data in future
