### PR TITLE
CBG-4664: Add Resync Metrics

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -591,6 +591,11 @@ type CollectionStats struct {
 	NumDocWrites *SgwIntStat `json:"num_doc_writes"`
 	// The total number of bytes written to this collection as part of document writes since Sync Gateway node startup.
 	DocWritesBytes *SgwIntStat `json:"doc_writes_bytes"`
+
+	// The total number of processed documents for resync on this collection.
+	ResyncNumProcessed *SgwIntStat `json:"resync_num_processed"`
+	// The total number of changed documents for resync on this collection.
+	ResyncNumChanged *SgwIntStat `json:"resync_num_changed"`
 }
 
 type DatabaseStats struct {
@@ -676,6 +681,10 @@ type DatabaseStats struct {
 	SyncFunctionExceptionCount *SgwIntStat `json:"sync_function_exception_count"`
 	// The total number of times a replication connection is rejected due ot it being over the threshold
 	NumReplicationsRejectedLimit *SgwIntStat `json:"num_replications_rejected_limit"`
+	// The total number of processed documents for resync on this database.
+	ResyncNumProcessed *SgwIntStat `json:"resync_num_processed"`
+	// The total number of changed documents for resync on this database.
+	ResyncNumChanged *SgwIntStat `json:"resync_num_changed"`
 
 	// These can be cleaned up in future versions of SGW, implemented as maps to reduce amount of potential risk
 	// prior to Hydrogen release. These are not exported as part of prometheus and only exposed through expvars
@@ -1812,6 +1821,14 @@ func (d *DbStats) initDatabaseStats() error {
 	if err != nil {
 		return err
 	}
+	resUtil.ResyncNumProcessed, err = NewIntStat(SubsystemDatabaseKey, "resync_num_processed", StatUnitNoUnits, ResyncNumProcessedDesc, StatAddedVersion3dot3dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
+	resUtil.ResyncNumChanged, err = NewIntStat(SubsystemDatabaseKey, "resync_num_changed", StatUnitNoUnits, ResyncNumChangedDesc, StatAddedVersion3dot3dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
 	resUtil.NumPublicRestRequests, err = NewIntStat(SubsystemDatabaseKey, "num_public_rest_requests", StatUnitNoUnits, NumPublicRestRequestsDesc, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityVolatile, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
@@ -1876,6 +1893,8 @@ func (d *DbStats) unregisterDatabaseStats() {
 	prometheus.Unregister(d.DatabaseStats.SyncFunctionTime)
 	prometheus.Unregister(d.DatabaseStats.SyncFunctionExceptionCount)
 	prometheus.Unregister(d.DatabaseStats.NumReplicationsRejectedLimit)
+	prometheus.Unregister(d.DatabaseStats.ResyncNumProcessed)
+	prometheus.Unregister(d.DatabaseStats.ResyncNumChanged)
 	prometheus.Unregister(d.DatabaseStats.NumPublicRestRequests)
 	prometheus.Unregister(d.DatabaseStats.TotalSyncTime)
 	prometheus.Unregister(d.DatabaseStats.PublicRestBytesRead)
@@ -2031,6 +2050,8 @@ func (d *DbStats) unregisterCollectionStats(scopeAndCollectionName string) {
 
 	prometheus.Unregister(d.CollectionStats[scopeAndCollectionName].NumDocWrites)
 	prometheus.Unregister(d.CollectionStats[scopeAndCollectionName].DocWritesBytes)
+	prometheus.Unregister(d.CollectionStats[scopeAndCollectionName].ResyncNumProcessed)
+	prometheus.Unregister(d.CollectionStats[scopeAndCollectionName].ResyncNumChanged)
 }
 
 func (d *DbStats) unregisterSecurityStats() {
@@ -2087,6 +2108,14 @@ func NewCollectionStats(dbName, scopeAndCollectionName string) (stats *Collectio
 		return nil, err
 	}
 	stats.DocWritesBytes, err = NewIntStat(SubsystemCollection, "doc_writes_bytes", StatUnitBytes, DocWritesBytesCollDesc, StatAddedVersion3dot1dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return nil, err
+	}
+	stats.ResyncNumProcessed, err = NewIntStat(SubsystemCollection, "resync_num_processed", StatUnitBytes, ResyncNumProcessedCollDesc, StatAddedVersion3dot3dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return nil, err
+	}
+	stats.ResyncNumChanged, err = NewIntStat(SubsystemCollection, "resync_num_changed", StatUnitBytes, ResyncNumChangedCollDesc, StatAddedVersion3dot3dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/base/stats_descriptions.go
+++ b/base/stats_descriptions.go
@@ -307,6 +307,10 @@ const (
 
 	NumReplicationsRejectedLimitDesc = "The total number of times a replication connection is rejected due to it being over the threshold."
 
+	ResyncNumProcessedDesc = "The total number of processed documents for resync on this database."
+
+	ResyncNumChangedDesc = "The total number of changed documents for resync on this database."
+
 	NumPublicRestRequestsDesc = "The total number of requests sent over the public REST api."
 
 	TotalSyncTimeDesc = "The total total sync time is a proxy for websocket connections. Tracking long lived and potentially idle connections. " +
@@ -467,4 +471,8 @@ const (
 	NumDocWritesCollDesc = "The total number of documents written to this collection since Sync Gateway node startup (i.e. receiving from a client)"
 
 	DocWritesBytesCollDesc = "The total number of bytes written to this collection as part of document writes since Sync Gateway node startup."
+
+	ResyncNumProcessedCollDesc = "The total number of processed documents for resync on this collection."
+
+	ResyncNumChangedCollDesc = "The total number of changed documents for resync on this collection."
 )

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -141,7 +141,9 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]interface
 		}
 
 		r.DocsProcessed.Add(1)
+		db.DbStats.Database().ResyncNumProcessed.Add(1)
 		databaseCollection := db.CollectionByID[event.CollectionID]
+		databaseCollection.collectionStats.ResyncNumProcessed.Add(1)
 		collectionCtx := databaseCollection.AddCollectionContext(ctx)
 		_, unusedSequences, err := (&DatabaseCollectionWithUser{
 			DatabaseCollection: databaseCollection,
@@ -151,6 +153,8 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]interface
 
 		if err == nil {
 			r.DocsChanged.Add(1)
+			db.DbStats.Database().ResyncNumChanged.Add(1)
+			databaseCollection.collectionStats.ResyncNumChanged.Add(1)
 		} else if err != base.ErrUpdateCancel {
 			base.WarnfCtx(collectionCtx, "[%s] Error updating doc %q: %v", resyncLoggingID, base.UD(docID), err)
 		}

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -411,7 +411,7 @@ func TestResycnManagerDCPResumeStoppedProcess(t *testing.T) {
 }
 
 // helper function to insert documents equals to docsToCreate, and update sync function if updateResyncFuncAfterDocsAdded set to true
-func setupTestDBForResyncWithDocs(t *testing.T, docsToCreate int, updateResyncFuncAfterDocsAdded bool) (*Database, context.Context) {
+func setupTestDBForResyncWithDocs(t testing.TB, docsToCreate int, updateResyncFuncAfterDocsAdded bool) (*Database, context.Context) {
 	db, ctx := setupTestDB(t)
 	db.Options.QueryPaginationLimit = 100
 	syncFn := `

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -214,6 +214,11 @@ func TestResyncManagerDCPStart(t *testing.T) {
 		db, ctx := setupTestDBForResyncWithDocs(t, docsToCreate, false)
 		defer db.Close(ctx)
 
+		dbc, _ := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+		scopeAndCollectionName := dbc.ScopeAndCollectionName()
+		scopeName := scopeAndCollectionName.ScopeName()
+		collectionName := scopeAndCollectionName.CollectionName()
+
 		resyncMgr := NewResyncManagerDCP(db.MetadataStore, base.TestUseXattrs(), db.MetadataKeys)
 
 		require.NotNil(t, resyncMgr)
@@ -239,6 +244,14 @@ func TestResyncManagerDCPStart(t *testing.T) {
 		assert.Equal(t, int64(docsToCreate), stats.DocsProcessed)
 		assert.Equal(t, int64(0), stats.DocsChanged)
 
+		assert.Equal(t, db.DbStats.Database().ResyncNumProcessed.Value(), int64(docsToCreate))
+		assert.Equal(t, db.DbStats.Database().ResyncNumChanged.Value(), int64(0))
+
+		cs, err := db.DbStats.CollectionStat(scopeName, collectionName)
+		require.NoError(t, err)
+		assert.Equal(t, int64(docsToCreate), cs.ResyncNumProcessed.Value())
+		assert.Equal(t, int64(0), cs.ResyncNumChanged.Value())
+
 		assert.Equal(t, db.DbStats.Database().SyncFunctionCount.Value(), int64(docsToCreate))
 	})
 
@@ -246,6 +259,11 @@ func TestResyncManagerDCPStart(t *testing.T) {
 		docsToCreate := 100
 		db, ctx := setupTestDBForResyncWithDocs(t, docsToCreate, true)
 		defer db.Close(ctx)
+
+		dbc, _ := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+		scopeAndCollectionName := dbc.ScopeAndCollectionName()
+		scopeName := scopeAndCollectionName.ScopeName()
+		collectionName := scopeAndCollectionName.CollectionName()
 
 		resyncMgr := NewResyncManagerDCP(db.MetadataStore, base.TestUseXattrs(), db.MetadataKeys)
 		require.NotNil(t, resyncMgr)
@@ -275,6 +293,14 @@ func TestResyncManagerDCPStart(t *testing.T) {
 		// be greater than DocsChanged
 		assert.LessOrEqual(t, int64(docsToCreate), stats.DocsProcessed)
 		assert.Equal(t, int64(docsToCreate), stats.DocsChanged)
+
+		assert.Equal(t, db.DbStats.Database().ResyncNumProcessed.Value(), int64(docsToCreate))
+		assert.Equal(t, db.DbStats.Database().ResyncNumChanged.Value(), int64(docsToCreate))
+
+		cs, err := db.DbStats.CollectionStat(scopeName, collectionName)
+		require.NoError(t, err)
+		assert.Equal(t, int64(docsToCreate), cs.ResyncNumProcessed.Value())
+		assert.Equal(t, int64(docsToCreate), cs.ResyncNumChanged.Value())
 
 		deltaOk := assert.InDelta(t, int64(docsToCreate), db.DbStats.Database().SyncFunctionCount.Value(), 2)
 		assert.True(t, deltaOk, "DCP stream has processed some documents more than once than allowed delta. Try rerunning the test.")


### PR DESCRIPTION
CBG-4664

Add db and collection level resync stats - tracking num processed and num changed.

![Screenshot 2025-06-10 at 20 22 17](https://github.com/user-attachments/assets/2187fcac-ccc5-41d5-adeb-f59c4ad5027b)

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3149/
- [x] `GSI=true,xattrs=true,default_colllection` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3150/
  - `TestBlipPushRevOnResurrection/allowConflicts=true/revTree` unrelated - test not tolerant to extra warnings when run with default collection