### PR TITLE
CBG-3203: Remove non-leaf channel history information from sync metadata

### DIFF
--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -435,10 +435,10 @@ func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBa
 
 		if isRemoval {
 			return removalBodyBytes, removalHistory, activeChannels, isRemoval, nil, isDelete, nil, hlv, nil
-		} else {
-			// If this wasn't a removal, return the original error from getRevision
-			return bodyBytes, history, channels, removed, nil, isDelete, nil, hlv, err
 		}
+
+		// If this wasn't a removal, return the original error from getRevision
+		return bodyBytes, history, channels, removed, nil, isDelete, nil, hlv, err
 	}
 	deleted = doc.History[revid].Deleted
 
@@ -447,7 +447,9 @@ func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBa
 		return bodyBytes, history, channels, removed, nil, deleted, nil, hlv, getHistoryErr
 	}
 	history = encodeRevisions(ctx, doc.ID, validatedHistory)
-	channels = doc.History[revid].Channels
+	if revChannels, ok := doc.channelsForRevTreeID(revid); ok {
+		channels = revChannels
+	}
 	if doc.HLV != nil {
 		hlv = doc.HLV
 	}

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -45,11 +45,10 @@ func (t *testBackingStore) GetDocument(ctx context.Context, docid string, unmars
 	doc._body = Body{
 		"testing": true,
 	}
-	doc.SetRevTreeID("1-abc")
+	const revTreeID = "1-abc"
+	doc.SetRevTreeID(revTreeID)
 	doc.History = RevTree{
-		doc.GetRevTreeID(): {
-			Channels: base.SetOf("*"),
-		},
+		revTreeID: {},
 	}
 
 	doc.HLV = &HybridLogicalVector{

--- a/rest/access_test.go
+++ b/rest/access_test.go
@@ -590,10 +590,13 @@ func TestAllDocsAccessControl(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, allDocsResult.Rows, 3)
 	assert.Equal(t, "doc3", allDocsResult.Rows[0].ID)
+	require.NotNil(t, allDocsResult.Rows[0].Value.Channels)
 	assert.Equal(t, []string{"Cinemax"}, allDocsResult.Rows[0].Value.Channels)
 	assert.Equal(t, "doc4", allDocsResult.Rows[1].ID)
+	require.NotNil(t, allDocsResult.Rows[1].Value.Channels)
 	assert.Equal(t, []string{"Cinemax"}, allDocsResult.Rows[1].Value.Channels)
 	assert.Equal(t, "doc5", allDocsResult.Rows[2].ID)
+	require.NotNil(t, allDocsResult.Rows[2].Value.Channels)
 	assert.Equal(t, []string{"Cinemax"}, allDocsResult.Rows[2].Value.Channels)
 
 	// Check all docs limit option
@@ -606,6 +609,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, allDocsResult.Rows, 1)
 	assert.Equal(t, "doc3", allDocsResult.Rows[0].ID)
+	require.NotNil(t, allDocsResult.Rows[0].Value.Channels)
 	assert.Equal(t, []string{"Cinemax"}, allDocsResult.Rows[0].Value.Channels)
 
 	// Check all docs startkey option
@@ -618,6 +622,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, allDocsResult.Rows, 1)
 	assert.Equal(t, "doc5", allDocsResult.Rows[0].ID)
+	require.NotNil(t, allDocsResult.Rows[0].Value.Channels)
 	assert.Equal(t, []string{"Cinemax"}, allDocsResult.Rows[0].Value.Channels)
 
 	// Check all docs startkey option with double quote
@@ -630,6 +635,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, allDocsResult.Rows, 1)
 	assert.Equal(t, "doc5", allDocsResult.Rows[0].ID)
+	require.NotNil(t, allDocsResult.Rows[0].Value.Channels)
 	assert.Equal(t, []string{"Cinemax"}, allDocsResult.Rows[0].Value.Channels)
 
 	// Check all docs endkey option
@@ -642,6 +648,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, allDocsResult.Rows, 1)
 	assert.Equal(t, "doc3", allDocsResult.Rows[0].ID)
+	require.NotNil(t, allDocsResult.Rows[0].Value.Channels)
 	assert.Equal(t, []string{"Cinemax"}, allDocsResult.Rows[0].Value.Channels)
 
 	// Check all docs endkey option
@@ -654,6 +661,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, allDocsResult.Rows, 1)
 	assert.Equal(t, "doc3", allDocsResult.Rows[0].ID)
+	require.NotNil(t, allDocsResult.Rows[0].Value.Channels)
 	assert.Equal(t, []string{"Cinemax"}, allDocsResult.Rows[0].Value.Channels)
 
 	// Check _all_docs with include_docs option:
@@ -681,6 +689,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	require.Len(t, allDocsResult.Rows, 4)
 	assert.Equal(t, "doc4", allDocsResult.Rows[0].Key)
 	assert.Equal(t, "doc4", allDocsResult.Rows[0].ID)
+	require.NotNil(t, allDocsResult.Rows[0].Value)
 	assert.Equal(t, "1-e0351a57554e023a77544d33dd21e56c", allDocsResult.Rows[0].Value.Rev)
 	assert.Equal(t, []string{"Cinemax"}, allDocsResult.Rows[0].Value.Channels)
 	assert.Equal(t, "doc1", allDocsResult.Rows[1].Key)
@@ -688,6 +697,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	assert.Nil(t, allDocsResult.Rows[1].Value)
 	assert.Equal(t, "doc3", allDocsResult.Rows[2].ID)
 	assert.Equal(t, []string{"Cinemax"}, allDocsResult.Rows[2].Value.Channels)
+	require.NotNil(t, allDocsResult.Rows[2].Value)
 	assert.Equal(t, "1-20912648f85f2bbabefb0993ddd37b41", allDocsResult.Rows[2].Value.Rev)
 	assert.Equal(t, "b0gus", allDocsResult.Rows[3].Key)
 	assert.Equal(t, "not_found", allDocsResult.Rows[3].Error)
@@ -704,13 +714,17 @@ func TestAllDocsAccessControl(t *testing.T) {
 	require.Len(t, allDocsResult.Rows, 4)
 	assert.Equal(t, "doc4", allDocsResult.Rows[0].Key)
 	assert.Equal(t, "doc4", allDocsResult.Rows[0].ID)
+	require.NotNil(t, allDocsResult.Rows[0].Value)
 	assert.Equal(t, []string{"Cinemax"}, allDocsResult.Rows[0].Value.Channels)
 	assert.Equal(t, "doc1", allDocsResult.Rows[1].Key)
 	assert.Equal(t, "forbidden", allDocsResult.Rows[1].Error)
+	assert.Nil(t, allDocsResult.Rows[1].Value)
 	assert.Equal(t, "doc3", allDocsResult.Rows[2].ID)
+	require.NotNil(t, allDocsResult.Rows[2].Value)
 	assert.Equal(t, []string{"Cinemax"}, allDocsResult.Rows[2].Value.Channels)
 	assert.Equal(t, "b0gus", allDocsResult.Rows[3].Key)
 	assert.Equal(t, "not_found", allDocsResult.Rows[3].Error)
+	assert.Nil(t, allDocsResult.Rows[3].Value)
 
 	// Check POST to _all_docs with limit option:
 	body = `{"keys": ["doc4", "doc1", "doc3", "b0gus"]}`
@@ -724,6 +738,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	require.Len(t, allDocsResult.Rows, 1)
 	assert.Equal(t, "doc4", allDocsResult.Rows[0].Key)
 	assert.Equal(t, "doc4", allDocsResult.Rows[0].ID)
+	assert.NotNil(t, allDocsResult.Rows[0].Value)
 	assert.Equal(t, []string{"Cinemax"}, allDocsResult.Rows[0].Value.Channels)
 
 	// Check _all_docs as admin:
@@ -738,6 +753,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	assert.Equal(t, "doc1", allDocsResult.Rows[0].ID)
 	assert.Equal(t, "doc2", allDocsResult.Rows[1].ID)
 }
+
 func TestChannelAccessChanges(t *testing.T) {
 	base.TestRequiresDCPResync(t)
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges, base.KeyCRUD)

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1898,18 +1898,15 @@ func TestGetRemovedDoc(t *testing.T) {
 	// TODO: CBG-4840 - Requires restoration of non-delta sync RevTree revision backups
 	// assert.NoError(t, err, "Unexpected Error")
 
-	// Try to get rev 3 via BLIP API and assert that _removed == true
+	// Try to get rev 3 via BLIP API and assert that there's a norev - modern clients will recieve a replacement rev instead
 	resultDoc, err = bt2.GetDocAtRev("foo", "3-cde")
-	assert.NoError(t, err, "Unexpected Error")
-	assert.True(t, resultDoc.IsRemoved())
+	require.ErrorContains(t, err, "404 missing", "Expected norev 404 error")
 
-	// Try to get rev 3 via REST API, and assert that _removed == true
+	// Try to get rev 3 via REST API, and assert that it's now missing
 	headers := map[string]string{}
 	headers["Authorization"] = GetBasicAuthHeader(t, btSpec.connectingUsername, RestTesterDefaultUserPassword)
 	response := rt.SendRequestWithHeaders("GET", "/{{.keyspace}}/foo?rev=3-cde", "", headers)
-	restDocument := response.GetRestDocument()
-	assert.True(t, restDocument.IsRemoved())
-
+	RequireStatus(t, response, http.StatusNotFound)
 }
 
 // Reproduce issue SG #3738

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1899,7 +1899,7 @@ func TestGetRemovedDoc(t *testing.T) {
 	// assert.NoError(t, err, "Unexpected Error")
 
 	// Try to get rev 3 via BLIP API and assert that there's a norev - modern clients will receive a replacement rev instead
-	resultDoc, err = bt2.GetDocAtRev("foo", "3-cde")
+	_, err = bt2.GetDocAtRev("foo", "3-cde")
 	require.ErrorContains(t, err, "404 missing", "Expected norev 404 error")
 
 	// Try to get rev 3 via REST API, and assert that it's now missing

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1898,7 +1898,7 @@ func TestGetRemovedDoc(t *testing.T) {
 	// TODO: CBG-4840 - Requires restoration of non-delta sync RevTree revision backups
 	// assert.NoError(t, err, "Unexpected Error")
 
-	// Try to get rev 3 via BLIP API and assert that there's a norev - modern clients will recieve a replacement rev instead
+	// Try to get rev 3 via BLIP API and assert that there's a norev - modern clients will receive a replacement rev instead
 	resultDoc, err = bt2.GetDocAtRev("foo", "3-cde")
 	require.ErrorContains(t, err, "404 missing", "Expected norev 404 error")
 
@@ -2863,10 +2863,10 @@ func TestSendRevisionNoRevHandling(t *testing.T) {
 				defer btc.Close()
 
 				// Change noRev handler so it's known when a noRev is received
-				recievedNoRevs := make(chan *blip.Message)
+				receivedNoRevs := make(chan *blip.Message)
 				btc.pullReplication.bt.blipContext.HandlerForProfile[db.MessageNoRev] = func(msg *blip.Message) {
 					fmt.Println("Received noRev", msg.Properties)
-					recievedNoRevs <- msg
+					receivedNoRevs <- msg
 				}
 
 				version := rt.PutDoc(docName, `{"foo": "bar"}`)
@@ -2886,7 +2886,7 @@ func TestSendRevisionNoRevHandling(t *testing.T) {
 
 				// Wait 3 seconds for noRev to be received
 				select {
-				case msg := <-recievedNoRevs:
+				case msg := <-receivedNoRevs:
 					if test.expectNoRev {
 						assert.Equal(t, docName, msg.Properties["id"])
 					} else {

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -1877,6 +1877,10 @@ func TestChangesIncludeDocs(t *testing.T) {
 	cvHash := base.Crc32cHashString([]byte(cvs[0]))
 	err = collection.PurgeOldRevisionJSON(ctx, "doc_pruned", cvHash)
 	require.NoError(t, err)
+
+	// since 4.0 we cannot differentiate between an old channel removal and a missing document - in this case the document body is not returned
+	expectedResults[5] = `{"seq":12,"id":"doc_pruned","removed":["alpha"],"changes":[{"rev":"2-5afcb73bd3eb50615470e3ba54b80f00"}]}`
+
 	postFlushChanges := rt.GetChanges("/{{.keyspace}}/_changes?include_docs=true", "user1")
 
 	assert.Equal(t, len(expectedResults), len(postFlushChanges.Results))


### PR DESCRIPTION
CBG-3203

Remove non-leaf channel history information from sync metadata.

Originally proposed PR: #6368 

Functional changes:
- Clients requesting old revisions that are now purged from the revcache (and have no backup revision) now get a 404 like they would for a non-existent rev.
  - This is instead of building an adhoc removal notification from the channel history (#2821)
  - This should be of no noticeable impact for modern CBL clients with the replacement revs feature, and minimal impact for CBL clients that handle `norev` appropriately.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/81/
