### PR TITLE
CBG-4833: Send replacement revision as CV where possible

### DIFF
--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -704,7 +704,12 @@ func (bsc *BlipSyncContext) sendRevision(ctx context.Context, sender *blip.Sende
 		}
 
 		replacedRevID = revID
-		revID = replacementRev.RevID
+		// Send replacement as CV where possible
+		if bsc.useHLV() && !replacementRev.CV.IsEmpty() {
+			revID = replacementRev.CV.String()
+		} else {
+			revID = replacementRev.RevID
+		}
 		docRev = replacementRev
 	} else if originalErr != nil {
 		return fmt.Errorf("failed to GetRev for doc %s with rev %s: %w", base.UD(docID).Redact(), base.MD(revID).Redact(), originalErr)


### PR DESCRIPTION
CBG-4833

Removes hard-coded RevTree ID replacement rev and test assertions and use CV where possible.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/95/
