### PR TITLE
CBG-3806 reenable skipped tests

### DIFF
--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -557,7 +557,6 @@ func TestBlipLegacyAttachNameChange(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires legacy attachment upgrade to HLV (CBG-3806)
 
 	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTester(t, rtConfig)
@@ -605,7 +604,6 @@ func TestBlipLegacyAttachDocUpdate(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires legacy attachment upgrade to HLV (CBG-3806)
 
 	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTester(t, rtConfig)


### PR DESCRIPTION
These tests work after https://github.com/couchbase/sync_gateway/commit/daaa0852584e1bddceedf5a82099fe7aca8122cb
