### PR TITLE
CBG-2094: Upgrade Go to 1.17.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.17.5
+          go-version: 1.17.11
       - uses: actions/checkout@v2
       - name: gofmt
         run: |
@@ -49,7 +49,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.17.5
+          go-version: 1.17.11
       - uses: actions/checkout@v2
       - name: Build
         run: go build -v "./..."
@@ -69,7 +69,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.17.5
+          go-version: 1.17.11
       - uses: actions/checkout@v2
       - name: Run Tests
         run: go test -race -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
     }
 
     tools {
-        go '1.17.5'
+        go '1.17.11'
     }
 
     stages {

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Download Sync Gateway and other Couchbase packages for Linux, Windows and macOS 
 
 To build Sync Gateway from source, you must have the following installed:
 
-* Go 1.17.5 or later.
+* Go 1.17.11 or later.
 * Building the Enterprise Edition requires access to private repos, and is intended for internal use only.
 
 **Install Go**

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Download Sync Gateway and other Couchbase packages for Linux, Windows and macOS 
 
 To build Sync Gateway from source, you must have the following installed:
 
-* Go 1.17.11 or later.
+* Go 1.17 or later.
 * Building the Enterprise Edition requires access to private repos, and is intended for internal use only.
 
 **Install Go**

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -6,7 +6,7 @@
             "release_name": "Couchbase Sync Gateway",
             "production": true,
             "interval": 30,
-            "go_version": "1.17.5",
+            "go_version": "1.17.11",
             "trigger_blackduck": true,
             "start_build": 1
         },


### PR DESCRIPTION
CBG-2094

Switches build configuration to use Go 1.17.11 - picks up the latest bug fixes, while not yet making the jump to 1.18 because of ecosystem support.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/316/
