### PR TITLE
CBG-4761: use FrontKey() function for getOldest()

### DIFF
--- a/db/skipped_sequence.go
+++ b/db/skipped_sequence.go
@@ -114,12 +114,7 @@ func (s *SkippedSequenceSkiplist) PushSkippedSequenceEntry(entry skiplist.Skippe
 
 // getOldest returns the start sequence of the first element in the skipped sequence list
 func (s *SkippedSequenceSkiplist) getOldest() uint64 {
-	elem := s.list.Front()
-	if elem != nil {
-		return elem.Key().Start
-	}
-	// list empty
-	return 0
+	return s.list.FrontKey().Start
 }
 
 // getStats will return all associated stats with the skipped sequence list

--- a/db/skipped_sequence_test.go
+++ b/db/skipped_sequence_test.go
@@ -697,7 +697,7 @@ func TestGetOldestSkippedSequence(t *testing.T) {
 			expected:  2,
 		},
 		{
-			name:     "empty_slice",
+			name:     "empty_list",
 			empty:    true,
 			expected: 0,
 		},

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/couchbase/gomemcached v0.2.1
 	github.com/couchbase/goutils v0.1.2
 	github.com/couchbase/sg-bucket v0.0.0-20250522135601-8c9a5acda2c2
-	github.com/couchbasedeps/fast-skiplist v0.0.0-20250722115811-260c3ec862fc
+	github.com/couchbasedeps/fast-skiplist v0.0.0-20250722125747-e0dd031fe2ac
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338
 	github.com/couchbaselabs/gocbconnstr v1.0.5
 	github.com/couchbaselabs/rosmar v0.0.0-20250226134616-3b9ac157a3cd

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/couchbase/gomemcached v0.2.1
 	github.com/couchbase/goutils v0.1.2
 	github.com/couchbase/sg-bucket v0.0.0-20250522135601-8c9a5acda2c2
-	github.com/couchbasedeps/fast-skiplist v0.0.0-20250612112434-65f227bb1892
+	github.com/couchbasedeps/fast-skiplist v0.0.0-20250722115811-260c3ec862fc
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338
 	github.com/couchbaselabs/gocbconnstr v1.0.5
 	github.com/couchbaselabs/rosmar v0.0.0-20250226134616-3b9ac157a3cd

--- a/go.sum
+++ b/go.sum
@@ -64,10 +64,8 @@ github.com/couchbase/tools-common/testing v1.0.1 h1:GVc5OjMN5gj79cnjMTocouwXBSW6
 github.com/couchbase/tools-common/testing v1.0.1/go.mod h1:HeOA1IU1H+u83li+Qe6G8f7dnlVPrKJuhsF9I5r83S8=
 github.com/couchbase/tools-common/types v1.1.4 h1:YAZn9VOkkmn05YC24/TEm7eXa/j8k/R4tqy6folkSWo=
 github.com/couchbase/tools-common/types v1.1.4/go.mod h1:089L74+qhIDvDLEZzWk7PoQKAxij9j7KwUnw2aMYUv4=
-github.com/couchbasedeps/fast-skiplist v0.0.0-20250612112434-65f227bb1892 h1:LOejWK/W0fU/KTtq30qnb3damJyaQLNZdaB9psK0ed8=
-github.com/couchbasedeps/fast-skiplist v0.0.0-20250612112434-65f227bb1892/go.mod h1:fxGN9x1k//Vpl+GIeIENqNgysUmCKHb+bCV2AzXO5R4=
-github.com/couchbasedeps/fast-skiplist v0.0.0-20250722115811-260c3ec862fc h1:P1cQj+Wi5ZGxDTZloAOkyRRpxHE2H8/yNCHbqXbSERw=
-github.com/couchbasedeps/fast-skiplist v0.0.0-20250722115811-260c3ec862fc/go.mod h1:ssmbsFABKtkHCeT2fN/xeRUnvmsOihRL9CAh3BDzfhU=
+github.com/couchbasedeps/fast-skiplist v0.0.0-20250722125747-e0dd031fe2ac h1:6ekMSvH+AJkT30hMfZtto+M7viRNHCSbJgMwCvO4p64=
+github.com/couchbasedeps/fast-skiplist v0.0.0-20250722125747-e0dd031fe2ac/go.mod h1:ssmbsFABKtkHCeT2fN/xeRUnvmsOihRL9CAh3BDzfhU=
 github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338 h1:xMeDnMiapTiq8n8J83Mo2tPjQNIU7GssSsbQsP1CLOY=
 github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338/go.mod h1:0f+dmhfcTKK+4quAe6rwqQUVVWtHX/eztNB8cmBUniQ=
 github.com/couchbaselabs/gocaves/client v0.0.0-20250107114554-f96479220ae8 h1:MQfvw4BiLTuyR69FuA5Kex+tXUeLkH+/ucJfVL1/hkM=

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/couchbase/tools-common/types v1.1.4 h1:YAZn9VOkkmn05YC24/TEm7eXa/j8k/
 github.com/couchbase/tools-common/types v1.1.4/go.mod h1:089L74+qhIDvDLEZzWk7PoQKAxij9j7KwUnw2aMYUv4=
 github.com/couchbasedeps/fast-skiplist v0.0.0-20250612112434-65f227bb1892 h1:LOejWK/W0fU/KTtq30qnb3damJyaQLNZdaB9psK0ed8=
 github.com/couchbasedeps/fast-skiplist v0.0.0-20250612112434-65f227bb1892/go.mod h1:fxGN9x1k//Vpl+GIeIENqNgysUmCKHb+bCV2AzXO5R4=
+github.com/couchbasedeps/fast-skiplist v0.0.0-20250722115811-260c3ec862fc h1:P1cQj+Wi5ZGxDTZloAOkyRRpxHE2H8/yNCHbqXbSERw=
+github.com/couchbasedeps/fast-skiplist v0.0.0-20250722115811-260c3ec862fc/go.mod h1:ssmbsFABKtkHCeT2fN/xeRUnvmsOihRL9CAh3BDzfhU=
 github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338 h1:xMeDnMiapTiq8n8J83Mo2tPjQNIU7GssSsbQsP1CLOY=
 github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338/go.mod h1:0f+dmhfcTKK+4quAe6rwqQUVVWtHX/eztNB8cmBUniQ=
 github.com/couchbaselabs/gocaves/client v0.0.0-20250107114554-f96479220ae8 h1:MQfvw4BiLTuyR69FuA5Kex+tXUeLkH+/ucJfVL1/hkM=


### PR DESCRIPTION
CBG-4761

- Use a new function called FrontKey() to get oldest skipped sequence

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [x] Link upstream PRs - https://github.com/couchbasedeps/fast-skiplist/pull/3
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
