### PR TITLE
Docs/API: Fix outdated 'keyspace_map' ISGR collections config reference

### DIFF
--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -786,7 +786,7 @@ Retrieved-replication:
       type: string
     collections_enabled:
       description: |-
-        If true, the replicator will run with collections, and will replicate all collections, unless otherwise limited by `keyspace_map`.
+        If true, the replicator will run with collections, and will replicate all collections, unless otherwise limited by `collections_local`.
 
         If false, the replicator will only replicate the default collection.
       type: boolean
@@ -1017,7 +1017,7 @@ Replication:
       type: string
     collections_enabled:
       description: |-
-        If true, the replicator will run with collections, and will replicate all collections, unless otherwise limited by `keyspace_map`.
+        If true, the replicator will run with collections, and will replicate all collections, unless otherwise limited by `collections_local`.
 
         If false, the replicator will only replicate the default collection.
       type: boolean


### PR DESCRIPTION
This was missed when we changed from in-development version of ISGR collections when `keyspace_map` was replaced by `collections_local` and `collections_remote`.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a