### PR TITLE
CBG-1761: Fixed panic and added meaningful error in sanitizeDbConfigs when no server address is provided

### DIFF
--- a/rest/main.go
+++ b/rest/main.go
@@ -263,17 +263,20 @@ func automaticConfigUpgrade(configPath string) (sc *StartupConfig, disablePersis
 // validate / sanitize db configs
 // - remove fields no longer valid for persisted db configs
 // - ensure servers are the same
+// - ensure a server is provided in at least one db config
 func sanitizeDbConfigs(configMap DbConfigMap) (DbConfigMap, error) {
 	var databaseServerAddress string
 
 	for dbName, dbConfig := range configMap {
-		if databaseServerAddress == "" {
-			databaseServerAddress = *dbConfig.Server
-		}
+		if dbConfig.Server != nil {
+			if databaseServerAddress == "" {
+				databaseServerAddress = *dbConfig.Server
+			}
 
-		if *dbConfig.Server != databaseServerAddress {
-			return nil, fmt.Errorf("automatic upgrade to persistent config requires matching server addresses in " +
-				"2.x config")
+			if *dbConfig.Server != databaseServerAddress {
+				return nil, fmt.Errorf("automatic upgrade to persistent config requires matching server addresses in " +
+					"2.x config")
+			}
 		}
 
 		if dbConfig.Bucket == nil || *dbConfig.Bucket == "" {
@@ -293,6 +296,11 @@ func sanitizeDbConfigs(configMap DbConfigMap) (DbConfigMap, error) {
 
 		// Make sure any updates are written back to the config
 		configMap[dbName] = dbConfig
+	}
+
+	if databaseServerAddress == "" {
+		return nil, fmt.Errorf("automatic upgrade to persistent config requires at least 1 database config to have a " +
+			"server address specified in the 2.x config")
 	}
 	return configMap, nil
 }

--- a/rest/main.go
+++ b/rest/main.go
@@ -262,8 +262,7 @@ func automaticConfigUpgrade(configPath string) (sc *StartupConfig, disablePersis
 
 // validate / sanitize db configs
 // - remove fields no longer valid for persisted db configs
-// - ensure servers are the same
-// - ensure a server is provided in at least one db config
+// - ensure matching servers are provided in all db configs
 func sanitizeDbConfigs(configMap DbConfigMap) (DbConfigMap, error) {
 	var databaseServerAddress string
 

--- a/rest/main.go
+++ b/rest/main.go
@@ -268,15 +268,18 @@ func sanitizeDbConfigs(configMap DbConfigMap) (DbConfigMap, error) {
 	var databaseServerAddress string
 
 	for dbName, dbConfig := range configMap {
-		if dbConfig.Server != nil {
-			if databaseServerAddress == "" {
-				databaseServerAddress = *dbConfig.Server
-			}
+		if dbConfig.Server == nil || *dbConfig.Server == "" {
+			return nil, fmt.Errorf("automatic upgrade to persistent config requires each database config to have a server " +
+				"address specified that are all matching in the 2.x config")
+		}
 
-			if *dbConfig.Server != databaseServerAddress {
-				return nil, fmt.Errorf("automatic upgrade to persistent config requires matching server addresses in " +
-					"2.x config")
-			}
+		if databaseServerAddress == "" {
+			databaseServerAddress = *dbConfig.Server
+		}
+
+		if *dbConfig.Server != databaseServerAddress {
+			return nil, fmt.Errorf("automatic upgrade to persistent config requires matching server addresses in " +
+				"2.x config")
 		}
 
 		if dbConfig.Bucket == nil || *dbConfig.Bucket == "" {
@@ -296,11 +299,6 @@ func sanitizeDbConfigs(configMap DbConfigMap) (DbConfigMap, error) {
 
 		// Make sure any updates are written back to the config
 		configMap[dbName] = dbConfig
-	}
-
-	if databaseServerAddress == "" {
-		return nil, fmt.Errorf("automatic upgrade to persistent config requires at least 1 database config to have a " +
-			"server address specified in the 2.x config")
 	}
 	return configMap, nil
 }

--- a/rest/main_test.go
+++ b/rest/main_test.go
@@ -109,7 +109,7 @@ func TestParseFlags(t *testing.T) {
 }
 
 func TestSanitizeDbConfigs(t *testing.T) {
-	expectedError := "automatic upgrade to persistent config requires at least 1 database config to have a server address specified in the 2.x config"
+	expectedError := "automatic upgrade to persistent config requires each database config to have a server address specified that are all matching in the 2.x config"
 	testCases := []struct {
 		name  string
 		input DbConfigMap
@@ -129,6 +129,18 @@ func TestSanitizeDbConfigs(t *testing.T) {
 			name: "Filled in server, and nil server",
 			input: DbConfigMap{"1": &DbConfig{BucketConfig: BucketConfig{Server: base.StringPtr("1.2.3.4")}},
 				"2": &DbConfig{}},
+			error: true,
+		},
+		{
+			name: "Filled in server, and empty server",
+			input: DbConfigMap{"1": &DbConfig{BucketConfig: BucketConfig{Server: base.StringPtr("")}},
+				"2": &DbConfig{BucketConfig: BucketConfig{Server: base.StringPtr("1.2.3.4")}}},
+			error: true,
+		},
+		{
+			name: "Filled in matching servers",
+			input: DbConfigMap{"1": &DbConfig{BucketConfig: BucketConfig{Server: base.StringPtr("1.2.3.4")}},
+				"2": &DbConfig{BucketConfig: BucketConfig{Server: base.StringPtr("1.2.3.4")}}},
 			error: false,
 		},
 	}


### PR DESCRIPTION
CBG-1761

- Added nil check when dereferencing bucket server
- Added error when no server is specified in any of the dbConfigs
- Unit test

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1​29​0
