### PR TITLE
CBG-4839 allow vBucketsMaxCas to not be populated

### DIFF
--- a/base/collection.go
+++ b/base/collection.go
@@ -361,9 +361,9 @@ func (b *GocbV2Bucket) GetCCVSettings(ctx context.Context) (ccvEnabled bool, max
 	highCAS := make(map[VBNo]uint64, numVBuckets)
 	// we'd always expect a CAS value per vbucket if CCV is enabled and has propagated correctly
 	// except after a bucket flushed in Server < 7.6.8 see MB-64705
-	// Treating this as ECCV=false, which will mean imports will all get tagged with bucket SourceID.
+	// Treating this as ECCV=true with startingCas=0, which will mean imports will all get tagged with bucket SourceID.
 	if len(response.VBucketsMaxCas) != int(numVBuckets) {
-		InfofCtx(ctx, KeyBucket, "Bucket %q has enableCrossClusterVersioning set but unexpected number of vbucket CAS values - expected %d, got %+v. Running with enableCrossClusterVersioning=false.", MD(b.GetName()), numVBuckets, response.VBucketsMaxCas)
+		InfofCtx(ctx, KeyBucket, "Bucket %q has enableCrossClusterVersioning=true but unexpected number of vbucket CAS values - expected %d, got %+v. Treating all imports as originating on this Couchbase Server cluster.", MD(b.GetName()), numVBuckets, response.VBucketsMaxCas)
 		for i := range numVBuckets {
 			highCAS[VBNo(i)] = 0
 		}

--- a/db/database.go
+++ b/db/database.go
@@ -1681,7 +1681,11 @@ func (db *DatabaseContext) GetVersionPruningWindow(ctx context.Context, forceRef
 func (db *DatabaseContext) updateCCVSettings(ctx context.Context) error {
 	cbStore, ok := base.AsCouchbaseBucketStore(db.Bucket)
 	if !ok {
-		db.CachedCCVEnabled.Store(false)
+		// for rosmar, ECCV is always enabled, mark starting cas as 0
+		db.CachedCCVEnabled.Store(true)
+		for vbNo := range db.numVBuckets {
+			db.CachedCCVStartingCas.Store(base.VBNo(vbNo), 0)
+		}
 		return nil
 	}
 

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -119,9 +119,6 @@ func TestFeedImport(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			if base.UnitTestUrlIsWalrus() {
-				t.Skip("rosmar does not support vBuckets and unknownSource")
-			}
 			docID := SafeDocumentName(t, t.Name())
 			db.CachedCCVEnabled.Store(testCase.eccv)
 			for vBucket := range db.numVBuckets {
@@ -282,9 +279,6 @@ func TestOnDemandImport(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			if base.UnitTestUrlIsWalrus() {
-				t.Skip("rosmar does not support vBuckets and unknownSource")
-			}
 			docID := SafeDocumentName(t, t.Name())
 			db.CachedCCVEnabled.Store(testCase.eccv)
 			for vBucket := range db.numVBuckets {


### PR DESCRIPTION
CBG-4839 allow vBucketsMaxCas to not be populated

At least https://jira.issues.couchbase.com/browse/MB-64705 can cause this issue, but I think there might be other cases, since it seems non deterministic in the jenkins jobs which don't have -shuffle=on. That might be because of the way the bucket pool works, not picking up the same tests each time. Most tests with SG_TEST_USE_GSI=true do not flush buckets, but we do test /_flush endpoint.

The downsides of ignoring ECCV are just that Unknown Source will not be set for documents imported before ECCV is enabled, which is better than the database not being allowed to search.

Currently, there is no version of Couchbase Server (needs 7.6.8, not yet released) that will allow recovery to see `vBucketsMaxCas` after a bucket has been flushed.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/114/
