### PR TITLE
CBG-4734: fix for race when removing a value that is being loaded into rev cache

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -503,7 +503,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent, docType DocumentType)
 
 	// Now add the entry for the new doc revision:
 	if len(rawUserXattr) > 0 {
-		collection.revisionCache.RemoveWithRev(ctx, docID, syncData.CurrentRev)
+		collection.revisionCache.RemoveRevOnly(ctx, docID, syncData.CurrentRev)
 	}
 
 	change := &LogEntry{

--- a/db/crud.go
+++ b/db/crud.go
@@ -2546,7 +2546,7 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 
 			// Prior to saving doc, remove the revision in cache
 			if createNewRevIDSkipped {
-				db.revisionCache.RemoveWithRev(ctx, doc.ID, doc.CurrentRev)
+				db.revisionCache.RemoveRevOnly(ctx, doc.ID, doc.CurrentRev)
 			}
 
 			base.DebugfCtx(ctx, base.KeyCRUD, "Saving doc (seq: #%d, id: %v rev: %v)", doc.Sequence, base.UD(doc.ID), doc.CurrentRev)

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -128,6 +128,10 @@ func (rc *BypassRevisionCache) RemoveWithRev(ctx context.Context, docID, revID s
 	// no-op
 }
 
+func (rc *BypassRevisionCache) RemoveRevOnly(ctx context.Context, docID, revID string, collectionID uint32) {
+	// no-op
+}
+
 func (rc *BypassRevisionCache) RemoveWithCV(ctx context.Context, docID string, cv *Version, collectionID uint32) {
 	// no-op
 }

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -55,6 +55,8 @@ type RevisionCache interface {
 	// RemoveWithCV evicts a revision from the cache using its current version.
 	RemoveWithCV(ctx context.Context, docID string, cv *Version, collectionID uint32)
 
+	RemoveRevOnly(ctx context.Context, docID, revID string, collectionID uint32)
+
 	// UpdateDelta stores the given toDelta value in the given rev if cached
 	UpdateDelta(ctx context.Context, docID, revID string, collectionID uint32, toDelta RevisionDelta)
 
@@ -170,6 +172,10 @@ func (c *collectionRevisionCache) Upsert(ctx context.Context, docRev DocumentRev
 // RemoveWithRev is for per collection access to Remove method
 func (c *collectionRevisionCache) RemoveWithRev(ctx context.Context, docID, revID string) {
 	(*c.revCache).RemoveWithRev(ctx, docID, revID, c.collectionID)
+}
+
+func (c *collectionRevisionCache) RemoveRevOnly(ctx context.Context, docID, revID string) {
+	(*c.revCache).RemoveRevOnly(ctx, docID, revID, c.collectionID)
 }
 
 // RemoveWithCV is for per collection access to Remove method

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -520,7 +520,7 @@ func (rc *LRURevisionCache) removeFromCacheByCV(ctx context.Context, docID strin
 	elem := element.Value.(*revCacheValue)
 
 	// we can only remove this value if the value has finished loading from the bucket
-	_, _ = base.RetryLoop(ctx, "remove from revision cache by rev", func() (shouldRetry bool, err error, _ any) {
+	_, _ = base.RetryLoop(ctx, "remove from revision cache by cv", func() (shouldRetry bool, err error, _ any) {
 		if !elem.canEvict.Load() {
 			// value is still in process of being loaded from bucket, we need to wait for this to finish
 			return true, nil, nil

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -93,6 +93,10 @@ func (sc *ShardedLRURevisionCache) RemoveWithCV(ctx context.Context, docID strin
 	sc.getShard(docID).RemoveWithCV(ctx, docID, cv, collectionID)
 }
 
+func (sc *ShardedLRURevisionCache) RemoveRevOnly(ctx context.Context, docID, revID string, collectionID uint32) {
+	sc.getShard(docID).RemoveRevOnly(ctx, docID, revID, collectionID)
+}
+
 // An LRU cache of document revision bodies, together with their channel access.
 type LRURevisionCache struct {
 	backingStores        map[uint32]RevisionCacheBackingStore
@@ -507,6 +511,12 @@ func (rc *LRURevisionCache) RemoveWithCV(ctx context.Context, docID string, cv *
 	rc.removeFromCacheByCV(ctx, docID, cv, collectionID)
 }
 
+// RemoveRevOnly removes a rev from revision cache lookup map, if present.
+func (rc *LRURevisionCache) RemoveRevOnly(ctx context.Context, docID, revID string, collectionID uint32) {
+	// This will only remove the entry from the rev lookup map, not the lru list
+	rc.removeFromRevLookup(ctx, docID, revID, collectionID)
+}
+
 // removeFromCacheByCV removes an entry from rev cache by CV
 func (rc *LRURevisionCache) removeFromCacheByCV(ctx context.Context, docID string, cv *Version, collectionID uint32) {
 	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.Value, CollectionID: collectionID}
@@ -518,15 +528,6 @@ func (rc *LRURevisionCache) removeFromCacheByCV(ctx context.Context, docID strin
 	}
 	// grab the revid key from the value to enable us to remove the reference from the rev lookup map too
 	elem := element.Value.(*revCacheValue)
-
-	// we can only remove this value if the value has finished loading from the bucket
-	_, _ = base.RetryLoop(ctx, "remove from revision cache by cv", func() (shouldRetry bool, err error, _ any) {
-		if !elem.canEvict.Load() {
-			// value is still in process of being loaded from bucket, we need to wait for this to finish
-			return true, nil, nil
-		}
-		return false, nil, nil
-	}, base.CreateMaxDoublingSleeperFunc(30, 10, 500))
 
 	legacyKey := IDAndRev{DocID: docID, RevID: elem.revID, CollectionID: collectionID}
 	rc.lruList.Remove(element)
@@ -549,15 +550,6 @@ func (rc *LRURevisionCache) removeFromCacheByRev(ctx context.Context, docID, rev
 	// grab the cv key from the value to enable us to remove the reference from the rev lookup map too
 	elem := element.Value.(*revCacheValue)
 
-	// we can only remove this value if the value has finished loading from the bucket
-	_, _ = base.RetryLoop(ctx, "remove from revision cache by rev", func() (shouldRetry bool, err error, _ any) {
-		if !elem.canEvict.Load() {
-			// value is still in process of being loaded from bucket, we need to wait for this to finish
-			return true, nil, nil
-		}
-		return false, nil, nil
-	}, base.CreateMaxDoublingSleeperFunc(30, 10, 500))
-
 	hlvKey := IDandCV{DocID: docID, Source: elem.cv.SourceID, Version: elem.cv.Value, CollectionID: collectionID}
 	rc.lruList.Remove(element)
 	// decrement the overall memory bytes count
@@ -566,6 +558,16 @@ func (rc *LRURevisionCache) removeFromCacheByRev(ctx context.Context, docID, rev
 	// remove from CV lookup map too
 	delete(rc.hlvCache, hlvKey)
 	rc.cacheNumItems.Add(-1)
+}
+
+// removeFromRevLookup will only remove the entry from the rev lookup map, if present. Underlying element must stay in list for eviction to work.
+func (rc *LRURevisionCache) removeFromRevLookup(ctx context.Context, docID, revID string, collectionID uint32) {
+	key := IDAndRev{DocID: docID, RevID: revID, CollectionID: collectionID}
+	rc.lock.Lock()
+	defer rc.lock.Unlock()
+	// only delete from rev lookup map, if we delete underlying element in list, the now elem in the HLV lookup map
+	// will never be evicted leading to potential unbounded growth of HLV lookup map
+	delete(rc.cache, key)
 }
 
 // removeValue removes a value from the revision cache, if present and the value matches the the value. If there's an item in the revision cache with a matching docID and revID but the document is different, this item will not be removed from the rev cache.
@@ -603,8 +605,17 @@ func (rc *LRURevisionCache) _numberCapacityEviction() (numItemsEvicted int64, nu
 		}
 		hlvKey := IDandCV{DocID: value.id, Source: value.cv.SourceID, Version: value.cv.Value, CollectionID: value.collectionID}
 		revKey := IDAndRev{DocID: value.id, RevID: value.revID, CollectionID: value.collectionID}
-		delete(rc.cache, revKey)
 		delete(rc.hlvCache, hlvKey)
+		if elem := rc.cache[revKey]; elem != nil {
+			revValue := elem.Value.(*revCacheValue)
+			// we need to check if the value pointed to by the rev lookup map is the same value we're evicting, this is
+			// because we can have can currently have two items with the same docID and revID, but different CVs due to
+			// a new HLV being generated for user xattr updates where we don't generate a new revID.
+			if revValue.cv.String() == value.cv.String() {
+				// this rev lookup item matches the value we're evicting, so remove it
+				delete(rc.cache, revKey)
+			}
+		}
 		numItemsEvicted++
 		numBytesEvicted += value.getItemBytes()
 	}
@@ -852,8 +863,17 @@ func (rc *LRURevisionCache) performEviction(ctx context.Context) {
 			}
 			revKey := IDAndRev{DocID: value.id, RevID: value.revID, CollectionID: value.collectionID}
 			hlvKey := IDandCV{DocID: value.id, Source: value.cv.SourceID, Version: value.cv.Value, CollectionID: value.collectionID}
-			delete(rc.cache, revKey)
 			delete(rc.hlvCache, hlvKey)
+			if elem := rc.cache[revKey]; elem != nil {
+				revValue := elem.Value.(*revCacheValue)
+				// we need to check if the value pointed to by the rev lookup map is the same value we're evicting, this is
+				// because we can have can currently have two items with the same docID and revID, but different CVs due to
+				// a new HLV being generated for user xattr updates where we don't generate a new revID.
+				if revValue.cv.String() == value.cv.String() {
+					// this rev lookup item matches the value we're evicting, so remove it
+					delete(rc.cache, revKey)
+				}
+			}
 			numItemsRemoved++
 			valueBytes := value.getItemBytes()
 			numBytesRemoved += valueBytes


### PR DESCRIPTION
CBG-4734

Added a new function to remove only from rev lookup and have extra logic around eviction to enure we are evicting values we should be

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3235/
