### PR TITLE
CBG-4316 wait for database online in test

### DIFF
--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3485,8 +3485,8 @@ func TestAllowConflictsConfig(t *testing.T) {
 
 	// Recreate the database with the original configuration and verify it is online.
 	rt.CreateDatabase(dbName, dbConfig)
+	rt.WaitForDBOnline()
 	resp = rt.SendAdminRequest(http.MethodGet, allDBsURL, "")
 	RequireStatus(t, resp, http.StatusOK)
-	rt.WaitForDBOnline()
 	require.Equal(t, fmt.Sprintf(`[{"db_name":"%s","bucket":"%s","state":"Online"}]`, rt.GetDatabase().Name, rt.GetDatabase().Bucket.GetName()), resp.Body.String())
 }

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3487,5 +3487,6 @@ func TestAllowConflictsConfig(t *testing.T) {
 	rt.CreateDatabase(dbName, dbConfig)
 	resp = rt.SendAdminRequest(http.MethodGet, allDBsURL, "")
 	RequireStatus(t, resp, http.StatusOK)
+	rt.WaitForDBOnline()
 	require.Equal(t, fmt.Sprintf(`[{"db_name":"%s","bucket":"%s","state":"Online"}]`, rt.GetDatabase().Name, rt.GetDatabase().Bucket.GetName()), resp.Body.String())
 }


### PR DESCRIPTION
CBG-4316 wait for database online in test

Fix test flake in https://github.com/couchbase/sync_gateway/commit/b42ef7a04a44284ae22540b1eaa381cc28783764, see:

https://jenkins.sgwdev.com/job/MainIntegration/46/testReport/junit/github/com_couchbase_sync_gateway_rest/TestAllowConflictsConfig/

```
    api_test.go:3490: 
        	Error Trace:	/home/ec2-user/workspace/MainIntegration/rest/api_test.go:3490
        	Error:      	Not equal: 
        	            	expected: "[{\"db_name\":\"db1\",\"bucket\":\"sg_int_1_1757429820988659564\",\"state\":\"Online\"}]"
        	            	actual  : "[{\"db_name\":\"db1\",\"bucket\":\"sg_int_1_1757429820988659564\",\"state\":\"Starting\"}]"
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1 +1 @@
        	            	-[{"db_name":"db1","bucket":"sg_int_1_1757429820988659564","state":"Online"}]
        	            	+[{"db_name":"db1","bucket":"sg_int_1_1757429820988659564","state":"Starting"}]
        	Test:       	TestAllowConflictsConfig
```        	