### PR TITLE
Relax document processed assertions for SG_TEST_USE_GSI=true

### DIFF
--- a/rest/attachmentmigrationtest/attachment_migration_api_test.go
+++ b/rest/attachmentmigrationtest/attachment_migration_api_test.go
@@ -74,7 +74,9 @@ func TestAttachmentMigrationAPI(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, db.BackgroundProcessStateCompleted, migrationStatus.State)
 	assert.Equal(t, int64(5), migrationStatus.DocsChanged)
-	assert.Equal(t, int64(10), migrationStatus.DocsProcessed)
+	// With GSI test bucket pool, a past document might sneak in in the case it was:
+	// mutated & deleted but did not pass the snapshot boundary.
+	assert.GreaterOrEqual(t, migrationStatus.DocsProcessed, int64(10))
 	assert.Empty(t, migrationStatus.LastErrorMessage)
 }
 


### PR DESCRIPTION
Reproducible running this test in a loop.

See:

https://github.com/couchbase/sync_gateway/blob/d20b778af1a458e242740f2a8f628eb30ace48ed/db/background_mgr_attachment_migration.go#L133-L144
