### PR TITLE
CBG-4853: Cut `release/4.0.0` and move `main` to 4.1

### DIFF
--- a/base/version.go
+++ b/base/version.go
@@ -20,7 +20,7 @@ const (
 	ProductName = "Couchbase Sync Gateway"
 
 	ProductAPIVersionMajor = "4"
-	ProductAPIVersionMinor = "0"
+	ProductAPIVersionMinor = "1"
 	ProductAPIVersion      = ProductAPIVersionMajor + "." + ProductAPIVersionMinor
 )
 

--- a/docs/api/admin-capella.yaml
+++ b/docs/api/admin-capella.yaml
@@ -10,7 +10,7 @@ openapi: 3.0.3
 info:
   title: App Services Admin API
   description: 'App Services manages access and synchronization between Couchbase Lite and Couchbase Capella'
-  version: '4.0'
+  version: '4.1'
   license:
     name: Business Source License 1.1 (BSL)
     url: 'https://github.com/couchbase/sync_gateway/blob/master/LICENSE'

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -13,7 +13,7 @@ info:
     # Introduction
 
     The Sync Gateway Admin REST API is used to administer user accounts and roles, and to run administrative tasks in superuser mode.
-  version: '4.0'
+  version: '4.1'
   license:
     name: Business Source License 1.1 (BSL)
     url: 'https://github.com/couchbase/sync_gateway/blob/master/LICENSE'

--- a/docs/api/diagnostic.yaml
+++ b/docs/api/diagnostic.yaml
@@ -10,7 +10,7 @@ openapi: 3.0.3
 info:
   title: Sync Gateway
   description: Sync Gateway manages access and synchronization between Couchbase Lite and Couchbase Server
-  version: '4.0'
+  version: '4.1'
   license:
     name: Business Source License 1.1 (BSL)
     url: 'https://github.com/couchbase/sync_gateway/blob/master/LICENSE'

--- a/docs/api/metric-capella.yaml
+++ b/docs/api/metric-capella.yaml
@@ -10,7 +10,7 @@ openapi: 3.0.3
 info:
   title: App Services Metrics API
   description: 'App Services manages access and synchronization between Couchbase Lite and Couchbase Capella'
-  version: '4.0'
+  version: '4.1'
   license:
     name: Business Source License 1.1 (BSL)
     url: 'https://github.com/couchbase/sync_gateway/blob/master/LICENSE'

--- a/docs/api/metric.yaml
+++ b/docs/api/metric.yaml
@@ -14,7 +14,7 @@ info:
 
     Sync Gateway manages access and synchronization between Couchbase Lite and Couchbase Server.
     The Sync Gateway Metrics REST API returns Sync Gateway metrics, in JSON or Prometheus-compatible formats, for performance monitoring and diagnostic purposes.
-  version: '4.0'
+  version: '4.1'
   license:
     name: Business Source License 1.1 (BSL)
     url: 'https://github.com/couchbase/sync_gateway/blob/master/LICENSE'

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -14,7 +14,7 @@ info:
 
     Sync Gateway manages access and synchronization between Couchbase Lite and Couchbase Server.
     The Sync Gateway Public REST API is used for client replication.
-  version: '4.0'
+  version: '4.1'
   license:
     name: Business Source License 1.1 (BSL)
     url: 'https://github.com/couchbase/sync_gateway/blob/master/LICENSE'

--- a/manifest/4.0.xml
+++ b/manifest/4.0.xml
@@ -18,13 +18,13 @@ licenses/APL2.txt.
   <!-- Build Scripts (required on CI servers) -->
   <project name="product-texts" path="product-texts" remote="couchbase"/>
   <project name="build" path="cbbuild" remote="couchbase" revision="b1dc2359603ab411ce0788854ea879ce804c9055">
-    <annotation name="VERSION" value="4.1.0"     keep="true"/>
+    <annotation name="VERSION" value="4.0.0"     keep="true"/>
     <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
     <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
   </project>
 
 
   <!-- Sync Gateway -->
-   <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="main" />
+   <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="release/4.0.0" />
 
 </manifest>

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -2,13 +2,13 @@
     "product": "sync_gateway",
     "manifests": {
         "manifest/default.xml": {
-            "release": "4.0.0",
+            "release": "4.1.0",
             "release_name": "Couchbase Sync Gateway",
             "production": true,
             "interval": 30,
             "go_version": "1.24.4",
             "trigger_blackduck": true,
-            "start_build": 123
+            "start_build": 1
         },
         "manifest/1.4.0.xml": {
             "do-build": false,
@@ -726,6 +726,15 @@
             "go_version": "1.24.4",
             "trigger_blackduck": true,
             "start_build": 285
+        },
+        "manifest/4.0.xml": {
+            "release": "4.0.0",
+            "release_name": "Couchbase Sync Gateway 4.0.0",
+            "production": true,
+            "interval": 120,
+            "go_version": "1.24.4",
+            "trigger_blackduck": true,
+            "start_build": 243
         },
         "manifest/dev.xml": {
             "do-build": false,


### PR DESCRIPTION
CBG-4853

- Cut 4.0.0 release branch and bump `main` to next minor version