### PR TITLE
CBG-1755: Handle multiple compaction IDs

### DIFF
--- a/base/bucket_xattr.go
+++ b/base/bucket_xattr.go
@@ -39,6 +39,14 @@ func (bucket *CouchbaseBucketGoCB) SetXattr(k string, xattrKey string, xv []byte
 	return SetXattr(bucket, k, xattrKey, xv)
 }
 
+func (bucket *CouchbaseBucketGoCB) RemoveXattr(k string, xattrKey string, cas uint64) (err error) {
+	return RemoveXattr(bucket, k, xattrKey, cas)
+}
+
+func (bucket *CouchbaseBucketGoCB) DeleteXattr(k string, xattrKey string) (err error) {
+	return DeleteXattr(bucket, k, xattrKey)
+}
+
 func (bucket *CouchbaseBucketGoCB) UpdateXattr(k string, xattrKey string, exp uint32, cas uint64, xv interface{}, deleteBody bool, isDelete bool) (casOut uint64, err error) {
 	return UpdateTombstoneXattr(bucket, k, xattrKey, exp, cas, xv, deleteBody)
 }

--- a/base/collection_xattr.go
+++ b/base/collection_xattr.go
@@ -58,6 +58,14 @@ func (c *Collection) SetXattr(k string, xattrKey string, xv []byte) (casOut uint
 	return SetXattr(c, k, xattrKey, xv)
 }
 
+func (c *Collection) RemoveXattr(k string, xattrKey string, cas uint64) (err error) {
+	return RemoveXattr(c, k, xattrKey, cas)
+}
+
+func (c *Collection) DeleteXattr(k string, xattrKey string) (err error) {
+	return DeleteXattr(c, k, xattrKey)
+}
+
 func (c *Collection) UpdateXattr(k string, xattrKey string, exp uint32, cas uint64, xv interface{}, deleteBody bool, isDelete bool) (casOut uint64, err error) {
 	return UpdateTombstoneXattr(c, k, xattrKey, exp, cas, xv, deleteBody)
 }

--- a/base/collection_xattr_common.go
+++ b/base/collection_xattr_common.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/couchbase/gocb/v2"
 	sgbucket "github.com/couchbase/sg-bucket"
 	pkgerrors "github.com/pkg/errors"
 )
@@ -283,8 +284,8 @@ func RemoveXattr(store SubdocXattrStore, k string, xattrKey string, cas uint64) 
 			return false, nil, nil
 		}
 
-		if errors.Is(err, ErrCasFailureShouldRetry) {
-			return false, err, nil
+		if errors.Is(err, gocb.ErrCasMismatch) {
+			return false, ErrCasFailureShouldRetry, nil
 		}
 
 		shouldRetry = store.isRecoverableWriteError(writeErr)

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -255,8 +255,8 @@ func (b *LeakyBucket) RemoveXattr(k string, xattrKey string, cas uint64) (err er
 	return b.bucket.RemoveXattr(k, xattrKey, cas)
 }
 
-func (b *LeakyBucket) DeleteXattr(k string, xattrKey string) (err error) {
-	return b.bucket.DeleteXattr(k, xattrKey)
+func (b *LeakyBucket) DeleteXattrs(k string, xattrKeys ...string) (err error) {
+	return b.bucket.DeleteXattrs(k, xattrKeys...)
 }
 
 func (b *LeakyBucket) SubdocInsert(docID string, fieldPath string, cas uint64, value interface{}) error {

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -251,6 +251,14 @@ func (b *LeakyBucket) SetXattr(k string, xattrKey string, xv []byte) (casOut uin
 	return b.bucket.SetXattr(k, xattrKey, xv)
 }
 
+func (b *LeakyBucket) RemoveXattr(k string, xattrKey string, cas uint64) (err error) {
+	return b.bucket.RemoveXattr(k, xattrKey, cas)
+}
+
+func (b *LeakyBucket) DeleteXattr(k string, xattrKey string) (err error) {
+	return b.bucket.DeleteXattr(k, xattrKey)
+}
+
 func (b *LeakyBucket) SubdocInsert(docID string, fieldPath string, cas uint64, value interface{}) error {
 	return b.bucket.SubdocInsert(docID, fieldPath, cas, value)
 }

--- a/base/logging_bucket.go
+++ b/base/logging_bucket.go
@@ -121,9 +121,9 @@ func (b *LoggingBucket) RemoveXattr(k string, xattrKey string, cas uint64) (err 
 	return b.bucket.RemoveXattr(k, xattrKey, cas)
 }
 
-func (b *LoggingBucket) DeleteXattr(k string, xattrKey string) (err error) {
+func (b *LoggingBucket) DeleteXattrs(k string, xattrKey ...string) (err error) {
 	defer b.log(time.Now(), k, xattrKey)
-	return b.bucket.DeleteXattr(k, xattrKey)
+	return b.bucket.DeleteXattrs(k, xattrKey...)
 }
 
 func (b *LoggingBucket) SubdocInsert(docID string, fieldPath string, cas uint64, value interface{}) error {

--- a/base/logging_bucket.go
+++ b/base/logging_bucket.go
@@ -116,6 +116,16 @@ func (b *LoggingBucket) SetXattr(k string, xattrKey string, xv []byte) (casOut u
 	return b.bucket.SetXattr(k, xattrKey, xv)
 }
 
+func (b *LoggingBucket) RemoveXattr(k string, xattrKey string, cas uint64) (err error) {
+	defer b.log(time.Now(), k, xattrKey)
+	return b.bucket.RemoveXattr(k, xattrKey, cas)
+}
+
+func (b *LoggingBucket) DeleteXattr(k string, xattrKey string) (err error) {
+	defer b.log(time.Now(), k, xattrKey)
+	return b.bucket.DeleteXattr(k, xattrKey)
+}
+
 func (b *LoggingBucket) SubdocInsert(docID string, fieldPath string, cas uint64, value interface{}) error {
 	defer b.log(time.Now(), docID, fieldPath)
 	return b.bucket.SubdocInsert(docID, fieldPath, cas, value)

--- a/db/attachment_compaction.go
+++ b/db/attachment_compaction.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
+	"time"
 
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
@@ -96,8 +98,7 @@ func Mark(db *Database, compactionID string, terminator chan struct{}, markedAtt
 
 		for attachmentName, attachmentDocID := range attachmentKeys {
 			// Stamp the current compaction ID into the attachment xattr. This is performing the actual marking
-			xattrValue := []byte(`{"` + CompactionIDKey + `": "` + compactionID + `"}`)
-			_, err = db.Bucket.SetXattr(attachmentDocID, base.AttachmentCompactionXattrName, xattrValue)
+			_, err = db.Bucket.SetXattr(attachmentDocID, getCompactionIDSubDocPath(compactionID), []byte(strconv.Itoa(int(time.Now().Unix()))))
 
 			// If an error occurs while stamping in that ID we need to fail this process and then the entire compaction
 			// process. Otherwise, an attachment could end up getting erroneously deleted in the later sweep phase.
@@ -290,8 +291,8 @@ func Sweep(db *Database, compactionID string, terminator chan struct{}, purgedAt
 					return true
 				}
 
-				docCompactID, ok := syncData[CompactionIDKey]
-				if ok && docCompactID == compactionID {
+				compactIDSync, compactIDSyncPresent := syncData[CompactionIDKey]
+				if _, compactionIDPresent := compactIDSync.(map[string]interface{})[compactionID]; compactIDSyncPresent && compactionIDPresent {
 					return true
 				}
 			}
@@ -343,4 +344,130 @@ func Sweep(db *Database, compactionID string, terminator chan struct{}, purgedAt
 	}
 
 	return attachmentsDeleted, dcpClient.Close()
+}
+
+func Cleanup(db *Database, compactionID string, terminator chan struct{}) error {
+	base.InfofCtx(db.Ctx, base.KeyAll, "Starting third phase of attachment compaction (cleanup phase) with compactionID: %q", compactionID)
+	compactionLoggingID := "Compaction Cleanup: " + compactionID
+
+	callback := func(event sgbucket.FeedEvent) bool {
+
+		docID := string(event.Key)
+
+		if !strings.HasPrefix(docID, base.AttPrefix) {
+			return true
+		}
+
+		if event.DataType&base.MemcachedDataTypeXattr != 0 {
+			_, xattr, _, err := parseXattrStreamData(base.AttachmentCompactionXattrName, "", event.Value)
+			if err != nil && !errors.Is(err, base.ErrXattrNotFound) {
+				base.WarnfCtx(db.Ctx, "[%s] Unexpected error occurred attempting to parse attachment xattr: %v", compactionLoggingID, err)
+				return true
+			}
+
+			if xattr != nil {
+				var syncData map[string]interface{}
+				err = base.JSONUnmarshal(xattr, &syncData)
+				if err != nil {
+					base.WarnfCtx(db.Ctx, "[%s] Failed to unmarshal xattr data: %v", compactionLoggingID, err)
+					return true
+				}
+
+				// Get compactID map containing all compactIDs on the document, if one is not present for some reason we
+				// can skip this
+				compactIDSync, compactIDSyncPresent := syncData[CompactionIDKey]
+				if !compactIDSyncPresent {
+					return true
+				}
+
+				// Attempt to type assert compaction ID a map, so we can iterate over the compact IDs
+				compactIDSyncMap, ok := compactIDSync.(map[string]interface{})
+				if !ok {
+					return true
+				}
+
+				// Build up a unique set of compactionIDs that we can remove from the xattr. We always add the current
+				// compaction ID as we're now done with it. Also check if any other compaction IDs are present. If any
+				// are older than 30 days we can remove them.
+				toDelete := map[string]struct{}{
+					compactionID: {},
+				}
+				for compactID, compactIDTimestampI := range compactIDSyncMap {
+					compactIDTimestampFloat, ok := compactIDTimestampI.(float64)
+					if !ok {
+						continue
+					}
+
+					compactIDTimestamp := time.Unix(int64(compactIDTimestampFloat), 0)
+					diff := time.Now().UTC().Sub(compactIDTimestamp.UTC())
+					if diff > time.Hour*24*30 {
+						toDelete[compactID] = struct{}{}
+					}
+				}
+
+				// If all the current compact IDs are to be deleted we can remove the entire attachment compaction
+				// xattr.
+				// Note that if this operation fails with a cas mismatch we will fall through to the following per ID
+				// delete. This can occur if another compact process ends up mutating / deleting the xattr.
+				if len(compactIDSyncMap) == len(toDelete) {
+					err = db.Bucket.RemoveXattr(docID, base.AttachmentCompactionXattrName, event.Cas)
+					if err == nil {
+						return true
+					}
+					if err != nil && !errors.Is(err, base.ErrCasFailureShouldRetry) {
+						base.WarnfCtx(db.Ctx, "[%s] Failed to remove compaction ID xattr for doc %s: %v", compactionLoggingID, base.UD(docID), err)
+						return true
+					}
+
+				}
+
+				// If we only want to remove select compact IDs iterate over them and delete each one
+				for compactID, _ := range toDelete {
+					err = db.Bucket.DeleteXattr(docID, getCompactionIDSubDocPath(compactID))
+					if err != nil && !errors.Is(err, base.ErrXattrNotFound) {
+						base.WarnfCtx(db.Ctx, "[%s] Failed to delete compaction ID xattr key %s for doc %s: %v", compactionLoggingID, compactID, base.UD(docID), err)
+						return true
+					}
+				}
+			}
+		}
+
+		return true
+	}
+
+	cbStore, ok := base.AsCouchbaseStore(db.Bucket)
+	if !ok {
+		return fmt.Errorf("bucket is not a Couchbase Store")
+	}
+
+	clientOptions := base.DCPClientOptions{
+		OneShot: true,
+	}
+
+	base.InfofCtx(db.Ctx, base.KeyAll, "[%s] Starting DCP feed for cleanup phase of attachment compaction", compactionLoggingID)
+	dcpClient, err := base.NewDCPClient(compactionID, callback, clientOptions, cbStore)
+	if err != nil {
+		return err
+	}
+
+	doneChan, err := dcpClient.Start()
+	if err != nil {
+		_ = dcpClient.Close()
+		return err
+	}
+
+	select {
+	case <-doneChan:
+		base.InfofCtx(db.Ctx, base.KeyAll, "[%s] Cleanup phase of attachment compaction completed", compactionLoggingID)
+	case <-terminator:
+		base.InfofCtx(db.Ctx, base.KeyAll, "[%s] Cleanup phase of attachment compaction was terminated", compactionLoggingID)
+	}
+
+	return dcpClient.Close()
+}
+
+// getCompactionIDSubDocPath is just a tiny helper func that just concatenates the subdoc path we're using to store
+// compactionIDs
+func getCompactionIDSubDocPath(compactionID string) string {
+	return base.AttachmentCompactionXattrName + "." + CompactionIDKey + "." + compactionID
 }

--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -281,6 +281,10 @@ func TestAttachmentMarkAndSweepAndCleanup(t *testing.T) {
 }
 
 func CreateLegacyAttachmentDoc(t *testing.T, db *Database, docID string, body []byte, attID string, attBody []byte) string {
+	if !base.TestUseXattrs() {
+		t.Skip("Requires xattrs")
+	}
+
 	attDigest := Sha1DigestKey(attBody)
 
 	attDocID := MakeAttachmentKey(AttVersion1, docID, attDigest)

--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -324,7 +324,7 @@ func (a *AttachmentCompactionManager) Run(options map[string]interface{}, termin
 		return err
 	}
 
-	return nil
+	return Cleanup(database, uniqueUUID.String(), terminator)
 }
 
 type AttachmentManagerResponse struct {

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -40,7 +40,7 @@ licenses/APL2.txt.
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="CBG-1755"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="6db8e07afd1fb977cddc87ff7ff1d16587a4626e"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="74908f5398d1b5e28a4c8873a7c8931076ad81e3"/>
 
@@ -59,7 +59,7 @@ licenses/APL2.txt.
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="4201f50df22f08f75a0491451fa6507387d41304"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="CBG-1755"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="de3fe8f77a83ac70786a33e5b69e1d6a4f1e3bc4"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -40,7 +40,7 @@ licenses/APL2.txt.
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="a5872ff542ba9cf0452528bdbe7ec3f7e90e73d0"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="CBG-1755"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="74908f5398d1b5e28a4c8873a7c8931076ad81e3"/>
 
@@ -59,7 +59,7 @@ licenses/APL2.txt.
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="4201f50df22f08f75a0491451fa6507387d41304"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="1972e5eab603e22c8be5e75cffc6f78de4a8b70c"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="CBG-1755"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/rest/attachment_compaction_api_test.go
+++ b/rest/attachment_compaction_api_test.go
@@ -142,6 +142,10 @@ func TestAttachmentCompactionAPI(t *testing.T) {
 }
 
 func CreateLegacyAttachmentDoc(t *testing.T, testDB *db.Database, docID string, body []byte, attID string, attBody []byte) string {
+	if !base.TestUseXattrs() {
+		t.Skip("Requires xattrs")
+	}
+
 	attDigest := db.Sha1DigestKey(attBody)
 
 	attDocID := db.MakeAttachmentKey(db.AttVersion1, docID, attDigest)


### PR DESCRIPTION
CBG-1755

- Switch to storing multiple compaction IDs in an xattr instead of just one --> Have a map with compactionID - timestamp
- Mark adds a compactionID with subdoc op
- Sweep reads the compactionIDs and does a basic check if the current running compactionID is present in the map
- Adds an additional phase which does a 'cleanup':
	- Deletes the current running compactionID from the map
	- If any other runs are more than 30 days old we also delete those (can occur if an earlier cleanup phase fails)

- Adds RemoveXattr which does a cas safe subdoc delete operation
- Adds DeleteXattr which does a straight delete operation with no cas check

## Dependencies
- [x] https://github.com/couchbaselabs/walrus/pull/60
- [x] https://github.com/couchbase/sg-bucket/pull/67

## Integration Tests
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1319/
- [x] `xattrs=false` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1313/
