### PR TITLE
CBG-4878 Set _mou from attachment migration

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -1075,7 +1075,7 @@ func (c *DatabaseCollectionWithUser) MigrateAttachmentMetadata(ctx context.Conte
 	}
 	revSeqNo, err := unmarshalRevSeqNo(xattrs[base.VirtualXattrRevSeqNo])
 	if err != nil {
-		base.WarnfCtx(ctx, "Could not determine revSeqNo found when attempting to migrate sync data attachments to global xattr for doc %q. Assuming 0. Error: %v", base.UD(docID), err)
+		base.InfofCtx(ctx, base.KeyCRUD, "Could not determine revSeqNo found when attempting to migrate sync data attachments to global xattr for doc %q. Assuming 0. Error: %v", base.UD(docID), err)
 	}
 
 	metadataOnlyUpdate := &MetadataOnlyUpdate{

--- a/db/crud.go
+++ b/db/crud.go
@@ -1051,7 +1051,7 @@ func (db *DatabaseCollectionWithUser) updateHLV(ctx context.Context, d *Document
 
 // MigrateAttachmentMetadata will move any attachment metadata defined in sync data to global sync xattr
 func (c *DatabaseCollectionWithUser) MigrateAttachmentMetadata(ctx context.Context, docID string, cas uint64, syncData *SyncData) error {
-	xattrs, _, err := c.dataStore.GetXattrs(ctx, docID, []string{base.GlobalXattrName})
+	xattrs, _, err := c.dataStore.GetXattrs(ctx, docID, []string{base.GlobalXattrName, base.VirtualXattrRevSeqNo})
 	if err != nil && !base.IsXattrNotFoundError(err) {
 		return err
 	}
@@ -1073,14 +1073,32 @@ func (c *DatabaseCollectionWithUser) MigrateAttachmentMetadata(ctx context.Conte
 	if err != nil {
 		return base.RedactErrorf("Failed to Marshal sync data when attempting to migrate sync data attachments to global xattr with id: %s. Error: %v", base.UD(docID), err)
 	}
+	revSeqNo, err := unmarshalRevSeqNo(xattrs[base.VirtualXattrRevSeqNo])
+	if err != nil {
+		base.WarnfCtx(ctx, "Could not determine revSeqNo found when attempting to migrate sync data attachments to global xattr for doc %q. Assuming 0. Error: %v", base.UD(docID), err)
+	}
+
+	metadataOnlyUpdate := &MetadataOnlyUpdate{
+		HexCAS:           expandMacroCASValueString, // when non-empty, this is replaced with cas macro expansion
+		PreviousHexCAS:   syncData.Cas,
+		PreviousRevSeqNo: revSeqNo,
+	}
+	rawMouXattr, err := base.JSONMarshal(metadataOnlyUpdate)
+	if err != nil {
+		return base.RedactErrorf("Failed to Marshal _mou when attempting to migrate sync data attachments to global xattr with id: %s. Error: %v", base.UD(docID), err)
+	}
 
 	// build macro expansion for sync data. This will avoid the update to xattrs causing an extra import event (i.e. sync cas will be == to doc cas)
 	opts := &sgbucket.MutateInOptions{}
-	spec := macroExpandSpec(base.SyncXattrName)
+	spec := append(macroExpandSpec(base.SyncXattrName), sgbucket.NewMacroExpansionSpec(XattrMouCasPath(), sgbucket.MacroCas))
 	opts.MacroExpansion = spec
 	opts.PreserveExpiry = true // if doc has expiry, we should preserve this
 
-	updatedXattr := map[string][]byte{base.SyncXattrName: rawSyncXattr, base.GlobalXattrName: globalXattr}
+	updatedXattr := map[string][]byte{
+		base.SyncXattrName:   rawSyncXattr,
+		base.GlobalXattrName: globalXattr,
+		base.MouXattrName:    rawMouXattr,
+	}
 	_, err = c.dataStore.UpdateXattrs(ctx, docID, 0, cas, updatedXattr, opts)
 	return err
 }

--- a/db/crud.go
+++ b/db/crud.go
@@ -1085,7 +1085,7 @@ func (c *DatabaseCollectionWithUser) MigrateAttachmentMetadata(ctx context.Conte
 	}
 	rawMouXattr, err := base.JSONMarshal(metadataOnlyUpdate)
 	if err != nil {
-		return base.RedactErrorf("Failed to Marshal _mou when attempting to migrate sync data attachments to global xattr with id: %s. Error: %v", base.UD(docID), err)
+		return base.RedactErrorf("Failed to marshal _mou when attempting to migrate sync data attachments to global xattr with id: %s. Error: %v", base.UD(docID), err)
 	}
 
 	// build macro expansion for sync data. This will avoid the update to xattrs causing an extra import event (i.e. sync cas will be == to doc cas)

--- a/xdcr/xdcr_test.go
+++ b/xdcr/xdcr_test.go
@@ -686,7 +686,7 @@ func TestXDCRBeforeAttachmentMigration(t *testing.T) {
 	sd := db.GetRawSyncXattr(t, srcDs, docID)
 	require.NoError(t, srcColl.MigrateAttachmentMetadata(srcColl.AddCollectionContext(srcCtx), docID, fromCas, &sd))
 
-	// Since metadata migration writes _mou, the document will be processed but Wait for the migration's _globalSync xattr update to replicate to the target
+	// Since metadata migration writes _mou, the document will be processed. Wait for the migration's _globalSync xattr update to replicate to the target.
 	requireWaitForXDCRDocsProcessed(t, xdcr, 4)
 
 	stats, err := xdcr.Stats(ctx)

--- a/xdcr/xdcr_test.go
+++ b/xdcr/xdcr_test.go
@@ -630,7 +630,7 @@ func TestReplicateXattrs(t *testing.T) {
 func TestXDCRBeforeAttachmentMigration(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
-	srcBucket, srcDs, dstBucket, dstDs := getTwoBucketDataStores(t)
+	srcBucket, srcDs, dstBucket, _ := getTwoBucketDataStores(t)
 	ctx := base.TestCtx(t)
 
 	srcDB, srcCtx := db.CreateTestDatabase(t, base.NoCloseClone(srcBucket), db.DatabaseContextOptions{EnableXattr: true, Scopes: db.GetScopesOptions(t, srcBucket, 1)})
@@ -675,7 +675,7 @@ func TestXDCRBeforeAttachmentMigration(t *testing.T) {
 	requireWaitForXDCRDocsWritten(t, xdcr, 2)
 
 	// Verify doc is present and attachment wasn't found - via REST-like call Get1xRevAndChannels
-	b, _, _, _, _, dstPreMigrateSeq, dstPreMigrateRev, _, err := dstColl.Get1xRevAndChannels(dstCtx, docID, "", false)
+	b, _, _, _, _, _, _, _, err := dstColl.Get1xRevAndChannels(dstCtx, docID, "", false)
 	require.NoError(t, err)
 	attsLocal := db.GetAttachmentsFromInlineBody(t, b)
 	require.Len(t, attsLocal, 0)
@@ -686,28 +686,12 @@ func TestXDCRBeforeAttachmentMigration(t *testing.T) {
 	sd := db.GetRawSyncXattr(t, srcDs, docID)
 	require.NoError(t, srcColl.MigrateAttachmentMetadata(srcColl.AddCollectionContext(srcCtx), docID, fromCas, &sd))
 
-	// Wait for the migration's _globalSync xattr update to replicate to the target
-	requireWaitForXDCRDocsWritten(t, xdcr, 3)
+	// Since metadata migration writes _mou, the document will be processed but Wait for the migration's _globalSync xattr update to replicate to the target
+	requireWaitForXDCRDocsProcessed(t, xdcr, 4)
 
-	// check that we can fetch the attachment now
-	// Due to CBG-4878, this writes a new revision since _vv.ver > _sync.rev.ver even though the body didn't change.
-	// This isn't ideal and it would be better to not have this issue a new revision.
-	//
-	// Note: The versions remaining the same means that clients that observe the missing attachment never get it until a subsequent doc update
-	// The benefit of doing this though, is that every other client (who has had this attachment) doesn't get a no-op document update post-migration.
-	b, _, _, _, _, dstPostMigrateSeq, dstPostMigrateRev, _, err := dstColl.Get1xRevAndChannels(dstCtx, docID, "", false)
+	stats, err := xdcr.Stats(ctx)
 	require.NoError(t, err)
-	atts := db.GetAttachmentsFromInlineBody(t, b)
-	require.Len(t, atts, 1)
-	assert.Contains(t, atts, attName)
-
-	// Also assert _globalSync.attachments_meta present on target
-	attachmentsAfter := db.GetRawGlobalSyncAttachments(t, dstDs, docID)
-	require.Contains(t, attachmentsAfter, attName)
-
-	// CBG-4878 causes these to not be equal but equality would be better.
-	assert.NotEqual(t, dstPreMigrateSeq, dstPostMigrateSeq)
-	assert.NotEqual(t, dstPreMigrateRev, dstPostMigrateRev)
+	require.Equal(t, uint64(2), stats.DocsWritten)
 }
 
 // TestVVMultiActor verifies that updates by multiple actors (updates to different clusters/buckets) are properly


### PR DESCRIPTION
CBG-4878 Set _mou from attachment migration

Running attachment migration moves _sync.attachments to _globalSync.attachments, so this is a metadata only update. This means this mutation will not be replicated by XDCR.


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/105/ (failures unrelated to change)
