### PR TITLE
CBG-1756: Improve mark phase unmarshal efficiency

### DIFF
--- a/db/attachment_compaction.go
+++ b/db/attachment_compaction.go
@@ -7,6 +7,7 @@ import (
 
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/channels"
 )
 
 const CompactionIDKey = "compactID"
@@ -29,25 +30,15 @@ func Mark(db *Database, compactionID string, terminator chan struct{}, markedAtt
 	callback := func(event sgbucket.FeedEvent) bool {
 		defer markedAttachmentCallback(&attachmentsMarked)
 
+		docID := string(event.Key)
+
 		// We've had an error previously so no point doing work for any remaining items
 		if markProcessFailureErr != nil {
 			return false
 		}
 
 		// We only want to process full docs. Not any sync docs.
-		if strings.HasPrefix(string(event.Key), base.SyncPrefix) {
-			return true
-		}
-
-		// Attempt to unmarshal the feed data into a document
-		doc, err := UnmarshalDocumentFromFeed(string(event.Key), event.Cas, event.Value, event.DataType, "")
-		if err != nil {
-			return failProcess(err, "[%s] Failed to unmarshal doc %s from feed. Err: %v", compactionLoggingID, base.UD(string(event.Key)), err)
-		}
-
-		// Any doc written by SGW should have this value set. Not having this means we can skip this doc as it has not
-		// got sync data
-		if doc.Cas == uint64(0) {
+		if strings.HasPrefix(docID, base.SyncPrefix) {
 			return true
 		}
 
@@ -55,34 +46,55 @@ func Mark(db *Database, compactionID string, terminator chan struct{}, markedAtt
 		// We will build up a list of attachment names which map to attachment doc IDs. Avoids doing multiple KV ops
 		// when marking if multiple leaves are referencing the same attachment.
 		attachmentKeys := make(map[string]string)
-		for _, leafRevision := range doc.History.GetLeaves() {
-			_, _, attachmentMeta, err := db.getRevision(doc, leafRevision)
-			if err != nil {
-				return failProcess(err, "[%s] Failed to get doc %s revision %s. Err: %v", compactionLoggingID, base.UD(string(event.Key)), base.UD(leafRevision), err)
+		attachmentData, err := getAttachmentSyncData(event.DataType, event.Value)
+		if err != nil {
+			return failProcess(err, "[%s] Failed to obtain required sync data from doc %s from feed. Err: %v", compactionID, base.UD(docID), err)
+		}
+
+		// Its possible a doc doesn't have sync data. If not a sync gateway doc we can skip it.
+		if attachmentData == nil {
+			return true
+		}
+
+		handleAttachments(attachmentKeys, docID, attachmentData.Attachments)
+
+		// If we're in a conflict state we need to go and check and mark attachments from other leaves, not just winning
+		if attachmentData.Flags&channels.Conflict != 0 {
+
+			type AttachmentsMetaMap struct {
+				Attachments map[string]AttachmentsMeta `json:"_attachments"`
 			}
 
-			// Iterate over the attachments
-			for attID, attMeta := range attachmentMeta {
-				attMetaMap, ok := attMeta.(map[string]interface{})
-				if !ok {
+			// Iterate over body map
+			// These are strings containing conflicting bodies, need to scan these for attachments
+			for _, bodyMap := range attachmentData.History.BodyMap {
+				var body AttachmentsMetaMap
+				err = base.JSONUnmarshal([]byte(bodyMap), &body)
+				if err != nil {
 					continue
 				}
 
-				attVer, ok := GetAttachmentVersion(attMetaMap)
-				if !ok {
+				handleAttachments(attachmentKeys, docID, body.Attachments)
+			}
+
+			// Iterate over body key map
+			// These are strings containing IDs to documents containing conflicting bodies
+			for _, bodyKey := range attachmentData.History.BodyKeyMap {
+				bodyRaw, _, err := db.Bucket.GetRaw(bodyKey)
+				if err != nil {
+					if base.IsDocNotFoundError(err) {
+						continue
+					}
+					return failProcess(err, "[%s] Unable to obtain document from %s bodyKeyMap with ID %s: %v", compactionID, base.UD(docID), base.UD(bodyKey), err)
+				}
+
+				var body AttachmentsMetaMap
+				err = base.JSONUnmarshal(bodyRaw, &body)
+				if err != nil {
 					continue
 				}
 
-				if attVer != AttVersion1 {
-					continue
-				}
-
-				digest, ok := attMetaMap["digest"]
-				if !ok {
-					continue
-				}
-				attKey := MakeAttachmentKey(AttVersion1, string(event.Key), digest.(string))
-				attachmentKeys[attID] = attKey
+				handleAttachments(attachmentKeys, docID, body.Attachments)
 			}
 		}
 
@@ -92,12 +104,12 @@ func Mark(db *Database, compactionID string, terminator chan struct{}, markedAtt
 			_, err = db.Bucket.SetXattr(attachmentDocID, base.AttachmentCompactionXattrName, xattrValue)
 
 			// If an error occurs while stamping in that ID we need to fail this process and then the entire compaction
-			// process. Otherwise an attachment could end up getting erroneously deleted in the later sweep phase.
+			// process. Otherwise, an attachment could end up getting erroneously deleted in the later sweep phase.
 			if err != nil {
-				return failProcess(err, "[%s] Failed to mark attachment %s from doc %s with attachment docID %s. Err: %v", compactionLoggingID, base.UD(attachmentName), base.UD(string(event.Key)), base.UD(attachmentDocID), err)
+				return failProcess(err, "[%s] Failed to mark attachment %s from doc %s with attachment docID %s. Err: %v", compactionLoggingID, base.UD(attachmentName), base.UD(docID), base.UD(attachmentDocID), err)
 			}
 
-			base.DebugfCtx(db.Ctx, base.KeyAll, "[%s] Marked attachment %s from doc %s with attachment docID %s", compactionLoggingID, base.UD(attachmentName), base.UD(string(event.Key)), base.UD(attachmentDocID))
+			base.DebugfCtx(db.Ctx, base.KeyAll, "[%s] Marked attachment %s from doc %s with attachment docID %s", compactionLoggingID, base.UD(attachmentName), base.UD(docID), base.UD(attachmentDocID))
 			attachmentsMarked++
 		}
 		return true
@@ -139,6 +151,76 @@ func Mark(db *Database, compactionID string, terminator chan struct{}, markedAtt
 	return attachmentsMarked, dcpClient.Close()
 }
 
+// AttachmentCompactionData struct to unmarshal a document sync data into in order to process attachments during mark
+// phase. Contains only what is necessary
+type AttachmentCompactionData struct {
+	Attachments map[string]AttachmentsMeta `json:"attachments"`
+	Flags       uint8                      `json:"flags"`
+	History     struct {
+		BodyMap    map[string]string `json:"bodymap"`
+		BodyKeyMap map[string]string `json:"BodyKeyMap"`
+	} `json:"history"`
+}
+
+// getAttachmentSyncData takes the data type and data from the DCP feed and will return a AttachmentCompactionData
+// struct containing data needed to process attachments on a document.
+func getAttachmentSyncData(dataType uint8, data []byte) (*AttachmentCompactionData, error) {
+	if dataType&base.MemcachedDataTypeXattr != 0 {
+		_, xattr, _, err := parseXattrStreamData(base.SyncXattrName, "", data)
+		if err != nil {
+			if errors.Is(err, base.ErrXattrNotFound) {
+				return nil, nil
+			}
+			return nil, err
+		}
+
+		var attachmentData *AttachmentCompactionData
+		err = base.JSONUnmarshal(xattr, &attachmentData)
+		if err != nil {
+			return nil, err
+		}
+
+		return attachmentData, nil
+	}
+
+	type AttachmentDataSync struct {
+		AttachmentData AttachmentCompactionData `json:"_sync"`
+	}
+	var attachmentDataSync AttachmentDataSync
+	err := base.JSONUnmarshal(data, &attachmentDataSync)
+	if err != nil {
+		return nil, err
+	}
+
+	return &attachmentDataSync.AttachmentData, nil
+}
+
+// handleAttachments will iterate over the provided attachments and add any attachment doc IDs to the provided map
+// Doesn't require an error return as if we fail at any point in here the attachment is either not a v1 attachment, or
+// is unreadable which is likely unrecoverable.
+func handleAttachments(attachmentKeyMap map[string]string, docKey string, attachmentsMap map[string]AttachmentsMeta) {
+	for attName, attachmentMeta := range attachmentsMap {
+		attMetaMap := attachmentMeta
+
+		attVer, ok := GetAttachmentVersion(attMetaMap)
+		if !ok {
+			continue
+		}
+
+		if attVer != AttVersion1 {
+			continue
+		}
+
+		digest, ok := attMetaMap["digest"]
+		if !ok {
+			continue
+		}
+
+		attKey := MakeAttachmentKey(AttVersion1, docKey, digest.(string))
+		attachmentKeyMap[attName] = attKey
+	}
+}
+
 func Sweep(db *Database, compactionID string, terminator chan struct{}, purgedAttachmentCallback func(purgedAttachments *int)) (int, error) {
 	base.InfofCtx(db.Ctx, base.KeyAll, "Starting second phase of attachment compaction (sweep phase) with compactionID: %q", compactionID)
 	compactionLoggingID := "Compaction Sweep: " + compactionID
@@ -151,8 +233,10 @@ func Sweep(db *Database, compactionID string, terminator chan struct{}, purgedAt
 	callback := func(event sgbucket.FeedEvent) bool {
 		defer purgedAttachmentCallback(&attachmentsDeleted)
 
+		docID := string(event.Key)
+
 		// We only want to look over v1 attachment docs, skip otherwise
-		if !strings.HasPrefix(string(event.Key), base.AttPrefix) {
+		if !strings.HasPrefix(docID, base.AttPrefix) {
 			return true
 		}
 
@@ -186,13 +270,13 @@ func Sweep(db *Database, compactionID string, terminator chan struct{}, purgedAt
 		// - Has a compactionID set in its xattr but it is from a previous run and therefore is not equal to the passed
 		// in compactionID
 		// Therefore, we want to purge the doc
-		_, err := db.Bucket.Remove(string(event.Key), event.Cas)
+		_, err := db.Bucket.Remove(docID, event.Cas)
 		if err != nil {
-			base.WarnfCtx(db.Ctx, "[%s] Unable to purge attachment %s: %v", compactionLoggingID, base.UD(string(event.Key)), err)
+			base.WarnfCtx(db.Ctx, "[%s] Unable to purge attachment %s: %v", compactionLoggingID, base.UD(docID), err)
 			return true
 		}
 
-		base.DebugfCtx(db.Ctx, base.KeyAll, "[%s] Purged attachment %s", compactionLoggingID, base.UD(string(event.Key)))
+		base.DebugfCtx(db.Ctx, base.KeyAll, "[%s] Purged attachment %s", compactionLoggingID, base.UD(docID))
 		attachmentsDeleted++
 
 		return true

--- a/db/attachment_compaction.go
+++ b/db/attachment_compaction.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"strings"
@@ -214,7 +215,7 @@ func getAttachmentSyncData(dataType uint8, data []byte) (*AttachmentCompactionDa
 // checkForInlineAttachments will scan a body for "_attachments" for pre-2.5 attachments and will return any attachments
 // found
 func checkForInlineAttachments(body []byte) (*AttachmentsMetaMap, error) {
-	if strings.Contains(string(body), BodyAttachments) {
+	if bytes.Contains(body, []byte(BodyAttachments)) {
 		var attachmentBody AttachmentsMetaMap
 		err := base.JSONUnmarshal(body, &attachmentBody)
 		if err != nil {

--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -27,7 +27,7 @@ func TestAttachmentMark(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
-	attKeys := make([]string, 0, 10)
+	attKeys := make([]string, 0, 11)
 	for i := 0; i < 10; i++ {
 		docID := fmt.Sprintf("testDoc-%d", i)
 		attKey := fmt.Sprintf("att-%d", i)
@@ -40,10 +40,13 @@ func TestAttachmentMark(t *testing.T) {
 	err := testDb.Bucket.SetRaw("testDocx", 0, []byte("{}"))
 	assert.NoError(t, err)
 
+	attKeys = append(attKeys, createConflictingDocOneLeafHasAttachmentBodyMap(t, "conflictAtt", "attForConflict", []byte(`{"value": "att"}`), testDb))
+	attKeys = append(attKeys, createConflictingDocOneLeafHasAttachmentBodyKey(t, "conflictAttBodyKey", "attForConflict2", []byte(`{"val": "bodyKeyAtt"}`), testDb))
+
 	terminator := make(chan struct{})
 	attachmentsMarked, err := Mark(testDb, t.Name(), terminator, func(markedAttachments *int) {})
 	assert.NoError(t, err)
-	assert.Equal(t, 10, attachmentsMarked)
+	assert.Equal(t, 12, attachmentsMarked)
 
 	for _, attDocKey := range attKeys {
 		var attachmentData Body
@@ -191,6 +194,119 @@ func CreateLegacyAttachmentDoc(t *testing.T, db *Database, docID string, body []
 		return doc, xattr, false, nil, nil
 	})
 	require.NoError(t, err)
+
+	return attDocID
+}
+
+func createConflictingDocOneLeafHasAttachmentBodyMap(t *testing.T, docID string, attID string, attBody []byte, db *Database) string {
+	attDigest := Sha1DigestKey(attBody)
+	attLength := len(attBody)
+
+	syncData := `{
+      "rev": "2-b",
+      "flags": 24,
+      "sequence": 3,
+      "recent_sequences": [
+        1,
+        2,
+        3
+      ],
+      "history": {
+        "revs": [
+          "2-5d3308aae9930225ed7f6614cf115366",
+          "2-b",
+		  "1-ca9ad22802b66f662ff171f226211d5c"
+        ],
+        "parents": [
+          2,
+          2,
+          -1
+        ],
+        "bodymap": {
+          "0": "{\"_attachments\":{\"` + attID + `\":{\"digest\":\"` + attDigest + `\",\"length\":` + strconv.Itoa(attLength) + `,\"revpos\":1,\"stub\":true}}}"
+        },
+        "channels": [
+          null,
+          null,
+          null
+        ]
+      },
+      "cas": "0x0000502dcaefad16",
+      "value_crc32c": "0x5a0a8886",
+      "time_saved": "2021-10-14T16:38:11.359443+01:00"
+    }`
+
+	_, err := db.Bucket.WriteWithXattr(docID, base.SyncXattrName, 0, 0, []byte(`{"Winning Rev": true}`), []byte(syncData), false, false)
+	assert.NoError(t, err)
+
+	attDocID := MakeAttachmentKey(AttVersion1, docID, attDigest)
+	_, err = db.Bucket.AddRaw(attDocID, 0, attBody)
+	require.NoError(t, err)
+
+	return attDocID
+}
+
+func createConflictingDocOneLeafHasAttachmentBodyKey(t *testing.T, docID string, attID string, attBody []byte, db *Database) string {
+	attDigest := Sha1DigestKey(attBody)
+
+	syncData := `{
+      "rev": "2-b",
+      "flags": 24,
+      "sequence": 3,
+      "recent_sequences": [
+        1,
+        2,
+        3
+      ],
+      "history": {
+        "revs": [
+          "1-ca9ad22802b66f662ff171f226211d5c",
+          "2-01b555fc7738f62c68dd16da92009740",
+          "2-b"
+        ],
+        "parents": [
+          -1,
+          0,
+          0
+        ],
+        "bodyKeyMap": {
+          "1": "_sync:rb:PVLZc9dMcSQWX9uiA9tvlMDcs/PXoFIowRvfjcSurvU="
+        },
+        "channels": [
+          null,
+          null,
+          null
+        ]
+      },
+      "cas": "0x000013a35309b016",
+      "value_crc32c": "0x5a0a8886",
+      "channel_set": null,
+      "channel_set_history": null,
+      "time_saved": "2021-10-21T12:48:39.549095+01:00"
+    }`
+
+	_, err := db.Bucket.WriteWithXattr(docID, base.SyncXattrName, 0, 0, []byte(`{"Winning Rev": true}`), []byte(syncData), false, false)
+	assert.NoError(t, err)
+
+	attDocID := MakeAttachmentKey(AttVersion1, docID, attDigest)
+	_, err = db.Bucket.AddRaw(attDocID, 0, attBody)
+	require.NoError(t, err)
+
+	backupKey := "_sync:rb:PVLZc9dMcSQWX9uiA9tvlMDcs/PXoFIowRvfjcSurvU="
+	bodyBackup := `
+	{
+	  "_attachments": {
+		"` + attID + `": {
+		  "revpos": 1,
+		  "stub": true,
+		  "digest": "` + attDigest + `"
+		}
+	  },
+	  "testval": "val"
+	}`
+
+	err = db.Bucket.SetRaw(backupKey, 0, []byte(bodyBackup))
+	assert.NoError(t, err)
 
 	return attDocID
 }


### PR DESCRIPTION
CBG-1756

PR aims to improve the efficiency of the attachment compaction mark phase. Mainly:
- Avoid marshaling body if not required
- Only look over body map / body key map if a conflict is present
- If the above is deems we need to look over body map / body key only marshal the required data from these
- If the document sync data does not contain an attachment we will scan the body too for pre-2.5 attachments.

Added to an existing test to ensure items in body map / body key map are looked at. 

It may be valid to remove the work to look in body map / body key depending on resolution of CBG-1757 
- If we have an issue where these weren't being backed up there is no need to do this work to look through them.


## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1294/
(Couple unrelated looking failures)
- [ ] `xattrs=false` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration//
TODO