### PR TITLE
Skip TestImportRollbackMultiplePartitions if vbucket count not 1024

### DIFF
--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -2301,6 +2301,12 @@ func TestImportRollbackMultiplePartitions(t *testing.T) {
 	bucket := base.GetTestBucket(t)
 	defer bucket.Close(ctx)
 
+	numVBuckets, err := bucket.GetMaxVbno()
+	require.NoError(t, err)
+	if numVBuckets != 1024 {
+		t.Skipf("Test requires 1024 vBuckets, but only had %d", numVBuckets)
+	}
+
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
 		CustomTestBucket: bucket.NoCloseClone(),
 		PersistentConfig: false,

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -2304,7 +2304,7 @@ func TestImportRollbackMultiplePartitions(t *testing.T) {
 	numVBuckets, err := bucket.GetMaxVbno()
 	require.NoError(t, err)
 	if numVBuckets != 1024 {
-		t.Skipf("Test requires 1024 vBuckets, but only had %d", numVBuckets)
+		t.Skipf("Test requires 1024 vBuckets, but only had %d, will fix in CBG-4544", numVBuckets)
 	}
 
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{


### PR DESCRIPTION
Test fails on MacOS' 64 vBuckets (and won't work with 100 either)

Skip for now - ticket was already filed to adapt this test CBG-4544 for other counts 