### PR TITLE
Create temporary skip for mobile jenkins

### DIFF
--- a/topologytest/main_test.go
+++ b/topologytest/main_test.go
@@ -20,6 +20,15 @@ import (
 	"github.com/couchbase/sync_gateway/db"
 )
 
+func skipMobileJenkinsCBG4826(t *testing.T) {
+	// these tests fail on slow machines but could flake under any machine
+	mobileJenkins := "https://mobile.jenkins.couchbase.com/"
+	if os.Getenv("JENKINS_URL") == mobileJenkins {
+		t.Skipf("Skipping topology tests on %s until CBG-4826 is resolved. There are race conditions which occur on slow machines and are pending investigation", mobileJenkins)
+
+	}
+}
+
 func TestMain(m *testing.M) {
 	ctx := context.Background() // start of test process
 	runTests, _ := strconv.ParseBool(os.Getenv(base.TbpEnvTopologyTests))

--- a/topologytest/main_test.go
+++ b/topologytest/main_test.go
@@ -24,7 +24,7 @@ func skipMobileJenkinsCBG4826(t *testing.T) {
 	// these tests fail on slow machines but could flake under any machine
 	mobileJenkins := "https://mobile.jenkins.couchbase.com/"
 	if os.Getenv("JENKINS_URL") == mobileJenkins {
-		t.Skipf("Skipping topology tests on %s until CBG-4826 is resolved. There are race conditions which occur on slow machines and are pending investigation", mobileJenkins)
+		t.Skipf("Skipping topology tests on %s until CBG-4856 is resolved. There are race conditions which occur on slow machines and are pending investigation", mobileJenkins)
 
 	}
 }

--- a/topologytest/multi_actor_conflict_test.go
+++ b/topologytest/multi_actor_conflict_test.go
@@ -18,6 +18,7 @@ import (
 //  3. wait for documents to exist with a matching CV for Couchbase Lite peers, and a full HLV match for non Couchbase
 //     Lite peers. The body should match.
 func TestMultiActorConflictCreate(t *testing.T) {
+	skipMobileJenkinsCBG4826(t)
 	for _, topologySpec := range append(simpleTopologySpecifications, TopologySpecifications...) {
 		t.Run(topologySpec.description, func(t *testing.T) {
 			collectionName, topology := setupTests(t, topologySpec)
@@ -40,6 +41,7 @@ func TestMultiActorConflictCreate(t *testing.T) {
 //  7. wait for documents to exist with a matching CV for Couchbase Lite peers, and a full HLV match for non Couchbase
 //     Lite peers. The body should match.
 func TestMultiActorConflictUpdate(t *testing.T) {
+	skipMobileJenkinsCBG4826(t)
 	for _, topologySpec := range append(simpleTopologySpecifications, TopologySpecifications...) {
 		t.Run(topologySpec.description, func(t *testing.T) {
 			collectionName, topology := setupTests(t, topologySpec)
@@ -68,6 +70,7 @@ func TestMultiActorConflictUpdate(t *testing.T) {
 // 6. start replications
 // 7. assert that the documents are deleted on all peers and have hlv sources equal to the number of active peers
 func TestMultiActorConflictDelete(t *testing.T) {
+	skipMobileJenkinsCBG4826(t)
 	for _, topologySpec := range append(simpleTopologySpecifications, TopologySpecifications...) {
 		t.Run(topologySpec.description, func(t *testing.T) {
 			collectionName, topology := setupTests(t, topologySpec)
@@ -103,6 +106,7 @@ func TestMultiActorConflictDelete(t *testing.T) {
 //  11. assert that the documents are resurrected on all peers and have matching hlvs for non Couchbase Lite peers and
 //     matching CV for Couchbase Lite peers.
 func TestMultiActorConflictResurrect(t *testing.T) {
+	skipMobileJenkinsCBG4826(t)
 	for _, topologySpec := range append(simpleTopologySpecifications, TopologySpecifications...) {
 		t.Run(topologySpec.description, func(t *testing.T) {
 			collectionName, topology := setupTests(t, topologySpec)


### PR DESCRIPTION
All the topology tests have flakes in mobile jenkins right now due to slow machines. They mostly work on sgw jenkins since we are using c7i which are fast. They will flake rarely on github actions if the shared machines are slow.

The underlying problem can occur for any test which uses CBL and XDCR, so skipping these tests.

I hope this to be in place for as short a time as possible, maybe only days until I can resolve the underlying issues and be sure that they won't flake on mobile jenkins. I'm can reproduce these tests running on a t3.medium, so I'll be more confident that I resolve the underlying issue.

CBG-4856 for the fundamental issue.