### PR TITLE
Cherry-pick: CBG-1906: Include 'database went away' error handling for ISGR (#5403)

### DIFF
--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -143,6 +143,15 @@ func (a *activeReplicatorCommon) reconnectLoop() {
 	}
 }
 
+// reconnect will disconnect and stop the replicator, but not set the state - such that it will be reassigned and started again.
+func (a *activeReplicatorCommon) reconnect() error {
+	a.lock.Lock()
+	err := a._disconnect()
+	a._publishStatus()
+	a.lock.Unlock()
+	return err
+}
+
 // stopAndDisconnect runs _disconnect and _stop on the replicator, and sets the Stopped replication state.
 func (a *activeReplicatorCommon) stopAndDisconnect() error {
 	a.lock.Lock()

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -109,7 +109,13 @@ func (apr *ActivePushReplicator) _connect() error {
 			if err != nil {
 				base.Errorf("Failed to stop and disconnect replication: %v", err)
 			}
+		} else if strings.Contains(err.Error(), ErrDatabaseWentAway.Message) {
+			err = apr.reconnect()
+			if err != nil {
+				base.Errorf("Failed to reconnect replication: %v", err)
+			}
 		}
+		// No special handling for error
 	}
 
 	apr.activeSendChanges.Set(true)

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -63,6 +63,10 @@ type blipHandlerFunc func(*blipHandler, *blip.Message) error
 var (
 	ErrUseProposeChanges = base.HTTPErrorf(http.StatusConflict, "Use 'proposeChanges' instead")
 
+	// ErrDatabaseWentAway is returned when a replication tries to use a closed database.
+	// HTTP 503 tells the client to reconnect and try again.
+	ErrDatabaseWentAway = base.HTTPErrorf(http.StatusServiceUnavailable, "Sync Gateway database went away - asking client to reconnect")
+
 	// ErrAttachmentNotFound is returned when the attachment that is asked by one of the peers does
 	// not exist in another to prove that it has the attachment during Inter-Sync Gateway Replication.
 	ErrAttachmentNotFound = base.HTTPErrorf(http.StatusNotFound, "attachment not found")
@@ -449,7 +453,7 @@ func (bh *blipHandler) sendBatchOfChanges(sender *blip.Sender, changeArray [][]i
 		// Spawn a goroutine to await the client's response:
 		go func(bh *blipHandler, sender *blip.Sender, response *blip.Message, changeArray [][]interface{}, sendTime time.Time, database *Database) {
 			if err := bh.handleChangesResponse(sender, response, changeArray, sendTime, database); err != nil {
-				base.ErrorfCtx(bh.loggingCtx, "Error from bh.handleChangesResponse: %v", err)
+				base.WarnfCtx(bh.loggingCtx, "Error from bh.handleChangesResponse: %v", err)
 				if bh.fatalErrorCallback != nil {
 					bh.fatalErrorCallback(err)
 				}

--- a/db/blip_messages.go
+++ b/db/blip_messages.go
@@ -137,7 +137,7 @@ func (rq *SetSGR2CheckpointRequest) Response() (*SetSGR2CheckpointResponse, erro
 			// conflict writing checkpoint
 			return nil, base.HTTPErrorf(http.StatusConflict, "Document update conflict")
 		}
-		return nil, fmt.Errorf("unknown response type: %v - %s", msgType, respBody)
+		return nil, fmt.Errorf("unexpected error response: %s", respBody)
 	}
 
 	return &SetSGR2CheckpointResponse{
@@ -199,7 +199,7 @@ func (rq *GetSGR2CheckpointRequest) Response() (*SGR2Checkpoint, error) {
 			// no checkpoint found
 			return nil, nil
 		}
-		return nil, fmt.Errorf("unknown response type: %v - %s", msgType, respBody)
+		return nil, fmt.Errorf("unexpected error response: %s", respBody)
 	}
 
 	bodyBytes, err := respMsg.Body()

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -155,7 +155,7 @@ func (bsc *BlipSyncContext) register(profile string, handlerFn func(*blipHandler
 					base.InfofCtx(bsc.loggingCtx, base.KeySync, "Database bucket closed underneath request %v - asking client to reconnect", rq)
 					base.DebugfCtx(bsc.loggingCtx, base.KeySync, "PANIC handling BLIP request %v: %v\n%s", rq, err, debug.Stack())
 					// HTTP 503 asks CBL to disconnect and retry.
-					rq.Response().SetError("HTTP", 503, "Sync Gateway database went away - asking client to reconnect")
+					rq.Response().SetError("HTTP", ErrDatabaseWentAway.Status, ErrDatabaseWentAway.Message)
 					return
 				}
 

--- a/db/changes.go
+++ b/db/changes.go
@@ -1464,6 +1464,7 @@ loop:
 			break loop
 		}
 		if sendErr != nil {
+			forceClose = true
 			return &ChangesSendErr{sendErr}, forceClose
 		}
 	}

--- a/rest/blip_api_no_race_test.go
+++ b/rest/blip_api_no_race_test.go
@@ -25,16 +25,23 @@ import (
 
 // TestBlipPusherUpdateDatabase starts a push replication and updates the database underneath the replication.
 // Expect to see the connection closed with an error, instead of continuously panicking.
+// This is the CBL version of TestPushReplicationAPIUpdateDatabase
 //
 // This test causes the race detector to flag the bucket=nil operation and any in-flight requests being made using that bucket, prior to the replication being reset.
 // TODO CBG-1903: Can be fixed by draining in-flight requests before fully closing the database.
 func TestBlipPusherUpdateDatabase(t *testing.T) {
 
+	t.Skip("Skipping test - revisit in CBG-1908")
+
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyHTTP, base.KeyHTTPResp, base.KeySync)()
+
+	tb := base.GetTestBucket(t)
+	defer tb.Close()
 
 	rtConfig := RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{},
 		guestEnabled:   true,
+		TestBucket:     tb.NoCloseClone(),
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
@@ -72,7 +79,9 @@ func TestBlipPusherUpdateDatabase(t *testing.T) {
 	require.NoError(t, err)
 
 	// just change the sync function to cause the database to reload
-	resp, err := rt.UpsertDbConfig("db", DbConfig{Sync: base.StringPtr(`function(doc){console.log("update");}`)})
+	dbConfig := *rt.ServerContext().GetDbConfig("db")
+	dbConfig.Sync = base.StringPtr(`function(doc){console.log("update");}`)
+	resp, err := rt.ReplaceDbConfig("db", dbConfig)
 	require.NoError(t, err)
 	assertStatus(t, resp, http.StatusCreated)
 

--- a/rest/replication_api_no_race_test.go
+++ b/rest/replication_api_no_race_test.go
@@ -1,0 +1,101 @@
+//  Copyright 2016-Present Couchbase, Inc.
+//
+//  Use of this software is governed by the Business Source License included
+//  in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+//  in that file, in accordance with the Business Source License, use of this
+//  software will be governed by the Apache License, Version 2.0, included in
+//  the file licenses/APL2.txt.
+//go:build !race
+// +build !race
+
+package rest
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPushReplicationAPIUpdateDatabase starts a push replication and updates the passive database underneath the replication.
+// Expect to see the connection closed with an error, instead of continuously panicking.
+// This is the ISGR version of TestBlipPusherUpdateDatabase
+//
+// This test causes the race detector to flag the bucket=nil operation and any in-flight requests being made using that bucket, prior to the replication being reset.
+// TODO CBG-1903: Can be fixed by draining in-flight requests before fully closing the database.
+func TestPushReplicationAPIUpdateDatabase(t *testing.T) {
+
+	t.Skip("Skipping test - revisit in CBG-1908")
+
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("Test does not support Walrus - depends on closing and re-opening persistent bucket")
+	}
+
+	base.RequireNumTestBuckets(t, 2)
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()
+
+	rt1, rt2, remoteURLString, teardown := setupSGRPeers(t)
+	defer teardown()
+
+	// Create initial doc on rt1
+	docID := t.Name() + "rt1doc"
+	_ = rt1.putDoc(docID, `{"source":"rt1","channels":["alice"]}`)
+
+	// Create push replication, verify running
+	replicationID := t.Name()
+	rt1.createReplication(replicationID, remoteURLString, db.ActiveReplicatorTypePush, nil, true, db.ConflictResolverDefault)
+	rt1.assertReplicationState(replicationID, db.ReplicationStateRunning)
+
+	// wait for document originally written to rt1 to arrive at rt2
+	changesResults := rt2.RequireWaitChanges(1, "0")
+	require.Equal(t, docID, changesResults.Results[0].ID)
+
+	var lastDocID atomic.Value
+
+	// Wait for the background updates to finish at the end of the test
+	shouldCreateDocs := base.NewAtomicBool(true)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	defer func() {
+		shouldCreateDocs.Set(false)
+		wg.Wait()
+	}()
+
+	// Start creating documents in the background on rt1 for the replicator to push to rt2
+	go func() {
+		// for i := 0; i < 10; i++ {
+		for i := 0; shouldCreateDocs.IsTrue(); i++ {
+			resp := rt1.putDoc(fmt.Sprintf("%s-doc%d", t.Name(), i), fmt.Sprintf(`{"i":%d,"channels":["alice"]}`, i))
+			lastDocID.Store(resp.ID)
+		}
+		_ = rt1.WaitForPendingChanges()
+		wg.Done()
+	}()
+
+	// and wait for a few to be done before we proceed with updating database config underneath replication
+	_, err := rt2.WaitForChanges(5, "/db/_changes", "", true)
+	require.NoError(t, err)
+
+	// just change the sync function to cause the database to reload
+	dbConfig := *rt2.ServerContext().GetDbConfig("db")
+	dbConfig.Sync = base.StringPtr(`function(doc){channel(doc.channels);}`)
+	resp, err := rt2.ReplaceDbConfig("db", dbConfig)
+	require.NoError(t, err)
+	assertStatus(t, resp, http.StatusCreated)
+
+	shouldCreateDocs.Set(false)
+
+	lastDocIDString, ok := lastDocID.Load().(string)
+	require.True(t, ok)
+
+	// wait for the last document written to rt1 to arrive at rt2
+	waitAndAssertCondition(t, func() bool {
+		_, err := rt2.GetDatabase().GetDocument(lastDocIDString, db.DocUnmarshalNone)
+		return err == nil
+	})
+}


### PR DESCRIPTION
Forward-ports the 3.0 fix #5403 to master.

* Add ISGR handling for database went away error
* Pick up changes from branch to fix TestBlipPusherUpdateDatabase
* Skip new tests - revisit in CBG-1908

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1546/
  -TestLogFlush failed - https://issues.couchbase.com/browse/CBG-1869