### PR TITLE
CBG-4341: Compatibility check for Couchbase Server

### DIFF
--- a/base/cluster_n1ql.go
+++ b/base/cluster_n1ql.go
@@ -47,7 +47,7 @@ func NewClusterOnlyN1QLStore(cluster *gocb.Cluster, bucketName, scopeName, colle
 		collectionName: collectionName,
 	}
 
-	major, minor, err := getClusterVersion(cluster)
+	major, minor, err := GetClusterVersion(cluster)
 	if err != nil {
 		return nil, err
 	}

--- a/base/collection.go
+++ b/base/collection.go
@@ -91,8 +91,8 @@ func GetGoCBv2Bucket(ctx context.Context, spec BucketSpec) (*GocbV2Bucket, error
 
 }
 
-// getClusterVersion returns major and minor versions of connected cluster
-func getClusterVersion(cluster *gocb.Cluster) (int, int, error) {
+// GetClusterVersion returns major and minor versions of connected cluster
+func GetClusterVersion(cluster *gocb.Cluster) (int, int, error) {
 	// Query node meta to find cluster compat version
 	nodesMetadata, err := cluster.Internal().GetNodesMetadata(&gocb.GetNodesMetadataOptions{})
 	if err != nil || len(nodesMetadata) == 0 {
@@ -126,7 +126,7 @@ func GetGocbV2BucketFromCluster(ctx context.Context, cluster *gocb.Cluster, spec
 		WarnfCtx(ctx, "Error waiting for bucket to be ready: %v", err)
 		return nil, err
 	}
-	clusterCompatMajor, clusterCompatMinor, err := getClusterVersion(cluster)
+	clusterCompatMajor, clusterCompatMinor, err := GetClusterVersion(cluster)
 	if err != nil {
 		_ = cluster.Close(&gocb.ClusterCloseOptions{})
 		return nil, err

--- a/base/main_test_cluster.go
+++ b/base/main_test_cluster.go
@@ -47,7 +47,7 @@ func newTestCluster(ctx context.Context, clusterSpec CouchbaseClusterSpec) (*tbp
 	if err != nil {
 		return nil, fmt.Errorf("couldn't create cluster agent: %w", err)
 	}
-	version, ee, err := getCouchbaseServerVersion(agent, clusterSpec)
+	version, ee, err := GetCouchbaseServerVersion(agent, clusterSpec)
 	if err != nil {
 		err := fmt.Errorf("couldn't get cluster version: %w", err)
 		closeErr := agent.Close()
@@ -157,8 +157,8 @@ func (c *tbpCluster) MgmtRequest(method, path string, contentType string, body i
 	)
 }
 
-// getCouchbaseServerVersion retrieves the Couchbase Server version via a gocbcore.Agent
-func getCouchbaseServerVersion(agent *gocbcore.Agent, clusterSpec CouchbaseClusterSpec) (version *ComparableBuildVersion, ee bool, err error) {
+// GetCouchbaseServerVersion retrieves the Couchbase Server version via a gocbcore.Agent
+func GetCouchbaseServerVersion(agent *gocbcore.Agent, clusterSpec CouchbaseClusterSpec) (version *ComparableBuildVersion, ee bool, err error) {
 	mgmtEps := agent.MgmtEps()
 	if len(mgmtEps) == 0 {
 		return nil, false, fmt.Errorf("no management endpoints available")

--- a/base/util.go
+++ b/base/util.go
@@ -1840,3 +1840,8 @@ func IsRevTreeID(s string) bool {
 	}
 	return false
 }
+
+func ExtractVersion(s string) string {
+	parts := strings.Split(s, "-")
+	return parts[0]
+}

--- a/base/util.go
+++ b/base/util.go
@@ -1840,8 +1840,3 @@ func IsRevTreeID(s string) bool {
 	}
 	return false
 }
-
-func ExtractVersion(s string) string {
-	parts := strings.Split(s, "-")
-	return parts[0]
-}

--- a/rest/config.go
+++ b/rest/config.go
@@ -1606,11 +1606,11 @@ func SetupServerContext(ctx context.Context, config *StartupConfig, persistentCo
 	sc := NewServerContext(ctx, config, persistentConfig)
 
 	if !base.ServerIsWalrus(sc.Config.Bootstrap.Server) {
-		err := sc.initializeGocbAdminConnection(ctx)
+		err := sc.CheckSupportedCouchbaseVersion(ctx)
 		if err != nil {
 			return nil, err
 		}
-		err = sc.CheckSupportedCouchbaseVersion(ctx)
+		err = sc.initializeGocbAdminConnection(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/rest/config.go
+++ b/rest/config.go
@@ -1610,7 +1610,6 @@ func SetupServerContext(ctx context.Context, config *StartupConfig, persistentCo
 		if err != nil {
 			return nil, err
 		}
-		
 		err = sc.CheckSupportedCouchbaseVersion(ctx)
 		if err != nil {
 			return nil, err

--- a/rest/config.go
+++ b/rest/config.go
@@ -1614,6 +1614,9 @@ func SetupServerContext(ctx context.Context, config *StartupConfig, persistentCo
 	if err := sc.initializeBootstrapConnection(ctx); err != nil {
 		return nil, err
 	}
+	if err := sc.CheckSupportedCouchbaseVersion(ctx); err != nil {
+		return nil, err
+	}
 
 	// On successful server context creation, generate startup audit event
 	base.Audit(ctx, base.AuditIDSyncGatewayStartup, sc.StartupAuditFields())

--- a/rest/config.go
+++ b/rest/config.go
@@ -1610,11 +1610,13 @@ func SetupServerContext(ctx context.Context, config *StartupConfig, persistentCo
 		if err != nil {
 			return nil, err
 		}
+		
+		err = sc.CheckSupportedCouchbaseVersion(ctx)
+		if err != nil {
+			return nil, err
+		}
 	}
 	if err := sc.initializeBootstrapConnection(ctx); err != nil {
-		return nil, err
-	}
-	if err := sc.CheckSupportedCouchbaseVersion(ctx); err != nil {
 		return nil, err
 	}
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -2233,11 +2233,12 @@ func (sc *ServerContext) CheckSupportedCouchbaseVersion(ctx context.Context) err
 	}
 
 	errMsg := fmt.Sprintf(
-		"Sync Gateway requires mobile XDCR support, but Couchbase Server %d.%d does not support it. Couchbase Server %d.%d is required.",
+		"Sync Gateway requires Couchbase Server %d.%d or later, but found cluster version %d.%d",
+		CBXDCRCompatibleMajorVersion,
+		CBXDCRCompatibleMinorVersion,
 		major,
 		minor,
-		CBXDCRCompatibleMajorVersion,
-		CBXDCRCompatibleMinorVersion)
+	)
 
 	if major < CBXDCRCompatibleMajorVersion {
 		base.ErrorfCtx(ctx, errMsg)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -46,6 +46,8 @@ const defaultBytesStatsReportingInterval = 30 * time.Second
 
 const dbLoadedStateChangeMsg = "DB loaded from config"
 
+const CBXDCRCompatibleVersion = "7.6.4"
+
 var errCollectionsUnsupported = base.HTTPErrorf(http.StatusBadRequest, "Named collections specified in database config, but not supported by connected Couchbase Server.")
 
 var ErrSuspendingDisallowed = errors.New("database does not allow suspending")
@@ -2214,7 +2216,7 @@ func (sc *ServerContext) CheckSupportedCouchbaseVersion(ctx context.Context) err
 	if err != nil {
 		base.WarnfCtx(ctx, fmt.Sprintf("Couldn't close gocb agent: %v", err))
 	}
-	expectedCouchbaseServerVersion, err := base.NewComparableBuildVersionFromString("7.6.5")
+	expectedCouchbaseServerVersion, err := base.NewComparableBuildVersionFromString(CBXDCRCompatibleVersion)
 	if err != nil {
 		return fmt.Errorf("couldn't create expected cluster version: %w", err)
 	}


### PR DESCRIPTION
CBG-4341

Describe your PR here...
- SGW 4.0 requires Couchbase Server version 7.6.4
- Added a check for version
- If the version is lesser than 7.6.4, SGW fails to start
- Error snippet:
```
2025-09-12T16:07:09.709+05:30 [DBG] gocb+: Poller controller stopped, exiting
2025-09-12T16:07:09.709+05:30 [DBG] gocb+: KV Mux closing
2025-09-12T16:07:09.709+05:30 [DBG] gocb+: KV Mux closed
2025-09-12T16:07:09.709+05:30 [DBG] gocb+: Agent close complete
2025-09-12T16:07:09.709+05:30 [ERR] Sync Gateway requires mobile XDCR support, but Couchbase Server 7.2.7@8617 does not support it. Couchbase Server 7.6.4 is required. -- rest.(*ServerContext).CheckSupportedCouchbaseVersion() at server_context.go:2224
```

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/78/
- [ ]  `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/80/
