### PR TITLE
CBG-1760: Error upfront if logFilePath is unwritable

### DIFF
--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -27,7 +27,8 @@ import (
 )
 
 var (
-	ErrInvalidLogFilePath = errors.New("invalid log file path")
+	ErrInvalidLogFilePath    = errors.New("invalid log file path")
+	ErrUnwritableLogFilePath = errors.New("cannot write to log file path directory")
 
 	maxAgeLimit                            = 9999 // days
 	defaultMaxSize                         = 100  // 100 MB

--- a/base/logging_config.go
+++ b/base/logging_config.go
@@ -274,12 +274,13 @@ func validateLogFilePath(logFilePath string) error {
 		return errors.Wrap(ErrInvalidLogFilePath, "not a directory")
 	}
 
-	// Make temporary file to check if the log file path is writable
+	// Make temporary empty file to check if the log file path is writable
 	writeCheckFilePath := filepath.Join(logFilePath, ".SG_write_check")
 	err = os.WriteFile(writeCheckFilePath, nil, 0666)
 	if err != nil {
 		return errors.Wrap(err, ErrUnwritableLogFilePath.Error())
 	}
+	// best effort cleanup, but if we don't manage to remove it, WriteFile will overwrite on the next startup and try to remove again
 	_ = os.Remove(writeCheckFilePath)
 
 	return nil

--- a/base/logging_config.go
+++ b/base/logging_config.go
@@ -274,6 +274,17 @@ func validateLogFilePath(logFilePath string) error {
 		return errors.Wrap(ErrInvalidLogFilePath, "not a directory")
 	}
 
+	// Make temporary file to check if the log file path is writable
+	writeCheckFilePath := logFilePath + "/WritableCheck"
+	_, err = os.Create(writeCheckFilePath)
+	if err != nil {
+		return errors.Wrap(err, ErrUnwritableLogFilePath.Error())
+	}
+	err = os.Remove(writeCheckFilePath)
+	if err != nil {
+		return fmt.Errorf("cannot clean-up temporary folder for write check: %w", err)
+	}
+
 	return nil
 }
 

--- a/base/logging_config.go
+++ b/base/logging_config.go
@@ -275,15 +275,12 @@ func validateLogFilePath(logFilePath string) error {
 	}
 
 	// Make temporary file to check if the log file path is writable
-	writeCheckFilePath := logFilePath + "/WritableCheck"
-	_, err = os.Create(writeCheckFilePath)
+	writeCheckFilePath := filepath.Join(logFilePath, ".SG_write_check")
+	err = os.WriteFile(writeCheckFilePath, nil, 0666)
 	if err != nil {
 		return errors.Wrap(err, ErrUnwritableLogFilePath.Error())
 	}
-	err = os.Remove(writeCheckFilePath)
-	if err != nil {
-		return fmt.Errorf("cannot clean-up temporary folder for write check: %w", err)
-	}
+	_ = os.Remove(writeCheckFilePath)
 
 	return nil
 }

--- a/base/logging_config_test.go
+++ b/base/logging_config_test.go
@@ -13,6 +13,7 @@ package base
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,6 +33,11 @@ func TestValidateLogFileOutput(t *testing.T) {
 
 // CBG-1760: Error upfront when the configured logFilePath is not writable
 func TestLogFilePathWritable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// Cannot make folder inaccessible to writes or make read-only: https://github.com/golang/go/issues/35042
+		t.Skip("Test not compatible with Windows")
+	}
+
 	testCases := []struct {
 		name             string
 		logFilePathPerms os.FileMode
@@ -39,7 +45,7 @@ func TestLogFilePathWritable(t *testing.T) {
 	}{
 		{
 			name:             "Unwritable",
-			logFilePathPerms: 0444, // Only reads allowed
+			logFilePathPerms: 0444, // Read-only perms
 			error:            true,
 		},
 		{

--- a/base/logging_config_test.go
+++ b/base/logging_config_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestValidateLogFileOutput(t *testing.T) {
@@ -27,4 +28,42 @@ func TestValidateLogFileOutput(t *testing.T) {
 	logFileOutput = filepath.Join(os.TempDir(), "sglogfile.log")
 	err = validateLogFileOutput(logFileOutput)
 	assert.NoError(t, err, "log file output path should be validated")
+}
+
+// CBG-1760: Error upfront when the configured logFilePath is not writable
+func TestLogFilePathWritable(t *testing.T) {
+	testCases := []struct {
+		name             string
+		logFilePathPerms os.FileMode
+		error            bool
+	}{
+		{
+			name:             "Unwritable",
+			logFilePathPerms: 0444, // Only reads allowed
+			error:            true,
+		},
+		{
+			name:             "Writeable",
+			logFilePathPerms: 0777, // Full perms
+			error:            false,
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			tmpPath, err := os.MkdirTemp("", "TestLogFilePathWritable*") // Cannot use t.Name() due to slash separator
+			require.NoError(t, err)
+			defer func() { require.NoError(t, os.RemoveAll(tmpPath)) }()
+
+			logFilePath := tmpPath + "/logs"
+			err = os.Mkdir(logFilePath, test.logFilePathPerms)
+			require.NoError(t, err)
+
+			err = validateLogFilePath(logFilePath)
+			if test.error {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
 }

--- a/base/logging_config_test.go
+++ b/base/logging_config_test.go
@@ -54,7 +54,7 @@ func TestLogFilePathWritable(t *testing.T) {
 			require.NoError(t, err)
 			defer func() { require.NoError(t, os.RemoveAll(tmpPath)) }()
 
-			logFilePath := tmpPath + "/logs"
+			logFilePath := filepath.Join(tmpPath, "logs")
 			err = os.Mkdir(logFilePath, test.logFilePathPerms)
 			require.NoError(t, err)
 


### PR DESCRIPTION
CBG-1760

- SGW refuses to start if the log_file_path set is not writeable (eg. read-only, insufficient perms)
- Unit tested (non-Windows only due to https://github.com/golang/go/issues/35042 and other tests skip Windows when testing file/directory read-only perms)

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1​30​8
