### PR TITLE
CBG-2458: fix for race in TestBlipPushRevisionInspectChanges

### DIFF
--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -143,13 +143,11 @@ func TestBlipPushRevisionInspectChanges(t *testing.T) {
 	subChangesRequest.Properties["continuous"] = "true"
 	sent = bt.sender.Send(subChangesRequest)
 	assert.True(t, sent)
-	receivedChangesRequestWg.Add(1)
+	// Also expect the "changes" profile handler above to be called back again with an empty request that
+	// will be ignored since body will be "null" hence the incrementing for the wait group by 2
+	receivedChangesRequestWg.Add(2)
 	subChangesResponse := subChangesRequest.Response()
 	assert.Equal(t, subChangesRequest.SerialNumber(), subChangesResponse.SerialNumber())
-
-	// Also expect the "changes" profile handler above to be called back again with an empty request that
-	// will be ignored since body will be "null"
-	receivedChangesRequestWg.Add(1)
 
 	// Wait until we got the expected callback on the "changes" profile handler
 	timeoutErr := WaitWithTimeout(&receivedChangesRequestWg, time.Second*5)


### PR DESCRIPTION
CBG-2458

Test was getting intermittent negative wait group counter error. We get the empty changes response from blip before we get to incrementing the wait group by 1 for this thus getting to the `receivedChangesRequestWg.Done()` before we have incremented the wait group for it. So I have incremented the wait group for both the response and the empty response in one line to avoid this. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1086/
