### PR TITLE
CBG-4826 increase timeout for CI=true (jenkins/gh)

### DIFF
--- a/topologytest/peer_test.go
+++ b/topologytest/peer_test.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"iter"
 	"maps"
+	"os"
 	"slices"
 	"strings"
 	"testing"
@@ -34,7 +35,7 @@ var totalWaitTime = 8 * time.Second
 var pollInterval = 1 * time.Millisecond
 
 func init() {
-	if !base.UnitTestUrlIsWalrus() || raceEnabled {
+	if !base.UnitTestUrlIsWalrus() || raceEnabled || os.Getenv("CI") != "" {
 		totalWaitTime = 40 * time.Second
 	}
 }


### PR DESCRIPTION
CBG-4826 increase timeout for CI=true (jenkins/gh)

Noticed on github actions, the timeout is still getting hit, bump the timeout when `CI` env variable is set.

Followup from https://github.com/couchbase/sync_gateway/commit/a7ed84439df144b91241a2c4cedbe607b6cb6554