### PR TITLE
fix test flakes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,11 @@
+# Copyright 2025-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 [project] # this isn't a real project, but we need this to make the tools work
 name = "sgcollect_info"
 version = "0.0.1"

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -3601,7 +3601,7 @@ func TestBlipPullConflict(t *testing.T) {
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			_, _, postConflictCBLVersion := client.GetDoc(docID)
-			assert.NotEqual(t, preConflictCBLVersion, postConflictCBLVersion)
+			assert.Greater(c, postConflictCBLVersion.CV.Value, preConflictCBLVersion.CV.Value)
 		}, time.Second*10, time.Millisecond*10, "Expected sgVersion and cblVersion to be different")
 
 		postConflictDoc, postConflictHLV, postConflictVersion := client.GetDoc(docID)

--- a/topologytest/couchbase_lite_mock_peer_test.go
+++ b/topologytest/couchbase_lite_mock_peer_test.go
@@ -76,7 +76,10 @@ func (p *CouchbaseLiteMockPeer) GetDocumentIfExists(dsName sgbucket.DataStoreNam
 	if meta == nil {
 		return DocMetadata{}, nil, false
 	}
-	require.NotNil(p.TB(), meta, "docID:%s not found on %s", docID, p)
+	// document is tombstone
+	if bodyBytes == nil {
+		return *meta, nil, true
+	}
 	require.NoError(p.TB(), base.JSONUnmarshal(bodyBytes, &body))
 	return *meta, body, true
 }


### PR DESCRIPTION
Also, had to add missing license file since addlicense now finds the pyproject.toml file

In a recent commit, https://github.com/couchbase/sync_gateway/commit/1190eac6ac05ad11f10b0161800c9b600f7de549 

```assert.NotEqual(t, preConflictCBLVersion, postConflictCBLVersion)``` is buggy in two ways:

1. uses `t` instead of `c` so `require.EventuallyWithT` doesn't work
2. preConflictCBLVersion is DocVersion and postConflictCBL is *DocVersion so they were never going to be equal. It would be great if testify used generics to be type safe, but this is not on their roundmap.

Fix a separate flake with negative wait groups

```
    utilities_testing.go:1509: Panic while handling changes: sync: negative WaitGroup counter
        goroutine 34731 [running]:
        runtime/debug.Stack()
        	/home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.24.4/src/runtime/debug/stack.go:26 +0x67
        github.com/couchbase/sync_gateway/rest.createBlipTesterWithSpec.func2(0xc0013e6000, 0x0?, {0x2410800, 0x2b87c00})
        	/home/ec2-user/workspace/Pipeline_main/rest/utilities_testing.go:1508 +0x5f
        github.com/couchbase/go-blip.(*Context).dispatchRequest.func1()
        	/home/ec2-user/go/pkg/mod/github.com/couchbase/go-blip@v0.0.0-20250325132327-d73efab2df06/context.go:297 +0xd4
        panic({0x2410800?, 0x2b87c00?})
        	/home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.24.4/src/runtime/panic.go:792 +0x132
        sync.(*WaitGroup).Add(0xc000858b40, 0xffffffffffffffff)
        	/home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.24.4/src/sync/waitgroup.go:64 +0x19a
        sync.(*WaitGroup).Done(0xc000858b40)
        	/home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.24.4/src/sync/waitgroup.go:89 +0x2e
        github.com/couchbase/sync_gateway/rest.TestChangesResponseWithHLVInHistory.func2(0xc0013e6000)
        	/home/ec2-user/workspace/Pipeline_main/rest/blip_legacy_revid_test.go:716 +0x575
        github.com/couchbase/go-blip.(*Context).dispatchRequest(0xc0003ac900, 0xc0013e6000, 0xc000e1d560)
        	/home/ec2-user/go/pkg/mod/github.com/couchbase/go-blip@v0.0.0-20250325132327-d73efab2df06/context.go:319 +0x29c
        github.com/couchbase/go-blip.(*receiver).getPendingRequest.func1({0xc0013e6000?, 0x2b8d8a0?})
        	/home/ec2-user/go/pkg/mod/github.com/couchbase/go-blip@v0.0.0-20250325132327-d73efab2df06/receiver.go:275 +0x65
        github.com/couchbase/go-blip.(*Message).asyncRead.func1()
        	/home/ec2-user/go/pkg/mod/github.com/couchbase/go-blip@v0.0.0-20250325132327-d73efab2df06/message.go:388 +0x128
        created by github.com/couchbase/go-blip.(*Message).asyncRead in goroutine 34681
        	/home/ec2-user/go/pkg/mod/github.com/couchbase/go-blip@v0.0.0-20250325132327-d73efab2df06/message.go:374 +0x24d
2
```
