### PR TITLE
CBG-1754: Guest user is now migrated from legacy configs

### DIFF
--- a/rest/config_legacy_test.go
+++ b/rest/config_legacy_test.go
@@ -10,11 +10,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 
-	"github.com/couchbase/sync_gateway/base"
 	"github.com/stretchr/testify/assert"
-
 	"github.com/stretchr/testify/require"
 )
 

--- a/rest/config_legacy_test.go
+++ b/rest/config_legacy_test.go
@@ -1,9 +1,16 @@
 package rest
 
 import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/couchbase/sync_gateway/db"
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/stretchr/testify/assert"
@@ -266,4 +273,62 @@ func TestSGReplicateValidation(t *testing.T) {
 	_, err := readLegacyServerConfig(configReader)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), errText)
+}
+
+// CBG-1754 - Guest user not enabled during legacy config migration
+func TestLegacyGuestUserMigration(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("CBS required")
+	}
+
+	expected := db.PrincipalConfig{
+		ExplicitChannels: base.SetFromArray([]string{"*"}),
+		Disabled:         base.BoolPtr(false),
+	}
+
+	tb := base.GetTestBucket(t)
+	defer tb.Close()
+
+	config := `
+	{
+		"server_tls_skip_verify": ` + strconv.FormatBool(base.TestTLSSkipVerify()) + `,
+		"interface": ":4444",
+		"adminInterface": ":4445",
+		"databases": {
+			"db": {
+				"server": "%s",
+				"username": "%s",
+				"password": "%s",
+				"bucket": "%s",
+				"users": {
+					"GUEST": {
+						"disabled": false,
+						"admin_channels": ["*"]
+					}
+				}
+			}
+		}
+	}`
+
+	config = fmt.Sprintf(config, base.UnitTestUrl(), base.TestClusterUsername(), base.TestClusterPassword(), tb.GetName())
+
+	tmpDir, err := ioutil.TempDir("", t.Name())
+	require.NoError(t, err)
+	defer func() { require.NoError(t, os.RemoveAll(tmpDir)) }()
+
+	configPath := filepath.Join(tmpDir, "config.json")
+	err = ioutil.WriteFile(configPath, []byte(config), os.FileMode(0644))
+	require.NoError(t, err)
+
+	sc, _, err := automaticConfigUpgrade(configPath)
+	require.NoError(t, err)
+
+	cluster, err := createCouchbaseClusterFromStartupConfig(sc)
+	require.NoError(t, err)
+
+	var dbConfig DbConfig
+	_, err = cluster.GetConfig(tb.GetName(), persistentConfigDefaultGroupID, &dbConfig)
+	require.NoError(t, err)
+
+	assert.Equal(t, &expected, dbConfig.Guest)
 }

--- a/rest/main.go
+++ b/rest/main.go
@@ -284,8 +284,11 @@ func sanitizeDbConfigs(configMap DbConfigMap) (DbConfigMap, error) {
 		dbConfig.CertPath = ""
 		dbConfig.KeyPath = ""
 		dbConfig.CACertPath = ""
-		dbConfig.Users = nil
 		dbConfig.Roles = nil
+		// Keep guest user only
+		guestUser := dbConfig.Users["GUEST"]
+		dbConfig.Users = nil
+		dbConfig.Guest = guestUser
 
 		// Make sure any updates are written back to the config
 		configMap[dbName] = dbConfig

--- a/rest/main.go
+++ b/rest/main.go
@@ -207,6 +207,12 @@ func automaticConfigUpgrade(configPath string) (sc *StartupConfig, disablePersis
 			return nil, false, err
 		}
 
+		// Return users and roles separate from config
+		_ = dbc.Users // TODO: CBG-1751
+		_ = dbc.Roles
+		dbc.Roles = nil
+		dbc.Users = nil
+
 		configGroupID := persistentConfigDefaultGroupID
 		if startupConfig.Bootstrap.ConfigGroupID != "" {
 			configGroupID = startupConfig.Bootstrap.ConfigGroupID
@@ -284,11 +290,6 @@ func sanitizeDbConfigs(configMap DbConfigMap) (DbConfigMap, error) {
 		dbConfig.CertPath = ""
 		dbConfig.KeyPath = ""
 		dbConfig.CACertPath = ""
-		dbConfig.Roles = nil
-		// Keep guest user only
-		guestUser := dbConfig.Users["GUEST"]
-		dbConfig.Users = nil
-		dbConfig.Guest = guestUser
 
 		// Make sure any updates are written back to the config
 		configMap[dbName] = dbConfig


### PR DESCRIPTION
CBG-1754

- `automaticConfigUpgrade` takes out the `GUEST` user from the `Users` field then adds that to the `Guest` field. Users and roles captured for use in CBG-1751 
- Integration test to test this behaviour

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1286/
