### PR TITLE
CBG-4769: Omit cas mismatch log messages

### DIFF
--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -18,6 +18,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/couchbase/gocb/v2"
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 )
@@ -245,7 +246,9 @@ func (il *importListener) ImportFeedEvent(ctx context.Context, collection *Datab
 		// we have attachments to migrate
 		err := collection.MigrateAttachmentMetadata(ctx, docID, event.Cas, syncData)
 		if err != nil {
-			base.WarnfCtx(ctx, "error migrating attachment metadata from sync data to global sync for doc %s. Error: %v", base.UD(docID), err)
+			if !errors.Is(err, gocb.ErrCasMismatch) {
+				base.WarnfCtx(ctx, "error migrating attachment metadata from sync data to global sync for doc %s. Error: %v", base.UD(docID), err)
+			}
 		}
 	}
 }

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -18,7 +18,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/couchbase/gocb/v2"
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 )
@@ -245,10 +244,8 @@ func (il *importListener) ImportFeedEvent(ctx context.Context, collection *Datab
 		base.DebugfCtx(ctx, base.KeyImport, "Attachment metadata found in sync data for doc with id %s, migrating attachment metadata", base.UD(docID))
 		// we have attachments to migrate
 		err := collection.MigrateAttachmentMetadata(ctx, docID, event.Cas, syncData)
-		if err != nil {
-			if !errors.Is(err, gocb.ErrCasMismatch) {
-				base.WarnfCtx(ctx, "error migrating attachment metadata from sync data to global sync for doc %s. Error: %v", base.UD(docID), err)
-			}
+		if err != nil && !base.IsCasMismatch(err) {
+			base.WarnfCtx(ctx, "error migrating attachment metadata from sync data to global sync for doc %s. Error: %v", base.UD(docID), err)
 		}
 	}
 }


### PR DESCRIPTION
CBG-4769

Describe your PR here...
- CAS mismatch error log messages should not be logged as warn messages

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
