### PR TITLE
flip boolean so test runs only with CBS 7.1

### DIFF
--- a/base/main_test_bucket_pool_config.go
+++ b/base/main_test_bucket_pool_config.go
@@ -84,7 +84,7 @@ func TestsUseServerCE() bool {
 // TestsRequireMobileRBAC returns true if the server has Sync Gateway RBAC roles.
 func TestsRequireMobileRBAC(t *testing.T) {
 	ok, err := GTestBucketPool.cluster.supportsMobileRBAC()
-	if err != nil || ok {
+	if err != nil || !ok {
 		t.Skip("Mobile RBAC roles for Sync Gateway are only fully supported in CBS 7.1 or greater")
 	}
 }


### PR DESCRIPTION
## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1772/
