### PR TITLE
CBG-4241: Low risk refactoring in `_getOrAddDatabaseFromConfig`

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -465,6 +465,39 @@ func WaitUntilDataStoreReady(ctx context.Context, ds DataStore) error {
 	})
 }
 
+// GetDataStoreWithRetry will attempt to get a named DataStore from the given bucket, retrying until it can succeed, if failFast is false.
+func GetDataStoreWithRetry(ctx context.Context, bucket Bucket, scName ScopeAndCollectionName, failFast bool) (DataStore, error) {
+	if failFast {
+		return bucket.NamedDataStore(scName)
+	}
+
+	err, dataStore := RetryLoop(
+		ctx,
+		fmt.Sprintf("waiting for %s.%s.%s to exist", MD(bucket.GetName()), MD(scName.ScopeName()), MD(scName.CollectionName())),
+		func() (bool, error, interface{}) {
+			dataStore, err := bucket.NamedDataStore(scName)
+			return err != nil, err, dataStore
+		},
+		CreateMaxDoublingSleeperFunc(30, 10, 1000))
+	ds, ok := dataStore.(DataStore)
+	if !ok && err == nil {
+		AssertfCtx(ctx, "datastore %s.%s.%s was not a DataStore type, got %T", bucket.GetName(), scName.ScopeName(), scName.CollectionName(), dataStore)
+	}
+	return ds, err
+}
+
+// GetAndWaitUntilDataStoreReady will attempt to get a named DataStore from the given bucket, and ensure it's ready for use.
+func GetAndWaitUntilDataStoreReady(ctx context.Context, bucket Bucket, scName ScopeAndCollectionName, failFast bool) (DataStore, error) {
+	dataStore, err := GetDataStoreWithRetry(ctx, bucket, scName, failFast)
+	if err != nil {
+		return nil, err
+	}
+	if err := WaitUntilDataStoreReady(ctx, dataStore); err != nil {
+		return nil, err
+	}
+	return dataStore, nil
+}
+
 // RequireNoBucketTTL ensures there is no MaxTTL set on the bucket (SG #3314)
 func RequireNoBucketTTL(ctx context.Context, b Bucket) error {
 	cbs, ok := AsCouchbaseBucketStore(b)

--- a/base/bucket.go
+++ b/base/bucket.go
@@ -453,12 +453,14 @@ func AsSubdocStore(ds DataStore) (sgbucket.SubdocStore, bool) {
 	return subdocStore, ok && ds.IsSupported(sgbucket.BucketStoreFeatureSubdocOperations)
 }
 
-// WaitUntilDataStoreExists will try to perform an operation in the given DataStore until it can succeed.
+// WaitUntilDataStoreReady will try to perform a basic operation in the given DataStore until it can succeed.
+// It's not necessarily the case that a datastore that exists is ready to be used.
 //
-// There's no WaitForReady operation in GoCB for collections, only Buckets, so attempting to use Exists in this way this seems like our best option to check for availability.
-func WaitUntilDataStoreExists(ctx context.Context, ds DataStore) error {
+// There's no WaitForReady operation in GoCB for collections, only Buckets, so attempting to use Exists in this way this seems like our best option to check for usability.
+func WaitUntilDataStoreReady(ctx context.Context, ds DataStore) error {
 	return WaitForNoError(ctx, func() error {
-		_, err := ds.Exists("WaitUntilDataStoreExists")
+		// don't care whether the doc actually exists or not, just that we could perform the operation successfully
+		_, err := ds.Exists("WaitUntilDataStoreReady")
 		return err
 	})
 }

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -895,10 +895,8 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 			if dbcontext.RevsLimit < db.DefaultRevsLimitConflicts {
 				base.WarnfCtx(ctx, "Setting the revs_limit (%v) to less than %d, whilst having allow_conflicts set to true, may have unwanted results when documents are frequently updated. Please see documentation for details.", dbcontext.RevsLimit, db.DefaultRevsLimitConflicts)
 			}
-		} else {
-			if dbcontext.RevsLimit <= 0 {
-				return nil, fmt.Errorf("The revs_limit (%v) value in your Sync Gateway configuration must be greater than zero.", dbcontext.RevsLimit)
-			}
+		} else if dbcontext.RevsLimit <= 0 {
+			return nil, fmt.Errorf("The revs_limit (%v) value in your Sync Gateway configuration must be greater than zero.", dbcontext.RevsLimit)
 		}
 	}
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -787,52 +787,6 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		}
 	}
 
-	// Process unsupported config options or store runtime defaults if not set
-	if config.Unsupported == nil {
-		config.Unsupported = &db.UnsupportedOptions{}
-	}
-	if config.Unsupported.WarningThresholds == nil {
-		config.Unsupported.WarningThresholds = &db.WarningThresholds{}
-	}
-
-	if config.Unsupported.WarningThresholds.XattrSize == nil {
-		config.Unsupported.WarningThresholds.XattrSize = base.Uint32Ptr(uint32(base.DefaultWarnThresholdXattrSize))
-	} else {
-		lowerLimit := 0.1 * 1024 * 1024 // 0.1 MB
-		upperLimit := 1 * 1024 * 1024   // 1 MB
-		if *config.Unsupported.WarningThresholds.XattrSize < uint32(lowerLimit) {
-			return nil, fmt.Errorf("xattr_size warning threshold cannot be lower than %d bytes", uint32(lowerLimit))
-		} else if *config.Unsupported.WarningThresholds.XattrSize > uint32(upperLimit) {
-			return nil, fmt.Errorf("xattr_size warning threshold cannot be higher than %d bytes", uint32(upperLimit))
-		}
-	}
-
-	if config.Unsupported.WarningThresholds.ChannelsPerDoc == nil {
-		config.Unsupported.WarningThresholds.ChannelsPerDoc = &base.DefaultWarnThresholdChannelsPerDoc
-	} else {
-		lowerLimit := 5
-		if *config.Unsupported.WarningThresholds.ChannelsPerDoc < uint32(lowerLimit) {
-			return nil, fmt.Errorf("channels_per_doc warning threshold cannot be lower than %d", lowerLimit)
-		}
-	}
-
-	if config.Unsupported.WarningThresholds.ChannelsPerUser == nil {
-		config.Unsupported.WarningThresholds.ChannelsPerUser = &base.DefaultWarnThresholdChannelsPerUser
-	}
-
-	if config.Unsupported.WarningThresholds.GrantsPerDoc == nil {
-		config.Unsupported.WarningThresholds.GrantsPerDoc = &base.DefaultWarnThresholdGrantsPerDoc
-	} else {
-		lowerLimit := 5
-		if *config.Unsupported.WarningThresholds.GrantsPerDoc < uint32(lowerLimit) {
-			return nil, fmt.Errorf("access_and_role_grants_per_doc warning threshold cannot be lower than %d", lowerLimit)
-		}
-	}
-
-	if config.Unsupported.WarningThresholds.ChannelNameSize == nil {
-		config.Unsupported.WarningThresholds.ChannelNameSize = &base.DefaultWarnThresholdChannelNameSize
-	}
-
 	autoImport, err := config.AutoImportEnabled(ctx)
 	if err != nil {
 		return nil, err
@@ -1296,6 +1250,52 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 
 	if config.AllowConflicts != nil && *config.AllowConflicts {
 		base.WarnfCtx(ctx, `Deprecation notice: setting database configuration option "allow_conflicts" to true is due to be removed. In the future, conflicts will not be allowed.`)
+	}
+
+	// Process unsupported config options or store runtime defaults if not set
+	if config.Unsupported == nil {
+		config.Unsupported = &db.UnsupportedOptions{}
+	}
+	if config.Unsupported.WarningThresholds == nil {
+		config.Unsupported.WarningThresholds = &db.WarningThresholds{}
+	}
+
+	if config.Unsupported.WarningThresholds.XattrSize == nil {
+		config.Unsupported.WarningThresholds.XattrSize = base.Uint32Ptr(uint32(base.DefaultWarnThresholdXattrSize))
+	} else {
+		lowerLimit := 0.1 * 1024 * 1024 // 0.1 MB
+		upperLimit := 1 * 1024 * 1024   // 1 MB
+		if *config.Unsupported.WarningThresholds.XattrSize < uint32(lowerLimit) {
+			return db.DatabaseContextOptions{}, fmt.Errorf("xattr_size warning threshold cannot be lower than %d bytes", uint32(lowerLimit))
+		} else if *config.Unsupported.WarningThresholds.XattrSize > uint32(upperLimit) {
+			return db.DatabaseContextOptions{}, fmt.Errorf("xattr_size warning threshold cannot be higher than %d bytes", uint32(upperLimit))
+		}
+	}
+
+	if config.Unsupported.WarningThresholds.ChannelsPerDoc == nil {
+		config.Unsupported.WarningThresholds.ChannelsPerDoc = &base.DefaultWarnThresholdChannelsPerDoc
+	} else {
+		lowerLimit := 5
+		if *config.Unsupported.WarningThresholds.ChannelsPerDoc < uint32(lowerLimit) {
+			return db.DatabaseContextOptions{}, fmt.Errorf("channels_per_doc warning threshold cannot be lower than %d", lowerLimit)
+		}
+	}
+
+	if config.Unsupported.WarningThresholds.ChannelsPerUser == nil {
+		config.Unsupported.WarningThresholds.ChannelsPerUser = &base.DefaultWarnThresholdChannelsPerUser
+	}
+
+	if config.Unsupported.WarningThresholds.GrantsPerDoc == nil {
+		config.Unsupported.WarningThresholds.GrantsPerDoc = &base.DefaultWarnThresholdGrantsPerDoc
+	} else {
+		lowerLimit := 5
+		if *config.Unsupported.WarningThresholds.GrantsPerDoc < uint32(lowerLimit) {
+			return db.DatabaseContextOptions{}, fmt.Errorf("access_and_role_grants_per_doc warning threshold cannot be lower than %d", lowerLimit)
+		}
+	}
+
+	if config.Unsupported.WarningThresholds.ChannelNameSize == nil {
+		config.Unsupported.WarningThresholds.ChannelNameSize = &base.DefaultWarnThresholdChannelNameSize
 	}
 
 	if config.Unsupported.DisableCleanSkippedQuery {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -982,14 +982,14 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		atomic.StoreUint32(&dbcontext.State, db.DBOnline)
 		_ = dbcontext.EventMgr.RaiseDBStateChangeEvent(ctx, dbName, "online", dbLoadedStateChangeMsg, &sc.Config.API.AdminInterface)
 		return dbcontext, nil
-	} else {
-		// If asyncOnline is requested, set state to Starting and spawn a separate goroutine to wait for init completion
-		// before going online
-		base.InfofCtx(ctx, base.KeyAll, "Waiting for database init to complete asynchonously...")
-		nonCancelCtx := base.NewNonCancelCtxForDatabase(ctx)
-		go sc.asyncDatabaseOnline(nonCancelCtx, dbcontext, dbInitDoneChan, config.Version)
-		return dbcontext, nil
 	}
+
+	// If asyncOnline is requested, set state to Starting and spawn a separate goroutine to wait for init completion
+	// before going online
+	base.InfofCtx(ctx, base.KeyAll, "Waiting for database init to complete asynchonously...")
+	nonCancelCtx := base.NewNonCancelCtxForDatabase(ctx)
+	go sc.asyncDatabaseOnline(nonCancelCtx, dbcontext, dbInitDoneChan, config.Version)
+	return dbcontext, nil
 }
 
 // asyncDatabaseOnline waits for async initialization to complete (based on doneChan).  On successful completion, brings the database online.

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -698,8 +698,8 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 				if err != nil {
 					return nil, fmt.Errorf("error attempting to create/update database: %w", err)
 				}
-				// Check if scope/collection specified exists. Will enter retry loop if connection unsuccessful
-				if err := base.WaitUntilDataStoreExists(ctx, dataStore); err != nil {
+				// Check if scope/collection specified is ready to use
+				if err := base.WaitUntilDataStoreReady(ctx, dataStore); err != nil {
 					return nil, fmt.Errorf("attempting to create/update database with a scope/collection that is not found")
 				}
 				metadataIndexOption := db.IndexesWithoutMetadata
@@ -1400,7 +1400,7 @@ func (sc *ServerContext) TakeDbOnline(nonContextStruct base.NonCancellableContex
 // validateMetadataStore will
 func validateMetadataStore(ctx context.Context, metadataStore base.DataStore) error {
 	// Check if scope/collection specified exists. Will enter retry loop if connection unsuccessful
-	err := base.WaitUntilDataStoreExists(ctx, metadataStore)
+	err := base.WaitUntilDataStoreReady(ctx, metadataStore)
 	if err == nil {
 		return nil
 	}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -611,10 +611,10 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	if previousDatabase != nil {
 		if options.useExisting {
 			return previousDatabase, nil
-		} else {
-			return nil, base.HTTPErrorf(http.StatusPreconditionFailed, // what CouchDB returns
-				"Duplicate database name %q", dbName)
 		}
+
+		return nil, base.HTTPErrorf(http.StatusPreconditionFailed, // what CouchDB returns
+			"Duplicate database name %q", dbName)
 	}
 
 	if err := db.ValidateDatabaseName(dbName); err != nil {
@@ -635,6 +635,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	if err != nil {
 		return nil, err
 	}
+
 	// If using a walrus bucket, force use of views
 	useViews := base.BoolDefault(config.UseViews, false)
 	if !useViews && spec.IsWalrusBucket() {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -587,6 +587,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	if dbName == "" {
 		dbName = spec.BucketName
 	}
+
 	defer func() {
 		if returnedError == nil {
 			return
@@ -603,6 +604,10 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		}
 	}()
 
+	if err := db.ValidateDatabaseName(dbName); err != nil {
+		return nil, err
+	}
+
 	if spec.Server == "" {
 		spec.Server = sc.Config.Bootstrap.Server
 	}
@@ -615,10 +620,6 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 
 		return nil, base.HTTPErrorf(http.StatusPreconditionFailed, // what CouchDB returns
 			"Duplicate database name %q", dbName)
-	}
-
-	if err := db.ValidateDatabaseName(dbName); err != nil {
-		return nil, err
 	}
 
 	// Connect to bucket


### PR DESCRIPTION
CBG-4241

Low risk cleanup/refactoring in `_getOrAddDatabaseFromConfig` prior to larger structural refactoring and improvements (rearranging collection init / index creation / waiting)

- Rename `WaitUntilDataStoreExists` to `WaitUntilDataStoreReady` to better describe functionality.
- Move `config.Unsupported.WarningThresholds` init down into `dbcOptionsFromConfig` function already doing config init work in same place.
- Push Get and WaitUntilReady logic for DataStore down into function
- Earlier validation of dbName
- Lint fixes along the lines of outdenting `if return ... else return`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2685/
