### PR TITLE
CBG-4735: Remove the _globalSync xattr with purge to avoid attachment metadata hanging around

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -1814,3 +1814,14 @@ func SlicesEqualIgnoreOrder[T comparable](a, b []T) bool {
 	}
 	return true
 }
+
+// KeysPresent returns the subset of keys that are present in m, preserving input order of keys.
+func KeysPresent[K comparable, V any](m map[K]V, keys []K) []K {
+	result := make([]K, 0, len(keys))
+	for _, k := range keys {
+		if _, ok := m[k]; ok {
+			result = append(result, k)
+		}
+	}
+	return result
+}

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -1807,3 +1807,50 @@ func TestSlicesEqualUnordered(t *testing.T) {
 		})
 	}
 }
+
+func TestKeysPresent(t *testing.T) {
+	tests := []struct {
+		name string
+		m    map[string]int
+		keys []string
+		want []string
+	}{
+		{
+			name: "all present",
+			m:    map[string]int{"a": 1, "b": 2, "c": 3},
+			keys: []string{"a", "b"},
+			want: []string{"a", "b"},
+		},
+		{
+			name: "some present",
+			m:    map[string]int{"a": 1, "b": 2},
+			keys: []string{"a", "x", "b", "y"},
+			want: []string{"a", "b"},
+		},
+		{
+			name: "none present",
+			m:    map[string]int{"a": 1},
+			keys: []string{"x", "y"},
+			want: []string{},
+		},
+		{
+			name: "empty keys",
+			m:    map[string]int{"a": 1},
+			keys: nil,
+			want: []string{},
+		},
+		{
+			name: "empty map",
+			m:    map[string]int{},
+			keys: []string{"a"},
+			want: []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := KeysPresent(tc.m, tc.keys)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/db/crud.go
+++ b/db/crud.go
@@ -2892,7 +2892,7 @@ func (db *DatabaseCollectionWithUser) Purge(ctx context.Context, key string, nee
 	}
 
 	if db.UseXattrs() {
-		err := db.dataStore.DeleteWithXattrs(ctx, key, []string{base.SyncXattrName})
+		err := db.dataStore.DeleteWithXattrs(ctx, key, []string{base.SyncXattrName, base.GlobalXattrName})
 		if err != nil {
 			return err
 		}

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -1803,9 +1803,9 @@ func TestPurgeWithOldAttachment(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, rawBody)
 	assert.NotNil(t, rawXattrs)
-	var gloablSync db.GlobalSyncData
-	require.NoError(t, json.Unmarshal(rawXattrs[base.GlobalXattrName], &gloablSync))
-	assert.Equal(t, len(att1), int(gloablSync.Attachments["att1"].(map[string]any)["length"].(float64)))
+	var globalSync db.GlobalSyncData
+	require.NoError(t, json.Unmarshal(rawXattrs[base.GlobalXattrName], &globalSync))
+	assert.Equal(t, len(att1), int(globalSync.Attachments["att1"].(map[string]any)["length"].(float64)))
 
 	response := rt.SendAdminRequest("POST", "/{{.keyspace}}/_purge", `{"doc1":["*"]}`)
 	rest.RequireStatus(t, response, http.StatusOK)
@@ -1830,10 +1830,10 @@ func TestPurgeWithOldAttachment(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, rawBody)
 	assert.NotNil(t, rawXattrs)
-	gloablSync = db.GlobalSyncData{}
-	require.NoError(t, json.Unmarshal(rawXattrs[base.GlobalXattrName], &gloablSync))
-	assert.NotContains(t, gloablSync.Attachments, "att1")
-	assert.Equal(t, len(att2), int(gloablSync.Attachments["att2"].(map[string]any)["length"].(float64)))
+	globalSync = db.GlobalSyncData{}
+	require.NoError(t, json.Unmarshal(rawXattrs[base.GlobalXattrName], &globalSync))
+	assert.NotContains(t, globalSync.Attachments, "att1")
+	assert.Equal(t, len(att2), int(globalSync.Attachments["att2"].(map[string]any)["length"].(float64)))
 }
 
 // TestRawRedaction tests the /_raw endpoint with and without redaction


### PR DESCRIPTION
CBG-4735

This won't cause any functional issues, since we overwrite the xattr completely on a subsequent document update. However, without this, we do leave attachment metadata around in the bucket for purged docs which is obviously not desirable.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3245/