### PR TITLE
CBG-4258 allow support of a CBL V3 client

### DIFF
--- a/topologytest/couchbase_lite_mock_peer_test.go
+++ b/topologytest/couchbase_lite_mock_peer_test.go
@@ -106,6 +106,8 @@ func (p *CouchbaseLiteMockPeer) CreateDocument(dsName sgbucket.DataStoreName, do
 		docVersion = client.AddRev(docID, rest.EmptyDocVersion(), body)
 	case PeerTypeCouchbaseLite:
 		docVersion, hlv = client.AddHLVRev(docID, rest.EmptyDocVersion(), body)
+	default:
+		require.Fail(p.TB(), fmt.Sprintf("unsupported peer type %s for creating document", p.Type()))
 	}
 	docMetadata := DocMetadataFromDocVersion(p.TB(), docID, hlv, docVersion)
 	p.TB().Logf("%s: Created document %s with %#v", p, docID, docMetadata)

--- a/topologytest/couchbase_lite_mock_peer_test.go
+++ b/topologytest/couchbase_lite_mock_peer_test.go
@@ -131,6 +131,8 @@ func (p *CouchbaseLiteMockPeer) WriteDocument(dsName sgbucket.DataStoreName, doc
 		docVersion = client.AddRev(docID, parentVersion, body)
 	case PeerTypeCouchbaseLite:
 		docVersion, hlv = client.AddHLVRev(docID, parentVersion, body)
+	default:
+		require.Fail(p.TB(), fmt.Sprintf("unsupported peer type %s for writing document", p.Type()))
 	}
 	docMetadata := DocMetadataFromDocVersion(p.TB(), docID, hlv, docVersion)
 	p.TB().Logf("%s: Wrote document %s with %#+v", p, docID, docMetadata)
@@ -213,7 +215,8 @@ func (p *CouchbaseLiteMockPeer) Close() {
 	}
 }
 
-// Type returns PeerTypeCouchbaseLite if CouchbaseLite V4 or PeerTypeCouchbaseLiteV3 if representing a 3.x client.
+// Type returns PeerTypeCouchbaseLite if representing a Couchbase Lite 4.x client or PeerTypeCouchbaseLiteV3
+// if representing a 3.x client.
 func (p *CouchbaseLiteMockPeer) Type() PeerType {
 	return p.peerType
 }

--- a/topologytest/couchbase_lite_mock_peer_test.go
+++ b/topologytest/couchbase_lite_mock_peer_test.go
@@ -43,6 +43,7 @@ type CouchbaseLiteMockPeer struct {
 	blipClients        map[string]*PeerBlipTesterClient
 	name               string
 	symmetricRedundant bool // there is another peer that is symmetric to this one
+	peerType           PeerType
 }
 
 func (p *CouchbaseLiteMockPeer) String() string {
@@ -98,7 +99,14 @@ func (p *CouchbaseLiteMockPeer) getSingleSGBlipClient() *PeerBlipTesterClient {
 // CreateDocument creates a document on the peer. The test will fail if the document already exists.
 func (p *CouchbaseLiteMockPeer) CreateDocument(dsName sgbucket.DataStoreName, docID string, body []byte) BodyAndVersion {
 	client := p.getSingleSGBlipClient().CollectionClient(dsName)
-	docVersion, hlv := client.AddHLVRev(docID, rest.EmptyDocVersion(), body)
+	var docVersion db.DocVersion
+	var hlv *db.HybridLogicalVector
+	switch p.Type() {
+	case PeerTypeCouchbaseLiteV3:
+		docVersion = client.AddRev(docID, rest.EmptyDocVersion(), body)
+	case PeerTypeCouchbaseLite:
+		docVersion, hlv = client.AddHLVRev(docID, rest.EmptyDocVersion(), body)
+	}
 	docMetadata := DocMetadataFromDocVersion(p.TB(), docID, hlv, docVersion)
 	p.TB().Logf("%s: Created document %s with %#v", p, docID, docMetadata)
 	return BodyAndVersion{
@@ -114,9 +122,16 @@ func (p *CouchbaseLiteMockPeer) WriteDocument(dsName sgbucket.DataStoreName, doc
 	_, parentMeta := p.getLatestDocVersion(dsName, docID)
 	parentVersion := rest.EmptyDocVersion()
 	if parentMeta != nil {
-		parentVersion = &db.DocVersion{CV: parentMeta.CV(p.TB())}
+		parentVersion = &db.DocVersion{CV: parentMeta.CV(p.TB()), RevTreeID: parentMeta.RevTreeID}
 	}
-	docVersion, hlv := client.AddHLVRev(docID, parentVersion, body)
+	var docVersion db.DocVersion
+	var hlv *db.HybridLogicalVector
+	switch p.Type() {
+	case PeerTypeCouchbaseLiteV3:
+		docVersion = client.AddRev(docID, parentVersion, body)
+	case PeerTypeCouchbaseLite:
+		docVersion, hlv = client.AddHLVRev(docID, parentVersion, body)
+	}
 	docMetadata := DocMetadataFromDocVersion(p.TB(), docID, hlv, docVersion)
 	p.TB().Logf("%s: Wrote document %s with %#+v", p, docID, docMetadata)
 	return BodyAndVersion{
@@ -132,7 +147,7 @@ func (p *CouchbaseLiteMockPeer) DeleteDocument(dsName sgbucket.DataStoreName, do
 	_, parentMeta := p.getLatestDocVersion(dsName, docID)
 	parentVersion := rest.EmptyDocVersion()
 	if parentMeta != nil {
-		parentVersion = &db.DocVersion{CV: parentMeta.CV(p.TB())}
+		parentVersion = &db.DocVersion{CV: parentMeta.CV(p.TB()), RevTreeID: parentMeta.RevTreeID}
 	}
 	docVersion, hlv := client.Delete(docID, parentVersion)
 	docMeta := DocMetadataFromDocVersion(p.TB(), docID, hlv, docVersion)
@@ -142,6 +157,7 @@ func (p *CouchbaseLiteMockPeer) DeleteDocument(dsName sgbucket.DataStoreName, do
 
 // WaitForDocVersion waits for a document to reach a specific version. The test will fail if the document does not reach the expected version in 20s.
 func (p *CouchbaseLiteMockPeer) WaitForDocVersion(dsName sgbucket.DataStoreName, docID string, expected DocMetadata, topology Topology) db.Body {
+	compareHLV := !topology.CompareRevTreeOnly()
 	var data []byte
 	require.EventuallyWithT(p.TB(), func(c *assert.CollectT) {
 		var actual *DocMetadata
@@ -149,7 +165,11 @@ func (p *CouchbaseLiteMockPeer) WaitForDocVersion(dsName sgbucket.DataStoreName,
 		if !assert.NotNil(c, actual, "Could not find docID:%+v on %p\nVersion %#v", docID, p, expected) {
 			return
 		}
-		assertHLVEqual(c, dsName, docID, p.name, *actual, data, expected, topology)
+		if compareHLV {
+			assertHLVEqual(c, dsName, docID, p.name, *actual, data, expected, topology)
+		} else {
+			assertRevTreeIDEqual(c, dsName, docID, p.name, *actual, data, expected, topology)
+		}
 	}, totalWaitTime, pollInterval)
 	var body db.Body
 	require.NoError(p.TB(), base.JSONUnmarshal(data, &body))
@@ -176,6 +196,9 @@ func (p *CouchbaseLiteMockPeer) WaitForCV(dsName sgbucket.DataStoreName, docID s
 func (p *CouchbaseLiteMockPeer) WaitForTombstoneVersion(dsName sgbucket.DataStoreName, docID string, expected DocMetadata, topology Topology) {
 	client := p.getSingleSGBlipClient().CollectionClient(dsName)
 	expectedVersion := db.DocVersion{CV: expected.CV(p.TB())}
+	if p.Type() == PeerTypeCouchbaseLiteV3 {
+		expectedVersion = db.DocVersion{RevTreeID: expected.RevTreeID}
+	}
 	require.EventuallyWithT(p.TB(), func(c *assert.CollectT) {
 		isTombstone, err := client.IsVersionTombstone(docID, expectedVersion)
 		require.NoError(c, err)
@@ -190,9 +213,9 @@ func (p *CouchbaseLiteMockPeer) Close() {
 	}
 }
 
-// Type returns PeerTypeCouchbaseLite.
+// Type returns PeerTypeCouchbaseLite if CouchbaseLite V4 or PeerTypeCouchbaseLiteV3 if representing a 3.x client.
 func (p *CouchbaseLiteMockPeer) Type() PeerType {
-	return PeerTypeCouchbaseLite
+	return p.peerType
 }
 
 // IsSymmetricRedundant returns true if there is another peer set up that is identical to this one, and this peer doesn't need to participate in unique actions.
@@ -226,8 +249,14 @@ func (p *CouchbaseLiteMockPeer) CreateReplication(peer Peer, config PeerReplicat
 	}
 	const username = "user"
 	sg.rt.CreateUser(username, []string{"*"})
-	replication.btcRunner.SetSubprotocols([]string{db.CBMobileReplicationV4.SubprotocolString()})
-	// intentionally do not use base.TestCtx to drop test name for readability
+	switch p.Type() {
+	case PeerTypeCouchbaseLite:
+		replication.btcRunner.SetSubprotocols([]string{db.CBMobileReplicationV4.SubprotocolString()})
+	case PeerTypeCouchbaseLiteV3:
+		replication.btcRunner.SetSubprotocols([]string{db.CBMobileReplicationV3.SubprotocolString()})
+	default:
+		require.Fail(p.TB(), fmt.Sprintf("unsupported peer type %v for pull replication", p.Type()))
+	}
 	ctx := base.CorrelationIDLogCtx(sg.rt.TB().Context(), p.name)
 	replication.btc = replication.btcRunner.NewBlipTesterClientOptsWithRTAndContext(ctx, sg.rt, &rest.BlipTesterClientOpts{
 		Username: "user",

--- a/topologytest/couchbase_server_peer_test.go
+++ b/topologytest/couchbase_server_peer_test.go
@@ -216,7 +216,11 @@ func (p *CouchbaseServerPeer) waitForDocVersion(dsName sgbucket.DataStoreName, d
 			return
 		}
 		version = getDocVersion(docID, p, cas, xattrs)
-		assertHLVEqual(c, dsName, docID, p.name, version, docBytes, expected, topology)
+		if expected.HasHLV() {
+			assertHLVEqual(c, dsName, docID, p.name, version, docBytes, expected, topology)
+		} else {
+			assertRevTreeIDEqual(c, dsName, docID, p.name, version, docBytes, expected, topology)
+		}
 	}, totalWaitTime, pollInterval)
 	return docBytes
 }

--- a/topologytest/hlv_test.go
+++ b/topologytest/hlv_test.go
@@ -172,7 +172,11 @@ func waitForConvergingTombstones(t *testing.T, dsName base.ScopeAndCollectionNam
 				nonCBLVersion = &version
 				continue
 			}
-			assertHLVEqual(c, dsName, docID, peer, version, nil, *nonCBLVersion, topology)
+			if topology.CompareRevTreeOnly() {
+				assertRevTreeIDEqual(c, dsName, docID, peer, version, nil, *nonCBLVersion, topology)
+			} else {
+				assertHLVEqual(c, dsName, docID, peer, version, nil, *nonCBLVersion, topology)
+			}
 		}
 	}, totalWaitTime, pollInterval)
 }

--- a/topologytest/multi_actor_no_conflict_test.go
+++ b/topologytest/multi_actor_no_conflict_test.go
@@ -24,8 +24,8 @@ func TestMultiActorUpdate(t *testing.T) {
 		t.Run(topologySpec.description, func(t *testing.T) {
 			collectionName, topology := setupTests(t, topologySpec)
 			topology.StartReplications()
-			for createPeerName, createPeer := range topology.peers.ActivePeers() {
-				for updatePeerName, updatePeer := range topology.SortedPeers() {
+			for createPeerName, createPeer := range topology.ActivePeers() {
+				for updatePeerName, updatePeer := range topology.ActivePeers() {
 					topology.Run(t, "create="+createPeerName+",update="+updatePeerName, func(t *testing.T) {
 						docID := getDocID(t) + "_create=" + createPeerName + ",update=" + updatePeerName
 						body1 := []byte(fmt.Sprintf(`{"activePeer": "%s", "createPeer": "%s", "updatePeer": "%s", "topology": "%s", "action": "create"}`, createPeerName, createPeerName, updatePeer, topology.specDescription))
@@ -55,7 +55,7 @@ func TestMultiActorDelete(t *testing.T) {
 			collectionName, topology := setupTests(t, topologySpec)
 			topology.StartReplications()
 			for createPeerName, createPeer := range topology.ActivePeers() {
-				for deletePeerName, deletePeer := range topology.SortedPeers() {
+				for deletePeerName, deletePeer := range topology.ActivePeers() {
 					topology.Run(t, "create="+createPeerName+",delete="+deletePeerName, func(t *testing.T) {
 						docID := getDocID(t) + "_create=" + createPeerName + ",update=" + deletePeerName
 						body1 := []byte(fmt.Sprintf(`{"activePeer": "%s", "createPeer": "%s", "deletePeer": "%s", "topology": "%s", "action": "create"}`, createPeerName, createPeerName, deletePeer, topology.specDescription))
@@ -85,8 +85,8 @@ func TestMultiActorResurrect(t *testing.T) {
 			collectionName, topology := setupTests(t, topologySpec)
 			topology.StartReplications()
 			for createPeerName, createPeer := range topology.ActivePeers() {
-				for deletePeerName, deletePeer := range topology.SortedPeers() {
-					for resurrectPeerName, resurrectPeer := range topology.SortedPeers() {
+				for deletePeerName, deletePeer := range topology.ActivePeers() {
+					for resurrectPeerName, resurrectPeer := range topology.ActivePeers() {
 						topology.Run(t, fmt.Sprintf("create=%s,delete=%s,resurrect=%s", createPeerName, deletePeerName, resurrectPeerName), func(t *testing.T) {
 							docID := getDocID(t) + "_create=" + createPeerName + ",delete=" + deletePeerName + ",resurrect=" + resurrectPeerName
 							body1 := []byte(fmt.Sprintf(`{"activePeer": "%s", "createPeer": "%s", "deletePeer": "%s", "resurrectPeer": "%s", "topology": "%s", "action": "create"}`, createPeerName, createPeerName, deletePeer, resurrectPeer, topologySpec.description))

--- a/topologytest/peer_test.go
+++ b/topologytest/peer_test.go
@@ -318,7 +318,7 @@ type PeerType int
 
 const (
 	// PeerTypeCouchbaseServer represents a Couchbase Server peer. This can be backed by rosmar or couchbase server (controlled by SG_TEST_BACKING_STORE).
-	PeerTypeCouchbaseServer PeerType = iota + 1
+	PeerTypeCouchbaseServer PeerType = iota
 	// PeerTypeCouchbaseLite represents a Couchbase Lite peer. This is currently backed in memory but will be backed by in memory structure that will send and receive blip messages. Future expansion to real Couchbase Lite peer in CBG-4260.
 	PeerTypeCouchbaseLite
 	// PeerTypeCouchbaseLiteV3 represents a Couchbase Lite peer. This is currently backed in memory but will be backed by in memory structure that will send and receive blip messages. Future expansion to real Couchbase Lite peer in CBG-4260.

--- a/topologytest/sync_gateway_peer_test.go
+++ b/topologytest/sync_gateway_peer_test.go
@@ -161,7 +161,11 @@ func (p *SyncGatewayPeer) WaitForDocVersion(dsName sgbucket.DataStoreName, docID
 		// Only assert on CV since RevTreeID might not be present if this was a Couchbase Server write
 		bodyBytes, err := doc.BodyBytes(ctx)
 		assert.NoError(c, err)
-		assertHLVEqual(c, dsName, docID, p.name, version, bodyBytes, expected, topology)
+		if expected.HasHLV() {
+			assertHLVEqual(c, dsName, docID, p.name, version, bodyBytes, expected, topology)
+		} else {
+			assertRevTreeIDEqual(c, dsName, docID, p.name, version, bodyBytes, expected, topology)
+		}
 	}, totalWaitTime, pollInterval)
 	return doc.Body(ctx)
 }

--- a/topologytest/topologies_test.go
+++ b/topologytest/topologies_test.go
@@ -60,6 +60,48 @@ var TopologySpecifications = []TopologySpecification{
 	},
 	{
 		/*
+			+ - - - - - - +
+			' +---------+ '
+			' |  cbs1   | '
+			' +---------+ '
+			' +---------+ '
+			' |   sg1   | '
+			' +---------+ '
+			+ - - - - - - +
+			      ^
+			      |
+			      |
+			      v
+			  +---------+
+			  |cbl1 (v3)|
+			  +---------+
+		*/
+		description: "CBLV3<->SG<->CBS 1.1",
+		peers: map[string]PeerOptions{
+			"cbs1": {Type: PeerTypeCouchbaseServer, BucketID: PeerBucketID1},
+			"sg1":  {Type: PeerTypeSyncGateway, BucketID: PeerBucketID1},
+			"cbl1": {Type: PeerTypeCouchbaseLiteV3},
+		},
+		replications: []PeerReplicationDefinition{
+			{
+				activePeer:  "cbl1",
+				passivePeer: "sg1",
+				config: PeerReplicationConfig{
+					direction: PeerReplicationDirectionPull,
+				},
+			},
+			{
+				activePeer:  "cbl1",
+				passivePeer: "sg1",
+				config: PeerReplicationConfig{
+					direction: PeerReplicationDirectionPush,
+				},
+			},
+		},
+	},
+
+	{
+		/*
 			Test topology 1.2
 
 			+ - - - - - - +      +- - - - - - -+

--- a/topologytest/version_test.go
+++ b/topologytest/version_test.go
@@ -110,5 +110,5 @@ func assertCVEqual(t assert.TestingT, dsName sgbucket.DataStoreName, docID strin
 
 // assertRevTreeIDEqual asserts that CV of the version is equal to the expected CV.
 func assertRevTreeIDEqual(t assert.TestingT, dsName sgbucket.DataStoreName, docID string, p string, version DocMetadata, body []byte, expected DocMetadata, topology Topology) {
-	assert.Equal(t, expected.RevTreeID, version.RevTreeID, "Actual revtree id match expected on %s for peer %s.  Expected: %#v, Actual: %#v\nActual Body: %s\n%s", docID, p, expected, version, body, topology.GetDocState(t, dsName, docID))
+	assert.Equal(t, expected.RevTreeID, version.RevTreeID, "Actual revtree id does not match expected on %s for peer %s.  Expected: %#v, Actual: %#v\nActual Body: %s\n%s", docID, p, expected, version, body, topology.GetDocState(t, dsName, docID))
 }

--- a/topologytest/version_test.go
+++ b/topologytest/version_test.go
@@ -108,7 +108,7 @@ func assertCVEqual(t assert.TestingT, dsName sgbucket.DataStoreName, docID strin
 	assert.Equal(t, expected.CV(t), version.CV(t), "Actual HLV's CV does not match expected on %s for peer %s.  Expected: %#v, Actual: %#v\nActual Body: %s\n%s", docID, p, expected, version, body, topology.GetDocState(t, dsName, docID))
 }
 
-// assertRevTreeIDEqual asserts that CV of the version is equal to the expected CV.
+// assertRevTreeIDEqual asserts that revtree ID of the version is equal to the expected CV.
 func assertRevTreeIDEqual(t assert.TestingT, dsName sgbucket.DataStoreName, docID string, p string, version DocMetadata, body []byte, expected DocMetadata, topology Topology) {
 	assert.Equal(t, expected.RevTreeID, version.RevTreeID, "Actual revtree id does not match expected on %s for peer %s.  Expected: %#v, Actual: %#v\nActual Body: %s\n%s", docID, p, expected, version, body, topology.GetDocState(t, dsName, docID))
 }

--- a/topologytest/version_test.go
+++ b/topologytest/version_test.go
@@ -29,6 +29,15 @@ type DocMetadata struct {
 	ImplicitHLV *db.HybridLogicalVector // ImplicitHLV is the version of the document, if there was no HLV
 }
 
+// HasHLV returns true if the version has an HLV. This will always return true on Couchbase Server or Sync Gateway
+// peers since they can construct an implicit HLV from the CAS.
+func (v DocMetadata) HasHLV() bool {
+	if v.HLV != nil && v.HLV.GetCurrentVersionString() != "" {
+		return true
+	}
+	return v.ImplicitHLV != nil && v.ImplicitHLV.GetCurrentVersionString() != ""
+}
+
 // CV returns the current version of the document.
 func (v DocMetadata) CV(t assert.TestingT) db.Version {
 	if v.ImplicitHLV != nil {
@@ -97,4 +106,9 @@ func assertHLVEqual(t assert.TestingT, dsName sgbucket.DataStoreName, docID stri
 // assertCV asserts that CV of the version is equal to the expected CV.
 func assertCVEqual(t assert.TestingT, dsName sgbucket.DataStoreName, docID string, p string, version DocMetadata, body []byte, expected DocMetadata, topology Topology) {
 	assert.Equal(t, expected.CV(t), version.CV(t), "Actual HLV's CV does not match expected on %s for peer %s.  Expected: %#v, Actual: %#v\nActual Body: %s\n%s", docID, p, expected, version, body, topology.GetDocState(t, dsName, docID))
+}
+
+// assertRevTreeIDEqual asserts that CV of the version is equal to the expected CV.
+func assertRevTreeIDEqual(t assert.TestingT, dsName sgbucket.DataStoreName, docID string, p string, version DocMetadata, body []byte, expected DocMetadata, topology Topology) {
+	assert.Equal(t, expected.RevTreeID, version.RevTreeID, "Actual revtree id match expected on %s for peer %s.  Expected: %#v, Actual: %#v\nActual Body: %s\n%s", docID, p, expected, version, body, topology.GetDocState(t, dsName, docID))
 }


### PR DESCRIPTION
CBG-4258 allow support of a CBL V3 client

This only adds a trivial scenario for CBL V3. I have not enabled all scenarios for XDCR since I am not sure which are valid. I will file a followup ticket for this. I only compare revtree IDs.

I do not yet think that XDCR with CBL 3.x clients is going to be supported since a CBL 3.x will push a revtree ID `1-abc` but it will have a CV `100@cbs` on Couchbase Server like a REST API. This means all CBL 3.x clients will have a CV like a REST api Sync Gateway 4.x push. I think this might be correct and not handled like a legacy rev from a CBL 4.x client. Either way, this is out of scope for this PR.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/TopologyTests/37/
