### PR TITLE
CBG-4693: close done chan in correct location

### DIFF
--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -264,12 +264,12 @@ func (listener *changeListener) StartNotifierBroadcaster(ctx context.Context) {
 	// for a value it already has
 	broadcastSlowMode := false
 	go func(terminator chan bool) {
+		defer func() {close(listener.broadcastChangesDoneChan)}()
 		var currCount uint64
 		for {
 			select {
 			case <-terminator:
 				ticker.Stop()
-				close(listener.broadcastChangesDoneChan)
 				return
 			case <-ticker.C:
 				// if the counter has changed, notify waiting clients

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -260,7 +260,6 @@ func (listener *changeListener) Notify(ctx context.Context, keys channels.Set) {
 
 func (listener *changeListener) StartNotifierBroadcaster(ctx context.Context) {
 	ticker := time.NewTicker(DefaultBroadcastChangesTime)
-	defer func() { close(listener.broadcastChangesDoneChan) }()
 	// boolean to indicate whether ticker is using the default value, this is needed so we don't call reset on ticker
 	// for a value it already has
 	broadcastSlowMode := false
@@ -270,6 +269,7 @@ func (listener *changeListener) StartNotifierBroadcaster(ctx context.Context) {
 			select {
 			case <-terminator:
 				ticker.Stop()
+				close(listener.broadcastChangesDoneChan)
 				return
 			case <-ticker.C:
 				// if the counter has changed, notify waiting clients

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -264,7 +264,9 @@ func (listener *changeListener) StartNotifierBroadcaster(ctx context.Context) {
 	// for a value it already has
 	broadcastSlowMode := false
 	go func(terminator chan bool) {
-		defer func() {close(listener.broadcastChangesDoneChan)}()
+		defer func() {
+			close(listener.broadcastChangesDoneChan)
+		}()
 		var currCount uint64
 		for {
 			select {

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -263,9 +263,9 @@ func (listener *changeListener) StartNotifierBroadcaster(ctx context.Context) {
 	// boolean to indicate whether ticker is using the default value, this is needed so we don't call reset on ticker
 	// for a value it already has
 	broadcastSlowMode := false
-	go func(terminator chan bool) {
+	go func(terminator chan bool, doneChan chan struct{}) {
 		defer func() {
-			close(listener.broadcastChangesDoneChan)
+			close(doneChan)
 		}()
 		var currCount uint64
 		for {
@@ -294,7 +294,7 @@ func (listener *changeListener) StartNotifierBroadcaster(ctx context.Context) {
 				}
 			}
 		}
-	}(listener.terminator)
+	}(listener.terminator, listener.broadcastChangesDoneChan)
 }
 
 // tickerValForBroadcastSpeed will return the duration for the ticker to be reset to based on input boolean to indicate


### PR DESCRIPTION
CBG-4693

- calling close done chan in wrong place so stop change listener wasn't waiting for broadcast to close


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
