### PR TITLE
CBG-3796: Disable setting `enable_star_channel` to false

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -51,7 +51,7 @@ const (
 
 // Enable keeping a channel-log for the "*" channel (channel.UserStarChannel). The only time this channel is needed is if
 // someone has access to "*" (e.g. admin-party) and tracks its changes feed.
-var EnableStarChannelLog = true
+const EnableStarChannelLog = true
 
 // Manages a cache of the recent change history of all channels.
 //

--- a/db/database_error.go
+++ b/db/database_error.go
@@ -15,30 +15,32 @@ type DatabaseError struct {
 }
 
 var DatabaseErrorMap = map[databaseErrorCode]string{
-	DatabaseBucketConnectionError:      "Error connecting to bucket",
-	DatabaseInvalidDatastore:           "Collection(s) not available",
-	DatabaseInitSyncInfoError:          "Error initializing sync info",
-	DatabaseInitializationIndexError:   "Error initializing database indexes",
-	DatabaseCreateDatabaseContextError: "Error creating database context",
-	DatabaseSGRClusterError:            "Error with fetching SGR cluster definition",
-	DatabaseCreateReplicationError:     "Error creating replication during database init",
-	DatabaseOnlineProcessError:         "Error attempting to start online process",
-	DatabaseAllowConflictsError:        "Allow conflicts is set to true",
+	DatabaseBucketConnectionError:       "Error connecting to bucket",
+	DatabaseInvalidDatastore:            "Collection(s) not available",
+	DatabaseInitSyncInfoError:           "Error initializing sync info",
+	DatabaseInitializationIndexError:    "Error initializing database indexes",
+	DatabaseCreateDatabaseContextError:  "Error creating database context",
+	DatabaseSGRClusterError:             "Error with fetching SGR cluster definition",
+	DatabaseCreateReplicationError:      "Error creating replication during database init",
+	DatabaseOnlineProcessError:          "Error attempting to start online process",
+	DatabaseAllowConflictsError:         "Allow conflicts is set to true",
+	DatabaseEnableStarChannelFalseError: "Enable star channel is set to false",
 }
 
 type databaseErrorCode uint8
 
 // Error codes exposed for each error a database can encounter on load. These codes are consumed by Capella so must remain stable.
 const (
-	DatabaseBucketConnectionError      databaseErrorCode = 1
-	DatabaseInvalidDatastore           databaseErrorCode = 2
-	DatabaseInitSyncInfoError          databaseErrorCode = 3
-	DatabaseInitializationIndexError   databaseErrorCode = 4
-	DatabaseCreateDatabaseContextError databaseErrorCode = 5
-	DatabaseSGRClusterError            databaseErrorCode = 6
-	DatabaseCreateReplicationError     databaseErrorCode = 7
-	DatabaseOnlineProcessError         databaseErrorCode = 8
-	DatabaseAllowConflictsError        databaseErrorCode = 9
+	DatabaseBucketConnectionError       databaseErrorCode = 1
+	DatabaseInvalidDatastore            databaseErrorCode = 2
+	DatabaseInitSyncInfoError           databaseErrorCode = 3
+	DatabaseInitializationIndexError    databaseErrorCode = 4
+	DatabaseCreateDatabaseContextError  databaseErrorCode = 5
+	DatabaseSGRClusterError             databaseErrorCode = 6
+	DatabaseCreateReplicationError      databaseErrorCode = 7
+	DatabaseOnlineProcessError          databaseErrorCode = 8
+	DatabaseAllowConflictsError         databaseErrorCode = 9
+	DatabaseEnableStarChannelFalseError databaseErrorCode = 10
 )
 
 func NewDatabaseError(code databaseErrorCode) *DatabaseError {

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3491,6 +3491,11 @@ func TestAllowConflictsConfig(t *testing.T) {
 	require.Equal(t, fmt.Sprintf(`[{"db_name":"%s","bucket":"%s","state":"Online"}]`, rt.GetDatabase().Name, rt.GetDatabase().Bucket.GetName()), resp.Body.String())
 }
 
+// TestDisableAllowStarChannel verifies that the database configuration does not allow
+// the `enable_star_channel` property to be set to false. The star channel is a special
+// channel in Sync Gateway that provides access to all documents, and disabling it is
+// not supported. This test ensures that an attempt to disable the star channel results
+// in a bad request error.
 func TestDisableAllowStarChannel(t *testing.T) {
 	rt := NewRestTester(t, &RestTesterConfig{
 		PersistentConfig: true,

--- a/rest/config.go
+++ b/rest/config.go
@@ -824,7 +824,9 @@ func (dbConfig *DbConfig) validateVersion(ctx context.Context, isEnterpriseEditi
 			if lwm >= hwm {
 				multiError = multiError.Append(fmt.Errorf("cache.channel_cache.compact_high_watermark_pct (%v) must be greater than cache.channel_cache.compact_low_watermark_pct (%v)", hwm, lwm))
 			}
-
+			if dbConfig.CacheConfig.ChannelCacheConfig.EnableStarChannel != nil && !*dbConfig.CacheConfig.ChannelCacheConfig.EnableStarChannel {
+				multiError = multiError.Append(fmt.Errorf("enable_star_channel cannot be set to false"))
+			}
 		}
 
 		if dbConfig.CacheConfig.RevCacheConfig != nil {

--- a/rest/config_database_test.go
+++ b/rest/config_database_test.go
@@ -215,6 +215,18 @@ func TestDatabaseConfigValidation(t *testing.T) {
 			},
 			expectedError: "allow_conflicts cannot be set to true",
 		},
+		{
+			name: "setting enable_star_channel to false",
+			dbConfig: DbConfig{
+				Name: "db",
+				CacheConfig: &CacheConfig{
+					ChannelCacheConfig: &ChannelCacheConfig{
+						EnableStarChannel: base.Ptr(false),
+					},
+				},
+			},
+			expectedError: "enable_star_channel cannot be set to false",
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -690,6 +690,16 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 			"Duplicate database name %q", dbName)
 	}
 
+	if config.DbConfig.CacheConfig != nil {
+		if config.DbConfig.CacheConfig.ChannelCacheConfig != nil {
+			if config.DbConfig.CacheConfig.ChannelCacheConfig.EnableStarChannel != nil && !*config.DbConfig.CacheConfig.ChannelCacheConfig.EnableStarChannel {
+				base.WarnfCtx(ctx, `enable_star_channel config option is set to false, set it to true`)
+				sc._handleInvalidDatabaseConfig(ctx, spec.BucketName, config, db.NewDatabaseError(db.DatabaseEnableStarChannelFalseError))
+				return nil, errors.New("enable_star_channel in cache config is set to false, please set the value to true")
+			}
+		}
+	}
+
 	// Generate database context options from config and server context
 	contextOptions, err := dbcOptionsFromConfig(ctx, sc, &config.DbConfig, dbName)
 	if err != nil {
@@ -1164,10 +1174,6 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 			}
 			if config.CacheConfig.ChannelCacheConfig.MaxWaitSkipped != nil {
 				cacheOptions.CacheSkippedSeqMaxWait = time.Duration(*config.CacheConfig.ChannelCacheConfig.MaxWaitSkipped) * time.Millisecond
-			}
-			// set EnableStarChannelLog directly here (instead of via NewDatabaseContext), so that it's set when we create the channels view in ConnectToBucket
-			if config.CacheConfig.ChannelCacheConfig.EnableStarChannel != nil && !*config.CacheConfig.ChannelCacheConfig.EnableStarChannel {
-				base.WarnfCtx(ctx, `enable_star_channel config option is set to false, changing the value to true`)
 			}
 			if config.CacheConfig.ChannelCacheConfig.MaxLength != nil {
 				cacheOptions.ChannelCacheMaxLength = *config.CacheConfig.ChannelCacheConfig.MaxLength

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1166,9 +1166,8 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 				cacheOptions.CacheSkippedSeqMaxWait = time.Duration(*config.CacheConfig.ChannelCacheConfig.MaxWaitSkipped) * time.Millisecond
 			}
 			// set EnableStarChannelLog directly here (instead of via NewDatabaseContext), so that it's set when we create the channels view in ConnectToBucket
-			if config.CacheConfig.ChannelCacheConfig.EnableStarChannel != nil {
-				db.EnableStarChannelLog = *config.CacheConfig.ChannelCacheConfig.EnableStarChannel
-				base.WarnfCtx(ctx, `Deprecation notice: enable_star_channel config option is due to be removed, in future star channel will always be enabled`)
+			if config.CacheConfig.ChannelCacheConfig.EnableStarChannel != nil && !*config.CacheConfig.ChannelCacheConfig.EnableStarChannel {
+				base.WarnfCtx(ctx, `enable_star_channel config option is set to false, changing the value to true`)
 			}
 			if config.CacheConfig.ChannelCacheConfig.MaxLength != nil {
 				cacheOptions.ChannelCacheMaxLength = *config.CacheConfig.ChannelCacheConfig.MaxLength


### PR DESCRIPTION
CBG-3796

Describe your PR here...
- Removed ability to set `enable_star_channel` to false
- The value will always default to true
- Added test case to check if a DB is created by setting the value to false

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/76/
