### PR TITLE
CBG-4712 /_sgcollect_info endpoint to work with non default port

### DIFF
--- a/base/main_test_bucket_pool_config.go
+++ b/base/main_test_bucket_pool_config.go
@@ -15,6 +15,8 @@ import (
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 // Bucket names start with a fixed prefix and end with a sequential bucket number and a creation timestamp for uniqueness
@@ -212,4 +214,28 @@ func TestClusterPassword() string {
 		password = envClusterPassword
 	}
 	return password
+}
+
+// TestRunSGCollectIntegrationTests runs the tests only if a specific environment variable is set. These should always run under jenkins/github actions.
+func TestRunSGCollectIntegrationTests(t *testing.T) {
+	env := "SG_TEST_SGCOLLECT_INTEGRATION"
+	val, ok := os.LookupEnv(env)
+	if !ok {
+		ciEnvVars := []string{
+			"CI",          // convention by github actions
+			"JENKINS_URL", // from jenkins
+		}
+		for _, ciEnv := range ciEnvVars {
+			if os.Getenv(ciEnv) != "" {
+				return
+			}
+		}
+		t.Skip("Skipping sgcollect integration tests - set " + env + "=true to run")
+	}
+
+	runTests, err := strconv.ParseBool(val)
+	require.NoError(t, err, "Couldn't parse %s=%s as bool", env, val)
+	if !runTests {
+		t.Skip("Skipping sgcollect integration tests - set " + env + "=true to run")
+	}
 }

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -1683,7 +1683,7 @@ func (h *handler) handleSGCollect() error {
 	if h.server.Config.API.HTTPS.TLSCertPath != "" {
 		addr = "https://" + addr
 	} else {
-		params.adminURL = "http://" + addr
+		addr = "http://" + addr
 	}
 	params.adminURL = addr
 

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -1691,7 +1691,9 @@ func (h *handler) handleSGCollect() error {
 
 	logFilePath := h.server.Config.Logging.LogFilePath
 
-	if err := h.server.sgcollect.Start(logFilePath, h.serialNumber, zipFilename, params); err != nil {
+	ctx := base.CorrelationIDLogCtx(context.WithoutCancel(h.ctx()), fmt.Sprintf("SGCollect-%03d", h.serialNumber))
+
+	if err := h.server.sgcollect.Start(ctx, logFilePath, zipFilename, params); err != nil {
 		return base.HTTPErrorf(http.StatusInternalServerError, "Error running sgcollect_info: %v", err)
 	}
 

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -1637,7 +1637,7 @@ func (h *handler) handleSetLogging() error {
 
 func (h *handler) handleSGCollectStatus() error {
 	status := "stopped"
-	if h.server.sgcollect.IsRunning() {
+	if h.server.SGCollect.IsRunning() {
 		status = "running"
 	}
 
@@ -1647,7 +1647,7 @@ func (h *handler) handleSGCollectStatus() error {
 }
 
 func (h *handler) handleSGCollectCancel() error {
-	err := h.server.sgcollect.Stop()
+	err := h.server.SGCollect.Stop()
 	if err != nil {
 		return base.HTTPErrorf(http.StatusBadRequest, "Error stopping sgcollect_info: %v", err)
 	}
@@ -1664,7 +1664,7 @@ func (h *handler) handleSGCollect() error {
 		return err
 	}
 
-	var params sgCollectOptions
+	var params SGCollectOptions
 	if err = base.JSONUnmarshal(body, &params); err != nil {
 		return base.HTTPErrorf(http.StatusBadRequest, "Unable to parse request body: %v", err)
 	}
@@ -1687,13 +1687,13 @@ func (h *handler) handleSGCollect() error {
 	}
 	params.adminURL = addr
 
-	zipFilename := sgcollectFilename()
+	zipFilename := SGCollectFilename()
 
 	logFilePath := h.server.Config.Logging.LogFilePath
 
 	ctx := base.CorrelationIDLogCtx(context.WithoutCancel(h.ctx()), fmt.Sprintf("SGCollect-%03d", h.serialNumber))
 
-	if err := h.server.sgcollect.Start(ctx, logFilePath, zipFilename, params); err != nil {
+	if err := h.server.SGCollect.Start(ctx, logFilePath, zipFilename, params); err != nil {
 		return base.HTTPErrorf(http.StatusInternalServerError, "Error running sgcollect_info: %v", err)
 	}
 

--- a/rest/audit_test.go
+++ b/rest/audit_test.go
@@ -239,7 +239,7 @@ func TestAuditLoggingFields(t *testing.T) {
 			auditableAction: func(t testing.TB) {
 				headers := map[string]string{
 					requestInfoHeaderName: `{"extra":"field"}`,
-					"Authorization":       getBasicAuthHeader(requestUser, RestTesterDefaultUserPassword),
+					"Authorization":       GetBasicAuthHeader(t, requestUser, RestTesterDefaultUserPassword),
 				}
 				RequireStatus(t, rt.SendRequestWithHeaders(http.MethodGet, "/db/", "", headers), http.StatusOK)
 			},
@@ -442,7 +442,7 @@ func TestAuditLoggingFields(t *testing.T) {
 			name: "metrics request authenticated",
 			auditableAction: func(t testing.TB) {
 				headers := map[string]string{
-					"Authorization": getBasicAuthHeader(base.TestClusterUsername(), base.TestClusterPassword()),
+					"Authorization": GetBasicAuthHeader(t, base.TestClusterUsername(), base.TestClusterPassword()),
 				}
 				RequireStatus(t, rt.SendMetricsRequestWithHeaders(http.MethodGet, "/_metrics", "", headers), http.StatusOK)
 			},
@@ -473,7 +473,7 @@ func TestAuditLoggingFields(t *testing.T) {
 					t.Skip("Skipping subtest that requires admin auth to be enabled")
 				}
 				headers := map[string]string{
-					"Authorization": getBasicAuthHeader("notauser", base.TestClusterPassword()),
+					"Authorization": GetBasicAuthHeader(t, "notauser", base.TestClusterPassword()),
 				}
 				RequireStatus(t, rt.SendMetricsRequestWithHeaders(http.MethodGet, "/_metrics", "", headers), http.StatusUnauthorized)
 			},
@@ -724,7 +724,7 @@ func TestEffectiveUserID(t *testing.T) {
 	)
 	reqHeaders := map[string]string{
 		"user_header":   fmt.Sprintf(`{"%s": "%s", "%s":"%s"}`, headerDomain, cnfDomain, headerUser, cnfUser),
-		"Authorization": getBasicAuthHeader(realUser, RestTesterDefaultUserPassword),
+		"Authorization": GetBasicAuthHeader(t, realUser, RestTesterDefaultUserPassword),
 	}
 
 	rt := NewRestTester(t, &RestTesterConfig{

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -86,6 +86,8 @@ type ServerContext struct {
 	DatabaseInitManager           *DatabaseInitManager       // Manages database initialization (index creation and readiness) independent of database stop/start/reload, when using persistent config
 	ActiveReplicationsCounter
 	invalidDatabaseConfigTracking invalidDatabaseConfigs
+	// handle sgcollect processes for a given Server
+	sgcollect *sgCollect
 }
 
 type ActiveReplicationsCounter struct {
@@ -163,6 +165,7 @@ func NewServerContext(ctx context.Context, config *StartupConfig, persistentConf
 		BootstrapContext:    &bootstrapContext{sgVersion: *base.ProductVersion},
 		hasStarted:          make(chan struct{}),
 		_httpServers:        map[serverType]*serverInfo{},
+		sgcollect:           newSGCollect(ctx),
 	}
 	sc.invalidDatabaseConfigTracking = invalidDatabaseConfigs{
 		dbNames: map[string]*invalidConfigInfo{},

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -87,7 +87,7 @@ type ServerContext struct {
 	ActiveReplicationsCounter
 	invalidDatabaseConfigTracking invalidDatabaseConfigs
 	// handle sgcollect processes for a given Server
-	sgcollect *sgCollect
+	SGCollect *sgCollect
 }
 
 type ActiveReplicationsCounter struct {
@@ -165,7 +165,7 @@ func NewServerContext(ctx context.Context, config *StartupConfig, persistentConf
 		BootstrapContext:    &bootstrapContext{sgVersion: *base.ProductVersion},
 		hasStarted:          make(chan struct{}),
 		_httpServers:        map[serverType]*serverInfo{},
-		sgcollect:           newSGCollect(ctx),
+		SGCollect:           newSGCollect(ctx),
 	}
 	sc.invalidDatabaseConfigTracking = invalidDatabaseConfigs{
 		dbNames: map[string]*invalidConfigInfo{},

--- a/rest/sgcollect.go
+++ b/rest/sgcollect.go
@@ -262,10 +262,12 @@ func (o *sgCollectOutputStream) Close(ctx context.Context) {
 	select {
 	case <-o.stdoutDoneChan:
 	case <-time.After(5 * time.Second):
+		base.WarnfCtx(ctx, "sgcollect_info: timed out waiting for stdout processing to finish")
 	}
 	select {
 	case <-o.stderrDoneChan:
 	case <-time.After(5 * time.Second):
+		base.WarnfCtx(ctx, "sgcollect_info: timed out waiting for stderr processing to finish")
 	}
 }
 

--- a/rest/sgcollect.go
+++ b/rest/sgcollect.go
@@ -114,7 +114,7 @@ func (sg *sgCollect) Start(ctx context.Context, logFilePath string, zipFilename 
 
 	atomic.StoreUint32(sg.status, sgRunning)
 	startTime := time.Now()
-	base.InfofCtx(ctx, base.KeyAdmin, "sgcollect_info started with cmdline: %v", base.UD(cmdline))
+	base.InfofCtx(ctx, base.KeyAdmin, "sgcollect_info started with output zip: %v", base.UD(zipPath))
 
 	go func() {
 		// Blocks until command finishes

--- a/rest/sgcollect_test.go
+++ b/rest/sgcollect_test.go
@@ -228,6 +228,7 @@ func TestSgcollectOptionsArgs(t *testing.T) {
 }
 
 func TestSGCollectIntegration(t *testing.T) {
+	base.TestRunSGCollectIntegrationTests(t)
 	base.LongRunningTest(t) // this test is very long, and somewhat fragile, since it involves relying on the sgcollect_info tool to run successfully, which requires system python
 	cwd, err := os.Getwd()
 	require.NoError(t, err)

--- a/rest/sgcollect_test.go
+++ b/rest/sgcollect_test.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -241,7 +242,11 @@ func TestSGCollectIntegration(t *testing.T) {
 
 	sc.sgcollect.stdout = outputs["stdout"]
 	sc.sgcollect.stderr = outputs["stderr"]
-	sc.sgcollect.sgCollectPath = []string{"python", filepath.Join(cwd, "../tools/sgcollect_info")}
+	python := "python3"
+	if runtime.GOOS == "windows" {
+		python = "python"
+	}
+	sc.sgcollect.sgCollectPath = []string{python, filepath.Join(cwd, "../tools/sgcollect_info")}
 	sc.sgcollect.sgCollectPathErr = nil
 	validAuth := map[string]string{
 		"Authorization": getBasicAuthHeader(base.TestClusterUsername(), base.TestClusterPassword()),

--- a/rest/sgcollecttest/main_test.go
+++ b/rest/sgcollecttest/main_test.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2020-Present Couchbase, Inc.
+
+Use of this software is governed by the Business Source License included in
+the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+file, in accordance with the Business Source License, use of this software will
+be governed by the Apache License, Version 2.0, included in the file
+licenses/APL2.txt.
+*/
+
+package sgcollecttest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/rest"
+)
+
+func TestMain(m *testing.M) {
+	ctx := context.Background() // start of test process
+	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 8192, NumCollectionsPerBucket: 3}
+	rest.TestBucketPoolRestWithIndexes(ctx, m, tbpOptions)
+}

--- a/rest/sgcollecttest/sgcollect_test.go
+++ b/rest/sgcollecttest/sgcollect_test.go
@@ -230,6 +230,9 @@ func TestSgcollectOptionsArgs(t *testing.T) {
 
 func TestSGCollectIntegration(t *testing.T) {
 	base.TestRunSGCollectIntegrationTests(t)
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping sgcollect_info integration test on Windows - currently flaky when running wmic product get name, version, which can take 7+ minutes")
+	}
 	base.LongRunningTest(t) // this test is very long, and somewhat fragile, since it involves relying on the sgcollect_info tool to run successfully, which requires system python
 	cwd, err := os.Getwd()
 	require.NoError(t, err)

--- a/rest/utilities_testing_user.go
+++ b/rest/utilities_testing_user.go
@@ -76,6 +76,6 @@ func DeleteUser(t *testing.T, httpClient *http.Client, serverURL, username strin
 	require.NoError(t, resp.Body.Close(), "Error closing response body")
 }
 
-func getBasicAuthHeader(username, password string) string {
+func GetBasicAuthHeader(_ testing.TB, username, password string) string {
 	return "Basic " + base64.StdEncoding.EncodeToString([]byte(username+":"+password))
 }

--- a/tools-tests/sgcollect_info_test.py
+++ b/tools-tests/sgcollect_info_test.py
@@ -8,7 +8,9 @@
 
 import io
 import pathlib
-import unittest
+import unittest.mock
+import urllib.error
+from typing import Optional
 
 import pytest
 import sgcollect
@@ -146,3 +148,191 @@ def test_get_sgcollect_options_task(tmp_path, cmdline):
     ).read_text()
     assert "sync_gateway_password" not in output
     assert f"args: {args}" in output
+
+
+def test_get_paths_from_expvars_no_url() -> None:
+    assert (None, None) == sgcollect.get_paths_from_expvars(
+        sg_url="", sg_username="", sg_password=""
+    )
+
+
+@pytest.mark.parametrize(
+    "expvar_output,expected_sg_path,expected_config_path",
+    [
+        (b"", None, None),
+        (b"{}", None, None),
+        (b'{"cmdline": []}', None, None),
+        (b'{"cmdline": ["filename"]}', "filename", None),
+        (
+            b'{"cmdline": ["fake_sync_gateway", "real_file.txt"]}',
+            "fake_sync_gateway",
+            None,
+        ),
+        (
+            b'{"cmdline": ["fake_sync_gateway", "-json", "fake_sync_gateway_config.json"]}',
+            "fake_sync_gateway",
+            "{cwd}/fake_sync_gateway_config.json",
+        ),
+        (
+            b'{"cmdline": ["fake_sync_gateway", "-json", "{tmpdir}/real_file.json"]}',
+            "fake_sync_gateway",
+            "{tmpdir}/real_file.json",
+        ),
+    ],
+)
+def test_get_paths_from_expvars(
+    expvar_output: bytes,
+    expected_sg_path: Optional[str],
+    expected_config_path: Optional[str],
+    tmpdir: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_file = tmpdir / "real_file.json"
+    real_file.write_text("This is a real file.", encoding="utf-8")
+    subdir = tmpdir / "subdir"
+    subdir.mkdir()
+    monkeypatch.chdir(subdir)
+    cwd = pathlib.Path.cwd()
+    expvar_output = expvar_output.replace(b"{cwd}", str(cwd).encode("utf-8"))
+    expvar_output = expvar_output.replace(b"{tmpdir}", str(tmpdir).encode("utf-8"))
+
+    # interpolate cwd for pathlib.Path.resolve
+    if expected_config_path is not None:
+        expected_config_path = expected_config_path.format(
+            cwd=str(cwd), tmpdir=str(tmpdir)
+        )
+    with unittest.mock.patch(
+        "sgcollect.urlopen_with_basic_auth", return_value=io.BytesIO(expvar_output)
+    ):
+        sg_path, config_path = sgcollect.get_paths_from_expvars(
+            sg_url="fakeurl", sg_username="", sg_password=""
+        )
+    assert sg_path == expected_sg_path
+    assert config_path == expected_config_path
+
+
+def test_discover_sg_binary_path() -> None:
+    parser = sgcollect.create_option_parser()
+    options, _ = parser.parse_args([])
+    with unittest.mock.patch("os.path.exists", return_value=False):
+        assert (
+            sgcollect.discover_sg_binary_path(
+                options,
+                sg_url="",
+            )
+            == ""
+        )
+        options, _ = parser.parse_args(["--sync-gateway-executable", "fake_sg"])
+        with pytest.raises(
+            expected_exception=Exception,
+            match="executable passed in does not exist",
+        ):
+            sgcollect.discover_sg_binary_path(options, sg_url="")
+
+    options, _ = parser.parse_args([])
+    with unittest.mock.patch("os.path.exists", return_value=True):
+        assert (
+            sgcollect.discover_sg_binary_path(options, sg_url="")
+            == "/opt/couchbase-sync-gateway/bin/sync_gateway"
+        )
+    options, _ = parser.parse_args([])
+    with unittest.mock.patch("os.path.exists", side_effect=[False, True]):
+        assert (
+            sgcollect.discover_sg_binary_path(options, sg_url="")
+            == R"C:\Program Files (x86)\Couchbase\sync_gateway.exe"
+        )  # Windows (Pre-2.0)
+
+    with unittest.mock.patch("os.path.exists", side_effect=[False, False, True]):
+        assert (
+            sgcollect.discover_sg_binary_path(options, sg_url="")
+            == R"C:\Program Files\Couchbase\Sync Gateway\sync_gateway.exe"  # Windows (Post-2.0)
+        )
+
+
+@pytest.mark.parametrize(
+    "cmdline_args,expected_calls",
+    [
+        (
+            [],
+            [
+                unittest.mock.call(
+                    url="http://127.0.0.1:4985",
+                    username=None,
+                    password=None,
+                ),
+            ],
+        ),
+        (
+            ["--sync-gateway-username=myuser", "--sync-gateway-password=mypassword"],
+            [
+                unittest.mock.call(
+                    url="http://127.0.0.1:4985",
+                    username="myuser",
+                    password="mypassword",
+                ),
+            ],
+        ),
+        (
+            ["--sync-gateway-url=example.com"],
+            [
+                unittest.mock.call(
+                    url="http://example.com",
+                    username=None,
+                    password=None,
+                ),
+                unittest.mock.call(
+                    url="https://example.com",
+                    username=None,
+                    password=None,
+                ),
+                unittest.mock.call(
+                    url="http://127.0.0.1:4985",
+                    username=None,
+                    password=None,
+                ),
+            ],
+        ),
+        (
+            ["--sync-gateway-url=https://example.com:4985"],
+            [
+                unittest.mock.call(
+                    url="https://example.com:4985",
+                    username=None,
+                    password=None,
+                ),
+                unittest.mock.call(
+                    url="http://127.0.0.1:4985",
+                    username=None,
+                    password=None,
+                ),
+            ],
+        ),
+        (
+            ["--sync-gateway-url=http://example.com:4985"],
+            [
+                unittest.mock.call(
+                    url="http://example.com:4985",
+                    username=None,
+                    password=None,
+                ),
+                unittest.mock.call(
+                    url="http://127.0.0.1:4985",
+                    username=None,
+                    password=None,
+                ),
+            ],
+        ),
+    ],
+)
+def test_get_sg_url(
+    cmdline_args: list[str], expected_calls: list[unittest.mock._Call]
+) -> None:
+    parser = sgcollect.create_option_parser()
+    options, _ = parser.parse_args(cmdline_args)
+    with unittest.mock.patch(
+        "sgcollect.urlopen_with_basic_auth",
+        side_effect=urllib.error.URLError("mock error connecting"),
+    ) as mock_urlopen:
+        # this URL isn't correct but it is the fallback URL for this function
+        assert sgcollect.get_sg_url(options) == "https://127.0.0.1:4985"
+        assert mock_urlopen.mock_calls == expected_calls

--- a/tools-tests/sgcollect_info_test.py
+++ b/tools-tests/sgcollect_info_test.py
@@ -9,6 +9,7 @@
 import io
 import os
 import pathlib
+import sys
 import unittest.mock
 import urllib.error
 from typing import Optional
@@ -172,7 +173,10 @@ def test_get_paths_from_expvars_no_url() -> None:
         (
             b'{"cmdline": ["fake_sync_gateway", "-json", "fake_sync_gateway_config.json"]}',
             "fake_sync_gateway",
-            "{cwd}{pathsep}fake_sync_gateway_config.json",
+            # platform difference is https://github.com/python/cpython/issues/82852
+            "{cwd}{pathsep}fake_sync_gateway_config.json"
+            if sys.platform != "win32"
+            else "fake_sync_gateway_config.json",
         ),
         (
             b'{"cmdline": ["fake_sync_gateway", "-json", "{tmpdir}/real_file.json"]}',

--- a/tools-tests/sgcollect_info_test.py
+++ b/tools-tests/sgcollect_info_test.py
@@ -7,6 +7,7 @@
 # the file licenses/APL2.txt.
 
 import io
+import os
 import pathlib
 import unittest.mock
 import urllib.error
@@ -171,12 +172,12 @@ def test_get_paths_from_expvars_no_url() -> None:
         (
             b'{"cmdline": ["fake_sync_gateway", "-json", "fake_sync_gateway_config.json"]}',
             "fake_sync_gateway",
-            "{cwd}/fake_sync_gateway_config.json",
+            "{cwd}{pathsep}fake_sync_gateway_config.json",
         ),
         (
             b'{"cmdline": ["fake_sync_gateway", "-json", "{tmpdir}/real_file.json"]}',
             "fake_sync_gateway",
-            "{tmpdir}/real_file.json",
+            "{tmpdir}{pathsep}real_file.json",
         ),
     ],
 )
@@ -199,7 +200,9 @@ def test_get_paths_from_expvars(
     # interpolate cwd for pathlib.Path.resolve
     if expected_config_path is not None:
         expected_config_path = expected_config_path.format(
-            cwd=str(cwd), tmpdir=str(tmpdir)
+            cwd=str(cwd),
+            tmpdir=str(tmpdir),
+            pathsep=os.sep,
         )
     with unittest.mock.patch(
         "sgcollect.urlopen_with_basic_auth", return_value=io.BytesIO(expvar_output)

--- a/tools-tests/upload_test.py
+++ b/tools-tests/upload_test.py
@@ -70,8 +70,8 @@ def test_main_output_exists(args):
     with pytest.raises(SystemExit, check=lambda e: e.code == 0):
         with unittest.mock.patch("sys.argv", ["sg_collect", *args, ZIP_NAME]):
             sgcollect.main()
-        assert pathlib.Path(ZIP_NAME).exists()
-        assert not pathlib.Path(REDACTED_ZIP_NAME).exists()
+    assert pathlib.Path(ZIP_NAME).exists()
+    assert not pathlib.Path(REDACTED_ZIP_NAME).exists()
 
 
 @pytest.mark.usefixtures("main_norun_redacted_zip")

--- a/tools-tests/upload_test.py
+++ b/tools-tests/upload_test.py
@@ -67,18 +67,20 @@ class FakeFailureUrlOpener:
 @pytest.mark.usefixtures("main_norun")
 @pytest.mark.parametrize("args", [[], ["--log-redaction-level", "none"]])
 def test_main_output_exists(args):
-    with unittest.mock.patch("sys.argv", ["sg_collect", *args, ZIP_NAME]):
-        sgcollect.main()
-    assert pathlib.Path(ZIP_NAME).exists()
-    assert not pathlib.Path(REDACTED_ZIP_NAME).exists()
+    with pytest.raises(SystemExit, check=lambda e: e.code == 0):
+        with unittest.mock.patch("sys.argv", ["sg_collect", *args, ZIP_NAME]):
+            sgcollect.main()
+        assert pathlib.Path(ZIP_NAME).exists()
+        assert not pathlib.Path(REDACTED_ZIP_NAME).exists()
 
 
 @pytest.mark.usefixtures("main_norun_redacted_zip")
 def test_main_output_exists_with_redacted():
-    with unittest.mock.patch(
-        "sys.argv", ["sg_collect", "--log-redaction-level", "partial", ZIP_NAME]
-    ):
-        sgcollect.main()
+    with pytest.raises(SystemExit, check=lambda e: e.code == 0):
+        with unittest.mock.patch(
+            "sys.argv", ["sg_collect", "--log-redaction-level", "partial", ZIP_NAME]
+        ):
+            sgcollect.main()
     assert pathlib.Path(ZIP_NAME).exists()
     assert pathlib.Path(REDACTED_ZIP_NAME).exists()
 

--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -178,7 +178,7 @@ class Task(object):
             p = subprocess.Popen(
                 self.command,
                 bufsize=-1,
-                stdin=subprocess.DEVNULL,
+                stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 shell=use_shell,

--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -178,7 +178,7 @@ class Task(object):
             p = subprocess.Popen(
                 self.command,
                 bufsize=-1,
-                stdin=subprocess.PIPE,
+                stdin=subprocess.DEVNULL,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 shell=use_shell,
@@ -193,7 +193,6 @@ class Task(object):
             # to some system limit".
             fp.write(f"Failed to execute {self.command}: {e}".encode("utf-8"))
             return 127
-        p.stdin.close()
 
         timer = None
         timer_fired = threading.Event()

--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -178,7 +178,7 @@ class Task(object):
             p = subprocess.Popen(
                 self.command,
                 bufsize=-1,
-                stdin=subprocess.DEVNULL,
+                stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 shell=use_shell,
@@ -193,6 +193,7 @@ class Task(object):
             # to some system limit".
             fp.write(f"Failed to execute {self.command}: {e}".encode("utf-8"))
             return 127
+        p.stdin.close()
 
         timer = None
         timer_fired = threading.Event()

--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -178,7 +178,7 @@ class Task(object):
             p = subprocess.Popen(
                 self.command,
                 bufsize=-1,
-                stdin=subprocess.PIPE,
+                stdin=subprocess.DEVNULL,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 shell=use_shell,


### PR DESCRIPTION
CBG-4712 /_sgcollect_info endpoint to work with non default port

This fix was driven by the desire to have integration testing from go, and doing integration testing in go requires listening on ports that are not :4985 - it uses :0 and picks a port randomly.

Fixes made:

- pass `--sync-gateway-url` from `/_sgcollect_info`
- change the way URL is picked for SG (`--sync-gateway-url`, `http://127.0.0.1:4985`, `https://127.0.0.1:4985`)
- always use `--sync-gateway-executable` first if present, rather than picking up default locations
- remove `get_absolute_path` function since this would always throw an exception since upgrade to python3 (found with parsing log output for errors, then using python typing). This function mixes up bytes and str.
- Close the io.Pipe for stderr/stdout, without this, each time you run sgcollect 2 goroutines are leaked.

Testing only improvements:

- scope `sgCollect` instance to the `ServerContext`. In practice, this is the same for a sync gateway executable but for testing it means not worrying about cleaning up globals since we can modify the ServerContext and it is torn down between tests. This also allows `sgCollectPaths` to use a ctx with logging information on it, for filtering.
- Create `sgCollectOutputStream` struct to make handling output a bit easier. This needs to be closed if the command doesn't start (e.g. path not found). For testing, we need to wait for the output to be closed before reading it. Because it is buffered output, it lasts a bit longer than `cmd.Wait()` and the race detector is tripped. 
- Add `sgCollect.stderr` / `sgCollect.stdout` to monitor errors from sgcollect output.
- Return `sgCollectBinary` as a []string{} so it can be triggered via `python sgcollect_info`. This is only needed for testing, in normal production this will be a single executable that self extracts a python installation.

I think I'd like to set a build flag or environment variable so this test doesn't run as a part of standard dev runs, it is just too slow.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3179/
