### PR TITLE
Temporarily skip TestTerminateDCPFeed

### DIFF
--- a/base/dcp_client_test.go
+++ b/base/dcp_client_test.go
@@ -82,6 +82,7 @@ func TestOneShotDCP(t *testing.T) {
 }
 
 func TestTerminateDCPFeed(t *testing.T) {
+	t.Skip("Temporarily skipping test. CBG-1767")
 
 	if UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server")


### PR DESCRIPTION
PR simply adds a skip to TestTerminateDCPFeed which we've seen hang a lot during recent integration test runs. 
Filed a ticket and can be re-enabled once fixed - https://issues.couchbase.com/browse/CBG-1767