### PR TITLE
CBG-2711 add 3 node cluster option to jenkins

### DIFF
--- a/base/main_test_bucket_pool_config.go
+++ b/base/main_test_bucket_pool_config.go
@@ -54,6 +54,9 @@ const (
 
 	// wait this long when requesting a test bucket from the pool before giving up and failing the test.
 	waitForReadyBucketTimeout = time.Minute
+
+	// Creates buckets with a specific number of number of replicas
+	tbpEnvBucketNumReplicas = "SG_TEST_BUCKET_NUM_REPLICAS"
 )
 
 var tbpDefaultBucketSpec = BucketSpec{
@@ -134,6 +137,19 @@ func tbpNumBuckets() int {
 		}
 	}
 	return numBuckets
+}
+
+// tbpNumReplicasreturns the number of replicas to use in each bucket.
+func tbpNumReplicas() uint32 {
+	numReplicas := os.Getenv(tbpEnvBucketPoolSize)
+	if numReplicas == "" {
+		return 0
+	}
+	replicas, err := strconv.Atoi(numReplicas)
+	if err != nil {
+		FatalfCtx(context.TODO(), "Couldn't parse %s: %v", tbpEnvBucketPoolSize, err)
+	}
+	return uint32(replicas)
 }
 
 // tbpNumCollectionsPerBucket returns the configured number of collections prepared in a bucket.

--- a/base/main_test_bucket_pool_config.go
+++ b/base/main_test_bucket_pool_config.go
@@ -141,7 +141,7 @@ func tbpNumBuckets() int {
 
 // tbpNumReplicasreturns the number of replicas to use in each bucket.
 func tbpNumReplicas() uint32 {
-	numReplicas := os.Getenv(tbpEnvBucketPoolSize)
+	numReplicas := os.Getenv(tbpEnvBucketNumReplicas)
 	if numReplicas == "" {
 		return 0
 	}

--- a/base/main_test_cluster.go
+++ b/base/main_test_cluster.go
@@ -137,7 +137,7 @@ func (c *tbpClusterV2) insertBucket(name string, quotaMB int) error {
 			RAMQuotaMB:   uint64(quotaMB),
 			BucketType:   gocb.CouchbaseBucketType,
 			FlushEnabled: true,
-			NumReplicas:  0,
+			NumReplicas:  tbpNumReplicas(),
 		},
 	}
 

--- a/integration-test/docker-compose.yml
+++ b/integration-test/docker-compose.yml
@@ -1,0 +1,35 @@
+# Copyright 2023-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
+services:
+  couchbase:
+    container_name: couchbase
+    image: "couchbase/server:${COUCHBASE_DOCKER_IMAGE_NAME:-enterprise-7.1.4}"
+    ports:
+      - 8091:8091
+      - 8092:8092
+      - 8093:8093
+      - 8094:8094
+      - 8095:8095
+      - 8096:8096
+      - 11207:11207
+      - 11210:11210
+      - 11211:11211
+      - 18091:18091
+      - 18092:18092
+      - 18093:18093
+      - 18094:18094
+    volumes:
+      - "${DOCKER_CBS_ROOT_DIR:-.}/cbs:/root"
+      - "${WORKSPACE_ROOT:-.}:/workspace"
+  couchbase-replica1:
+    container_name: couchbase-replica1
+    image: "couchbase/${COUCHBASE_DOCKER_IMAGE_NAME:-server:enterprise-7.1.4}"
+  couchbase-replica2:
+    container_name: couchbase-replica2
+    image: "couchbase/server:${COUCHBASE_DOCKER_IMAGE_NAME:-enterprise-7.1.4}"

--- a/integration-test/start_server.sh
+++ b/integration-test/start_server.sh
@@ -7,7 +7,6 @@
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
 
-
 set -eux -o pipefail
 
 function usage() {
@@ -43,8 +42,13 @@ if [ "${CBS_ROOT_DIR:-}" != "" ]; then
     DOCKER_CBS_ROOT_DIR="${CBS_ROOT_DIR}"
 fi
 
+if [[ -n "${JENKINS_URL:-}" ]]; then
+    DOCKER_COMPOSE="docker-compose" # use docker-compose v1 for Jenkins AWS Linux 2
+else
+    DOCKER_COMPOSE="docker compose"
+fi
 cd -- "${BASH_SOURCE%/*}/"
-docker-compose down || true
+${DOCKER_COMPOSE} down || true
 export SG_TEST_COUCHBASE_SERVER_DOCKER_NAME=couchbase
 # Start CBS
 docker stop ${SG_TEST_COUCHBASE_SERVER_DOCKER_NAME} || true
@@ -54,7 +58,7 @@ docker rm ${SG_TEST_COUCHBASE_SERVER_DOCKER_NAME} || true
 if [[ -z "${MULTI_NODE:-}" ]]; then
     docker run -d --name ${SG_TEST_COUCHBASE_SERVER_DOCKER_NAME} --volume "${DOCKER_CBS_ROOT_DIR}/cbs:/root" --volume "${WORKSPACE_ROOT}:/workspace" -p 8091-8096:8091-8096 -p 11207:11207 -p 11210:11210 -p 11211:11211 -p 18091-18094:18091-18094 "couchbase/server:${COUCHBASE_DOCKER_IMAGE_NAME}"
 else
-    docker-compose up -d --force-recreate --renew-anon-volumes --remove-orphans
+    ${DOCKER_COMPOSE} up -d --force-recreate --renew-anon-volumes --remove-orphans
 fi
 
 # Test to see if Couchbase Server is up

--- a/integration-test/start_server.sh
+++ b/integration-test/start_server.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Copyright 2023-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
+
+set -eux -o pipefail
+
+function usage() {
+    echo "Usage: $0 [-m] [-h] containername"
+}
+
+if [ $# -gt 2 ]; then
+    echo "Expected maximally two arguments"
+    exit 1
+fi
+
+while [[ $# -gt 0 ]]; do
+    key="$1"
+    case $key in
+        -m | --multi-node)
+            MULTI_NODE=true
+            shift
+            ;;
+        -h | --help)
+            echo "Usage: $0 [-m] [-h] containername"
+            exit 1
+            ;;
+        *)
+            COUCHBASE_DOCKER_IMAGE_NAME="$1"
+            shift
+            ;;
+    esac
+done
+
+WORKSPACE_ROOT="$(pwd)"
+DOCKER_CBS_ROOT_DIR="$(pwd)"
+if [ "${CBS_ROOT_DIR:-}" != "" ]; then
+    DOCKER_CBS_ROOT_DIR="${CBS_ROOT_DIR}"
+fi
+
+cd -- "${BASH_SOURCE%/*}/"
+docker-compose down || true
+export SG_TEST_COUCHBASE_SERVER_DOCKER_NAME=couchbase
+# Start CBS
+docker stop ${SG_TEST_COUCHBASE_SERVER_DOCKER_NAME} || true
+docker rm ${SG_TEST_COUCHBASE_SERVER_DOCKER_NAME} || true
+# --volume: Makes and mounts a CBS folder for storing a CBCollect if needed
+
+if [[ -z "${MULTI_NODE:-}" ]]; then
+    docker run -d --name ${SG_TEST_COUCHBASE_SERVER_DOCKER_NAME} --volume "${DOCKER_CBS_ROOT_DIR}/cbs:/root" --volume "${WORKSPACE_ROOT}:/workspace" -p 8091-8096:8091-8096 -p 11207:11207 -p 11210:11210 -p 11211:11211 -p 18091-18094:18091-18094 "couchbase/server:${COUCHBASE_DOCKER_IMAGE_NAME}"
+else
+    docker-compose up -d --force-recreate --renew-anon-volumes --remove-orphans
+fi
+
+# Test to see if Couchbase Server is up
+# Each retry min wait 5s, max 10s. Retry 20 times with exponential backoff (delay 0), fail at 120s
+curl --retry-all-errors --connect-timeout 5 --max-time 10 --retry 20 --retry-delay 0 --retry-max-time 120 'http://127.0.0.1:8091'
+
+# Set up CBS
+
+docker exec couchbase couchbase-cli cluster-init --cluster-username Administrator --cluster-password password --cluster-ramsize 3072 --cluster-index-ramsize 3072 --cluster-fts-ramsize 256 --services data,index,query
+docker exec couchbase couchbase-cli setting-index --cluster couchbase://localhost --username Administrator --password password --index-threads 4 --index-log-level verbose --index-max-rollback-points 10 --index-storage-setting default --index-memory-snapshot-interval 150 --index-stable-snapshot-interval 40000
+
+curl -u Administrator:password -v -X POST http://127.0.0.1:8091/node/controller/rename -d 'hostname=127.0.0.1'
+
+if [[ -n "${MULTI_NODE:-}" ]]; then
+    REPLICA1_NAME=couchbase-replica1
+    REPLICA2_NAME=couchbase-replica2
+    CLI_ARGS=(-c couchbase://couchbase -u Administrator -p password)
+    docker exec ${REPLICA1_NAME} couchbase-cli node-init "${CLI_ARGS[@]}"
+    docker exec ${REPLICA2_NAME} couchbase-cli node-init "${CLI_ARGS[@]}"
+    REPLICA1_IP=$(docker inspect --format '{{json .NetworkSettings.Networks}}' ${REPLICA1_NAME} | jq -r 'first(.[]) | .IPAddress')
+    REPLICA2_IP=$(docker inspect --format '{{json .NetworkSettings.Networks}}' ${REPLICA2_NAME} | jq -r 'first(.[]) | .IPAddress')
+    docker exec ${SG_TEST_COUCHBASE_SERVER_DOCKER_NAME} couchbase-cli server-add "${CLI_ARGS[@]}" --server-add "$REPLICA2_IP" --server-add-username Administrator --server-add-password password --services data,index,query
+    docker exec ${SG_TEST_COUCHBASE_SERVER_DOCKER_NAME} couchbase-cli server-add "${CLI_ARGS[@]}" --server-add "$REPLICA1_IP" --server-add-username Administrator --server-add-password password --services data,index,query
+    docker exec ${SG_TEST_COUCHBASE_SERVER_DOCKER_NAME} couchbase-cli rebalance "${CLI_ARGS[@]}"
+fi

--- a/jenkins-integration-build.sh
+++ b/jenkins-integration-build.sh
@@ -62,7 +62,7 @@ else
     go install -v github.com/AlekSi/gocov-xml@latest
 fi
 
-if [[ -n "${JENKINS_URL}" ]]; then
+if [[ -n "${JENKINS_URL:-}" ]]; then
     # last 1.x version, when updating aws linux 2 docker, docker-compose becomes docker compose
     sudo yum install -y jq
     sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
@@ -141,7 +141,7 @@ if [ "${SG_EDITION}" == "EE" ]; then
     GO_TEST_FLAGS="${GO_TEST_FLAGS} -tags cb_sg_enterprise"
 fi
 
-go test ${GO_TEST_FLAGS} -coverprofile=coverage_int.out -coverpkg=github.com/couchbase/sync_gateway/... github.com/couchbase/sync_gateway/${TARGET_PACKAGE} 2>&1 | stdbuf -oL tee "${INT_LOG_FILE_NAME}.out.raw" | stdbuf -oL grep -a -P '(--- (FAIL|PASS|SKIP):|github.com/couchbase/sync_gateway(/.+)?\t|TEST: |panic: )'
+go test ${GO_TEST_FLAGS} -coverprofile=coverage_int.out -coverpkg=github.com/couchbase/sync_gateway/... github.com/couchbase/sync_gateway/${TARGET_PACKAGE} 2>&1 | stdbuf -oL tee "${INT_LOG_FILE_NAME}.out.raw" | stdbuf -oL grep -a -E '(--- (FAIL|PASS|SKIP):|github.com/couchbase/sync_gateway(/.+)?\t|TEST: |panic: )'
 if [ "${PIPESTATUS[0]}" -ne "0" ]; then # If test exit code is not 0 (failed)
     echo "Go test failed! Parsing logs to find cause..."
     TEST_FAILED=true


### PR DESCRIPTION
create ./integration-test/start_server.sh which allows you to start a cluster in a multinode or a single node setup. The intent is that SG developers could use this to set up clusters but I think I need another PR for this to work on OS X.

When creating a 3 node cluster (MULTI_NODE on jenkins), it will create each bucket with 1 replica.

Questions:

- Can we change the AMI to include a modern version of docker? This is one of those things that won't work on OS X because this uses docker compose v1 (written in python) and modern docker uses docker compose v2. This can be put off until we update the AMI. I also add jq at runtime if `JENKINS_URL` is set.
- Why do we set `--volume ${DOCKER_CBS_ROOT_DIR}/cbs:/root --volume ${WORKSPACE_ROOT}:/workspace` ? It seems like it is easier to use docker volumes and just do a `docker exec -t couchbase /opt/couchbase/bin/cbcollect_info /workspace/cbcollect.zip && docker cp couchbase:/workspace/cbcollect.zip cbcollect.zip` to get the file. The only reason to mount the disk seems like would be if we pick up partial files from checks. I can't figure out why we bind mount the `/root` volume at all.

Ran 6.6.5,7.1.4,7.0.3 with MULTI_NODE on and off for a base DCP test.