### PR TITLE
CBG-4684 remove dead/broken code

### DIFF
--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -37,7 +37,6 @@ from tasks import (
     TaskRunner,
     add_file_task,
     do_upload,
-    dump_utilities,
     flatten,
     generate_upload_url,
     log,
@@ -115,12 +114,6 @@ def create_option_parser():
         help="gather only product related information",
         action="store_true",
         default=False,
-    )
-    parser.add_option(
-        "-d",
-        action="callback",
-        callback=dump_utilities,
-        help="dump a list of commands that sgcollect_info needs",
     )
     parser.add_option(
         "--watch-stdin",

--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -13,7 +13,6 @@ licenses/APL2.txt.
 # -*- python -*-
 import atexit
 import base64
-import glob
 import gzip
 import hashlib
 import optparse
@@ -62,11 +61,6 @@ class LogRedactor:
         ofile = os.path.join(self.target_dir, filename)
         self._process_file(ifile, ofile, self.regular_log)
         return ofile
-
-    def redact_string(self, istring):
-        ostring = self.couchbase_log.do(b"RedactLevel")
-        ostring += self.regular_log.do(istring)
-        return ostring
 
 
 class CouchbaseLogProcessor:
@@ -432,10 +426,6 @@ class TaskRunner(object):
             zf.close()
 
 
-class SolarisTask(Task):
-    platforms = ["sunos5", "solaris"]
-
-
 class LinuxTask(Task):
     platforms = ["linux"]
 
@@ -448,8 +438,8 @@ class MacOSXTask(Task):
     platforms = ["darwin"]
 
 
-class UnixTask(SolarisTask, LinuxTask, MacOSXTask):
-    platforms = SolarisTask.platforms + LinuxTask.platforms + MacOSXTask.platforms
+class UnixTask(LinuxTask, MacOSXTask):
+    platforms = LinuxTask.platforms + MacOSXTask.platforms
 
 
 class AllOsTask(UnixTask, WindowsTask):
@@ -535,27 +525,6 @@ def add_file_task(
     return task
 
 
-def make_query_task(statement, user, password, port):
-    url = "http://127.0.0.1:%s/query/service?statement=%s" % (
-        port,
-        urllib.parse.quote(statement),
-    )
-
-    return make_curl_task(
-        name="Result of query statement '%s'" % statement,
-        user=user,
-        password=password,
-        url=url,
-    )
-
-
-def basedir():
-    mydir = os.path.dirname(sys.argv[0])
-    if mydir == "":
-        mydir = "."
-    return mydir
-
-
 def make_event_log_task():
     from datetime import datetime, timedelta
 
@@ -614,11 +583,6 @@ def make_os_tasks(processes):
         WindowsTask("Computer system", "wmic computersystem"),
         WindowsTask("Computer OS", "wmic os"),
         LinuxTask("System Hardware", "lshw -json || lshw"),
-        SolarisTask("Process list snapshot", "prstat -a -c -n 100 -t -v -L 1 10"),
-        SolarisTask("Service configuration", "svcs -a"),
-        SolarisTask("Swap configuration", "swap -l"),
-        SolarisTask("Disk activity", "zpool iostat 1 10"),
-        SolarisTask("Disk activity", "iostat -E 1 10"),
         LinuxTask("Raw /proc/vmstat", "cat /proc/vmstat"),
         LinuxTask("Raw /proc/mounts", "cat /proc/mounts"),
         LinuxTask("Raw /proc/partitions", "cat /proc/partitions"),
@@ -792,448 +756,6 @@ def flatten(iterable):
     return [e for e in iter_flatten(iterable)]
 
 
-def read_guts(guts, key):
-    return guts.get(key, "")
-
-
-def winquote_path(s):
-    return '"' + s.replace("\\\\", "\\").replace("/", "\\") + '"'
-
-
-# python's split splits empty string to [''] which doesn't make any
-# sense. So this function works around that.
-def correct_split(string, splitchar):
-    rv = string.split(splitchar)
-    if rv == [""]:
-        rv = []
-    return rv
-
-
-def make_stats_archives_task(guts, initargs_path):
-    escript = exec_name("escript")
-    escript_wrapper = find_script("escript-wrapper")
-    dump_stats = find_script("dump-stats")
-    stats_dir = read_guts(guts, "stats_dir")
-
-    if dump_stats is None or escript_wrapper is None or not stats_dir:
-        return []
-
-    return AllOsTask(
-        "stats archives",
-        [
-            escript,
-            escript_wrapper,
-            "--initargs-path",
-            initargs_path,
-            "--",
-            dump_stats,
-            stats_dir,
-        ],
-        no_header=True,
-        log_file="stats_archives.json",
-    )
-
-
-def make_product_task(guts, initargs_path, options):
-    root = os.path.abspath(os.path.join(initargs_path, "..", "..", "..", ".."))
-    dbdir = read_guts(guts, "db_dir")
-    viewdir = read_guts(guts, "idx_dir")
-
-    diag_url = "http://127.0.0.1:%s/diag?noLogs=1" % read_guts(guts, "rest_port")
-    if options.single_node_diag:
-        diag_url += "&oneNode=1"
-
-    from distutils.spawn import find_executable
-
-    lookup_cmd = None
-    for cmd in ["dig", "nslookup", "host"]:
-        if find_executable(cmd) is not None:
-            lookup_cmd = cmd
-            break
-
-    lookup_tasks = []
-    if lookup_cmd is not None:
-        lookup_tasks = [
-            UnixTask(
-                "DNS lookup information for %s" % node,
-                "%(lookup_cmd)s '%(node)s'" % locals(),
-            )
-            for node in correct_split(read_guts(guts, "nodes"), ",")
-        ]
-
-    query_tasks = []
-    query_port = read_guts(guts, "query_port")
-    if query_port:
-
-        def make(statement):
-            return make_query_task(
-                statement,
-                user="@",
-                password=read_guts(guts, "memcached_pass"),
-                port=query_port,
-            )
-
-        query_tasks = [
-            make("SELECT * FROM system:datastores"),
-            make("SELECT * FROM system:namespaces"),
-            make("SELECT * FROM system:keyspaces"),
-            make("SELECT * FROM system:indexes"),
-        ]
-
-    index_tasks = []
-    index_port = read_guts(guts, "indexer_http_port")
-    if index_port:
-        url = "http://127.0.0.1:%s/getIndexStatus" % index_port
-        index_tasks = [
-            make_curl_task(
-                name="Index definitions are: ",
-                user="@",
-                password=read_guts(guts, "memcached_pass"),
-                url=url,
-            )
-        ]
-
-    fts_tasks = []
-    fts_port = read_guts(guts, "fts_http_port")
-    if fts_port:
-        url = "http://127.0.0.1:%s/api/diag" % fts_port
-        fts_tasks = [
-            make_curl_task(
-                name="FTS /api/diag: ",
-                user="@",
-                password=read_guts(guts, "memcached_pass"),
-                url=url,
-            )
-        ]
-
-    _tasks = [
-        UnixTask("Directory structure", ["ls", "-lRai", root]),
-        UnixTask("Database directory structure", ["ls", "-lRai", dbdir]),
-        UnixTask("Index directory structure", ["ls", "-lRai", viewdir]),
-        UnixTask(
-            "couch_dbinfo",
-            [
-                "find",
-                dbdir,
-                "-type",
-                "f",
-                "-name",
-                "*.couch.*",
-                "-exec",
-                "couch_dbinfo",
-                "{}",
-                "+",
-            ],
-        ),
-        LinuxTask(
-            "Database directory filefrag info",
-            ["find", dbdir, "-type", "f", "-exec", "filefrag", "-v", "{}", "+"],
-        ),
-        LinuxTask(
-            "Index directory filefrag info",
-            ["find", viewdir, "-type", "f", "-exec", "filefrag", "-v", "{}", "+"],
-        ),
-        WindowsTask("Database directory structure", "dir /s " + winquote_path(dbdir)),
-        WindowsTask("Index directory structure", "dir /s " + winquote_path(viewdir)),
-        WindowsTask(
-            "Version file", "type " + winquote_path(basedir()) + "\\..\\VERSION.txt"
-        ),
-        WindowsTask(
-            "Manifest file", "type " + winquote_path(basedir()) + "\\..\\manifest.txt"
-        ),
-        WindowsTask(
-            "Manifest file", "type " + winquote_path(basedir()) + "\\..\\manifest.xml"
-        ),
-        LinuxTask("Version file", "cat '%s/VERSION.txt'" % root),
-        LinuxTask("Manifest file", "cat '%s/manifest.txt'" % root),
-        LinuxTask("Manifest file", "cat '%s/manifest.xml'" % root),
-        AllOsTask("Couchbase config", "", literal=read_guts(guts, "ns_config")),
-        AllOsTask(
-            "Couchbase static config", "", literal=read_guts(guts, "static_config")
-        ),
-        AllOsTask("Raw ns_log", "", literal=read_guts(guts, "ns_log")),
-        # TODO: just gather those in python
-        WindowsTask(
-            "Memcached logs",
-            "cd "
-            + winquote_path(read_guts(guts, "memcached_logs_path"))
-            + " && "
-            + "for /f %a IN ('dir /od /b memcached.log.*') do type %a",
-            log_file="memcached.log",
-        ),
-        UnixTask(
-            "Memcached logs",
-            [
-                "sh",
-                "-c",
-                'cd "$1"; for file in $(ls -tr memcached.log.*); do cat "$file"; done',
-                "--",
-                read_guts(guts, "memcached_logs_path"),
-            ],
-            log_file="memcached.log",
-        ),
-        [
-            WindowsTask(
-                "Ini files (%s)" % p, "type " + winquote_path(p), log_file="ini.log"
-            )
-            for p in read_guts(guts, "couch_inis").split(";")
-        ],
-        UnixTask(
-            "Ini files",
-            ["sh", "-c", 'for i in "$@"; do echo "file: $i"; cat "$i"; done', "--"]
-            + read_guts(guts, "couch_inis").split(";"),
-            log_file="ini.log",
-        ),
-        make_curl_task(
-            name="couchbase diags",
-            user="@",
-            password=read_guts(guts, "memcached_pass"),
-            timeout=600,
-            url=diag_url,
-            log_file="diag.log",
-        ),
-        make_curl_task(
-            name="master events",
-            user="@",
-            password=read_guts(guts, "memcached_pass"),
-            timeout=300,
-            url="http://127.0.0.1:%s/diag/masterEvents?o=1"
-            % read_guts(guts, "rest_port"),
-            log_file="master_events.log",
-            no_header=True,
-        ),
-        make_curl_task(
-            name="ale configuration",
-            user="@",
-            password=read_guts(guts, "memcached_pass"),
-            url="http://127.0.0.1:%s/diag/ale" % read_guts(guts, "rest_port"),
-            log_file="couchbase.log",
-        ),
-        [
-            AllOsTask(
-                "couchbase logs (%s)" % name,
-                "cbbrowse_logs %s" % name,
-                addenv=[("REPORT_DIR", read_guts(guts, "log_path"))],
-                log_file="ns_server.%s" % name,
-            )
-            for name in [
-                "debug.log",
-                "info.log",
-                "error.log",
-                "couchdb.log",
-                "xdcr.log",
-                "xdcr_errors.log",
-                "views.log",
-                "mapreduce_errors.log",
-                "stats.log",
-                "babysitter.log",
-                "ssl_proxy.log",
-                "reports.log",
-                "xdcr_trace.log",
-                "http_access.log",
-                "http_access_internal.log",
-                "ns_couchdb.log",
-                "goxdcr.log",
-                "query.log",
-                "projector.log",
-                "indexer.log",
-                "fts.log",
-                "metakv.log",
-            ]
-        ],
-        [
-            AllOsTask(
-                "memcached stats %s" % kind,
-                flatten(
-                    [
-                        "cbstats",
-                        "-a",
-                        "127.0.0.1:%s" % read_guts(guts, "memcached_port"),
-                        kind,
-                        "-b",
-                        read_guts(guts, "memcached_admin"),
-                        "-p",
-                        read_guts(guts, "memcached_pass"),
-                    ]
-                ),
-                log_file="stats.log",
-                timeout=60,
-            )
-            for kind in [
-                "all",
-                "allocator",
-                "checkpoint",
-                "config",
-                "dcp",
-                "dcpagg",
-                ["diskinfo", "detail"],
-                ["dispatcher", "logs"],
-                "failovers",
-                ["hash", "detail"],
-                "kvstore",
-                "kvtimings",
-                "memory",
-                "prev-vbucket",
-                "runtimes",
-                "scheduler",
-                "tap",
-                "tapagg",
-                "timings",
-                "uuid",
-                "vbucket",
-                "vbucket-details",
-                "vbucket-seqno",
-                "warmup",
-                "workload",
-            ]
-        ],
-        [
-            AllOsTask(
-                "memcached mcstat %s" % kind,
-                flatten(
-                    [
-                        "mcstat",
-                        "-h",
-                        "127.0.0.1:%s" % read_guts(guts, "memcached_port"),
-                        "-u",
-                        read_guts(guts, "memcached_admin"),
-                        "-P",
-                        read_guts(guts, "memcached_pass"),
-                        kind,
-                    ]
-                ),
-                log_file="stats.log",
-                timeout=60,
-            )
-            for kind in ["connections"]
-        ],
-        [
-            AllOsTask(
-                "ddocs for %s (%s)" % (bucket, path),
-                ["couch_dbdump", path],
-                log_file="ddocs.log",
-            )
-            for bucket in set(correct_split(read_guts(guts, "buckets"), ","))
-            - set(correct_split(read_guts(guts, "memcached_buckets"), ","))
-            for path in glob.glob(os.path.join(dbdir, bucket, "master.couch*"))
-        ],
-        [
-            AllOsTask(
-                "replication docs (%s)" % (path),
-                ["couch_dbdump", path],
-                log_file="ddocs.log",
-            )
-            for path in glob.glob(os.path.join(dbdir, "_replicator.couch*"))
-        ],
-        [
-            AllOsTask(
-                "Couchstore local documents (%s, %s)"
-                % (bucket, os.path.basename(path)),
-                ["couch_dbdump", "--local", path],
-                log_file="couchstore_local.log",
-            )
-            for bucket in set(correct_split(read_guts(guts, "buckets"), ","))
-            - set(correct_split(read_guts(guts, "memcached_buckets"), ","))
-            for path in glob.glob(os.path.join(dbdir, bucket, "*.couch.*"))
-        ],
-        [
-            UnixTask(
-                "moxi stats (port %s)" % port,
-                "echo stats proxy | nc 127.0.0.1 %s" % port,
-                log_file="stats.log",
-                timeout=60,
-            )
-            for port in correct_split(read_guts(guts, "moxi_ports"), ",")
-        ],
-        [
-            AllOsTask(
-                "mctimings",
-                [
-                    "mctimings",
-                    "-u",
-                    read_guts(guts, "memcached_admin"),
-                    "-P",
-                    read_guts(guts, "memcached_pass"),
-                    "-h",
-                    "127.0.0.1:%s" % read_guts(guts, "memcached_port"),
-                    "-v",
-                ]
-                + stat,
-                log_file="stats.log",
-                timeout=60,
-            )
-            for stat in ([], ["subdoc_execute"])
-        ],
-        make_stats_archives_task(guts, initargs_path),
-    ]
-
-    _tasks = flatten([lookup_tasks, query_tasks, index_tasks, fts_tasks, _tasks])
-
-    return _tasks
-
-
-def find_script(name):
-    dirs = [basedir(), os.path.join(basedir(), "scripts")]
-    for d in dirs:
-        path = os.path.join(d, name)
-        if os.path.exists(path):
-            log("Found %s: %s" % (name, path))
-            return path
-
-    return None
-
-
-def guess_utility(command):
-    if isinstance(command, list):
-        command = " ".join(command)
-
-    if not command:
-        return None
-
-    if re.findall(r"[|;&]|\bsh\b|\bsu\b|\bfind\b|\bfor\b", command):
-        # something hard to easily understand; let the human decide
-        return command
-    else:
-        return command.split()[0]
-
-
-def dump_utilities(*args, **kwargs):
-    specific_platforms = {
-        SolarisTask: "Solaris",
-        LinuxTask: "Linux",
-        WindowsTask: "Windows",
-        MacOSXTask: "Mac OS X",
-    }
-    platform_utils = dict((name, set()) for name in list(specific_platforms.values()))
-
-    class FakeOptions(object):
-        def __getattr__(self, name):
-            return None
-
-    tasks = make_os_tasks() + make_product_task({}, "", FakeOptions())
-
-    for task in tasks:
-        utility = guess_utility(task.command)
-        if utility is None:
-            continue
-
-        for platform, name in list(specific_platforms.items()):
-            if isinstance(task, platform):
-                platform_utils[name].add(utility)
-
-    print(
-        "This is an autogenerated, possibly incomplete and flawed list of utilites used by cbcollect_info"
-    )
-
-    for name, utilities in sorted(list(platform_utils.items()), key=lambda x: x[0]):
-        print("\n%s:" % name)
-
-        for utility in sorted(utilities):
-            print("        - %s" % utility)
-
-    sys.exit(0)
-
-
 def setup_stdin_watcher():
     def _in_thread():
         sys.stdin.readline()
@@ -1321,12 +843,6 @@ class CbcollectInfoOptions(optparse.Option):
     TYPES = optparse.Option.TYPES + ("ticket",)
     TYPE_CHECKER = copy(optparse.Option.TYPE_CHECKER)
     TYPE_CHECKER["ticket"] = check_ticket
-
-
-def exec_name(name):
-    if sys.platform == "win32":
-        name += ".exe"
-    return name
 
 
 def redactable_file(filename: Union[pathlib.Path, str]) -> bool:


### PR DESCRIPTION
CBG-4684 remove dead/broken code

- `dump_utilities` hasn't worked since https://github.com/couchbase/sync_gateway/pull/1789/files so I feel like it is probably safe to remove. This was copy pasted from cbcollect_info.
- `redact_string` is unused (according to `uvx vulture tools/sgcollect_info tools/*py`)
- removed SolarisTask
