### PR TITLE
CBG-4638 add missing require_resync to docs

### DIFF
--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -826,6 +826,9 @@ Retrieved-replication:
         - error
         - starting
         - reconnecting
+    cluster_uuid:
+      description: The cluster unique identifier.
+      type: string
   title: Replication
 Replication:
   description: Properties of a replication
@@ -2969,6 +2972,9 @@ Status:
           server_uuid:
             description: The server unique identifier.
             type: string
+          require_resync:
+            description: Indicates whether the database requires resync before it can be brought online.
+            type: boolean
           state:
             allOf: # use allOf to prevent DatabaseState from showing as the type in the display
               - $ref: '#/DatabaseState'
@@ -2979,6 +2985,9 @@ Status:
           cluster:
             type: object
             properties:
+              cluster_uuid:
+                description: The cluster unique identifier.
+                type: string
               replication:
                 description: Map of replication configs defined for the cluster.
                 type: object
@@ -3005,6 +3014,10 @@ Status:
 
         Blank if `api.hide_product_version=true` in the startup configuration.
       type: string
+    vendor:
+      description: Product name
+      type: string
+      example: Couchbase Sync Gateway
   title: Status
 NodeInfo:
   type: object

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -2954,6 +2954,23 @@ DeprecatedLogKeyMap:
   additionalProperties:
     description: The log key and whether it is enabled or not.
     type: boolean
+Vendor:
+  description: Product vendor
+  type: object
+  properties:
+    name:
+      description: Product name
+      type: string
+      example: Couchbase Sync Gateway
+    version:
+      description: |-
+        API version.
+        Omitted if `api.hide_product_version=true`
+      type: string
+      example: 3.1
+  required:
+    - name
+  title: Vendor
 Status:
   type: object
   properties:
@@ -3015,9 +3032,8 @@ Status:
         Blank if `api.hide_product_version=true` in the startup configuration.
       type: string
     vendor:
-      description: Product name
-      type: string
-      example: Couchbase Sync Gateway
+      allOf:
+        - $ref: '#/Vendor'
   title: Status
 NodeInfo:
   type: object
@@ -3031,21 +3047,8 @@ NodeInfo:
       type: string
       example: Welcome
     vendor:
-      description: Product vendor
-      type: object
-      properties:
-        name:
-          description: Product name
-          type: string
-          example: Couchbase Sync Gateway
-        version:
-          description: |-
-            API version.
-            Omitted if `api.hide_product_version=true`
-          type: string
-          example: 3.1
-      required:
-        - name
+      allOf:
+        - $ref: '#/Vendor'
     version:
       description: |-
         Product version, including the build number and edition (i.e. `EE` or `CE`)

--- a/docs/api/paths/admin/db-.yaml
+++ b/docs/api/paths/admin/db-.yaml
@@ -63,6 +63,9 @@ get:
                 description: Unique server identifier.
                 type: string
                 example: 995618a6a6cc9ac79731bd13240e19b5
+              require_resync:
+                description: Indicates whether the database requires resync before it can be brought online.
+                type: boolean
               init_in_progress:
                 description: Indicates whether database initialization is in progress.
                 type: boolean


### PR DESCRIPTION
CBG-4638 add missing require_resync to documentation

Evaluated GET /_status and added missing `vendor` and `cluster_uuid` properties.