### PR TITLE
CBG-3748: Support legacy RevTree IDs for Delta Sync

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -914,7 +914,7 @@ func (bh *blipHandler) handleProposeChanges(rq *blip.Message) error {
 func (bsc *BlipSyncContext) sendRevAsDelta(ctx context.Context, sender *blip.Sender, docID, revID string, deltaSrcRevID string, seq SequenceID, knownRevs map[string]bool, maxHistory int, handleChangesResponseCollection *DatabaseCollectionWithUser, collectionIdx *int) error {
 	bsc.replicationStats.SendRevDeltaRequestedCount.Add(1)
 
-	revDelta, redactedRev, err := handleChangesResponseCollection.GetDelta(ctx, docID, deltaSrcRevID, revID, bsc.useHLV())
+	revDelta, redactedRev, err := handleChangesResponseCollection.GetDelta(ctx, docID, deltaSrcRevID, revID)
 	if err == ErrForbidden { // nolint: gocritic // can't convert if/else if to switch since base.IsFleeceDeltaError is not switchable
 		return err
 	} else if base.IsFleeceDeltaError(err) {

--- a/db/crud.go
+++ b/db/crud.go
@@ -449,14 +449,15 @@ func (db *DatabaseCollectionWithUser) GetCV(ctx context.Context, docid string, c
 
 // GetDelta attempts to return the delta between fromRevId and toRevId.  If the delta can't be generated,
 // returns nil.
-func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromRev, toRev string, useCVRevCache bool) (delta *RevisionDelta, redactedRev *DocumentRevision, err error) {
+func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromRev, toRev string) (delta *RevisionDelta, redactedRev *DocumentRevision, err error) {
 
 	if docID == "" || fromRev == "" || toRev == "" {
 		return nil, nil, nil
 	}
 	var fromRevision DocumentRevision
 	var fromRevVrs Version
-	if useCVRevCache {
+	fromRevIsCV := !base.IsRevTreeID(fromRev)
+	if fromRevIsCV {
 		fromRevVrs, err = ParseVersion(fromRev)
 		if err != nil {
 			return nil, nil, err
@@ -510,7 +511,7 @@ func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromR
 
 		db.dbStats().DeltaSync().DeltaCacheMiss.Add(1)
 		var toRevision DocumentRevision
-		if useCVRevCache {
+		if !base.IsRevTreeID(toRev) {
 			cv, err := ParseVersion(toRev)
 			if err != nil {
 				return nil, nil, err
@@ -539,7 +540,7 @@ func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromR
 		// If the revision we're generating a delta to is a tombstone, mark it as such and don't bother generating a delta
 		if deleted {
 			revCacheDelta := newRevCacheDelta([]byte(base.EmptyDocument), fromRev, toRevision, deleted, nil)
-			if useCVRevCache {
+			if fromRevIsCV {
 				db.revisionCache.UpdateDeltaCV(ctx, docID, &fromRevVrs, revCacheDelta)
 			} else {
 				db.revisionCache.UpdateDelta(ctx, docID, fromRev, revCacheDelta)
@@ -583,7 +584,7 @@ func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromR
 		revCacheDelta := newRevCacheDelta(deltaBytes, fromRev, toRevision, deleted, toRevAttStorageMeta)
 
 		// Write the newly calculated delta back into the cache before returning
-		if useCVRevCache {
+		if fromRevIsCV {
 			db.revisionCache.UpdateDeltaCV(ctx, docID, &fromRevVrs, revCacheDelta)
 		} else {
 			db.revisionCache.UpdateDelta(ctx, docID, fromRev, revCacheDelta)

--- a/db/crud.go
+++ b/db/crud.go
@@ -2846,7 +2846,7 @@ func (db *DatabaseCollectionWithUser) postWriteUpdateHLV(ctx context.Context, do
 		revHash := base.Crc32cHashString([]byte(doc.HLV.GetCurrentVersionString()))
 		_ = db.setOldRevisionJSONBody(ctx, doc.ID, revHash, newBodyWithAtts, db.deltaSyncRevMaxAgeSeconds())
 		// Optionally store a lookup document to find the CV-based revHash by legacy RevTree ID
-		if db.deltaSyncStoreLegacyRevs() {
+		if db.storeLegacyRevTreeData() {
 			_ = db.setOldRevisionJSONPtr(ctx, doc, db.deltaSyncRevMaxAgeSeconds())
 		}
 	}

--- a/db/database.go
+++ b/db/database.go
@@ -76,6 +76,7 @@ const (
 var (
 	DefaultDeltaSyncEnabled   = false
 	DefaultDeltaSyncRevMaxAge = uint32(60 * 60 * 24) // 24 hours in seconds
+	DefaultStoreLegacyRevs    = true                 // for 4.0, this is opt-out - we can switch to opt-in at a later date
 )
 
 var (
@@ -240,6 +241,7 @@ type UserViewsOptions struct {
 type DeltaSyncOptions struct {
 	Enabled          bool   // Whether delta sync is enabled (EE only)
 	RevMaxAgeSeconds uint32 // The number of seconds deltas for old revs are available for
+	StoreLegacyRevs  bool   // Whether to store additional data to allow legacy RevTree ID support for delta sync
 }
 
 type APIEndpoints struct {

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -196,8 +196,8 @@ func (c *DatabaseCollection) deltaSyncRevMaxAgeSeconds() uint32 {
 	return c.dbCtx.Options.DeltaSyncOptions.RevMaxAgeSeconds
 }
 
-// deltaSyncStoreLegacyRevs returns true if legacy revtree IDs are stored to be used as a delta src. This is controlled at database level.
-func (c *DatabaseCollection) deltaSyncStoreLegacyRevs() bool {
+// storeLegacyRevTreeData returns true if legacy revision tree pointer data is stored. This is controlled at the database level.
+func (c *DatabaseCollection) storeLegacyRevTreeData() bool {
 	return c.dbCtx.Options.DeltaSyncOptions.StoreLegacyRevs
 }
 

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -196,6 +196,11 @@ func (c *DatabaseCollection) deltaSyncRevMaxAgeSeconds() uint32 {
 	return c.dbCtx.Options.DeltaSyncOptions.RevMaxAgeSeconds
 }
 
+// deltaSyncStoreLegacyRevs returns true if legacy revtree IDs are stored to be used as a delta src. This is controlled at database level.
+func (c *DatabaseCollection) deltaSyncStoreLegacyRevs() bool {
+	return c.dbCtx.Options.DeltaSyncOptions.StoreLegacyRevs
+}
+
 // eventMgr manages nofication events. This is controlled at database level.
 func (c *DatabaseCollection) eventMgr() *EventManager {
 	return c.dbCtx.EventMgr

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1057,6 +1057,7 @@ func TestDeltaSyncWhenFromRevIsChannelRemoval(t *testing.T) {
 				require.NoError(t, err, "Error purging old revision JSON")
 			} else {
 				err = collection.PurgeOldRevisionJSON(ctx, "doc1", rev2ID)
+				_ = err
 				// TODO: CBG-4840 - Requires restoration of RevTree ID-based old revision storage
 				//require.NoError(t, err, "Error purging old revision JSON")
 			}

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -967,17 +967,50 @@ func TestGetRemovalMultiChannel(t *testing.T) {
 	require.Equal(t, bodyExpected, body)
 }
 
+func TestDeltaSyncWhenFromRevIsLegacyRevTreeID(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+
+	if !base.IsEnterpriseEdition() {
+		t.Skip("Delta sync only supported in EE")
+	}
+
+	db, ctx := setupTestDB(t)
+	db.Options.DeltaSyncOptions = DeltaSyncOptions{
+		Enabled:          true,
+		RevMaxAgeSeconds: 300,
+		StoreLegacyRevs:  true,
+	}
+
+	defer db.Close(ctx)
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+	require.NoError(t, db.DbStats.InitDeltaSyncStats())
+
+	rev1, _, err := collection.Put(ctx, "doc1", Body{"foo": "bar", "bar": "buzz", "quux": "quax"})
+	require.NoError(t, err, "Error creating doc1")
+	rev2, _, err := collection.Put(ctx, "doc1", Body{"foo": "bar", "quux": "fuzz", BodyRev: rev1})
+	require.NoError(t, err, "Error updating doc1")
+
+	// force retrieval from backing store
+	db.FlushRevisionCacheForTest()
+
+	// get delta using legacy RevTree IDs - this should force a lookup for CV1 via the pointer backup revision doc
+	delta, _, err := collection.GetDelta(ctx, "doc1", rev1, rev2)
+	require.NoErrorf(t, err, "Error getting delta for doc %q from rev %q to %q", "doc1", rev1, rev2)
+	require.NotNil(t, delta)
+	assert.Equal(t, rev2, delta.ToRevID)
+	assert.Equal(t, []byte(`{"bar":[],"quux":"fuzz"}`), delta.DeltaBytes)
+}
+
 // Test delta sync behavior when the fromRevision is a channel removal.
 func TestDeltaSyncWhenFromRevIsChannelRemoval(t *testing.T) {
 	testCases := []struct {
 		name          string
 		versionVector bool
 	}{
-		// Revs are backed up by hash of CV now, now way to fetch backup revs by revID till CBG-3748 (backwards compatibility for revID)
-		//{
-		//	name:          "revTree test",
-		//	versionVector: false,
-		//},
+		{
+			name:          "revTree test",
+			versionVector: false,
+		},
 		{
 			name:          "versionVector test",
 			versionVector: true,
@@ -1024,7 +1057,8 @@ func TestDeltaSyncWhenFromRevIsChannelRemoval(t *testing.T) {
 				require.NoError(t, err, "Error purging old revision JSON")
 			} else {
 				err = collection.PurgeOldRevisionJSON(ctx, "doc1", rev2ID)
-				require.NoError(t, err, "Error purging old revision JSON")
+				// TODO: CBG-4840 - Requires restoration of RevTree ID-based old revision storage
+				//require.NoError(t, err, "Error purging old revision JSON")
 			}
 
 			// Request delta between rev2ID and rev3ID (toRevision "rev2ID" is channel removal)
@@ -1039,12 +1073,12 @@ func TestDeltaSyncWhenFromRevIsChannelRemoval(t *testing.T) {
 			if testCase.versionVector {
 				rev2 := docRev2.HLV.ExtractCurrentVersionFromHLV()
 				rev3 := docRev3.HLV.ExtractCurrentVersionFromHLV()
-				delta, redactedRev, err := collection.GetDelta(ctx, "doc1", rev2.String(), rev3.String(), true)
+				delta, redactedRev, err := collection.GetDelta(ctx, "doc1", rev2.String(), rev3.String())
 				require.Equal(t, base.HTTPErrorf(404, "missing"), err)
 				assert.Nil(t, delta)
 				assert.Nil(t, redactedRev)
 			} else {
-				delta, redactedRev, err := collection.GetDelta(ctx, "doc1", rev2ID, rev3ID, false)
+				delta, redactedRev, err := collection.GetDelta(ctx, "doc1", rev2ID, rev3ID)
 				require.Equal(t, base.HTTPErrorf(404, "missing"), err)
 				assert.Nil(t, delta)
 				assert.Nil(t, redactedRev)
@@ -1061,12 +1095,12 @@ func TestDeltaSyncWhenFromRevIsChannelRemoval(t *testing.T) {
 			if testCase.versionVector {
 				rev2 := docRev2.HLV.ExtractCurrentVersionFromHLV()
 				rev3 := docRev3.HLV.ExtractCurrentVersionFromHLV()
-				delta, redactedRev, err := collection.GetDelta(ctx, "doc1", rev2.String(), rev3.String(), true)
+				delta, redactedRev, err := collection.GetDelta(ctx, "doc1", rev2.String(), rev3.String())
 				require.Equal(t, base.HTTPErrorf(404, "missing"), err)
 				assert.Nil(t, delta)
 				assert.Nil(t, redactedRev)
 			} else {
-				delta, redactedRev, err := collection.GetDelta(ctx, "doc1", rev2ID, rev3ID, false)
+				delta, redactedRev, err := collection.GetDelta(ctx, "doc1", rev2ID, rev3ID)
 				require.Equal(t, base.HTTPErrorf(404, "missing"), err)
 				assert.Nil(t, delta)
 				assert.Nil(t, redactedRev)
@@ -1142,12 +1176,12 @@ func TestDeltaSyncWhenToRevIsChannelRemoval(t *testing.T) {
 			if testCase.versionVector {
 				rev2 := docRev2.HLV.ExtractCurrentVersionFromHLV()
 				rev3 := docRev3.HLV.ExtractCurrentVersionFromHLV()
-				delta, redactedRev, err := collection.GetDelta(ctx, "doc1", rev2.String(), rev3.String(), true)
+				delta, redactedRev, err := collection.GetDelta(ctx, "doc1", rev2.String(), rev3.String())
 				require.NoError(t, err)
 				assert.Nil(t, delta)
 				assert.Equal(t, `{"_removed":true}`, string(redactedRev.BodyBytes))
 			} else {
-				delta, redactedRev, err := collection.GetDelta(ctx, "doc1", rev1ID, rev2ID, false)
+				delta, redactedRev, err := collection.GetDelta(ctx, "doc1", rev1ID, rev2ID)
 				require.NoError(t, err)
 				assert.Nil(t, delta)
 				assert.Equal(t, `{"_removed":true}`, string(redactedRev.BodyBytes))
@@ -1163,12 +1197,12 @@ func TestDeltaSyncWhenToRevIsChannelRemoval(t *testing.T) {
 			if testCase.versionVector {
 				rev2 := docRev2.HLV.ExtractCurrentVersionFromHLV()
 				rev3 := docRev3.HLV.ExtractCurrentVersionFromHLV()
-				delta, redactedRev, err := collection.GetDelta(ctx, "doc1", rev2.String(), rev3.String(), true)
+				delta, redactedRev, err := collection.GetDelta(ctx, "doc1", rev2.String(), rev3.String())
 				require.Equal(t, base.HTTPErrorf(404, "missing"), err)
 				assert.Nil(t, delta)
 				assert.Nil(t, redactedRev)
 			} else {
-				delta, redactedRev, err := collection.GetDelta(ctx, "doc1", rev1ID, rev2ID, false)
+				delta, redactedRev, err := collection.GetDelta(ctx, "doc1", rev1ID, rev2ID)
 				require.Equal(t, base.HTTPErrorf(404, "missing"), err)
 				assert.Nil(t, delta)
 				assert.Nil(t, redactedRev)

--- a/db/import.go
+++ b/db/import.go
@@ -478,7 +478,7 @@ func (db *DatabaseCollectionWithUser) backupPreImportRevision(ctx context.Contex
 		return err
 	}
 
-	setOldRevErr := db.setOldRevisionJSON(ctx, docid, revid, oldRevJSON, db.oldRevExpirySeconds())
+	setOldRevErr := db.setOldRevisionJSONBody(ctx, docid, revid, oldRevJSON, db.oldRevExpirySeconds())
 	if setOldRevErr != nil {
 		return fmt.Errorf("Persistence error: %v", setOldRevErr)
 	}

--- a/db/revision_old.go
+++ b/db/revision_old.go
@@ -1,0 +1,57 @@
+// Copyright 2025-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package db
+
+import (
+	"context"
+
+	"github.com/couchbase/sync_gateway/base"
+)
+
+// nonJSONPrefix is a byte prepended to documents to ensure old revision bodies are hidden from N1QL/Views. This can be used as additional identifier to determine the type of data stored.
+type nonJSONPrefix byte
+
+const (
+	// nonJSONPrefixKindUnknown is an unused byte value but here for clarity between the zero value
+	nonJSONPrefixKindUnknown nonJSONPrefix = iota
+	// nonJSONPrefixKindRevBody is used for old revision bodies and denotes that everything following is a standard JSON document.
+	nonJSONPrefixKindRevBody
+	// nonJSONPrefixKindRevPtr is used for old revision RevTreeID->CV pointers. The bytes following this are the CV string to be used to fetch the actual body.
+	nonJSONPrefixKindRevPtr
+)
+
+// withNonJSONPrefix returns a new byte slice prefixed with a non-JSON byte. The input slice is not modified.
+func withNonJSONPrefix(kind nonJSONPrefix, body []byte) []byte {
+	buf := make([]byte, 1, len(body)+1)
+	buf[0] = byte(kind)
+	buf = append(buf, body...)
+	return buf
+}
+
+// stripNonJSONPrefix removes the non-JSON prefix byte and returns the kind and the remainder of the byte slice.
+func stripNonJSONPrefix(data []byte) (kind nonJSONPrefix, body []byte) {
+	if len(data) <= 1 {
+		return nonJSONPrefixKindUnknown, nil
+	}
+	return nonJSONPrefix(data[0]), data[1:]
+}
+
+// setOldRevisionJSONPtr stores a pointer from the old revision's RevTreeID to the Current Version hash used to fetch the body.
+func (db *DatabaseCollectionWithUser) setOldRevisionJSONPtr(ctx context.Context, doc *Document, expiry uint32) error {
+	ptrKey := oldRevisionKey(doc.ID, doc.GetRevTreeID())
+	revHash := base.Crc32cHashString([]byte(doc.HLV.GetCurrentVersionString()))
+	ptrBytes := withNonJSONPrefix(nonJSONPrefixKindRevPtr, []byte(revHash))
+	err := db.dataStore.SetRaw(ptrKey, expiry, nil, ptrBytes)
+	if err == nil {
+		base.DebugfCtx(ctx, base.KeyCRUD, "Backed up revision body legacy RevTree ID pointer %q -> %q/%q (%d bytes, ttl:%d)", doc.GetRevTreeID(), base.UD(doc.ID), revHash, len(ptrBytes), db.deltaSyncRevMaxAgeSeconds())
+	} else {
+		base.WarnfCtx(ctx, "Failed to write legacy rev pointer for %q rev %q: %v", base.UD(doc.ID), doc.GetRevTreeID(), err)
+	}
+	return err
+}

--- a/db/revision_old_test.go
+++ b/db/revision_old_test.go
@@ -1,9 +1,0 @@
-// Copyright 2025-Present Couchbase, Inc.
-//
-// Use of this software is governed by the Business Source License included
-// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
-// in that file, in accordance with the Business Source License, use of this
-// software will be governed by the Apache License, Version 2.0, included in
-// the file licenses/APL2.txt.
-
-package db

--- a/db/revision_old_test.go
+++ b/db/revision_old_test.go
@@ -1,0 +1,9 @@
+// Copyright 2025-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package db

--- a/db/revtree.go
+++ b/db/revtree.go
@@ -401,7 +401,7 @@ func (tree RevTree) getRevisionBody(revid string, loader RevLoaderFunc) ([]byte,
 	// as if the transient backup had expired. We are not attempting to repair the rev tree, as reclaiming storage
 	// is a much lower priority than avoiding write errors, and want to avoid introducing additional conflict scenarios.
 	// The invalid rev tree bodies will eventually be pruned through normal revision tree pruning.
-	if len(info.Body) > 0 && info.Body[0] == nonJSONPrefix {
+	if len(info.Body) > 0 && nonJSONPrefix(info.Body[0]) == nonJSONPrefixKindRevBody {
 		return nil, false
 	}
 	return info.Body, true

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1193,13 +1193,6 @@ Database:
             This defaults to 24 hours (in seconds).
           type: number
           default: 86400
-    store_legacy_revtree_data:
-      description: |-
-        Controls whether Sync Gateway stores additional legacy revision tree pointer data to support 3.x/early 4.x clients that still use RevTree IDs (for example when used as delta sources).
-
-        Disable this when you are confident all clients use newer CV-based revisions and no longer require legacy RevTree ID lookups.
-      type: boolean
-      default: true
     disable_password_auth:
       description: Whether to disable username/password authentication and only allow OIDC and guest access.
       type: boolean
@@ -1641,6 +1634,13 @@ Database:
       description: 'The amount of milliseconds a N1QL query should run before logging a warning. '
       type: number
       default: 500
+    store_legacy_revtree_data:
+      description: |-
+        Controls whether Sync Gateway stores additional legacy revision tree pointer data to support 3.x/early 4.x clients that still use RevTree IDs (for example when used as delta sources).
+
+        Disable this when you are confident all clients use newer CV-based revisions and no longer require legacy RevTree ID lookups.
+      type: boolean
+      default: true
     suspendable:
       description: |-
         Set to true to allow the database to be suspended.

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1193,10 +1193,13 @@ Database:
             This defaults to 24 hours (in seconds).
           type: number
           default: 86400
-        store_legacy_revs:
-          description: Allows legacy RevTree clients to continue using delta sync at the cost of one additional small lookup document stored in the bucket.
-          type: boolean
-          default: true
+    store_legacy_revtree_data:
+      description: |-
+        Controls whether Sync Gateway stores additional legacy revision tree pointer data to support 3.x/early 4.x clients that still use RevTree IDs (for example when used as delta sources).
+
+        Disable this when you are confident all clients use newer CV-based revisions and no longer require legacy RevTree ID lookups.
+      type: boolean
+      default: true
     disable_password_auth:
       description: Whether to disable username/password authentication and only allow OIDC and guest access.
       type: boolean

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1193,6 +1193,10 @@ Database:
             This defaults to 24 hours (in seconds).
           type: number
           default: 86400
+        store_legacy_revs:
+          description: Allows legacy RevTree clients to continue using delta sync at the cost of one additional small lookup document stored in the bucket.
+          type: boolean
+          default: true
     disable_password_auth:
       description: Whether to disable username/password authentication and only allow OIDC and guest access.
       type: boolean

--- a/rest/config.go
+++ b/rest/config.go
@@ -213,6 +213,7 @@ type CollectionConfig struct {
 type DeltaSyncConfig struct {
 	Enabled          *bool   `json:"enabled,omitempty"`             // Whether delta sync is enabled (requires EE)
 	RevMaxAgeSeconds *uint32 `json:"rev_max_age_seconds,omitempty"` // The number of seconds deltas for old revs are available for
+	StoreLegacyRevs  *bool   `json:"store_legacy_revs,omitempty"`   // Whether to store additional data to allow legacy RevTree ID support for delta sync
 }
 
 type DbConfigMap map[string]*DbConfig

--- a/rest/config.go
+++ b/rest/config.go
@@ -179,6 +179,7 @@ type DbConfig struct {
 	BucketOpTimeoutMs                *uint32                          `json:"bucket_op_timeout_ms,omitempty"`                 // How long bucket ops should block returning "operation timed out". If nil, uses GoCB default.  GoCB buckets only.
 	SlowQueryWarningThresholdMs      *uint32                          `json:"slow_query_warning_threshold,omitempty"`         // Log warnings if N1QL queries take this many ms
 	DeltaSync                        *DeltaSyncConfig                 `json:"delta_sync,omitempty"`                           // Config for delta sync
+	StoreLegacyRevTreeData           *bool                            `json:"store_legacy_revtree_data,omitempty"`            // Whether to store legacy revision tree pointer data to support older clients using RevTree IDs
 	CompactIntervalDays              *float32                         `json:"compact_interval_days,omitempty"`                // Interval between scheduled compaction runs (in days) - 0 means don't run
 	SGReplicateEnabled               *bool                            `json:"sgreplicate_enabled,omitempty"`                  // When false, node will not be assigned replications
 	SGReplicateWebsocketPingInterval *int                             `json:"sgreplicate_websocket_heartbeat_secs,omitempty"` // If set, uses this duration as a custom heartbeat interval for websocket ping frames
@@ -213,7 +214,6 @@ type CollectionConfig struct {
 type DeltaSyncConfig struct {
 	Enabled          *bool   `json:"enabled,omitempty"`             // Whether delta sync is enabled (requires EE)
 	RevMaxAgeSeconds *uint32 `json:"rev_max_age_seconds,omitempty"` // The number of seconds deltas for old revs are available for
-	StoreLegacyRevs  *bool   `json:"store_legacy_revs,omitempty"`   // Whether to store additional data to allow legacy RevTree ID support for delta sync
 }
 
 type DbConfigMap map[string]*DbConfig

--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -173,8 +173,8 @@ func DefaultDbConfig(sc *StartupConfig, useXattrs bool) *DbConfig {
 		DeltaSync: &DeltaSyncConfig{
 			Enabled:          base.Ptr(db.DefaultDeltaSyncEnabled),
 			RevMaxAgeSeconds: base.Ptr(db.DefaultDeltaSyncRevMaxAge),
-			StoreLegacyRevs:  base.Ptr(db.DefaultStoreLegacyRevs),
 		},
+		StoreLegacyRevTreeData:           base.Ptr(db.DefaultStoreLegacyRevs),
 		CompactIntervalDays:              base.Ptr(float32(db.DefaultCompactInterval.Hours() / 24)),
 		SGReplicateEnabled:               base.Ptr(db.DefaultSGReplicateEnabled),
 		SGReplicateWebsocketPingInterval: base.Ptr(int(db.DefaultSGReplicateWebsocketPingInterval.Seconds())),

--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -173,6 +173,7 @@ func DefaultDbConfig(sc *StartupConfig, useXattrs bool) *DbConfig {
 		DeltaSync: &DeltaSyncConfig{
 			Enabled:          base.Ptr(db.DefaultDeltaSyncEnabled),
 			RevMaxAgeSeconds: base.Ptr(db.DefaultDeltaSyncRevMaxAge),
+			StoreLegacyRevs:  base.Ptr(db.DefaultStoreLegacyRevs),
 		},
 		CompactIntervalDays:              base.Ptr(float32(db.DefaultCompactInterval.Hours() / 24)),
 		SGReplicateEnabled:               base.Ptr(db.DefaultSGReplicateEnabled),

--- a/rest/revision_old_revtree_test.go
+++ b/rest/revision_old_revtree_test.go
@@ -1,0 +1,85 @@
+// Copyright 2025-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package rest
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestGetOldRevisionBodyByRevTreeID ensures that fetching an older revision body using a legacy RevTree ID after flushing the revision cache works with store_legacy_revtree_data set.
+func TestGetOldRevisionBodyByRevTreeID(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD)
+
+	tests := []struct {
+		name                   string
+		storeLegacyRevTreeData bool
+		deltaSyncEnabled       bool
+		expectedToFindOldRev   bool
+	}{
+		{
+			name:                   "store_legacy_revtree_data=true, delta_sync=true",
+			storeLegacyRevTreeData: true,
+			deltaSyncEnabled:       true,
+			expectedToFindOldRev:   true,
+		},
+		{
+			name:                   "store_legacy_revtree_data=true, delta_sync=false",
+			storeLegacyRevTreeData: true,
+			deltaSyncEnabled:       false,
+			expectedToFindOldRev:   false, // TODO: CBG-4840 - Should be true - Requires restoration of non-delta sync rev storage
+		},
+		{
+			name:                   "store_legacy_revtree_data=false, delta_sync=true",
+			storeLegacyRevTreeData: false,
+			deltaSyncEnabled:       true,
+			expectedToFindOldRev:   false,
+		},
+		{
+			name:                   "store_legacy_revtree_data=false, delta_sync=false",
+			storeLegacyRevTreeData: false,
+			deltaSyncEnabled:       false,
+			expectedToFindOldRev:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rt := NewRestTester(t, &RestTesterConfig{
+				DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+					DeltaSync:              &DeltaSyncConfig{Enabled: base.Ptr(tc.deltaSyncEnabled)},
+					StoreLegacyRevTreeData: base.Ptr(tc.storeLegacyRevTreeData),
+				}},
+			})
+			defer rt.Close()
+
+			// Create and update a document to generate an old revision.
+			const docID = "doc1"
+			v1 := rt.PutDoc(docID, `{"v":1}`)
+			v2 := rt.UpdateDoc(docID, v1, `{"v":2}`)
+			_ = v2
+
+			// Flush the revision cache to force retrieval from bucket-stored old revision docs.
+			rt.GetDatabase().FlushRevisionCacheForTest()
+
+			resp := rt.SendAdminRequest(http.MethodGet, fmt.Sprintf("/{{.keyspace}}/%s?rev=%s", docID, v1.RevTreeID), "")
+			// Attempt to fetch the old revision body using its RevTree ID.
+			if tc.expectedToFindOldRev {
+				RequireStatus(t, resp, http.StatusOK)
+				assert.Contains(t, resp.BodyString(), `"v":1`)
+			} else {
+				RequireStatus(t, resp, http.StatusNotFound)
+			}
+		})
+	}
+}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1212,6 +1212,7 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 	deltaSyncOptions := db.DeltaSyncOptions{
 		Enabled:          db.DefaultDeltaSyncEnabled,
 		RevMaxAgeSeconds: db.DefaultDeltaSyncRevMaxAge,
+		StoreLegacyRevs:  db.DefaultStoreLegacyRevs,
 	}
 
 	if config.DeltaSync != nil {
@@ -1226,6 +1227,10 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 				return db.DatabaseContextOptions{}, fmt.Errorf("delta_sync.rev_max_age_seconds: %d must not be less than the configured old_rev_expiry_seconds: %d", *revMaxAge, oldRevExpirySeconds)
 			}
 			deltaSyncOptions.RevMaxAgeSeconds = *revMaxAge
+		}
+
+		if storeLegacyRevs := config.DeltaSync.StoreLegacyRevs; storeLegacyRevs != nil {
+			deltaSyncOptions.StoreLegacyRevs = *storeLegacyRevs
 		}
 	}
 	base.InfofCtx(ctx, base.KeyAll, "delta_sync enabled=%t with rev_max_age_seconds=%d for database %s", deltaSyncOptions.Enabled, deltaSyncOptions.RevMaxAgeSeconds, dbName)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1229,9 +1229,11 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 			deltaSyncOptions.RevMaxAgeSeconds = *revMaxAge
 		}
 
-		if storeLegacyRevs := config.DeltaSync.StoreLegacyRevs; storeLegacyRevs != nil {
-			deltaSyncOptions.StoreLegacyRevs = *storeLegacyRevs
-		}
+	}
+
+	// Database-level legacy revtree storage toggle (renamed from delta_sync.store_legacy_revs)
+	if storeLegacy := config.StoreLegacyRevTreeData; storeLegacy != nil {
+		deltaSyncOptions.StoreLegacyRevs = *storeLegacy
 	}
 	base.InfofCtx(ctx, base.KeyAll, "delta_sync enabled=%t with rev_max_age_seconds=%d for database %s", deltaSyncOptions.Enabled, deltaSyncOptions.RevMaxAgeSeconds, dbName)
 

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -95,7 +95,7 @@ func (rt *RestTester) GetDocVersion(docID string, version DocVersion) db.Body {
 
 // GetDocByRev returns the doc body for the given docID and Rev. If the document is not found, t.Fail will be called.
 func (rt *RestTester) GetDocByRev(docID, revTreeID string) db.Body {
-	rawResponse := rt.SendAdminRequest(http.MethodGet, fmt.Sprintf("/%s/%s?rev=%s", rt.GetSingleKeyspace(), docID, revTreeID), "")
+	rawResponse := rt.SendAdminRequest(http.MethodGet, fmt.Sprintf("/{{.keyspace}}/%s?rev=%s", docID, revTreeID), "")
 	RequireStatus(rt.TB(), rawResponse, http.StatusOK)
 	var body db.Body
 	require.NoError(rt.TB(), base.JSONUnmarshal(rawResponse.Body.Bytes(), &body))
@@ -104,14 +104,14 @@ func (rt *RestTester) GetDocByRev(docID, revTreeID string) db.Body {
 
 // CreateTestDoc creates a document with an arbitrary body.
 func (rt *RestTester) CreateTestDoc(docid string) DocVersion {
-	response := rt.SendAdminRequest(http.MethodPut, fmt.Sprintf("/%s/%s", rt.GetSingleKeyspace(), docid), `{"prop":true}`)
+	response := rt.SendAdminRequest(http.MethodPut, fmt.Sprintf("/{{.keyspace}}/%s", docid), `{"prop":true}`)
 	RequireStatus(rt.TB(), response, 201)
 	return DocVersionFromPutResponse(rt.TB(), response)
 }
 
 // PutDoc will upsert the document with a given contents.
 func (rt *RestTester) PutDoc(docID, body string) DocVersion {
-	rawResponse := rt.SendAdminRequest(http.MethodPut, fmt.Sprintf("/%s/%s", rt.GetSingleKeyspace(), docID), body)
+	rawResponse := rt.SendAdminRequest(http.MethodPut, fmt.Sprintf("/{{.keyspace}}/%s", docID), body)
 	RequireStatus(rt.TB(), rawResponse, 201)
 	return DocVersionFromPutResponse(rt.TB(), rawResponse)
 }


### PR DESCRIPTION
CBG-3748

Store a "pointer" revision backup doc keyed from a RevTree ID that points to the CV-based key for retrieval for 3.x clients and delta sync from RevTree IDs.

Can be disabled for customers that only have 4.x clients with a db-level config option, that can also control non-delta sync temporary revision backups (behind a TODO for 4.0, since it requires changes to restore previous functionality)

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/61/
