### PR TITLE
CBG-4718: log when setting reject writes unsupported option

### DIFF
--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2680,6 +2680,7 @@ func TestRejectWritesWhenInBroadcastSlowMode(t *testing.T) {
 	if !base.TestUseXattrs() {
 		t.Skip("Test requires xattrs to be enabled")
 	}
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	rt := NewRestTester(t, &RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2680,7 +2680,6 @@ func TestRejectWritesWhenInBroadcastSlowMode(t *testing.T) {
 	if !base.TestUseXattrs() {
 		t.Skip("Test requires xattrs to be enabled")
 	}
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	rt := NewRestTester(t, &RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1351,6 +1351,10 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 		config.Unsupported.WarningThresholds.ChannelNameSize = &base.DefaultWarnThresholdChannelNameSize
 	}
 
+	if config.Unsupported.RejectWritesWithSkippedSequences {
+		base.InfofCtx(ctx, base.KeyConfig, "Setting database configuration option 'reject_writes_with_skipped_sequences' to true")
+	}
+
 	if config.Unsupported.DisableCleanSkippedQuery {
 		base.WarnfCtx(ctx, `Deprecation notice: setting database configuration option "disable_clean_skipped_query" no longer has any functionality. In the future, this option will be removed.`)
 	}


### PR DESCRIPTION
CBG-4718

- Simple log line for setting reject writes unsupported option for test debugging

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
