### PR TITLE
CBG-4826: Ensure blip tester is terminated before Rest Tester

### DIFF
--- a/topologytest/couchbase_server_peer_test.go
+++ b/topologytest/couchbase_server_peer_test.go
@@ -11,6 +11,7 @@ package topologytest
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync/atomic"
 	"testing"
@@ -246,10 +247,16 @@ func (p *CouchbaseServerPeer) waitForCV(dsName sgbucket.DataStoreName, docID str
 // Close will shut down the peer and close any active replications on the peer.
 func (p *CouchbaseServerPeer) Close() {
 	for _, r := range p.pullReplications {
-		assert.NoError(p.TB(), r.Stop(p.Context()))
+		err := r.Stop(p.Context())
+		if err != nil && !errors.Is(err, xdcr.ErrReplicationNotRunning) {
+			assert.NoError(p.TB(), err)
+		}
 	}
 	for _, r := range p.pushReplications {
-		assert.NoError(p.TB(), r.Stop(p.Context()))
+		err := r.Stop(p.Context())
+		if err != nil && !errors.Is(err, xdcr.ErrReplicationNotRunning) {
+			assert.NoError(p.TB(), err)
+		}
 	}
 }
 

--- a/topologytest/peer_test.go
+++ b/topologytest/peer_test.go
@@ -410,7 +410,9 @@ func createPeerReplications(t *testing.T, peers map[string]Peer, configs []PeerR
 		require.True(t, ok, "active peer %s not found", config.activePeer)
 		passivePeer, ok := peers[config.passivePeer]
 		require.True(t, ok, "passive peer %s not found", config.passivePeer)
-		replications = append(replications, activePeer.CreateReplication(passivePeer, config.config))
+		repl := activePeer.CreateReplication(passivePeer, config.config)
+		t.Cleanup(repl.Stop)
+		replications = append(replications, repl)
 	}
 	return replications
 }


### PR DESCRIPTION
Fixes an error in topologytests when things do not actually stop replicating when the tests engage in teardown.

This might be because they are testing for convergence, but it actually only temporary convergence, or it is trying to continually push but getting rejected. Either way, this is not the intended behavior to have errors that look like: `ProposeChanges` response has an empty body and can't be unmarshalled.

Tear down via:

- shut down replications
- close peers (Rest Testers)

The only places this causes issues is inside the topologytests that I know about.