### PR TITLE
CBG-4849: updates to api docs for ISGR

### DIFF
--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -709,9 +709,14 @@ Replication:
         - custom
       x-enumDescriptions:
         default: |-
-          In priority order, this will cause
+          For Sync Gateway versions < 4.x, in priority order, this will cause
             - Deletes to always win (the delete with the longest revision history wins if both revisions are deletes)
             - The revision with the longest revision history to win. This means the the revision with the most changes and therefore the highest Revision Tree ID will win.
+          
+          For Sync Gateway versions >= 4.x, this will use
+            - Timestamp based conflict resolution (often referred to as "last write wins", or LWW). Which uses a document timestamp from most recent document revisions to compare.
+            - The revision with the most recent timestamp wins.
+            - If replicating a document that was last updated/written pre upgrade to SG 4.x, the default policy for versions < 4.x will be used.
         localWins: This will result in local revisions always being the winner in any conflict.
         remoteWins: This will result in remote revisions always being the winner in any conflict.
         custom: This will result in conflicts going through your own custom conflict resolver. You must provide this logic as a Javascript function in the `custom_conflict_resolver` parameter.
@@ -744,6 +749,8 @@ Replication:
         ```
 
         Using complex `custom_conflict_resolver` functions can noticeably degrade performance. Use a built-in resolver whenever possible.
+        
+        If a document merge is being done, the `_rev` and `_cv` properties should not be included in the returned document body as Sync Gateway will generate new values for these.
 
         This is an Enterprise Edition only feature.
       type: string

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -711,7 +711,7 @@ Replication:
         default: |-
           For Sync Gateway versions < 4.x, in priority order, this will cause
             - Deletes to always win (the delete with the longest revision history wins if both revisions are deletes)
-            - The revision with the longest revision history to win. This means the the revision with the most changes and therefore the highest Revision Tree ID will win.
+            - The revision with the longest revision history to win. This means the revision with the most changes and therefore the highest Revision Tree ID will win.
 
           For Sync Gateway versions >= 4.x, this will use
             - Timestamp based conflict resolution (often referred to as "last write wins", or LWW). Which uses a document timestamp from most recent document revisions to compare.

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -709,11 +709,7 @@ Replication:
         - custom
       x-enumDescriptions:
         default: |-
-          For Sync Gateway versions < 4.x, in priority order, this will cause
-            - Deletes to always win (the delete with the longest revision history wins if both revisions are deletes)
-            - The revision with the longest revision history to win. This means the revision with the most changes and therefore the highest Revision Tree ID will win.
-
-          For Sync Gateway versions >= 4.x, this will use
+          This will use:
             - Timestamp based conflict resolution (often referred to as "last write wins", or LWW). Which uses a document timestamp from most recent document revisions to compare.
             - The revision with the most recent timestamp wins.
             - If replicating a document that was last updated/written pre upgrade to SG 4.x, the default policy for versions < 4.x will be used.

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -712,7 +712,7 @@ Replication:
           For Sync Gateway versions < 4.x, in priority order, this will cause
             - Deletes to always win (the delete with the longest revision history wins if both revisions are deletes)
             - The revision with the longest revision history to win. This means the the revision with the most changes and therefore the highest Revision Tree ID will win.
-          
+
           For Sync Gateway versions >= 4.x, this will use
             - Timestamp based conflict resolution (often referred to as "last write wins", or LWW). Which uses a document timestamp from most recent document revisions to compare.
             - The revision with the most recent timestamp wins.
@@ -749,7 +749,7 @@ Replication:
         ```
 
         Using complex `custom_conflict_resolver` functions can noticeably degrade performance. Use a built-in resolver whenever possible.
-        
+
         If a document merge is being done, the `_rev` and `_cv` properties should not be included in the returned document body as Sync Gateway will generate new values for these.
 
         This is an Enterprise Edition only feature.


### PR DESCRIPTION
CBG-4849

- Details the new default policy 
- Note to remove the _rev and _cv properties for doc merges. 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
