### PR TITLE
CBG-4754: move silent handler to trace level

### DIFF
--- a/base/logging.go
+++ b/base/logging.go
@@ -406,6 +406,22 @@ func AssertLogContains(t *testing.T, s string, f func()) {
 	assert.Contains(t, b.String(), s)
 }
 
+// AssertLogNotContains asserts that the logs produced by function f do not contain string s.
+func AssertLogNotContains(t *testing.T, s string, f func()) {
+	// Temporarily override logger output
+	b := &bytes.Buffer{}
+	mw := io.MultiWriter(b, os.Stderr)
+	consoleLogger.Load().logger.SetOutput(mw)
+	// Call the given function
+	f()
+
+	FlushLogBuffers()
+	consoleLogger.Load().FlushBufferToLog()
+	// do not reset output in defer, since we are accessing b.String() after
+	consoleLogger.Load().logger.SetOutput(os.Stderr)
+	assert.NotContains(t, b.String(), s)
+}
+
 // AuditLogContents returns that the audit logs produced by function f.
 func AuditLogContents(t testing.TB, f func(t testing.TB)) []byte {
 	// Temporarily override logger output

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3171,7 +3171,7 @@ func TestPublicAllDocsApiStats(t *testing.T) {
 }
 
 func TestSilentHandlerLoggingInTrace(t *testing.T) {
-	// must have debug assert the ensure below endpoints don't show in debug logs
+	// must have debug to assert that the endpoints below don't show in debug logs
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyHTTPResp)
 
 	rt := NewRestTester(t, nil)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3179,7 +3179,7 @@ func TestSilentHandlerLoggingInTrace(t *testing.T) {
 
 	base.AssertLogNotContains(t, "_ping", func() {
 		resp := rt.SendRequest(http.MethodGet, "/_ping", "")
-		require.Equal(t, http.StatusOK, resp.Code)
+		RequireStatus(t, resp, http.StatusOK)
 	})
 
 	base.AssertLogNotContains(t, "/metrics", func() {

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3169,3 +3169,40 @@ func TestPublicAllDocsApiStats(t *testing.T) {
 	assert.Equal(t, int64(5), rt.GetDatabase().DbStats.DatabaseStats.NumDocsPreFilterPublicAllDocs.Value())
 	assert.Equal(t, int64(4), rt.GetDatabase().DbStats.DatabaseStats.NumDocsPostFilterPublicAllDocs.Value())
 }
+
+func TestSilentHandlerLoggingInTrace(t *testing.T) {
+	// must have debug assert the ensure below endpoints don't show in debug logs
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyHTTPResp)
+
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+
+	base.AssertLogNotContains(t, "_ping", func() {
+		resp := rt.SendRequest(http.MethodGet, "/_ping", "")
+		require.Equal(t, http.StatusOK, resp.Code)
+	})
+
+	base.AssertLogNotContains(t, "/metrics", func() {
+		headers := map[string]string{
+			"Authorization": GetBasicAuthHeader(t, base.TestClusterUsername(), base.TestClusterPassword()),
+		}
+		resp := rt.SendMetricsRequestWithHeaders(http.MethodGet, "/metrics", "", headers)
+		RequireStatus(t, resp, http.StatusOK)
+	})
+
+	base.AssertLogNotContains(t, "/_metrics", func() {
+		headers := map[string]string{
+			"Authorization": GetBasicAuthHeader(t, base.TestClusterUsername(), base.TestClusterPassword()),
+		}
+		resp := rt.SendMetricsRequestWithHeaders(http.MethodGet, "/_metrics", "", headers)
+		RequireStatus(t, resp, http.StatusOK)
+	})
+
+	base.AssertLogNotContains(t, "/_expvar", func() {
+		headers := map[string]string{
+			"Authorization": GetBasicAuthHeader(t, base.TestClusterUsername(), base.TestClusterPassword()),
+		}
+		resp := rt.SendMetricsRequestWithHeaders(http.MethodGet, "/_expvar", "", headers)
+		RequireStatus(t, resp, http.StatusOK)
+	})
+}

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -126,6 +126,9 @@ const (
 	metricsPrivs
 )
 
+// silentRequestLogLevel is the log level used for handlers that are silent, meaning they only log at trace level
+const silentRequestLogLevel = base.LevelTrace
+
 type handlerMethod func(*handler) error
 
 // makeHandlerWithOptions creates an http.Handler that will run a handler with the given method handlerOptions
@@ -150,7 +153,7 @@ func makeHandler(server *ServerContext, privs handlerPrivs, accessPermissions []
 // makeSilentHandler creates an http.Handler that will run a handler with the given method only logging at debug
 func makeSilentHandler(server *ServerContext, privs handlerPrivs, accessPermissions []Permission, responsePermissions []Permission, method handlerMethod) http.Handler {
 	return makeHandlerWithOptions(server, privs, accessPermissions, responsePermissions, method, handlerOptions{
-		httpLogLevel: base.Ptr(base.LevelTrace),
+		httpLogLevel: base.Ptr(silentRequestLogLevel),
 	})
 }
 
@@ -748,7 +751,7 @@ func (h *handler) removeCorruptConfigIfExists(ctx context.Context, bucket, confi
 
 // isSilentRequest returns true if the handler represents a request we should suppress http logging on.
 func (h *handler) isSilentRequest() bool {
-	return h.httpLogLevel != nil && *h.httpLogLevel == base.LevelDebug
+	return h.httpLogLevel != nil && *h.httpLogLevel == silentRequestLogLevel
 }
 
 func (h *handler) logRequestLine() {

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -150,7 +150,7 @@ func makeHandler(server *ServerContext, privs handlerPrivs, accessPermissions []
 // makeSilentHandler creates an http.Handler that will run a handler with the given method only logging at debug
 func makeSilentHandler(server *ServerContext, privs handlerPrivs, accessPermissions []Permission, responsePermissions []Permission, method handlerMethod) http.Handler {
 	return makeHandlerWithOptions(server, privs, accessPermissions, responsePermissions, method, handlerOptions{
-		httpLogLevel: base.Ptr(base.LevelDebug),
+		httpLogLevel: base.Ptr(base.LevelTrace),
 	})
 }
 


### PR DESCRIPTION
CBG-4754

- Moves silent handler to trace logging 
- Adds test which has debug logging enabled and asserts that calls to /_expvar, /metrics, /_metrics and /_ping do not show up in logs 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
