### PR TITLE
CBG-4851: Compact old PreviousVersion entries from HLV on write

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -1035,10 +1035,7 @@ func (db *DatabaseCollectionWithUser) updateHLV(ctx context.Context, d *Document
 	// clean up PV only if we have more than a handful of source IDs - reduce Compaction and false-conflict risk where we don't need it
 	if len(d.HLV.PreviousVersions) > minPVEntriesBeforeCompaction {
 		mpi := db.dbCtx.GetMetadataPurgeInterval(ctx, false)
-		compactTimestamp := uint64(time.Now().Add(-mpi).UnixNano())
-		if err := d.HLV.Compact(ctx, d.ID, compactTimestamp); err != nil {
-			base.AssertfCtx(ctx, "Unable to compact HLV for doc %s, HLV: %#v: %v", base.UD(d.ID), d.HLV, err)
-		}
+		d.HLV.Compact(ctx, d.ID, mpi)
 	}
 	d.SyncData.SetCV(d.HLV)
 	return d, nil

--- a/db/crud.go
+++ b/db/crud.go
@@ -1031,8 +1031,7 @@ func (db *DatabaseCollectionWithUser) updateHLV(ctx context.Context, d *Document
 	default:
 		return nil, base.RedactErrorf("Unexpected docUpdateEvent %v in updateHLV for doc %s", docUpdateEvent, base.UD(d.ID))
 	}
-	// TODO: Move GetMetadataPurgeInterval to db ticker to avoid metadata purge interval call to CB Server on writes
-	mpi := db.dbCtx.GetMetadataPurgeInterval(ctx)
+	mpi := db.dbCtx.GetMetadataPurgeInterval(ctx, true)
 	if err := d.HLV.Compact(ctx, d.ID, mpi); err != nil {
 		base.AssertfCtx(ctx, "Unable to compact HLV for doc %s, HLV: %#v: %v", base.UD(d.ID), d.HLV, err)
 	}

--- a/db/crud.go
+++ b/db/crud.go
@@ -29,7 +29,6 @@ const (
 	kMaxRecentSequences            = 20    // Maximum number of sequences stored in RecentSequences before pruning is triggered
 	kMinRecentSequences            = 5     // Minimum number of sequences that should be left stored in RecentSequences during compaction
 	unusedSequenceWarningThreshold = 10000 // Warn when releasing more than this many sequences due to existing sequence on the document
-	minPVEntriesBeforeCompaction   = 5     // Minimum number of sources in the previous versions before timestamp-based compaction is considered
 )
 
 // ErrForbidden is returned when the user requests a document without a revision that they do not have access to.

--- a/db/crud.go
+++ b/db/crud.go
@@ -1031,6 +1031,11 @@ func (db *DatabaseCollectionWithUser) updateHLV(ctx context.Context, d *Document
 	default:
 		return nil, base.RedactErrorf("Unexpected docUpdateEvent %v in updateHLV for doc %s", docUpdateEvent, base.UD(d.ID))
 	}
+	// TODO: Move GetMetadataPurgeInterval to db ticker to avoid metadata purge interval call to CB Server on writes
+	mpi := db.dbCtx.GetMetadataPurgeInterval(ctx)
+	if err := d.HLV.Compact(ctx, d.ID, mpi); err != nil {
+		base.AssertfCtx(ctx, "Unable to compact HLV for doc %s, HLV: %#v: %v", base.UD(d.ID), d.HLV, err)
+	}
 	d.SyncData.SetCV(d.HLV)
 	return d, nil
 }

--- a/db/crud.go
+++ b/db/crud.go
@@ -1034,8 +1034,9 @@ func (db *DatabaseCollectionWithUser) updateHLV(ctx context.Context, d *Document
 	}
 	// clean up PV only if we have more than a handful of source IDs - reduce Compaction and false-conflict risk where we don't need it
 	if len(d.HLV.PreviousVersions) > minPVEntriesBeforeCompaction {
-		mpi := db.dbCtx.GetMetadataPurgeInterval(ctx, true)
-		if err := d.HLV.Compact(ctx, d.ID, mpi); err != nil {
+		mpi := db.dbCtx.GetMetadataPurgeInterval(ctx, false)
+		compactTimestamp := uint64(time.Now().Add(-mpi).UnixNano())
+		if err := d.HLV.Compact(ctx, d.ID, compactTimestamp); err != nil {
 			base.AssertfCtx(ctx, "Unable to compact HLV for doc %s, HLV: %#v: %v", base.UD(d.ID), d.HLV, err)
 		}
 	}

--- a/db/database.go
+++ b/db/database.go
@@ -200,7 +200,8 @@ type DatabaseContextOptions struct {
 	BlipStatsReportingInterval    int64          // interval to report blip stats in milliseconds
 	ChangesRequestPlus            bool           // Sets the default value for request_plus, for non-continuous changes feeds
 	ConfigPrincipals              *ConfigPrincipals
-	PurgeInterval                 atomic.Pointer[time.Duration] // The metadata purge interval. Populated by db.GetMetadataPurgeInterval
+	CachedPurgeInterval           atomic.Pointer[time.Duration] // The metadata purge interval. Populated by db.GetMetadataPurgeInterval
+	TestPurgeIntervalOverride     *time.Duration                // If set, use this value for CachedPurgeInterval - test seam to force specific purge interval for tests
 	LoggingConfig                 *base.DbLogConfig             // Per-database log configuration
 	MaxConcurrentChangesBatches   *int                          // Maximum number of changes batches to process concurrently per replication
 	MaxConcurrentRevs             *int                          // Maximum number of revs to process concurrently per replication
@@ -1463,7 +1464,7 @@ func (db *Database) Compact(ctx context.Context, skipRunningStateCheck bool, opt
 		return 0, nil
 	}
 
-	purgeInterval := db.GetMetadataPurgeInterval(ctx, false)
+	purgeInterval := db.GetMetadataPurgeInterval(ctx, true)
 	base.InfofCtx(ctx, base.KeyAll, "Tombstone compaction using the metadata purge interval of %.2f days.", purgeInterval.Hours()/24)
 
 	// Trigger view compaction for all tombstoned documents older than the purge interval
@@ -1586,33 +1587,39 @@ func (db *Database) Compact(ctx context.Context, skipRunningStateCheck bool, opt
 }
 
 // GetMetadataPurgeInterval returns the current value for the metadata purge interval for the backing bucket.
-// if useCachedInterval is false, we'll always fetch a new Metadat Purge Interval from the bucket. Otherwise we'll use the last value we got (if any).
-func (db *DatabaseContext) GetMetadataPurgeInterval(ctx context.Context, useCachedInterval bool) time.Duration {
+// if forceRefresh is set, we'll always fetch a new Metadata Purge Interval from the bucket, even if we had one cached.
+func (db *DatabaseContext) GetMetadataPurgeInterval(ctx context.Context, forceRefresh bool) time.Duration {
 	// look for metadata purge interval preferentially:
 	// 1. value specified in DatabaseContextOptions (testing seam)
-	// 2. bucket level
-	// 3. cluster level
-	// 4. default fallback value
-
-	if useCachedInterval {
-		if mpi := db.Options.PurgeInterval.Load(); mpi != nil {
-			return *mpi
-		}
+	// 2. cached metadata purge interval (if forceRefresh is false)
+	// 3. bucket level
+	// 4. cluster level
+	// 5. default fallback value
+	if db.Options.TestPurgeIntervalOverride != nil {
+		return *db.Options.TestPurgeIntervalOverride
 	}
 
+	if mpi := db.Options.CachedPurgeInterval.Load(); !forceRefresh && mpi != nil {
+		return *mpi
+	}
+
+	// fetch from server
 	cbStore, ok := base.AsCouchbaseBucketStore(db.Bucket)
 	if !ok {
 		return DefaultPurgeInterval
 	}
+
 	serverPurgeInterval, err := cbStore.MetadataPurgeInterval(ctx)
 	if err != nil {
 		base.WarnfCtx(ctx, "Unable to retrieve server's metadata purge interval - using default purge interval %.2f days. %s", DefaultPurgeInterval.Hours()/24, err)
 	}
+
 	mpi := DefaultPurgeInterval
 	if serverPurgeInterval > 0 {
 		mpi = serverPurgeInterval
 	}
-	db.Options.PurgeInterval.Store(&mpi)
+
+	db.Options.CachedPurgeInterval.Store(&mpi)
 	return mpi
 }
 
@@ -2331,7 +2338,7 @@ func (db *DatabaseContext) StartOnlineProcesses(ctx context.Context) (returnedEr
 
 	if db.UseXattrs() {
 		// Log the purge interval for tombstone compaction
-		mpi := db.GetMetadataPurgeInterval(ctx, false)
+		mpi := db.GetMetadataPurgeInterval(ctx, true)
 		base.InfofCtx(ctx, base.KeyAll, "Using metadata purge interval of %.2f days for tombstone compaction.", mpi.Hours()/24)
 
 		if db.Options.CompactInterval != 0 {

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -3380,7 +3380,8 @@ func TestTombstoneCompactionStopWithManager(t *testing.T) {
 	defer db.Close(ctx)
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 
-	db.Options.PurgeInterval.Store(base.Ptr(time.Duration(0)))
+	// force compaction
+	db.Options.TestPurgeIntervalOverride = base.Ptr(time.Duration(0))
 
 	for i := 0; i < 300; i++ {
 		docID := fmt.Sprintf("doc%d", i)
@@ -3792,7 +3793,8 @@ func TestImportCompactPanic(t *testing.T) {
 	defer db.Close(ctx)
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 
-	db.Options.PurgeInterval.Store(base.Ptr(time.Duration(0)))
+	// force compaction
+	db.Options.TestPurgeIntervalOverride = base.Ptr(time.Duration(0))
 
 	// Create a document, then delete it, to create a tombstone
 	rev, doc, err := collection.Put(ctx, "test", Body{})

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -3376,12 +3376,11 @@ func TestTombstoneCompactionStopWithManager(t *testing.T) {
 	}
 
 	bucket := base.GetTestBucket(t).LeakyBucketClone(base.LeakyBucketConfig{})
-	zero := time.Duration(0)
-	db, ctx := SetupTestDBForBucketWithOptions(t, bucket, DatabaseContextOptions{
-		PurgeInterval: &zero,
-	})
+	db, ctx := SetupTestDBForBucketWithOptions(t, bucket, DatabaseContextOptions{})
 	defer db.Close(ctx)
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+
+	db.Options.PurgeInterval.Store(base.Ptr(time.Duration(0)))
 
 	for i := 0; i < 300; i++ {
 		docID := fmt.Sprintf("doc%d", i)
@@ -3786,14 +3785,14 @@ func TestImportCompactPanic(t *testing.T) {
 		t.Skip("requires xattrs")
 	}
 
-	zero := time.Duration(0)
 	// Set the compaction and purge interval unrealistically low to reproduce faster
 	db, ctx := setupTestDBWithOptionsAndImport(t, nil, DatabaseContextOptions{
 		CompactInterval: 1,
-		PurgeInterval:   &zero,
 	})
 	defer db.Close(ctx)
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+
+	db.Options.PurgeInterval.Store(base.Ptr(time.Duration(0)))
 
 	// Create a document, then delete it, to create a tombstone
 	rev, doc, err := collection.Put(ctx, "test", Body{})

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -3376,12 +3376,11 @@ func TestTombstoneCompactionStopWithManager(t *testing.T) {
 	}
 
 	bucket := base.GetTestBucket(t).LeakyBucketClone(base.LeakyBucketConfig{})
-	db, ctx := SetupTestDBForBucketWithOptions(t, bucket, DatabaseContextOptions{})
+	db, ctx := SetupTestDBForBucketWithOptions(t, bucket, DatabaseContextOptions{
+		TestPurgeIntervalOverride: base.Ptr(time.Duration(0)),
+	})
 	defer db.Close(ctx)
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
-
-	// force compaction
-	db.Options.TestPurgeIntervalOverride = base.Ptr(time.Duration(0))
 
 	for i := 0; i < 300; i++ {
 		docID := fmt.Sprintf("doc%d", i)
@@ -3788,13 +3787,11 @@ func TestImportCompactPanic(t *testing.T) {
 
 	// Set the compaction and purge interval unrealistically low to reproduce faster
 	db, ctx := setupTestDBWithOptionsAndImport(t, nil, DatabaseContextOptions{
-		CompactInterval: 1,
+		CompactInterval:           1,
+		TestPurgeIntervalOverride: base.Ptr(time.Duration(0)),
 	})
 	defer db.Close(ctx)
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
-
-	// force compaction
-	db.Options.TestPurgeIntervalOverride = base.Ptr(time.Duration(0))
 
 	// Create a document, then delete it, to create a tombstone
 	rev, doc, err := collection.Put(ctx, "test", Body{})

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -30,6 +30,11 @@ import (
 // revtree ID.
 const encodedRevTreeSourceID = "Revision+Tree+Encoding"
 
+const (
+	minPVEntriesBeforeCompaction = 5 // minPVEntriesBeforeCompaction is the minimum number of sources in previous versions before timestamp-based compaction is considered.
+	minPVEntriesRetained         = 3 // minPVEntriesRetained defines the minimum number of PV entries that should be retained after compaction, to avoid removing all history for infrequently updated/replicated documents.
+)
+
 type HLVVersions map[string]uint64 // map of source ID to version uint64 version value
 
 // sorted will iterate through the map returning entries in a stable sorted order. Used by testing to make it easier
@@ -319,21 +324,35 @@ func (hlv *HybridLogicalVector) Compact(ctx context.Context, docID string, purge
 // this differs from Compact in that it takes a raw value instead of a duration - for easier unit testing purposes.
 func (hlv *HybridLogicalVector) compactWithValue(ctx context.Context, docID string, compactToValue uint64) {
 	// disabled/noop
-	if compactToValue == 0 {
+	pvCountBefore := len(hlv.PreviousVersions)
+	if compactToValue == 0 || pvCountBefore < minPVEntriesBeforeCompaction {
 		return
 	}
-	pvCountBefore := len(hlv.PreviousVersions)
-	for sourceID, version := range hlv.PreviousVersions {
-		if version < compactToValue {
-			base.TracefCtx(ctx, base.KeyCRUD, "Compacted HLV source %s@%d in PV for doc %q", sourceID, version, base.UD(docID))
-			delete(hlv.PreviousVersions, sourceID)
+
+	// Build candidate list (entries older than threshold)
+	var candidates []Version
+	for s, v := range hlv.PreviousVersions {
+		if v < compactToValue {
+			candidates = append(candidates, Version{SourceID: s, Value: v})
+			base.TracefCtx(ctx, base.KeyCRUD, "HLV PV %s@%d eligible for compaction for doc %q", s, v, base.UD(docID))
 		} else {
-			base.TracefCtx(ctx, base.KeyCRUD, "HLV source %s@%d within purge interval for doc %q - not compacting", sourceID, version, base.UD(docID))
+			base.TracefCtx(ctx, base.KeyCRUD, "HLV PV %s@%d within purge interval for doc %q - not compacting", s, v, base.UD(docID))
 		}
 	}
-	pvCountAfter := len(hlv.PreviousVersions)
 
-	base.DebugfCtx(ctx, base.KeyCRUD, "Compacted %d of %d HLV sources from PV for doc %q older than %d", pvCountBefore-pvCountAfter, pvCountBefore, base.UD(docID), compactToValue)
+	// sort oldest to newest
+	sort.Slice(candidates, func(i, j int) bool { return candidates[i].Value < candidates[j].Value })
+
+	for _, c := range candidates {
+		if len(hlv.PreviousVersions) <= minPVEntriesRetained {
+			base.TracefCtx(ctx, base.KeyCRUD, "HLV PV compaction reached minimum retained entries (%d) for doc %q - stopping compaction", minPVEntriesRetained, base.UD(docID))
+			break
+		}
+		base.TracefCtx(ctx, base.KeyCRUD, "Compacting HLV source %s@%d in PV for doc %q", c.SourceID, c.Value, base.UD(docID))
+		delete(hlv.PreviousVersions, c.SourceID)
+	}
+
+	base.DebugfCtx(ctx, base.KeyCRUD, "Compacted %d of %d HLV sources from PV for doc %q older than %d", pvCountBefore-len(hlv.PreviousVersions), pvCountBefore, base.UD(docID), compactToValue)
 }
 
 // AddVersion adds newVersion as the current version to the in memory representation of the HLV.

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -318,6 +318,10 @@ func (hlv *HybridLogicalVector) Compact(ctx context.Context, docID string, purge
 // compactWithValue removes Source ID entries from PV if they are older than the provided value
 // this differs from Compact in that it takes a raw value instead of a duration - for easier unit testing purposes.
 func (hlv *HybridLogicalVector) compactWithValue(ctx context.Context, docID string, compactToValue uint64) {
+	// disabled/noop
+	if compactToValue == 0 {
+		return
+	}
 	pvCountBefore := len(hlv.PreviousVersions)
 	for sourceID, version := range hlv.PreviousVersions {
 		if version < compactToValue {

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -117,7 +117,7 @@ func TestHLVCompact(t *testing.T) {
 	hlv.compactWithValue(base.TestCtx(t), t.Name(), 0)
 	assert.Equal(t, len(startingHLV.PreviousVersions), len(hlv.PreviousVersions))
 
-	// since we have <= 5 PVs, compact should be a no-op
+	// since we have < 5 PVs, compact should be a no-op, even if there are candidates based on the value
 	hlv.compactWithValue(base.TestCtx(t), t.Name(), compactValue)
 	assert.Equal(t, len(startingHLV.PreviousVersions), len(hlv.PreviousVersions))
 
@@ -137,9 +137,11 @@ func TestHLVCompact(t *testing.T) {
 	assert.Contains(t, hlv.PreviousVersions, "sourceD")
 	assert.Contains(t, hlv.PreviousVersions, "sourceE") // Was a candidate for compaction but retained 3 PVs
 	assert.Contains(t, hlv.PreviousVersions, "sourceF") // Was a candidate for compaction but retained 3 PVs
+	assert.NotContains(t, hlv.PreviousVersions, "sourceG")
 	assert.NotContains(t, hlv.PreviousVersions, "sourceH")
 	assert.NotContains(t, hlv.PreviousVersions, "sourceI")
 	assert.NotContains(t, hlv.PreviousVersions, "sourceJ")
+	assert.NotContains(t, hlv.PreviousVersions, "sourceK")
 
 	// Ensure Compact didn't touch anything else in the HLV
 	assert.Equal(t, startingHLV.SourceID, hlv.SourceID)

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -93,7 +93,7 @@ func TestInternalHLVFunctions(t *testing.T) {
 
 func TestHLVCompact(t *testing.T) {
 	// halfway through the HLV "timestamp" range for this test
-	purgeInterval := uint64(25)
+	compactValue := uint64(25)
 
 	hlv := HybridLogicalVector{
 		SourceID: "sourceA",
@@ -114,11 +114,11 @@ func TestHLVCompact(t *testing.T) {
 	startingHLV := hlv.Copy()
 
 	// test no-op condition - this is only really used in tests that want to avoid compacting on writes - production code defaults to 30d purge interval
-	require.NoError(t, hlv.Compact(base.TestCtx(t), t.Name(), 0))
+	hlv.compactWithValue(base.TestCtx(t), t.Name(), 0)
 	assert.Equal(t, len(startingHLV.PreviousVersions), len(hlv.PreviousVersions))
 
 	// run again and purge half the PVs
-	require.NoError(t, hlv.Compact(base.TestCtx(t), t.Name(), purgeInterval))
+	hlv.compactWithValue(base.TestCtx(t), t.Name(), compactValue)
 	assert.Equal(t, len(startingHLV.PreviousVersions)-3, len(hlv.PreviousVersions))
 	assert.Contains(t, hlv.PreviousVersions, "sourceD")
 	assert.Contains(t, hlv.PreviousVersions, "sourceE")

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -3753,7 +3753,7 @@ func TestTombstoneCompactionPurgeInterval(t *testing.T) {
 			_, err = database.Compact(ctx, false, nil, base.NewSafeTerminator(), false)
 			require.NoError(t, err)
 
-			assert.EqualValues(t, test.expectedPurgeIntervalAfterCompact, dbc.GetMetadataPurgeInterval(ctx))
+			assert.EqualValues(t, test.expectedPurgeIntervalAfterCompact, dbc.GetMetadataPurgeInterval(ctx, false))
 		})
 	}
 }

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -3753,7 +3753,7 @@ func TestTombstoneCompactionPurgeInterval(t *testing.T) {
 			_, err = database.Compact(ctx, false, nil, base.NewSafeTerminator(), false)
 			require.NoError(t, err)
 
-			assert.EqualValues(t, test.expectedPurgeIntervalAfterCompact, dbc.GetMetadataPurgeInterval(ctx, false))
+			assert.EqualValues(t, test.expectedPurgeIntervalAfterCompact, dbc.GetMetadataPurgeInterval(ctx, true))
 		})
 	}
 }

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3133,8 +3133,7 @@ func TestTombstoneCompactionAPI(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	zero := time.Duration(0)
-	rt.GetDatabase().Options.PurgeInterval = &zero
+	rt.GetDatabase().Options.PurgeInterval.Store(base.Ptr(time.Duration(0)))
 
 	for i := 0; i < 100; i++ {
 		docID := fmt.Sprintf("doc%d", i)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3133,7 +3133,8 @@ func TestTombstoneCompactionAPI(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	rt.GetDatabase().Options.PurgeInterval.Store(base.Ptr(time.Duration(0)))
+	// force compaction
+	rt.GetDatabase().Options.TestPurgeIntervalOverride = base.Ptr(time.Duration(0))
 
 	for i := 0; i < 100; i++ {
 		docID := fmt.Sprintf("doc%d", i)

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -3480,7 +3480,9 @@ func TestTombstoneCompaction(t *testing.T) {
 		rt = rest.NewRestTester(t, nil)
 	}
 	defer rt.Close()
-	rt.GetDatabase().Options.PurgeInterval.Store(base.Ptr(time.Duration(0)))
+
+	// force compaction
+	rt.GetDatabase().Options.TestPurgeIntervalOverride = base.Ptr(time.Duration(0))
 
 	for _, test := range tests {
 		for _, runAsScheduledBackgroundTask := range []bool{false, true} {

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -3480,7 +3480,7 @@ func TestTombstoneCompaction(t *testing.T) {
 		rt = rest.NewRestTester(t, nil)
 	}
 	defer rt.Close()
-	rt.GetDatabase().Options.PurgeInterval = base.Ptr(time.Duration(0))
+	rt.GetDatabase().Options.PurgeInterval.Store(base.Ptr(time.Duration(0)))
 
 	for _, test := range tests {
 		for _, runAsScheduledBackgroundTask := range []bool{false, true} {

--- a/rest/replicatortest/replicator_conflict_test.go
+++ b/rest/replicatortest/replicator_conflict_test.go
@@ -1030,6 +1030,10 @@ func TestActiveReplicatorHLVConflictNoCommonMVPV(t *testing.T) {
 			ctx1 := rt1.Context()
 			ctx2 := rt2.Context()
 
+			// disable purge interval so we can avoid HLV compaction for the artificially low HLV values in this test
+			rt1.GetDatabase().Options.TestPurgeIntervalOverride = base.Ptr(time.Duration(0))
+			rt2.GetDatabase().Options.TestPurgeIntervalOverride = base.Ptr(time.Duration(0))
+
 			docID := "doc1_"
 			version := rt2.PutDoc(docID, `{"source":"rt2","channels":["alice"]}`)
 			rt2.WaitForPendingChanges()


### PR DESCRIPTION
CBG-4851

If we have more than 5 sources in the PV part of the HLV, compact away based on metadata purge interval (down to a minimum number of 3 entries)
Provides a soft upper-bound on HLV metadata size for documents with large amounts of shared updates over a long time period.

Required changes to `GetMetadataPurgeInterval` to support caching of the server value, since this is being called in the document update codepath instead of only Database `Compact()`

Example logging from new test:

```go
2025-09-18T17:37:31.139+01:00 [TRC] CRUD+: t:TestHLVCompact HLV PV sourceK@2 eligible for compaction for doc "<ud>TestHLVCompact</ud>" -- db.(*HybridLogicalVector).compactWithValue() at hybrid_logical_vector.go:337
2025-09-18T17:37:31.139+01:00 [TRC] CRUD+: t:TestHLVCompact HLV PV sourceD@26 within purge interval for doc "<ud>TestHLVCompact</ud>" - not compacting -- db.(*HybridLogicalVector).compactWithValue() at hybrid_logical_vector.go:339
2025-09-18T17:37:31.139+01:00 [TRC] CRUD+: t:TestHLVCompact HLV PV sourceE@25 within purge interval for doc "<ud>TestHLVCompact</ud>" - not compacting -- db.(*HybridLogicalVector).compactWithValue() at hybrid_logical_vector.go:339
2025-09-18T17:37:31.139+01:00 [TRC] CRUD+: t:TestHLVCompact HLV PV sourceF@24 eligible for compaction for doc "<ud>TestHLVCompact</ud>" -- db.(*HybridLogicalVector).compactWithValue() at hybrid_logical_vector.go:337
2025-09-18T17:37:31.139+01:00 [TRC] CRUD+: t:TestHLVCompact HLV PV sourceG@15 eligible for compaction for doc "<ud>TestHLVCompact</ud>" -- db.(*HybridLogicalVector).compactWithValue() at hybrid_logical_vector.go:337
2025-09-18T17:37:31.139+01:00 [TRC] CRUD+: t:TestHLVCompact HLV PV sourceH@10 eligible for compaction for doc "<ud>TestHLVCompact</ud>" -- db.(*HybridLogicalVector).compactWithValue() at hybrid_logical_vector.go:337
2025-09-18T17:37:31.139+01:00 [TRC] CRUD+: t:TestHLVCompact HLV PV sourceI@5 eligible for compaction for doc "<ud>TestHLVCompact</ud>" -- db.(*HybridLogicalVector).compactWithValue() at hybrid_logical_vector.go:337
2025-09-18T17:37:31.139+01:00 [TRC] CRUD+: t:TestHLVCompact HLV PV sourceJ@3 eligible for compaction for doc "<ud>TestHLVCompact</ud>" -- db.(*HybridLogicalVector).compactWithValue() at hybrid_logical_vector.go:337
2025-09-18T17:37:31.139+01:00 [TRC] CRUD+: t:TestHLVCompact Compacting HLV source sourceK@2 in PV for doc "<ud>TestHLVCompact</ud>" -- db.(*HybridLogicalVector).compactWithValue() at hybrid_logical_vector.go:351
2025-09-18T17:37:31.139+01:00 [TRC] CRUD+: t:TestHLVCompact Compacting HLV source sourceJ@3 in PV for doc "<ud>TestHLVCompact</ud>" -- db.(*HybridLogicalVector).compactWithValue() at hybrid_logical_vector.go:351
2025-09-18T17:37:31.139+01:00 [TRC] CRUD+: t:TestHLVCompact Compacting HLV source sourceI@5 in PV for doc "<ud>TestHLVCompact</ud>" -- db.(*HybridLogicalVector).compactWithValue() at hybrid_logical_vector.go:351
2025-09-18T17:37:31.139+01:00 [TRC] CRUD+: t:TestHLVCompact Compacting HLV source sourceH@10 in PV for doc "<ud>TestHLVCompact</ud>" -- db.(*HybridLogicalVector).compactWithValue() at hybrid_logical_vector.go:351
2025-09-18T17:37:31.139+01:00 [TRC] CRUD+: t:TestHLVCompact Compacting HLV source sourceG@15 in PV for doc "<ud>TestHLVCompact</ud>" -- db.(*HybridLogicalVector).compactWithValue() at hybrid_logical_vector.go:351
2025-09-18T17:37:31.139+01:00 [TRC] CRUD+: t:TestHLVCompact HLV PV compaction reached minimum retained entries (3) for doc "<ud>TestHLVCompact</ud>" - stopping compaction -- db.(*HybridLogicalVector).compactWithValue() at hybrid_logical_vector.go:348
2025-09-18T17:37:31.139+01:00 [DBG] CRUD+: t:TestHLVCompact Compacted 5 of 8 HLV sources from PV for doc "<ud>TestHLVCompact</ud>" older than 25
```

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/89/
- [x] `topologytests` https://jenkins.sgwdev.com/job/TopologyTests/66 