### PR TITLE
CBG-4847: legacy rev loading from bucket leave rev cache in inconsistent state

### DIFF
--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -215,7 +215,10 @@ func (rc *LRURevisionCache) getFromCacheByRev(ctx context.Context, docID, revID 
 		rc.incrRevCacheMemoryUsage(ctx, value.getItemBytes())
 		// check for memory based eviction
 		rc.revCacheMemoryBasedEviction(ctx)
-		rc.addToHLVMapPostLoad(docID, docRev.RevID, docRev.CV, collectionID)
+		err = rc.addToHLVMapPostLoad(docID, docRev.RevID, docRev.CV, collectionID)
+		if err != nil {
+			base.WarnfCtx(ctx, "Error adding to HLV map post load: %v", err)
+		}
 	}
 
 	if err != nil {
@@ -277,13 +280,15 @@ func (rc *LRURevisionCache) GetActive(ctx context.Context, docID string, collect
 		rc.incrRevCacheMemoryUsage(ctx, value.getItemBytes())
 		// check for rev cache memory based eviction
 		rc.revCacheMemoryBasedEviction(ctx)
+		// add successfully fetched value to CV lookup map too
+		err = rc.addToHLVMapPostLoad(docID, docRev.RevID, docRev.CV, collectionID)
+		if err != nil {
+			base.WarnfCtx(ctx, "Error adding to HLV map post load: %v", err)
+		}
 	}
 
 	if err != nil {
 		rc.removeValue(value) // don't keep failed loads in the cache
-	} else {
-		// add successfully fetched value to CV lookup map too
-		rc.addToHLVMapPostLoad(docID, docRev.RevID, docRev.CV, collectionID)
 	}
 
 	return docRev, err
@@ -472,8 +477,17 @@ func (rc *LRURevisionCache) addToRevMapPostLoad(docID, revID string, cv *Version
 }
 
 // addToHLVMapPostLoad will generate and entry in the CV lookup map for a new document entering the cache
-func (rc *LRURevisionCache) addToHLVMapPostLoad(docID, revID string, cv *Version, collectionID uint32) {
+func (rc *LRURevisionCache) addToHLVMapPostLoad(docID, revID string, cv *Version, collectionID uint32) error {
 	legacyKey := IDAndRev{DocID: docID, RevID: revID, CollectionID: collectionID}
+
+	if cv == nil {
+		// we have loaded a legacy rev document, create CV from revID
+		encodedCV, err := LegacyRevToRevTreeEncodedVersion(revID)
+		if err != nil {
+			return err
+		}
+		cv = &encodedCV
+	}
 	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.Value, CollectionID: collectionID}
 
 	rc.lock.Lock()
@@ -484,13 +498,13 @@ func (rc *LRURevisionCache) addToHLVMapPostLoad(docID, revID string, cv *Version
 	if !revFound {
 		// its possible the element has been evicted if we don't find the element above (high churn on rev cache)
 		// need to return doc revision to caller still but no need repopulate the cache
-		return
+		return nil
 	}
 	// Check if another goroutine has already updated the cv map
 	if cvFound {
 		if cvElem == revElem {
 			// already match, return
-			return
+			return nil
 		}
 		// if CV map and rev map are targeting different list elements, update to have both use the cv map element
 		rc.cache[legacyKey] = cvElem
@@ -499,6 +513,7 @@ func (rc *LRURevisionCache) addToHLVMapPostLoad(docID, revID string, cv *Version
 		// if not found we need to add the element to the hlv lookup
 		rc.hlvCache[key] = revElem
 	}
+	return nil
 }
 
 // Remove removes a value from the revision cache, if present.
@@ -708,7 +723,10 @@ func (value *revCacheValue) asDocumentRevision(delta *RevisionDelta) (DocumentRe
 		Deleted:     value.deleted,
 		Removed:     value.removed,
 		hlvHistory:  value.hlvHistory,
-		CV:          &value.cv,
+	}
+	// only populate CV if we have a value
+	if !value.cv.IsEmpty() {
+		docRev.CV = &value.cv
 	}
 	docRev.Delta = delta
 

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -2321,7 +2321,7 @@ func TestLoadFromBucketLegacyRevsThatAreBackedUpPreUpgrade(t *testing.T) {
 		revIDs = append(revIDs, newRev)
 		legacyRev = newRev // OCC val
 	}
-	// simulate doc revs that are backup to bucket pre upgrade
+	// simulate doc revs that are backed up to bucket pre upgrade
 	for i := 0; i < 2; i++ {
 		err := collection.setOldRevisionJSONBody(ctx, docID, revIDs[i], []byte(`{"foo":"bar"}`), collection.oldRevExpirySeconds())
 		require.NoError(t, err)
@@ -2343,7 +2343,7 @@ func TestLoadFromBucketLegacyRevsThatAreBackedUpPreUpgrade(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, revID, docRev.RevID)
 	}
-	// no peek for CV so just do fetch for CV from, legacy rev CV
+	// no peek for CV so just do fetch for CV from legacy rev CV
 	for _, revID := range revIDs {
 		cvVal, err := LegacyRevToRevTreeEncodedVersion(revID)
 		require.NoError(t, err)

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -2298,3 +2298,61 @@ func TestRemoveFromRevLookup(t *testing.T) {
 	assert.Equal(t, 10, len(cache.cache)) // we should now have 10 items in rev lookup given the item above aligned the lookups after eviction
 	assert.Equal(t, 10, len(cache.hlvCache))
 }
+
+func TestLoadFromBucketLegacyRevsThatAreBackedUpPreUpgrade(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+	db, ctx := SetupTestDBWithOptions(t, DatabaseContextOptions{
+		OldRevExpirySeconds: base.DefaultOldRevExpirySeconds,
+		RevisionCacheOptions: &RevisionCacheOptions{
+			ShardCount:   1, // turn off sharding for simplicity
+			MaxItemCount: DefaultRevisionCacheSize,
+			MaxBytes:     0, // turn off memory limit
+		},
+	})
+	defer db.Close(ctx)
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+
+	// create a few legacy revs
+	docID := t.Name()
+	revIDs := make([]string, 0)
+	legacyRev, _ := collection.CreateDocNoHLV(t, ctx, docID, Body{"foo": "bar"})
+	revIDs = append(revIDs, legacyRev)
+	for i := 0; i < 2; i++ {
+		newRev, _ := collection.CreateDocNoHLV(t, ctx, docID, Body{BodyRev: legacyRev, "foo": "bar"})
+		revIDs = append(revIDs, newRev)
+		legacyRev = newRev // OCC val
+	}
+	// simulate doc revs that are backup to bucket pre upgrade
+	for i := 0; i < 2; i++ {
+		err := collection.setOldRevisionJSONBody(ctx, docID, revIDs[i], []byte(`{"foo":"bar"}`), collection.oldRevExpirySeconds())
+		require.NoError(t, err)
+	}
+
+	// flush all revisions from rev cache to force load from bucket
+	db.FlushRevisionCacheForTest()
+
+	// fetch all three legacy revisions, first two should be loaded from old backup revisions
+	for i := 0; i < 3; i++ {
+		docRev, err := collection.getRev(ctx, docID, revIDs[i], 0, nil)
+		require.NoError(t, err)
+		assert.Equal(t, revIDs[i], docRev.RevID)
+	}
+
+	// here fails because addToHLVMapPostLoad will notice that cv and revID maps mismatch for the 'same' element
+	// when in relation cv lookup doesn't point to the same element, it points to revision 1 fetched above but because
+	// no CV is present hlv map lookup has no way to differentiate between the different doc revisions. Need to explore
+	// using legacy rev tree encoding to cv for legacy revs in rev cache lookups
+	for _, revID := range revIDs {
+		docRev, ok := collection.revisionCache.Peek(ctx, docID, revID)
+		require.True(t, ok)
+		assert.Equal(t, revID, docRev.RevID)
+	}
+	// no peek for CV so just do fetch for CV from, legacy rev CV
+	for _, revID := range revIDs {
+		cvVal, err := LegacyRevToRevTreeEncodedVersion(revID)
+		require.NoError(t, err)
+		docRev, err := collection.revisionCache.GetWithCV(ctx, docID, &cvVal, RevCacheOmitDelta)
+		require.NoError(t, err)
+		assert.Equal(t, revID, docRev.RevID)
+	}
+}


### PR DESCRIPTION
CBG-4847

- Fix for edge case where loading some legacy backup revs from pre upgrade would result in the rev cache being in a weird state and returning the wrong data for fetches. 
- Makes use of the rev -> cv utility we now have to create a cv from revID to populate the rev cache hlv lookup map with 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/75/
