### PR TITLE
CBG-1767 Avoid deadlock on DCP Client done channel

### DIFF
--- a/base/dcp_client.go
+++ b/base/dcp_client.go
@@ -62,7 +62,7 @@ func NewDCPClient(ID string, callback sgbucket.FeedEventCallbackFunc, options DC
 		ID:          ID,
 		spec:        store.GetSpec(),
 		terminator:  make(chan bool),
-		doneChannel: make(chan error),
+		doneChannel: make(chan error, 1),
 	}
 
 	// Initialize active vbuckets

--- a/base/dcp_client.go
+++ b/base/dcp_client.go
@@ -357,6 +357,12 @@ func (dc *DCPClient) fatalError(err error) {
 func (dc *DCPClient) setCloseError(err error) {
 	dc.closeErrorLock.Lock()
 	defer dc.closeErrorLock.Unlock()
+	// If the DCPClient is already closing, don't update the error.  If an initial error triggered the close,
+	// then closeError will already be set.  In the event of a requested close, we want to ignore EOF errors associated
+	// with stream close
+	if dc.closing.IsTrue() {
+		return
+	}
 	if dc.closeError == nil {
 		dc.closeError = err
 	}


### PR DESCRIPTION
CBG-1767

When the done channel was updated to return error, it should have been updated to a buffered channel.  In scenarios where the feed exited with error and the doneChannel wasn't being read, it would deadlock.

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1315/
