### PR TITLE
CBG-4813 refactor tests to use consistent HLV format

### DIFF
--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -228,7 +228,7 @@ func (hlv *HybridLogicalVector) GetCurrentVersion() (string, uint64) {
 	return hlv.SourceID, hlv.Version
 }
 
-// GetCurrentVersion returns the current version in transport format
+// GetCurrentVersionString returns the current version in transport format
 func (hlv *HybridLogicalVector) GetCurrentVersionString() string {
 	if hlv == nil || hlv.SourceID == "" {
 		return ""
@@ -240,7 +240,7 @@ func (hlv *HybridLogicalVector) GetCurrentVersionString() string {
 	return version.String()
 }
 
-// IsVersionKnown checks to see whether the HLV already contains a Version for the provided
+// DominatesSource checks to see whether the HLV already contains a Version for the provided
 // source with a matching or newer value
 func (hlv *HybridLogicalVector) DominatesSource(version Version) bool {
 	existingValueForSource, found := hlv.GetValue(version.SourceID)

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -179,7 +179,7 @@ func createHLVForTest(tb *testing.T, input string) *HybridLogicalVector {
 	return hlv
 }
 
-func TestAddNewerVersions(t *testing.T) {
+func TestHLVAddNewerVersions(t *testing.T) {
 	testCases := []struct {
 		name        string
 		existingHLV string
@@ -211,6 +211,46 @@ func TestAddNewerVersions(t *testing.T) {
 			incomingHLV: "4@c",
 			finalHLV:    "4@c;2@b,1@a",
 		},
+		{
+			name:        "incoming pv overwrite mv, equal values",
+			existingHLV: "3@c,2@b,1@a",
+			incomingHLV: "4@c;2@b,1@a",
+			finalHLV:    "4@c;2@b,1@a",
+		},
+		{
+			name:        "incoming mv overwrite pv, equal values",
+			existingHLV: "3@c;2@b,1@a",
+			incomingHLV: "4@c,2@b,1@a",
+			finalHLV:    "4@c,2@b,1@a",
+		},
+		{
+			name:        "incoming mv overwrite pv, greater values",
+			existingHLV: "3@c;2@b,1@a",
+			incomingHLV: "4@c,5@b,6@a",
+			finalHLV:    "4@c,5@b,6@a",
+		},
+		/* FIXME, this does not work yet.
+		{
+			name:        "incoming does not dominate pv",
+			existingHLV: "3@c;5@b,6@a",
+			incomingHLV: "4@c,1@b,2@a",
+			finalHLV:    "3@c;5@b,6@a",
+		},
+		*/
+		{
+			name:        "incoming mv partially overlaps with pv",
+			existingHLV: "3@c;2@b,1@a",
+			incomingHLV: "4@c,2@b,6@a",
+			finalHLV:    "4@c,2@b,6@a",
+		},
+		/* FIXME: this doesn't work yet
+		{
+			name:        "incoming mv partially overlaps with pv, but incoming mv should be wiped out",
+			existingHLV: "3@c;2@b,6@a",
+			incomingHLV: "4@c,2@b,1@a",
+			finalHLV:    "4@c;2@b,6@a",
+		},
+		*/
 	}
 
 	for _, test := range testCases {

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -124,7 +124,7 @@ func TestConflictDetectionDominating(t *testing.T) {
 		},
 		{
 			name:           "B CV older than A's PV for same source",
-			inputListHLVA:  "20@cluster1;10@cluster2",
+			inputListHLVA:  "20@cluster1;15@cluster2",
 			inputListHLVB:  "10@cluster2;15@cluster1",
 			expectedResult: true,
 		},

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -91,10 +91,10 @@ func TestInternalHLVFunctions(t *testing.T) {
 	require.Equal(t, hlv.PreviousVersions, expectedPV)
 }
 
-// TestConflictDetectionDominating:
-//   - Tests cases where one HLV's is said to be 'dominating' over another
+// TestHLVIsDominating:
+//   - Tests cases where one HLV is said to be 'dominating' over another
 //   - Assert that all scenarios returns false from IsInConflict method, as we have a HLV that is dominating in each case
-func TestConflictDetectionDominating(t *testing.T) {
+func TestHLVIsDominating(t *testing.T) {
 	testCases := []struct {
 		name           string
 		HLVA           string
@@ -164,18 +164,18 @@ func TestConflictDetectionDominating(t *testing.T) {
 			name:           "a.MV doesn't dominate B.CV",
 			HLVA:           "20@cluster1,5@cluster2,5@cluster3",
 			HLVB:           "10@cluster2",
-			expectedResult: true,
+			expectedResult: false,
 		},
 		{
 			name:           "b.CV.source occurs in both a.CV and a.MV, dominates both",
-			HLVA:           "10@cluster1,10@cluster1,5@cluster2",
-			HLVB:           "15@cluster2",
+			HLVA:           "2@cluster1,1@cluster1,3@cluster2",
+			HLVB:           "4@cluster1",
 			expectedResult: true,
 		},
 		{
 			name:           "b.CV.source occurs in both a.CV and a.MV, dominates only a.MV",
-			HLVA:           "20@cluster1,5@cluster2,5@cluster3",
-			HLVB:           "15@cluster2",
+			HLVA:           "4@cluster1,1@cluster1,2@cluster2",
+			HLVB:           "3@cluster1",
 			expectedResult: false,
 		},
 	}


### PR DESCRIPTION
CBG-4813 refactor tests to use consistent HLV format so these test cases can be lifted to validate CBL.

@adamcfraser can you validate the expected output for the FIXME tests and see if there are other tests that should be added?

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

