### PR TITLE
CBG-4828: pre upgraded document conflict resolution

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -1344,7 +1344,6 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 	// If the doc is a tombstone we want to allow conflicts when running SGR2
 	// bh.conflictResolver != nil represents an active SGR2 and BLIPClientTypeSGR2 represents a passive SGR2
 	forceAllowConflictingTombstone := newDoc.Deleted && (!bh.conflictResolver.IsEmpty() || bh.clientType == BLIPClientTypeSGR2)
-	// TOD0: CBG-4828 for legacy rev writes we should be able to use PutExistingCurrentVersion with implicit CV generated from revID
 	if bh.useHLV() && changeIsVector {
 		opts := PutDocOptions{
 			NewDoc:                         newDoc,

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -768,7 +768,7 @@ func (bsc *BlipSyncContext) sendRevision(ctx context.Context, sender *blip.Sende
 		history = append(history, docRev.RevID)
 		history = append(history, revTreeHistory...)
 	} else if bsc.sendRevTreeProperty() && !localIsLegacyRev {
-		// If we are commentating in > 4 subprotocol versions and the client is another SGW peer, we have a revTree
+		// If we are communicating in > 4 subprotocol versions and the client is another SGW peer, we have a revTree
 		// property we can populate with the rev tree to keep rev tree reconciled on the replication. This property
 		// should only be sent if the local + remote revisions are not a legacy revisions as the rev tree in this case will be
 		// sent in history property.

--- a/db/crud.go
+++ b/db/crud.go
@@ -1315,14 +1315,34 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 				newGeneration = prevGeneration
 			}
 		}
-		revTreeConflictChecked := false
-		var parent string
-		var currentRevIndex int
 
 		// We want skip conflict check for the following scenarios:
 		// 1. incoming doc is a tombstone and local doc is also a tombstone (for ISGR pull replications)
 		// 2. local doc has no hlv
 		allowConflictingTombstone := opts.ForceAllowConflictingTombstone && doc.IsDeleted()
+
+		// if local doc is a pre-upgraded mutation and the rev tree is conflicting with incoming, assign this local
+		// version an implicit hlv based on its rev tree ID + this nodes sourceID to allow HLV conflict resolution to occur
+		// between the two versions.
+		if doc.HLV == nil && doc.Cas != 0 && !allowConflictingTombstone {
+			_, _, conflictErr := db.revTreeConflictCheck(ctx, opts.RevTreeHistory, doc, opts.NewDoc.Deleted)
+			if conflictErr != nil {
+				// conflict detected between incoming rev and local rev revtrees, allow hlv conflict resolvers
+				// below to fix (for ISGR pull)
+				doc.HLV = NewHybridLogicalVector()
+				cvValue, err := LegacyRevToRevTreeEncodedVersion(doc.GetRevTreeID())
+				cvValue.SourceID = db.dbCtx.EncodedSourceID // give it this nodes sourceID
+				if err != nil {
+					return nil, nil, false, nil, err
+				}
+				err = doc.HLV.AddVersion(cvValue)
+				if err != nil {
+					return nil, nil, false, nil, err
+				}
+				base.DebugfCtx(ctx, base.KeyVV, "No existing HLV for existing doc %s, generated implicit CV from rev tree id, updated CV %#v", base.UD(doc.ID), doc.HLV.ExtractCurrentVersionFromHLV())
+			}
+		}
+		revTreeAlignedForCBL := false
 		if doc.HLV == nil || allowConflictingTombstone {
 			// only add new HLV if no hlv exists on local doc
 			if doc.HLV == nil {
@@ -1336,7 +1356,7 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 				}
 			}
 		} else {
-			conflictStatus := doc.IsInConflict(ctx, opts.NewDocHLV)
+			conflictStatus := doc.IsInConflict(ctx, db, opts.NewDocHLV, opts)
 			switch conflictStatus {
 			case HLVNoConflictRevAlreadyPresent:
 				base.DebugfCtx(ctx, base.KeyCRUD, "PutExistingCurrentVersion(%q): No new versions to add.  existing: %#v  new:%#v", base.UD(opts.NewDoc.ID), doc.HLV, opts.NewDocHLV)
@@ -1349,7 +1369,6 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 				// update hlv for all newer incoming source version pairs
 				doc.HLV.UpdateWithIncomingHLV(opts.NewDocHLV)
 				// the new document has a dominating hlv, so we can just update local revtree with incoming revtree
-				revTreeConflictChecked = true
 				if !opts.AlignRevTrees {
 					previousRevTreeID = doc.GetRevTreeID()
 				} else {
@@ -1360,11 +1379,9 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 					}
 				}
 			case HLVConflict:
-				// if the legacy rev list is from ISGR property, we should not do a conflict check
+				// if we have been supplied a rev tree from cbl, perform conflict check on rev tree history
 				if len(opts.RevTreeHistory) > 0 && !opts.AlignRevTrees {
-					// TODO: CBG-4828 - conflict resolution for legacy rev documents
-					// conflict check on rev tree history, if there is a rev in rev tree history we have the parent of locally we are not in conflict
-					parent, currentRevIndex, err = db.revTreeConflictCheck(ctx, opts.RevTreeHistory, doc, opts.NewDoc.Deleted)
+					parent, currentRevIndex, err := db.revTreeConflictCheck(ctx, opts.RevTreeHistory, doc, opts.NewDoc.Deleted)
 					if err != nil {
 						base.InfofCtx(ctx, base.KeyCRUD, "conflict detected between the two HLV's for doc %s, incoming version %s, local version %s, and conflict found in rev tree history", base.UD(doc.ID), opts.NewDocHLV.GetCurrentVersionString(), doc.HLV.GetCurrentVersionString())
 						return nil, nil, false, nil, err
@@ -1373,10 +1390,9 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 					if err != nil {
 						return nil, nil, false, nil, err
 					}
-					revTreeConflictChecked = true
+					revTreeAlignedForCBL = true // we have aligned the rev tree for CBL push here so skip later in function
 					doc.HLV.UpdateWithIncomingHLV(opts.NewDocHLV)
 				} else {
-					revTreeConflictChecked = true
 					base.DebugfCtx(ctx, base.KeyCRUD, "conflict detected between the two HLV's for doc %s, incoming version %v, local version %v", base.UD(doc.ID), opts.NewDocHLV.ExtractCurrentVersionFromHLV(), doc.HLV.ExtractCurrentVersionFromHLV())
 					if opts.ConflictResolver == nil {
 						// cancel rest of update, HLV is in conflict and no resolver is present
@@ -1405,19 +1421,13 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 				}
 			}
 		}
-		// rev tree conflict check if we have rev tree history to check against + finds current rev index to allow us
-		// to add any new revision to rev tree below.
-		// Only check for rev tree conflicts if we haven't already checked above AND if AlignRevTrees is false given
-		// AlignRevTrees can only be true for non legacy rev writes meaning when this is true we should be doing our
-		// conflict checking with incoming HLV
-		if !revTreeConflictChecked && len(opts.RevTreeHistory) > 0 && !opts.AlignRevTrees {
-			parent, currentRevIndex, err = db.revTreeConflictCheck(ctx, opts.RevTreeHistory, doc, opts.NewDoc.Deleted)
-			if err != nil {
-				return nil, nil, false, nil, err
-			}
-			_, err = doc.addNewerRevisionsToRevTreeHistory(opts.NewDoc, currentRevIndex, parent, opts.RevTreeHistory)
-			if err != nil {
-				return nil, nil, false, nil, err
+		// if we have revtree history available and we are communicating with CBL, we must update the rev tree
+		// to include the new to us revisions from the incoming rev tree history skipping history check given conflict
+		// check is done at this point.
+		if len(opts.RevTreeHistory) > 0 && !opts.AlignRevTrees && !revTreeAlignedForCBL {
+			addNewRevErr := doc.alignRevTreeHistoryForHLVWrite(ctx, db, opts.NewDoc, opts.RevTreeHistory, true)
+			if addNewRevErr != nil {
+				return nil, nil, false, nil, addNewRevErr
 			}
 		}
 
@@ -3452,6 +3462,12 @@ func (db *DatabaseCollectionWithUser) CheckChangeVersion(ctx context.Context, do
 	if hlv == nil {
 		// no hlv on local doc, convert revID into CV and use that as the local doc hlv
 		hlv, err = legacyRevToHybridLogicalVector(docid, syncData.GetRevTreeID())
+		// give local version a sourceID of this node. Needed given if we have a pull replication running and
+		// locally we have 3-def and remote has 3-abc, if we give the legacy rev sourceID to both nodes locally
+		// we will say we don't need 3-abc given 3-def resolves to higher version value (local dominates) but in
+		// reality we need to pull this conflict rev to solve it and push it back up. If we give local hlv our sourceID
+		// then we will say we need 3-abc as it is from a different sourceID and local hlv no longer dominates
+		hlv.SourceID = db.dbCtx.EncodedSourceID
 		if err != nil {
 			base.WarnfCtx(ctx, "%s", err)
 			missing = append(missing, rev)
@@ -3468,7 +3484,12 @@ func (db *DatabaseCollectionWithUser) CheckChangeVersion(ctx context.Context, do
 		return
 	}
 	// CBG-4792: enhance here for conflict check - return conflict rev similar to propose changes here link ticket
-	if hlv.DominatesSource(cvValue) {
+	localCV := hlv.ExtractCurrentVersionFromHLV()
+	// check if local hlv dominates incoming hlv. In the eventuality that an implicit HLV has been given to a legacy rev
+	// in the form of encodedRev@Revision+Tree+Encoding for incoming rev or encoded@localNodeSourceID for local rev we need to check
+	// also if each version value is equal. If they are equal they were generated from the same revID thus we
+	// do not need this change.
+	if hlv.DominatesSource(cvValue) || db.implicitCVEqual(*localCV, cvValue) {
 		// incoming version is dominated by local doc hlv, so it is not missing
 		return
 	}
@@ -3481,6 +3502,17 @@ func (db *DatabaseCollectionWithUser) CheckChangeVersion(ctx context.Context, do
 
 	missing = append(missing, rev)
 	return
+}
+
+// implicitCVEqual will check if two implicit CVs are equal.
+func (db *DatabaseCollectionWithUser) implicitCVEqual(localCV, incomingCV Version) bool {
+	if localCV.SourceID != db.dbCtx.EncodedSourceID || incomingCV.SourceID != encodedRevTreeSourceID {
+		return false
+	}
+	if localCV.Value == incomingCV.Value {
+		return true
+	}
+	return false
 }
 
 // ////// REVS_DIFF:

--- a/db/crud.go
+++ b/db/crud.go
@@ -3440,13 +3440,6 @@ func parseIncomingChange(docid, rev string) (cvValue Version, err error) {
 	return cvValue, nil
 }
 
-func (db *DatabaseCollectionWithUser) getHLVWithLocalSourceIDFromLegacyRev(docID, revID string) (hlv *HybridLogicalVector, err error) {
-	// no hlv on local doc, convert revID into CV and use that as the local doc hlv
-	hlv, err = legacyRevToHybridLogicalVector(docID, revID)
-	hlv.SourceID = db.dbCtx.EncodedSourceID
-	return hlv, err
-}
-
 func (db *DatabaseCollectionWithUser) CheckChangeVersion(ctx context.Context, docid, rev string) (missing, possible []string) {
 	if strings.HasPrefix(docid, "_design/") && db.user != nil {
 		return // Users can't upload design docs, so ignore them

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -4461,3 +4461,116 @@ func TestInitSyncInfoMetaVersionComparison(t *testing.T) {
 		})
 	}
 }
+
+func TestRevTreeConflictCheck(t *testing.T) {
+	testCases := []struct {
+		name             string
+		localHistory     []string
+		incomingHistory  []string
+		localDelete      bool
+		remoteDelete     bool
+		expectedConflict bool
+	}{
+		{
+			name:             "no conflict, simple update",
+			localHistory:     []string{"3-abc", "2-abc", "1-abc"},
+			incomingHistory:  []string{"4-abc", "3-abc", "2-abc", "1-abc"},
+			localDelete:      false,
+			remoteDelete:     false,
+			expectedConflict: false,
+		},
+		{
+			name:             "diff in history",
+			localHistory:     []string{"3-abc", "2-abc", "1-abc"},
+			incomingHistory:  []string{"3-def", "2-def", "1-abc"},
+			localDelete:      false,
+			remoteDelete:     false,
+			expectedConflict: true,
+		},
+		{
+			name:             "complete diff in history",
+			localHistory:     []string{"3-abc", "2-abc", "1-abc"},
+			incomingHistory:  []string{"3-def", "2-def", "1-def"},
+			localDelete:      false,
+			remoteDelete:     false,
+			expectedConflict: true,
+		},
+		{
+			name:             "gap in history",
+			localHistory:     []string{"5-abc", "4-abc", "3-abc", "2-abc", "1-abc"},
+			incomingHistory:  []string{"10-abc", "9-abc"},
+			localDelete:      false,
+			remoteDelete:     false,
+			expectedConflict: true,
+		},
+		{
+			name:             "incoming only has one entry in history, conflict 1",
+			localHistory:     []string{"3-abc", "2-abc", "1-abc"},
+			incomingHistory:  []string{"2-abc"},
+			localDelete:      false,
+			remoteDelete:     false,
+			expectedConflict: true,
+		},
+		{
+			name:             "incoming only has one entry in history, conflict 2",
+			localHistory:     []string{"3-abc", "2-abc", "1-abc"},
+			incomingHistory:  []string{"2-def"},
+			localDelete:      false,
+			remoteDelete:     false,
+			expectedConflict: true,
+		},
+		{
+			name:             "local is deleted and branch is disconnected",
+			localHistory:     []string{"3-abc", "2-abc", "1-abc"},
+			incomingHistory:  []string{"10-abc", "9-abc"},
+			localDelete:      true,
+			remoteDelete:     false,
+			expectedConflict: false,
+		},
+		{
+			name:             "remote is deleted and local branch is not tombstones",
+			localHistory:     []string{"3-abc", "2-abc", "1-abc"},
+			incomingHistory:  []string{"4-abc", "3-abc", "2-abc", "1-abc"},
+			localDelete:      false,
+			remoteDelete:     true,
+			expectedConflict: false,
+		},
+	}
+
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
+	collection, _ := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			doc := NewDocument("doc1")
+			if len(testCase.localHistory) != 0 {
+				doc.SetRevTreeID(testCase.localHistory[0])
+			}
+			if testCase.localDelete {
+				doc.Deleted = true
+				doc.setFlag(channels.Deleted, true)
+			}
+			lenLocalHistory := len(testCase.localHistory)
+
+			parent := ""
+			for i, revID := range testCase.localHistory {
+				err := doc.History.addRevision(revID,
+					RevInfo{
+						ID:      revID,
+						Parent:  parent, // set the parent of this revision to the element of docHistory from the last iteration
+						Deleted: i == lenLocalHistory-1 && testCase.localDelete})
+				require.NoError(t, err)
+				parent = revID
+			}
+
+			_, _, conflictErr := collection.revTreeConflictCheck(t.Context(), testCase.incomingHistory, doc, testCase.remoteDelete)
+			if testCase.expectedConflict {
+				require.Error(t, conflictErr)
+			} else {
+				require.NoError(t, conflictErr)
+			}
+		})
+	}
+
+}

--- a/db/document.go
+++ b/db/document.go
@@ -1450,7 +1450,7 @@ func (doc *Document) IsInConflict(ctx context.Context, db *DatabaseCollectionWit
 		return HLVNoConflict
 
 	}
-	// we need to check if local CV version was generated from a revIDm if so we need to perform slihtly differnet conflict check
+	// we need to check if local CV version was generated from a revID if so we need to perform slightly different conflict check
 	if doc.HLV.HasRevEncodedCV() {
 		// perform conflict check on rev tree history
 		_, _, isConflictErr := db.revTreeConflictCheck(ctx, putOpts.RevTreeHistory, doc, putOpts.NewDoc.Deleted)

--- a/db/document.go
+++ b/db/document.go
@@ -1450,9 +1450,8 @@ func (doc *Document) IsInConflict(ctx context.Context, db *DatabaseCollectionWit
 		return HLVNoConflict
 
 	}
-	// we need to check if local CV version was generated from a revID if so we need to perform slightly different conflict check
+	// we need to check if local CV version was generated from a revID if so we need to perform conflict check on rev tree history
 	if doc.HLV.HasRevEncodedCV() {
-		// perform conflict check on rev tree history
 		_, _, isConflictErr := db.revTreeConflictCheck(ctx, putOpts.RevTreeHistory, doc, putOpts.NewDoc.Deleted)
 		if isConflictErr != nil {
 			return HLVConflict

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -929,3 +929,10 @@ func LegacyRevToRevTreeEncodedVersion(legacyRev string) (Version, error) {
 		Value:    (uint64(generation) << 40) | value,
 	}, nil
 }
+
+func (hlv *HybridLogicalVector) HasRevEncodedCV() bool {
+	if hlv == nil {
+		return false
+	}
+	return hlv.SourceID == encodedRevTreeSourceID
+}

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -931,8 +931,5 @@ func LegacyRevToRevTreeEncodedVersion(legacyRev string) (Version, error) {
 }
 
 func (hlv *HybridLogicalVector) HasRevEncodedCV() bool {
-	if hlv == nil {
-		return false
-	}
 	return hlv.SourceID == encodedRevTreeSourceID
 }

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -933,3 +933,7 @@ func LegacyRevToRevTreeEncodedVersion(legacyRev string) (Version, error) {
 func (hlv *HybridLogicalVector) HasRevEncodedCV() bool {
 	return hlv.SourceID == encodedRevTreeSourceID
 }
+
+func GetGenerationFromEncodedVersionValue(value uint64) int {
+	return int((value >> 40) & 0xFFFFFF)
+}

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -1695,3 +1695,30 @@ func TestLegacyRevToVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestFindGenerationFromLegacyRev(t *testing.T) {
+	testCases := []struct {
+		name   string
+		rev    string
+		expGen int
+	}{
+		{
+			name:   "simple case",
+			rev:    "1-abcd",
+			expGen: 1,
+		},
+		{
+			name:   "large generation",
+			rev:    "12345-e0c8012361e94df6a1e1c2977169480e",
+			expGen: 12345,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cvVal, err := LegacyRevToRevTreeEncodedVersion(tc.rev)
+			require.NoError(t, err)
+			gen := GetGenerationFromEncodedVersionValue(cvVal.Value)
+			assert.Equal(t, tc.expGen, gen)
+		})
+	}
+}

--- a/rest/replicatortest/replicator_test_legacy_rev_test.go
+++ b/rest/replicatortest/replicator_test_legacy_rev_test.go
@@ -714,7 +714,7 @@ func TestActiveReplicatorConflictPreUpgradedVersionEachSide(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
 
 	const username = "alice"
-	// NOTE: below diagrams only show active rev tree branches not tombstones branches fom the conflict resolution
+	// NOTE: below diagrams only show active rev tree branches not tombstones branches from the conflict resolution
 	testCases := []struct {
 		name       string
 		activeWins bool
@@ -894,7 +894,7 @@ func TestActiveReplicatorConflictPreUpgradedVersionOneSide(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
 
 	const username = "alice"
-	// NOTE: below diagrams only show active rev tree branches not tombstones branches fom the conflict resolution
+	// NOTE: below diagrams only show active rev tree branches not tombstones branches from the conflict resolution
 	testCases := []struct {
 		name                            string
 		activePeerHasPostUpgradeVersion bool
@@ -1087,7 +1087,7 @@ func TestActiveReplicatorConflictPreUpgradedVersionOneSide(t *testing.T) {
 				require.JSONEq(t, expectedBody, string(rt1BodyBytes))
 				require.JSONEq(t, expectedBody, string(rt2BodyBytes))
 
-				// update doc on active side to ensure we cna push with no conflict
+				// update doc on active side to ensure we can push with no conflict
 				updateVer := rt1.UpdateDoc(docID, upgradedDocVersion, `{"channels": ["alice"], "source": "rt1-updated"}`)
 				rt2.WaitForVersion(docID, updateVer)
 			}


### PR DESCRIPTION
CBG-4828

- Pre upgraded conflicting mutation test cases for ISGR
- Enhancement has been made to not request any changes sent from another peer that have a revID generated CV that is already present locally. This avoids an echo back to a peer after legacy rev has been replicated. 
- If a local doc has no hlv and the rev tree sent by a client is in conflict with local rev tree, we now assign implicit hlv based on local SourceID and local revID and use that to run through HLV conflict resolution. 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/79/
