### PR TITLE
CBG-4810 blip test: separate user creation

### DIFF
--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -396,7 +396,7 @@ func TestFlush(t *testing.T) {
 
 	log.Printf("Flushing db...")
 	rest.RequireStatus(t, rt.SendAdminRequest("POST", "/db/_flush", ""), 200)
-	require.NoError(t, rt.SetAdminParty(true)) // needs to be re-enabled after flush since guest user got wiped
+	rt.SetAdminParty(true) // needs to be re-enabled after flush since guest user got wiped
 
 	// After the flush, the db exists but the documents are gone:
 	rest.RequireStatus(t, rt.SendAdminRequest("GET", "/db/", ""), 200)

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2438,10 +2438,9 @@ func TestProveAttachmentNotFound(t *testing.T) {
 	dbConfig := rt.NewDbConfig()
 	dbConfig.AllowConflicts = base.Ptr(true)
 	RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
-	require.NoError(t, rt.SetAdminParty(true))
+	rt.SetAdminParty(true)
 
-	bt, err := NewBlipTesterFromSpecWithRT(t, nil, rt)
-	assert.NoError(t, err, "Error creating BlipTester")
+	bt := NewBlipTesterFromSpecWithRT(rt, nil)
 	defer bt.Close()
 
 	attachmentData := []byte("attachmentA")
@@ -2527,13 +2526,10 @@ func TestPutInvalidAttachment(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
-	// Create blip tester
-	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
-		connectingUsername:          "user1",
-		connectingPassword:          "1234",
-		connectingUserChannelGrants: []string{"*"}, // All channels
+	const username = "user1"
+	bt := NewBlipTesterFromSpec(t, BlipTesterSpec{
+		connectingUsername: username,
 	})
-	require.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
 
 	for _, test := range tests {
@@ -2878,6 +2874,7 @@ func TestBlipPushRevWithAttachment(t *testing.T) {
 		rt := NewRestTesterPersistentConfig(t)
 		defer rt.Close()
 		const username = "bernard"
+		rt.CreateUser(username, nil)
 
 		opts := &BlipTesterClientOpts{Username: username, SupportedBLIPProtocols: SupportedBLIPProtocols}
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)

--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -413,13 +413,10 @@ func TestPutAttachmentViaBlipGetViaRest(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
-	// Create blip tester
-	bt, err := NewBlipTesterFromSpec(t,
+	bt := NewBlipTesterFromSpec(t,
 		BlipTesterSpec{
 			connectingUsername: "user1",
-			connectingPassword: "1234",
 		})
-	require.NoError(t, err)
 	defer bt.Close()
 
 	attachmentBody := "attach"
@@ -458,13 +455,9 @@ func TestPutAttachmentViaBlipGetViaRest(t *testing.T) {
 func TestPutAttachmentViaBlipGetViaBlip(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
-	// Create blip tester
-	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
-		connectingUsername:          "user1",
-		connectingPassword:          "1234",
-		connectingUserChannelGrants: []string{"*"}, // All channels
+	bt := NewBlipTesterFromSpec(t, BlipTesterSpec{
+		GuestEnabled: true,
 	})
-	require.NoError(t, err)
 	defer bt.Close()
 
 	attachmentBody := "attach"

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -3496,7 +3496,7 @@ func TestChangesFeedExitDisconnect(t *testing.T) {
 		const alice = "alice"
 		rt.CreateUser(alice, []string{"*"})
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt,
-			&BlipTesterClientOpts{Username: "alice"},
+			&BlipTesterClientOpts{Username: alice},
 		)
 		defer btc.Close()
 		var blipContextClosed atomic.Bool

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -551,9 +551,10 @@ func TestBlipDeltaSyncPullRemoved(t *testing.T) {
 			&rtConfig)
 		defer rt.Close()
 
+		const alice = "alice"
+		rt.CreateUser(alice, []string{"public"})
 		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
-			Username:               "alice",
-			Channels:               []string{"public"},
+			Username:               alice,
 			ClientDeltas:           true,
 			SupportedBLIPProtocols: []string{db.CBMobileReplicationV2.SubprotocolString()},
 		})
@@ -618,6 +619,8 @@ func TestBlipDeltaSyncPullTombstoned(t *testing.T) {
 			rtConfig)
 		defer rt.Close()
 
+		const alice = "alice"
+		rt.CreateUser(alice, []string{"public"})
 		if rt.GetDatabase().DbStats.DeltaSync() != nil {
 			deltaCacheHitsStart = rt.GetDatabase().DbStats.DeltaSync().DeltaCacheHit.Value()
 			deltaCacheMissesStart = rt.GetDatabase().DbStats.DeltaSync().DeltaCacheMiss.Value()
@@ -626,8 +629,7 @@ func TestBlipDeltaSyncPullTombstoned(t *testing.T) {
 		}
 
 		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
-			Username:               "alice",
-			Channels:               []string{"public"},
+			Username:               alice,
 			ClientDeltas:           true,
 			SupportedBLIPProtocols: SupportedBLIPProtocols,
 		})
@@ -709,6 +711,14 @@ func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 			rtConfig)
 		defer rt.Close()
 
+		const (
+			user1 = "client1"
+			user2 = "client2"
+		)
+
+		rt.CreateUser(user1, []string{"*"})
+		rt.CreateUser(user2, []string{"*"})
+
 		var deltaCacheHitsStart int64
 		var deltaCacheMissesStart int64
 		var deltasRequestedStart int64
@@ -721,16 +731,14 @@ func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 			deltasSentStart = rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
 		}
 		client1 := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
-			Username:               "client1",
-			Channels:               []string{"*"},
+			Username:               user1,
 			ClientDeltas:           true,
 			SupportedBLIPProtocols: SupportedBLIPProtocols,
 		})
 		defer client1.Close()
 
 		client2 := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
-			Username:               "client2",
-			Channels:               []string{"*"},
+			Username:               user2,
 			ClientDeltas:           true,
 			SupportedBLIPProtocols: SupportedBLIPProtocols,
 		})

--- a/rest/blip_channel_filter_test.go
+++ b/rest/blip_channel_filter_test.go
@@ -13,12 +13,14 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/require"
 )
 
 func TestChannelFilterRemovalFromChannel(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyChanges, base.KeyCache, base.KeyCRUD, base.KeyHTTP)
 	btcRunner := NewBlipTesterClientRunner(t)
 	btcRunner.Run(func(t *testing.T, _ []string) {
 		for _, sendDocWithChannelRemoval := range []bool{true, false} {
@@ -34,12 +36,16 @@ func TestChannelFilterRemovalFromChannel(t *testing.T) {
 					BlipSendDocsWithChannelRemoval: sendDocWithChannelRemoval,
 				}
 				rt.CreateDatabase("db", dbConfig)
-				rt.CreateUser("alice", []string{"*"})
-				rt.CreateUser("bob", []string{"A"})
+
+				const (
+					alice = "alice"
+					bob   = "bob"
+				)
+				rt.CreateUser(alice, []string{"*"})
+				rt.CreateUser(bob, []string{"A"})
 
 				btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
-					Username:        "alice",
-					Channels:        []string{"A"},
+					Username:        alice,
 					SendRevocations: false,
 				})
 				defer btc.Close()

--- a/rest/blip_legacy_revid_test.go
+++ b/rest/blip_legacy_revid_test.go
@@ -31,12 +31,11 @@ import (
 func TestLegacyProposeChanges(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
-	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
+	bt := NewBlipTesterFromSpec(t, BlipTesterSpec{
 		allowConflicts: false,
 		GuestEnabled:   true,
 		blipProtocols:  []string{db.CBMobileReplicationV4.SubprotocolString()},
 	})
-	assert.NoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
 
 	proposeChangesRequest := bt.newRequest()
@@ -67,12 +66,11 @@ func TestLegacyProposeChanges(t *testing.T) {
 func TestProposeChangesHandlingWithExistingRevs(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
-	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
+	bt := NewBlipTesterFromSpec(t, BlipTesterSpec{
 		allowConflicts: false,
 		GuestEnabled:   true,
 		blipProtocols:  []string{db.CBMobileReplicationV4.SubprotocolString()},
 	})
-	assert.NoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
 	rt := bt.restTester
 	collection, _ := rt.GetSingleTestDatabaseCollection()
@@ -248,12 +246,11 @@ func TestProposeChangesHandlingWithExistingRevs(t *testing.T) {
 func TestProcessLegacyRev(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
-	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
+	bt := NewBlipTesterFromSpec(t, BlipTesterSpec{
 		allowConflicts: false,
 		GuestEnabled:   true,
 		blipProtocols:  []string{db.CBMobileReplicationV4.SubprotocolString()},
 	})
-	assert.NoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
 	rt := bt.restTester
 	collection, _ := rt.GetSingleTestDatabaseCollection()
@@ -309,12 +306,11 @@ func TestProcessLegacyRev(t *testing.T) {
 func TestProcessRevWithLegacyHistory(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
-	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
+	bt := NewBlipTesterFromSpec(t, BlipTesterSpec{
 		allowConflicts: false,
 		GuestEnabled:   true,
 		blipProtocols:  []string{db.CBMobileReplicationV4.SubprotocolString()},
 	})
-	assert.NoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
 	rt := bt.restTester
 	ds := rt.GetSingleDataStore()
@@ -463,12 +459,11 @@ func TestProcessRevWithLegacyHistory(t *testing.T) {
 func TestProcessRevWithLegacyHistoryConflict(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelTrace, base.KeyHTTP, base.KeySync, base.KeySyncMsg, base.KeyCRUD, base.KeyChanges, base.KeyImport)
 
-	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
+	bt := NewBlipTesterFromSpec(t, BlipTesterSpec{
 		allowConflicts: false,
 		GuestEnabled:   true,
 		blipProtocols:  []string{db.CBMobileReplicationV4.SubprotocolString()},
 	})
-	assert.NoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
 	rt := bt.restTester
 	ds := rt.GetSingleDataStore()
@@ -536,12 +531,11 @@ func TestProcessRevWithLegacyHistoryConflict(t *testing.T) {
 func TestChangesResponseLegacyRev(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeySyncMsg, base.KeyChanges)
 
-	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
+	bt := NewBlipTesterFromSpec(t, BlipTesterSpec{
 		allowConflicts: false,
 		GuestEnabled:   true,
 		blipProtocols:  []string{db.CBMobileReplicationV4.SubprotocolString()},
 	})
-	assert.NoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
 	rt := bt.restTester
 
@@ -636,12 +630,11 @@ func TestChangesResponseLegacyRev(t *testing.T) {
 func TestChangesResponseWithHLVInHistory(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeySyncMsg, base.KeyChanges)
 
-	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
+	bt := NewBlipTesterFromSpec(t, BlipTesterSpec{
 		allowConflicts: false,
 		GuestEnabled:   true,
 		blipProtocols:  []string{db.CBMobileReplicationV4.SubprotocolString()},
 	})
-	assert.NoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
 	rt := bt.restTester
 	collection, ctx := rt.GetSingleTestDatabaseCollection()
@@ -739,12 +732,11 @@ func TestChangesResponseWithHLVInHistory(t *testing.T) {
 func TestCBLHasPreUpgradeMutationThatHasNotBeenReplicated(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeySyncMsg, base.KeyChanges)
 
-	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
+	bt := NewBlipTesterFromSpec(t, BlipTesterSpec{
 		allowConflicts: false,
 		GuestEnabled:   true,
 		blipProtocols:  []string{db.CBMobileReplicationV4.SubprotocolString()},
 	})
-	assert.NoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
 	rt := bt.restTester
 	collection, ctx := rt.GetSingleTestDatabaseCollection()
@@ -776,12 +768,11 @@ func TestCBLHasPreUpgradeMutationThatHasNotBeenReplicated(t *testing.T) {
 func TestCBLHasOfPreUpgradeMutationThatSGWAlreadyKnows(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeySyncMsg, base.KeyChanges)
 
-	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
+	bt := NewBlipTesterFromSpec(t, BlipTesterSpec{
 		allowConflicts: false,
 		GuestEnabled:   true,
 		blipProtocols:  []string{db.CBMobileReplicationV4.SubprotocolString()},
 	})
-	assert.NoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
 	rt := bt.restTester
 	collection, ctx := rt.GetSingleTestDatabaseCollection()
@@ -815,12 +806,11 @@ func TestCBLHasOfPreUpgradeMutationThatSGWAlreadyKnows(t *testing.T) {
 func TestPushOfPostUpgradeMutationThatHasCommonAncestorToSGWVersion(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeySyncMsg, base.KeyChanges)
 
-	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
+	bt := NewBlipTesterFromSpec(t, BlipTesterSpec{
 		allowConflicts: false,
 		GuestEnabled:   true,
 		blipProtocols:  []string{db.CBMobileReplicationV4.SubprotocolString()},
 	})
-	assert.NoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
 	rt := bt.restTester
 	collection, ctx := rt.GetSingleTestDatabaseCollection()
@@ -854,12 +844,11 @@ func TestPushOfPostUpgradeMutationThatHasCommonAncestorToSGWVersion(t *testing.T
 func TestPushDocConflictBetweenPreUpgradeCBLMutationAndPreUpgradeSGWMutation(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeySyncMsg, base.KeyChanges)
 
-	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
+	bt := NewBlipTesterFromSpec(t, BlipTesterSpec{
 		allowConflicts: false,
 		GuestEnabled:   true,
 		blipProtocols:  []string{db.CBMobileReplicationV4.SubprotocolString()},
 	})
-	assert.NoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
 	rt := bt.restTester
 	collection, ctx := rt.GetSingleTestDatabaseCollection()
@@ -897,12 +886,11 @@ func TestPushDocConflictBetweenPreUpgradeCBLMutationAndPreUpgradeSGWMutation(t *
 func TestPushDocConflictBetweenPreUpgradeCBLMutationAndPostUpgradeSGWMutation(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeySyncMsg, base.KeyChanges)
 
-	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
+	bt := NewBlipTesterFromSpec(t, BlipTesterSpec{
 		allowConflicts: false,
 		GuestEnabled:   true,
 		blipProtocols:  []string{db.CBMobileReplicationV4.SubprotocolString()},
 	})
-	assert.NoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
 	rt := bt.restTester
 	collection, ctx := rt.GetSingleTestDatabaseCollection()
@@ -937,12 +925,11 @@ func TestPushDocConflictBetweenPreUpgradeCBLMutationAndPostUpgradeSGWMutation(t 
 func TestConflictBetweenPostUpgradeCBLMutationAndPostUpgradeSGWMutation(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeySyncMsg, base.KeyChanges)
 
-	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
+	bt := NewBlipTesterFromSpec(t, BlipTesterSpec{
 		allowConflicts: false,
 		GuestEnabled:   true,
 		blipProtocols:  []string{db.CBMobileReplicationV4.SubprotocolString()},
 	})
-	assert.NoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
 	rt := bt.restTester
 	collection, ctx := rt.GetSingleTestDatabaseCollection()
@@ -984,12 +971,11 @@ func TestConflictBetweenPostUpgradeCBLMutationAndPostUpgradeSGWMutation(t *testi
 
 func TestLegacyRevNotInConflict(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeySyncMsg, base.KeyCRUD)
-	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
+	bt := NewBlipTesterFromSpec(t, BlipTesterSpec{
 		allowConflicts: false,
 		GuestEnabled:   true,
 		blipProtocols:  []string{db.CBMobileReplicationV4.SubprotocolString()},
 	})
-	require.NoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
 	rt := bt.restTester
 	collection, ctx := rt.GetSingleTestDatabaseCollection()

--- a/rest/blip_stats_test.go
+++ b/rest/blip_stats_test.go
@@ -34,8 +34,7 @@ func waitForStatGreaterThan(t *testing.T, getStatFunc func() int64, expected int
 }
 
 func TestBlipStatsBasic(t *testing.T) {
-	bt, err := NewBlipTester(t)
-	require.NoError(t, err)
+	bt := NewBlipTester(t)
 	defer bt.Close()
 
 	// make sure requests have not incremented stats.
@@ -59,8 +58,7 @@ func TestBlipStatsBasic(t *testing.T) {
 }
 
 func TestBlipStatsFastReport(t *testing.T) {
-	bt, err := NewBlipTester(t)
-	require.NoError(t, err)
+	bt := NewBlipTester(t)
 	defer bt.Close()
 	sendRequest := func() {
 		rq := bt.newRequest()

--- a/rest/changestest/changes_collection_test.go
+++ b/rest/changestest/changes_collection_test.go
@@ -255,8 +255,7 @@ func TestMultiCollectionChangesUserDynamicGrant(t *testing.T) {
 	lastSeq := changes.Last_Seq.String()
 
 	// Grant user access to channel ABC in collection 1
-	err = rt.SetAdminChannels("bernard", rt.GetKeyspaces()[0], "ABC", "PBS")
-	require.NoError(t, err)
+	rt.SetAdminChannels("bernard", rest.RestTesterDefaultUserPassword, rt.GetKeyspaces()[0], "ABC", "PBS")
 	rt.WaitForPendingChanges()
 
 	// confirm that change from c1 is sent, along with user doc
@@ -311,8 +310,7 @@ func TestMultiCollectionChangesUserDynamicGrantDCP(t *testing.T) {
 	require.Len(t, changes.Results, 1)
 
 	// Grant user access to channel ABC in collection 1
-	err = rt.SetAdminChannels("bernard", rt.GetKeyspaces()[0], "ABC", "PBS")
-	require.NoError(t, err)
+	rt.SetAdminChannels("bernard", rest.RestTesterDefaultUserPassword, rt.GetKeyspaces()[0], "ABC", "PBS")
 
 	// Write additional docs to the cached channels, should be served via DCP/cache
 	response = rt.SendAdminRequest("PUT", "/{{.keyspace1}}/abc2_c1", `{"value":1, "channels":["ABC"]}`)

--- a/rest/cors_test.go
+++ b/rest/cors_test.go
@@ -421,7 +421,7 @@ func TestCORSBlipSync(t *testing.T) {
 	}
 
 	rt.CreateDatabase("corsdb", dbConfig)
-	require.NoError(t, rt.SetAdminParty(true))
+	rt.SetAdminParty(true)
 	testCases := []struct {
 		name         string
 		origin       *string
@@ -446,7 +446,7 @@ func TestCORSBlipSync(t *testing.T) {
 
 			spec := getDefaultBlipTesterSpec()
 			spec.origin = test.origin
-			_, err := createBlipTesterWithSpec(t, spec, rt)
+			_, err := createBlipTesterWithSpec(rt, spec)
 			if test.errorMessage == "" {
 				require.NoError(t, err)
 			} else {
@@ -471,13 +471,13 @@ func TestCORSBlipSyncStar(t *testing.T) {
 		Origin: []string{"*"},
 	}
 	rt.CreateDatabase("corsdb", dbConfig)
-	require.NoError(t, rt.SetAdminParty(true))
+	rt.SetAdminParty(true)
 	urls := []string{"http://example.com", "http://example2.com", "https://example.com"}
 	for _, url := range urls {
 		rt.Run(url, func(t *testing.T) {
 			spec := getDefaultBlipTesterSpec()
 			spec.origin = &url
-			_, err := createBlipTesterWithSpec(t, spec, rt)
+			_, err := createBlipTesterWithSpec(rt, spec)
 			require.NoError(t, err)
 		})
 	}
@@ -500,14 +500,14 @@ func TestCORSBlipNoConfig(t *testing.T) {
 	}
 
 	rt.CreateDatabase("corsdb", dbConfig)
-	require.NoError(t, rt.SetAdminParty(true))
+	rt.SetAdminParty(true)
 
 	urls := []string{"http://example.com", "http://example2.com", "https://example.com"}
 	for _, url := range urls {
 		rt.Run(url, func(t *testing.T) {
 			spec := getDefaultBlipTesterSpec()
 			spec.origin = &url
-			_, err := createBlipTesterWithSpec(t, spec, rt)
+			_, err := createBlipTesterWithSpec(rt, spec)
 			require.Error(t, err)
 		})
 	}
@@ -518,7 +518,7 @@ func TestCORSBlipNoConfig(t *testing.T) {
 // requireBlipHandshakeEmptyCORS creates a new blip tester with no Origin header
 func requireBlipHandshakeEmptyCORS(rt *RestTester) {
 	spec := getDefaultBlipTesterSpec()
-	_, err := createBlipTesterWithSpec(rt.TB(), spec, rt)
+	_, err := createBlipTesterWithSpec(rt, spec)
 	require.NoError(rt.TB(), err)
 }
 
@@ -526,7 +526,7 @@ func requireBlipHandshakeEmptyCORS(rt *RestTester) {
 func requireBlipHandshakeMatchingHost(rt *RestTester) {
 	spec := getDefaultBlipTesterSpec()
 	spec.useHostOrigin = true
-	_, err := createBlipTesterWithSpec(rt.TB(), spec, rt)
+	_, err := createBlipTesterWithSpec(rt, spec)
 	require.NoError(rt.TB(), err)
 }
 

--- a/rest/jwt_auth_test.go
+++ b/rest/jwt_auth_test.go
@@ -88,7 +88,6 @@ func TestLocalJWTAuthenticationE2E(t *testing.T) {
 			}
 			restTesterConfig := RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{LocalJWTConfig: providers}}}
 			restTester := NewRestTester(t, &restTesterConfig)
-			require.NoError(t, restTester.SetAdminParty(false))
 			defer restTester.Close()
 
 			mockSyncGateway := httptest.NewServer(restTester.TestPublicHandler())
@@ -236,7 +235,6 @@ func TestLocalJWTAuthenticationEdgeCases(t *testing.T) {
 				testProviderName: cfg,
 			}}}}
 			restTester := NewRestTester(t, &restTesterConfig)
-			require.NoError(t, restTester.SetAdminParty(false))
 			defer restTester.Close()
 
 			mockSyncGateway := httptest.NewServer(restTester.TestPublicHandler())
@@ -374,7 +372,6 @@ func TestLocalJWTAndOIDCCoexistence(t *testing.T) {
 
 		restTesterConfig := RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: *config}}
 		restTester := NewRestTester(t, &restTesterConfig)
-		require.NoError(t, restTester.SetAdminParty(false))
 		defer restTester.Close()
 
 		mockSyncGateway := httptest.NewServer(restTester.TestPublicHandler())
@@ -451,7 +448,6 @@ func TestLocalJWTRolesChannels(t *testing.T) {
 		testProviderName: baseProvider,
 	}}}}
 	restTester := NewRestTester(t, &restTesterConfig)
-	require.NoError(t, restTester.SetAdminParty(false))
 	defer restTester.Close()
 	collection := restTester.GetSingleDataStore()
 	c := collection.CollectionName()

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -838,7 +838,6 @@ func TestOpenIDConnectAuthCodeFlow(t *testing.T) {
 			opts := auth.OIDCOptions{Providers: tc.providers, DefaultProvider: &tc.defaultProvider}
 			restTesterConfig := RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{OIDCConfig: &opts}}}
 			restTester := NewRestTester(t, &restTesterConfig)
-			require.NoError(t, restTester.SetAdminParty(false))
 			defer restTester.Close()
 
 			// Create the user first if the test requires a registered user.
@@ -1052,7 +1051,6 @@ func TestOpenIDConnectImplicitFlow(t *testing.T) {
 			opts := auth.OIDCOptions{Providers: tc.providers, DefaultProvider: &tc.defaultProvider}
 			restTesterConfig := RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{OIDCConfig: &opts}}}
 			restTester := NewRestTester(t, &restTesterConfig)
-			require.NoError(t, restTester.SetAdminParty(false))
 			defer restTester.Close()
 
 			// Create the user first if the test requires a registered user.
@@ -1109,7 +1107,6 @@ func TestOpenIDConnectImplicitFlowInitWithKeyspace(t *testing.T) {
 	opts := auth.OIDCOptions{Providers: testProviders, DefaultProvider: &defaultProvider}
 	restTesterConfig := RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{OIDCConfig: &opts}}}
 	restTester := NewRestTester(t, &restTesterConfig)
-	require.NoError(t, restTester.SetAdminParty(false))
 	defer restTester.Close()
 
 	createUser(t, restTester, "foo_noah")
@@ -1145,7 +1142,6 @@ func TestOpenIDConnectImplicitFlowReuseToken(t *testing.T) {
 
 	// JWT claim based grants do not support named collections
 	restTester := NewRestTesterDefaultCollection(t, &restTesterConfig)
-	require.NoError(t, restTester.SetAdminParty(false))
 	defer restTester.Close()
 
 	createUser(t, restTester, "foo_noah")
@@ -1242,7 +1238,6 @@ func TestUserAPIReadOnlyFields(t *testing.T) {
 
 	// JWT claim based grants do not support named collections
 	restTester := NewRestTesterDefaultCollection(t, &restTesterConfig)
-	require.NoError(t, restTester.SetAdminParty(false))
 	defer restTester.Close()
 
 	createUser(t, restTester, "foo_noah")
@@ -1307,7 +1302,6 @@ func TestAdminAndJWTChannels(t *testing.T) {
 
 	// JWT claim based grants do not support named collections
 	restTester := NewRestTesterDefaultCollection(t, &restTesterConfig)
-	require.NoError(t, restTester.SetAdminParty(false))
 	defer restTester.Close()
 
 	// Create user with admin channels and roles
@@ -1416,7 +1410,6 @@ func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
 	opts := auth.OIDCOptions{Providers: providers, DefaultProvider: &defaultProvider}
 	restTesterConfig := RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{OIDCConfig: &opts}}}
 	restTester := NewRestTester(t, &restTesterConfig)
-	require.NoError(t, restTester.SetAdminParty(false))
 	defer restTester.Close()
 
 	ctx := restTester.Context()
@@ -2064,7 +2057,6 @@ func TestCallbackStateClientCookies(t *testing.T) {
 		}},
 	}
 	restTester := NewRestTester(t, &restTesterConfig)
-	require.NoError(t, restTester.SetAdminParty(false))
 	defer restTester.Close()
 
 	mockSyncGateway := httptest.NewServer(restTester.TestPublicHandler())
@@ -2305,7 +2297,6 @@ func TestOpenIDConnectAuthCodeFlowWithUsernameClaim(t *testing.T) {
 				}},
 			}
 			restTester := NewRestTester(t, &restTesterConfig)
-			require.NoError(t, restTester.SetAdminParty(false))
 			defer restTester.Close()
 
 			issuerURL, err := url.Parse(mockAuthServer.options.issuer)
@@ -2415,7 +2406,6 @@ func TestEventuallyReachableOIDCClient(t *testing.T) {
 			opts := auth.OIDCOptions{Providers: tc.providers, DefaultProvider: &tc.defaultProvider}
 			restTesterConfig := RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{OIDCConfig: &opts}}}
 			restTester := NewRestTester(t, &restTesterConfig)
-			require.NoError(t, restTester.SetAdminParty(false))
 			defer restTester.Close()
 
 			// Create the user first if the test requires a registered user.
@@ -2525,7 +2515,6 @@ func TestOpenIDConnectRolesChannelsClaims(t *testing.T) {
 				}},
 			}
 			restTester := NewRestTesterDefaultCollection(t, &restTesterConfig) // CBG-2618: fix collection channel access
-			require.NoError(t, restTester.SetAdminParty(false))
 			defer restTester.Close()
 
 			// Create the test roles and document
@@ -2539,7 +2528,7 @@ func TestOpenIDConnectRolesChannelsClaims(t *testing.T) {
 				}
 				payloadJSON, err := json.Marshal(payload)
 				require.NoError(t, err, "Failed to marshal role payload")
-				res := restTester.SendAdminRequest(http.MethodPut, fmt.Sprintf("/%s/_role/%s", restTester.DatabaseConfig.Name, roleName), string(payloadJSON))
+				res := restTester.SendAdminRequest(http.MethodPut, fmt.Sprintf("/%s/_role/%s", restTester.GetDatabase().Name, roleName), string(payloadJSON))
 				RequireStatus(t, res, http.StatusCreated)
 			}
 
@@ -2550,7 +2539,7 @@ func TestOpenIDConnectRolesChannelsClaims(t *testing.T) {
 			}
 			testDocJSON, err := json.Marshal(testDocBody)
 			require.NoError(t, err, "Failed to marshal test doc payload")
-			res := restTester.SendAdminRequest(http.MethodPut, fmt.Sprintf("/%s/%s", restTester.DatabaseConfig.Name, testDocName), string(testDocJSON))
+			res := restTester.SendAdminRequest(http.MethodPut, fmt.Sprintf("/%s/%s", restTester.GetDatabase().Name, testDocName), string(testDocJSON))
 			RequireStatus(t, res, http.StatusCreated)
 
 			mockSyncGateway := httptest.NewServer(restTester.TestPublicHandler())
@@ -2707,7 +2696,6 @@ func TestOpenIDConnectIssuerChange(t *testing.T) {
 		CustomTestBucket: tb1,
 	}
 	rt1 := NewRestTesterDefaultCollection(t, &rt1Config) // CBG-2618: fix collection channel access
-	require.NoError(t, rt1.SetAdminParty(false))
 	defer rt1.Close()
 
 	msg1 := httptest.NewServer(rt1.TestPublicHandler())

--- a/rest/oidc_test_provider_test.go
+++ b/rest/oidc_test_provider_test.go
@@ -160,7 +160,6 @@ func TestProviderOIDCAuthWithTlsSkipVerifyEnabled(t *testing.T) {
 	restTesterConfig := restTesterConfigWithTestProviderEnabled()
 	restTesterConfig.DatabaseConfig.Unsupported.OidcTlsSkipVerify = true
 	restTester := NewRestTester(t, &restTesterConfig)
-	require.NoError(t, restTester.SetAdminParty(false))
 	defer restTester.Close()
 	mockSyncGateway := httptest.NewTLSServer(restTester.TestPublicHandler())
 	defer mockSyncGateway.Close()
@@ -216,7 +215,6 @@ func TestProviderOIDCAuthWithTlsSkipVerifyDisabled(t *testing.T) {
 	restTesterConfig := restTesterConfigWithTestProviderEnabled()
 	restTesterConfig.DatabaseConfig.Unsupported.OidcTlsSkipVerify = false
 	restTester := NewRestTester(t, &restTesterConfig)
-	require.NoError(t, restTester.SetAdminParty(false))
 	defer restTester.Close()
 	mockSyncGateway := httptest.NewTLSServer(restTester.TestPublicHandler())
 	defer mockSyncGateway.Close()
@@ -310,7 +308,6 @@ func TestOpenIDConnectTestProviderWithRealWorldToken(t *testing.T) {
 				}}}
 			restTester := NewRestTester(t,
 				&restTesterConfig)
-			require.NoError(t, restTester.SetAdminParty(false))
 			defer restTester.Close()
 
 			mockSyncGateway := httptest.NewServer(restTester.TestPublicHandler())
@@ -413,7 +410,6 @@ func TestOIDCWithBasicAuthDisabled(t *testing.T) {
 		}}}
 	restTester := NewRestTester(t,
 		&restTesterConfig)
-	require.NoError(t, restTester.SetAdminParty(false))
 	defer restTester.Close()
 
 	mockSyncGateway := httptest.NewServer(restTester.TestPublicHandler())

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -1963,6 +1963,7 @@ func TestReplicatorRevocationsWithChannelFilter(t *testing.T) {
 		},
 		Continuous:          false,
 		PurgeOnRemoval:      true,
+		FilterChannels:      []string{"ABC"},
 		ReplicationStatsMap: dbstats,
 		CollectionsEnabled:  base.TestsUseNamedCollections(),
 	})

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -1962,7 +1962,6 @@ func TestReplicatorRevocationsWithChannelFilter(t *testing.T) {
 			DatabaseContext: rt1.GetDatabase(),
 		},
 		Continuous:          false,
-		FilterChannels:      []string{"ABC"},
 		PurgeOnRemoval:      true,
 		ReplicationStatsMap: dbstats,
 		CollectionsEnabled:  base.TestsUseNamedCollections(),
@@ -2211,7 +2210,6 @@ func TestRevocationMessage(t *testing.T) {
 
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
 			Username:               "user",
-			Channels:               []string{"*"},
 			ClientDeltas:           false,
 			SendRevocations:        true,
 			SupportedBLIPProtocols: SupportedBLIPProtocols,
@@ -2321,7 +2319,6 @@ func TestRevocationNoRev(t *testing.T) {
 
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
 			Username:               "user",
-			Channels:               []string{"*"},
 			ClientDeltas:           false,
 			SendRevocations:        true,
 			SupportedBLIPProtocols: SupportedBLIPProtocols,
@@ -2403,7 +2400,6 @@ func TestRevocationGetSyncDataError(t *testing.T) {
 
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
 			Username:               "user",
-			Channels:               []string{"*"},
 			ClientDeltas:           false,
 			SendRevocations:        true,
 			SupportedBLIPProtocols: SupportedBLIPProtocols,

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1373,7 +1373,7 @@ func NewBlipTesterFromSpecWithRT(rt *RestTester, spec *BlipTesterSpec) *BlipTest
 		blipTesterSpec = &BlipTesterSpec{}
 	}
 	if blipTesterSpec.syncFn != "" {
-		rt.TB().Errorf("Setting BlipTesterSpec.SyncFn is incompatible with passing a custom RestTester. Use SyncFn on RestTesterig")
+		rt.TB().Errorf("Setting BlipTesterSpec.SyncFn is incompatible with passing a custom RestTester. Use SyncFn on RestTester")
 	}
 	if blipTesterSpec.GuestEnabled {
 		rt.TB().Errorf("Setting BlipTesterSpec.GuestEnabled is incompatible with passing a custom RestTester. Use GuestEnabled on RestTester")

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -14,7 +14,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -410,9 +409,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 		rt.TestBucket.Bucket = rt.RestTesterServerContext.Database(ctx, rt.DatabaseConfig.Name).Bucket
 
 		if rt.DatabaseConfig.Guest == nil {
-			if err := rt.SetAdminParty(rt.GuestEnabled); err != nil {
-				rt.TB().Fatalf("Error from SetAdminParty %v", err)
-			}
+			rt.SetAdminParty(rt.GuestEnabled)
 		}
 	}
 
@@ -622,13 +619,12 @@ func (rt *RestTester) WaitForPendingChanges() {
 	}
 }
 
-func (rt *RestTester) SetAdminParty(partyTime bool) error {
+// SetAdminParty toggles the guest user between disabled and enabled.  If enabled, the guest user is given access to the UserStar channel on all collections.
+func (rt *RestTester) SetAdminParty(partyTime bool) {
 	ctx := rt.Context()
 	a := rt.GetDatabase().Authenticator(ctx)
 	guest, err := a.GetUser("")
-	if err != nil {
-		return err
-	}
+	require.NoError(rt.TB(), err)
 	guest.SetDisabled(!partyTime)
 	var chans channels.TimedSet
 	if partyTime {
@@ -639,12 +635,12 @@ func (rt *RestTester) SetAdminParty(partyTime bool) error {
 		guest.SetExplicitChannels(chans, 1)
 	} else {
 		for scopeName, scope := range a.Collections {
-			for collectionName, _ := range scope {
+			for collectionName := range scope {
 				guest.SetCollectionExplicitChannels(scopeName, collectionName, chans, 1)
 			}
 		}
 	}
-	return a.Save(guest)
+	require.NoError(rt.TB(), a.Save(guest))
 }
 
 func (rt *RestTester) Close() {
@@ -1078,21 +1074,22 @@ func (rt *RestTester) SendAdminRequestWithHeaders(method, resource string, body 
 	return response
 }
 
-func (rt *RestTester) SetAdminChannels(username string, keyspace string, channels ...string) error {
+// SetAdminChannels creates or updates a user with the specified channels.
+func (rt *RestTester) SetAdminChannels(username string, password string, keyspace string, channels ...string) {
 	dbName, scopeName, collectionName, err := ParseKeyspace(keyspace)
-	if err != nil {
-		return err
-	}
-	// Get the current user document
-	userResponse := rt.SendAdminRequest("GET", "/"+dbName+"/_user/"+username, "")
-	if userResponse.Code != 200 {
-		return fmt.Errorf("User %s not found", username)
-	}
-
+	require.NoError(rt.TB(), err)
 	var currentConfig auth.PrincipalConfig
-	if err := base.JSONUnmarshal(userResponse.Body.Bytes(), &currentConfig); err != nil {
-		return err
+	user, err := rt.GetDatabase().Authenticator(rt.Context()).GetUser(username)
+	require.NoError(rt.TB(), err)
+	newUser := user == nil
+	if !newUser {
+		userResponse := rt.SendAdminRequest("GET", "/"+dbName+"/_user/"+username, "")
+		if userResponse.Code != http.StatusNotFound {
+			RequireStatus(rt.TB(), userResponse, http.StatusOK)
+			require.NoError(rt.TB(), base.JSONUnmarshal(userResponse.Body.Bytes(), &currentConfig))
+		}
 	}
+	currentConfig.Password = &password
 
 	if scopeName == nil || collectionName == nil {
 		if channels != nil {
@@ -1103,22 +1100,22 @@ func (rt *RestTester) SetAdminChannels(username string, keyspace string, channel
 	}
 	// Remove read only properties returned from the user api
 	for _, scope := range currentConfig.CollectionAccess {
-		if scope != nil {
-			for _, collectionAccess := range scope {
-				collectionAccess.Channels_ = nil
-				collectionAccess.JWTChannels_ = nil
-				collectionAccess.JWTLastUpdated = nil
-			}
+		for _, collectionAccess := range scope {
+			collectionAccess.Channels_ = nil
+			collectionAccess.JWTChannels_ = nil
+			collectionAccess.JWTLastUpdated = nil
 		}
 	}
 
-	newConfigBytes, _ := base.JSONMarshal(currentConfig)
+	newConfigBytes, err := base.JSONMarshal(currentConfig)
+	require.NoError(rt.TB(), err)
 
-	userResponse = rt.SendAdminRequest("PUT", "/"+dbName+"/_user/"+username, string(newConfigBytes))
-	if userResponse.Code != 200 {
-		return fmt.Errorf("User update failed: %s", userResponse.Body.Bytes())
+	userResponse := rt.SendAdminRequest("PUT", "/"+dbName+"/_user/"+username, string(newConfigBytes))
+	if newUser {
+		RequireStatus(rt.TB(), userResponse, http.StatusCreated)
+	} else {
+		RequireStatus(rt.TB(), userResponse, http.StatusOK)
 	}
-	return nil
 }
 
 // GetDocumentSequence looks up the sequence for a document using the _raw endpoint.
@@ -1293,18 +1290,9 @@ type BlipTesterSpec struct {
 	// If an underlying RestTester is created, it will propagate this setting to the underlying RestTester.
 	GuestEnabled bool
 
-	// The Sync Gateway username and password to connect with.  If set, then you
-	// may want to disable "Admin Party" mode, which will allow guest user access.
-	// By default, the created user will have access to a single channel that matches their username.
-	// If you need to grant the user access to more channels, you can override this behavior with the
-	// connectingUserChannelGrants field
+	// The Sync Gateway username to connect with. This will always use RestTesterDefaultUserPassword to connect if username is set.
+	// If not set, then you may want to enabled Guest access.
 	connectingUsername string
-	connectingPassword string
-
-	// By default, the created user will have access to a single channel that matches their username.
-	// If you need to grant the user access to more channels, you can override this behavior by specifying
-	// the channels the user should have access in this string slice
-	connectingUserChannelGrants []string
 
 	// Allow tests to further customized a RestTester or re-use it across multiple BlipTesters if needed.
 	// If a RestTester is passed in, certain properties of the BlipTester such as GuestEnabled will be ignored, since
@@ -1379,21 +1367,22 @@ func getDefaultBlipTesterSpec() BlipTesterSpec {
 }
 
 // NewBlipTesterFromSpecWithRT creates a blip tester from an existing rest tester
-func NewBlipTesterFromSpecWithRT(tb testing.TB, spec *BlipTesterSpec, rt *RestTester) (blipTester *BlipTester, err error) {
+func NewBlipTesterFromSpecWithRT(rt *RestTester, spec *BlipTesterSpec) *BlipTester {
 	blipTesterSpec := spec
 	if spec == nil {
 		blipTesterSpec = &BlipTesterSpec{}
 	}
 	if blipTesterSpec.syncFn != "" {
-		tb.Errorf("Setting BlipTesterSpec.SyncFn is incompatible with passing a custom RestTester. Use SyncFn on RestTester or DatabaseConfig")
+		rt.TB().Errorf("Setting BlipTesterSpec.SyncFn is incompatible with passing a custom RestTester. Use SyncFn on RestTesterig")
 	}
-	blipTester, err = createBlipTesterWithSpec(tb, *blipTesterSpec, rt)
-	if err != nil {
-		return nil, err
+	if blipTesterSpec.GuestEnabled {
+		rt.TB().Errorf("Setting BlipTesterSpec.GuestEnabled is incompatible with passing a custom RestTester. Use GuestEnabled on RestTester")
 	}
+	blipTester, err := createBlipTesterWithSpec(rt, *blipTesterSpec)
+	require.NoError(rt.TB(), err)
 	blipTester.avoidRestTesterClose = true
 
-	return blipTester, err
+	return blipTester
 }
 
 // NewBlipTesterDefaultCollection creates a blip tester that has a RestTester only using a single database and `_default._default` collection.
@@ -1410,28 +1399,35 @@ func NewBlipTesterDefaultCollectionFromSpec(tb testing.TB, spec BlipTesterSpec) 
 		SyncFn:         spec.syncFn,
 	}
 	rt := newRestTester(tb, &rtConfig, useSingleCollectionDefaultOnly, 1)
-	bt, err := createBlipTesterWithSpec(tb, spec, rt)
+	bt, err := createBlipTesterWithSpec(rt, spec)
 	require.NoError(tb, err)
 	return bt
 }
 
-// Create a BlipTester using the default spec
-func NewBlipTester(tb testing.TB) (*BlipTester, error) {
+// NewBlipTester creates a blip tester with an underlying Rest Tester in the default configuration.
+func NewBlipTester(tb testing.TB) *BlipTester {
 	return NewBlipTesterFromSpec(tb, getDefaultBlipTesterSpec())
 }
 
-func NewBlipTesterFromSpec(tb testing.TB, spec BlipTesterSpec) (*BlipTester, error) {
+// NewBlipTesterFromSpec creates a BlipTester using options. This will create a RestTester underneath the BlipTester.
+func NewBlipTesterFromSpec(tb testing.TB, spec BlipTesterSpec) *BlipTester {
 	rtConfig := RestTesterConfig{
 		AllowConflicts: spec.allowConflicts,
 		GuestEnabled:   spec.GuestEnabled,
 		SyncFn:         spec.syncFn,
 	}
 	rt := NewRestTester(tb, &rtConfig)
-	return createBlipTesterWithSpec(tb, spec, rt)
+	if spec.connectingUsername != "" {
+		rt.CreateUser(spec.connectingUsername, nil)
+	}
+	bt, err := createBlipTesterWithSpec(rt, spec)
+	require.NoError(tb, err)
+	return bt
 }
 
-// Create a BlipTester using the given spec
-func createBlipTesterWithSpec(tb testing.TB, spec BlipTesterSpec, rt *RestTester) (*BlipTester, error) {
+// createBlipTesterWithSpec creates a blip tester targeting a specific RestTester. Returns an error to allow for
+// testing connection error conditions. Use NewBlipTesterFromSpec for most tests.
+func createBlipTesterWithSpec(rt *RestTester, spec BlipTesterSpec) (*BlipTester, error) {
 	bt := &BlipTester{
 		restTester: rt,
 	}
@@ -1443,31 +1439,6 @@ func createBlipTesterWithSpec(tb testing.TB, spec BlipTesterSpec, rt *RestTester
 	// Since blip requests all go over the public handler, wrap the public handler with the httptest server
 	publicHandler := bt.restTester.TestPublicHandler()
 
-	if len(spec.connectingUsername) > 0 {
-
-		// By default, the user will be granted access to a single channel equal to their username
-		adminChannels := []string{spec.connectingUsername}
-
-		// If the caller specified a list of channels to grant the user access to, then use that instead.
-		if len(spec.connectingUserChannelGrants) > 0 {
-			adminChannels = []string{} // empty it
-			adminChannels = append(adminChannels, spec.connectingUserChannelGrants...)
-		}
-
-		userDocBody, err := getUserBodyDoc(spec.connectingUsername, spec.connectingPassword, bt.restTester.GetSingleDataStore(), adminChannels)
-		if err != nil {
-			return nil, err
-		}
-		log.Printf("Creating user: %v", userDocBody)
-
-		// Create a user.  NOTE: this must come *after* the bt.rt.TestPublicHandler() call, otherwise it will end up getting ignored
-		_ = bt.restTester.SendAdminRequest(
-			"POST",
-			"/{{.db}}/_user/",
-			userDocBody,
-		)
-	}
-
 	// Create a _temporary_ test server bound to an actual port that is used to make the blip connection.
 	// This is needed because the mock-based approach fails with a "Connection not hijackable" error when
 	// trying to do the websocket upgrade.  Since it's only needed to setup the websocket, it can be closed
@@ -1478,9 +1449,7 @@ func createBlipTesterWithSpec(tb testing.TB, spec BlipTesterSpec, rt *RestTester
 	// Construct URL to connect to blipsync target endpoint
 	destUrl := fmt.Sprintf("%s/%s/_blipsync", srv.URL, rt.GetDatabase().Name)
 	u, err := url.Parse(destUrl)
-	if err != nil {
-		return nil, err
-	}
+	require.NoError(bt.TB(), err)
 	u.Scheme = "ws"
 
 	// If protocols are not set use V3 as a V3 client would
@@ -1495,18 +1464,18 @@ func createBlipTesterWithSpec(tb testing.TB, spec BlipTesterSpec, rt *RestTester
 	}
 	// Make BLIP/Websocket connection.  Not specifying cancellation context here as this is a
 	// client blip context that doesn't require cancellation-based close
-	_, bt.blipContext, err = db.NewSGBlipContextWithProtocols(base.TestCtx(tb), "", origin, protocols, nil)
+	_, bt.blipContext, err = db.NewSGBlipContextWithProtocols(rt.Context(), "", origin, protocols, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	// Ensure that errors get correctly surfaced in tests
 	bt.blipContext.FatalErrorHandler = func(err error) {
-		tb.Fatalf("BLIP fatal error: %v", err)
+		bt.TB().Fatalf("BLIP fatal error: %v", err)
 	}
 	bt.blipContext.HandlerPanicHandler = func(request, response *blip.Message, err interface{}) {
 		stack := debug.Stack()
-		tb.Fatalf("Panic while handling %s: %v\n%s", request.Profile(), err, string(stack))
+		bt.TB().Fatalf("Panic while handling %s: %v\n%s", request.Profile(), err, string(stack))
 	}
 
 	config := blip.DialOptions{
@@ -1515,11 +1484,11 @@ func createBlipTesterWithSpec(tb testing.TB, spec BlipTesterSpec, rt *RestTester
 
 	config.HTTPHeader = make(http.Header)
 	if len(spec.connectingUsername) > 0 {
-		config.HTTPHeader.Add("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(spec.connectingUsername+":"+spec.connectingPassword)))
+		config.HTTPHeader.Add("Authorization", GetBasicAuthHeader(bt.TB(), spec.connectingUsername, RestTesterDefaultUserPassword))
 	}
 	if spec.origin != nil {
 		if spec.useHostOrigin {
-			require.Fail(tb, "setting both origin and useHostOrigin is not supported")
+			require.Fail(bt.TB(), "setting both origin and useHostOrigin is not supported")
 		}
 		config.HTTPHeader.Add("Origin", *spec.origin)
 	} else if spec.useHostOrigin {
@@ -1528,13 +1497,11 @@ func createBlipTesterWithSpec(tb testing.TB, spec BlipTesterSpec, rt *RestTester
 
 	bt.sender, err = bt.blipContext.DialConfig(&config)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Error dialing blip context: %w", err)
 	}
 
 	bt.activeSubprotocol, err = db.ParseSubprotocolString(bt.blipContext.ActiveSubprotocol())
-	if err != nil {
-		tb.Fatalf("Unable to parse subprotocol string: %v", err)
-	}
+	require.NoError(bt.TB(), err)
 
 	collections := bt.restTester.getCollectionsForBLIP()
 	if !spec.skipCollectionsInitialization && len(collections) > 0 {
@@ -1545,19 +1512,9 @@ func createBlipTesterWithSpec(tb testing.TB, spec BlipTesterSpec, rt *RestTester
 
 }
 
-func getUserBodyDoc(username, password string, collection sgbucket.DataStore, adminChans []string) (string, error) {
-	config := PrincipalConfigForWrite{}
-	if username != "" {
-		config.Name = &username
-	}
-	if password != "" {
-		config.Password = &password
-	}
-	marshalledConfig, err := addChannelsToPrincipal(config, collection, adminChans)
-	if err != nil {
-		return "", err
-	}
-	return string(marshalledConfig), nil
+// TB returns the current testing.TB
+func (bt *BlipTester) TB() testing.TB {
+	return bt.restTester.TB()
 }
 
 func (bt *BlipTester) initializeCollections(collections []string) {

--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -62,7 +62,6 @@ func (c BlipTesterClientConflictResolverType) IsValid() bool {
 type BlipTesterClientOpts struct {
 	ClientDeltas                  bool // Support deltas on the client side
 	Username                      string
-	Channels                      []string
 	SendRevocations               bool
 	SupportedBLIPProtocols        []string
 	SkipCollectionsInitialization bool
@@ -982,15 +981,12 @@ func (btcc *BlipTesterCollectionClient) updateLastReplicatedRev(docID string, ve
 }
 
 func newBlipTesterReplication(tb testing.TB, id string, btc *BlipTesterClient, skipCollectionsInitialization bool) *BlipTesterReplicator {
-	bt, err := NewBlipTesterFromSpecWithRT(tb, &BlipTesterSpec{
-		connectingPassword:            RestTesterDefaultUserPassword,
+	bt := NewBlipTesterFromSpecWithRT(btc.rt, &BlipTesterSpec{
 		connectingUsername:            btc.Username,
-		connectingUserChannelGrants:   btc.Channels,
 		blipProtocols:                 btc.SupportedBLIPProtocols,
 		skipCollectionsInitialization: skipCollectionsInitialization,
 		origin:                        btc.origin,
-	}, btc.rt)
-	require.NoError(tb, err)
+	})
 
 	r := &BlipTesterReplicator{
 		id:       id,

--- a/topologytest/couchbase_lite_mock_peer_test.go
+++ b/topologytest/couchbase_lite_mock_peer_test.go
@@ -224,9 +224,10 @@ func (p *CouchbaseLiteMockPeer) CreateReplication(peer Peer, config PeerReplicat
 		btcRunner:   rest.NewBlipTesterClientRunner(sg.rt.TB().(*testing.T)),
 		direction:   config.direction,
 	}
+	const username = "user"
+	sg.rt.CreateUser(username, []string{"*"})
 	replication.btc = replication.btcRunner.NewBlipTesterClientOptsWithRT(sg.rt, &rest.BlipTesterClientOpts{
-		Username:               "user",
-		Channels:               []string{"*"},
+		Username:               username,
 		SupportedBLIPProtocols: []string{db.CBMobileReplicationV4.SubprotocolString()},
 		AllowCreationWithoutBlipTesterClientRunner: true,
 		SourceID: p.SourceID(),


### PR DESCRIPTION
Separate user creation and channel grants in blip tests to avoid confusion. Only the first specification of this would take effect due to ignoring errors from a PUT /db/_user/

This got very confusing when working on a PR to swap `RestTester` from underneath the BlipTester.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/40/ (known flake, independent of PR)
