### PR TITLE
CBG-4716: remove repeated calls to was skipped in processEntry

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -447,7 +447,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent, docType DocumentType)
 			changedChannels := c.processEntry(ctx, change)
 			changedChannelsCombined = changedChannelsCombined.Update(changedChannels)
 		}
-		base.InfofCtx(ctx, base.KeyCache, "Received unused sequences %d in unused_sequences property for (%q / %q)", syncData.UnusedSequences, base.UD(docID), syncData.CurrentRev)
+		base.DebugfCtx(ctx, base.KeyCache, "Received unused sequences in unused_sequences property for (%q / %q): %v", base.UD(docID), syncData.CurrentRev, syncData.UnusedSequences)
 	}
 
 	// If the recent sequence history includes any sequences earlier than the current sequence, and
@@ -495,7 +495,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent, docType DocumentType)
 			}
 		}
 		if len(seqsCached) > 0 {
-			base.InfofCtx(ctx, base.KeyCache, "Received deduplicated seqs %d in recent_sequences property for (%q / %q)", seqsCached, base.UD(docID), syncData.CurrentRev)
+			base.DebugfCtx(ctx, base.KeyCache, "Received deduplicated seqs in recent_sequences property for (%q / %q): %v", base.UD(docID), syncData.CurrentRev, seqsCached)
 		}
 	}
 

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -211,7 +211,7 @@ func (c *channelCacheImpl) AddToCache(ctx context.Context, change *LogEntry) cha
 	// twice)
 	if change.Skipped {
 		c.lateSeqLock.Lock()
-		base.InfofCtx(ctx, base.KeyChanges, "Acquired late sequence lock in order to cache %d - doc %q / %q", change.Sequence, base.UD(change.DocID), change.RevID)
+		base.DebugfCtx(ctx, base.KeyChanges, "Acquired late sequence lock in order to cache %d - doc %q / %q", change.Sequence, base.UD(change.DocID), change.RevID)
 		defer c.lateSeqLock.Unlock()
 	}
 

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -211,7 +211,6 @@ func (c *channelCacheImpl) AddToCache(ctx context.Context, change *LogEntry) cha
 	// twice)
 	if change.Skipped {
 		c.lateSeqLock.Lock()
-		base.DebugfCtx(ctx, base.KeyChanges, "Acquired late sequence lock in order to cache %d - doc %q / %q", change.Sequence, base.UD(change.DocID), change.RevID)
 		defer c.lateSeqLock.Unlock()
 	}
 


### PR DESCRIPTION
CBG-4716

Looking at the perf profiling for the new skiplist, I see that we use a bit too much time in WasSkipped function. We do call this twice on skipped sequences, once to check for duplicates and once to mark as skipped. We should just be able to call this once per skipped entry. 

Also noticed info logging taking some time up so dropped some to debug given we only log sequence related info at debug usually. Plus moved some info logging out of loops. 

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3182/