### PR TITLE
Improve assertion in TestLogFlush for better failure reporting

### DIFF
--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -626,16 +626,16 @@ func TestLogFlush(t *testing.T) {
 				}
 
 				if testCase.ExpectedLogFileCount == len(files) {
-					return false, nil, nil
+					return false, nil, files
 				}
 
-				return true, nil, nil
+				return true, nil, files
 			}
 
 			sleeper := base.CreateSleeperFunc(200, 100)
-			err, _ = base.RetryLoop("Wait for log files", worker, sleeper)
-			require.NoError(t, err)
-
+			err, files := base.RetryLoop("Wait for log files", worker, sleeper)
+			assert.NoError(t, err)
+			assert.Len(t, files, testCase.ExpectedLogFileCount)
 		})
 	}
 


### PR DESCRIPTION
Return the list of files in `TestLogFlush` for an actual assertion on them so we can see why the retry loop failed.

Seen a one-off fail here but didn't have enough information to see why: http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1284

## Before

```
--- FAIL: TestLogFlush (20.07s)
    --- FAIL: TestLogFlush/Default (20.07s)
        require.go:794: 
            	Error Trace:	server_context_test.go:637
            	Error:      	Received unexpected error:
            	            	RetryLoop for Wait for log files giving up after 201 attempts
            	Test:       	TestLogFlush/Default
```

## After

```
    server_context_test.go:637: 
        	Error Trace:	server_context_test.go:637
        	Error:      	Received unexpected error:
        	            	RetryLoop for Wait for log files giving up after 201 attempts
        	Test:       	TestLogFlush/Default
    server_context_test.go:638: 
        	Error Trace:	server_context_test.go:638
        	Error:      	"[sg_error.log sg_info.log sg_warn.log]" should have 4 item(s), but has 3
        	Test:       	TestLogFlush/Default
2021-10-20T10:41:04.168+01:00 [INF] rest.TestLogFlush.func5: Reset logging
    --- FAIL: TestLogFlush/Default (20.66s)
```