### PR TITLE
[3.1.2] Fix for incorrect value being logged for attempts to open dcp stream

### DIFF
--- a/base/dcp_client.go
+++ b/base/dcp_client.go
@@ -469,7 +469,7 @@ func (dc *DCPClient) openStream(vbID uint16, maxRetries uint32) error {
 		attempts++
 	}
 
-	return fmt.Errorf("openStream failed to complete after %d attempts, last error: %w", openRetryCount, openStreamErr)
+	return fmt.Errorf("openStream failed to complete after %d attempts, last error: %w", attempts, openStreamErr)
 }
 
 func (dc *DCPClient) rollback(ctx context.Context, vbID uint16, seqNo gocbcore.SeqNo) {


### PR DESCRIPTION
CBG-0000

[Backport]
During investigation with KV for a CBSE this week, we noticed that incorrect attempts to open dcp stream was being logged inside sync gateway. We should be logging the attempts we have made to open a stream not the openRetryCount value which is a constant value of 10.

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
