### PR TITLE
[4.0.0 backport] CBG-4886: delta sync for legacy rev mutations over ISGR will not send deltas

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -1112,13 +1112,11 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 		newDoc.HLV = incomingHLV
 	}
 
-	isBlipRevTreeProperty := false
 	// if the client is SGW and there are no legacy revs being sent (i.e. doc is not a pre-upgraded doc) check the rev tree property
 	if bh.clientType == BLIPClientTypeSGR2 && len(legacyRevList) == 0 {
 		revTree, ok := rq.Properties[RevMessageTreeHistory]
 		if ok {
 			legacyRevList = append(legacyRevList, strings.Split(revTree, ",")...)
-			isBlipRevTreeProperty = true
 			if len(legacyRevList) > 0 {
 				newDoc.RevID = legacyRevList[0]
 			}
@@ -1352,7 +1350,7 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 			ExistingDoc:                    rawBucketDoc,
 			NewDocHLV:                      incomingHLV,
 			ConflictResolver:               bh.conflictResolver.hlvConflictResolver,
-			AlignRevTrees:                  isBlipRevTreeProperty,
+			ISGRWrite:                      bh.clientType == BLIPClientTypeSGR2,
 		}
 		_, _, _, err = bh.collection.PutExistingCurrentVersion(bh.loggingCtx, opts)
 	} else {

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -597,11 +597,12 @@ func (bsc *BlipSyncContext) sendDelta(ctx context.Context, sender *blip.Sender, 
 	properties := blipRevMessageProperties(history, revDelta.ToDeleted, seq, "", revTreeProperty)
 	properties[RevMessageDeltaSrc] = deltaSrcRevID
 
-	base.DebugfCtx(ctx, base.KeySync, "Sending rev %q %s as delta. DeltaSrc:%s", base.UD(docID), revDelta.ToRevID, deltaSrcRevID)
 	if bsc.useHLV() {
+		base.DebugfCtx(ctx, base.KeySync, "Sending rev %q %s as delta. DeltaSrc:%s", base.UD(docID), revDelta.ToCV, deltaSrcRevID)
 		return bsc.sendRevisionWithProperties(ctx, sender, docID, revDelta.ToCV, collectionIdx, revDelta.DeltaBytes, revDelta.AttachmentStorageMeta,
 			properties, seq, resendFullRevisionFunc)
 	} else {
+		base.DebugfCtx(ctx, base.KeySync, "Sending rev %q %s as delta. DeltaSrc:%s", base.UD(docID), revDelta.ToRevID, deltaSrcRevID)
 		return bsc.sendRevisionWithProperties(ctx, sender, docID, revDelta.ToRevID, collectionIdx, revDelta.DeltaBytes, revDelta.AttachmentStorageMeta,
 			properties, seq, resendFullRevisionFunc)
 	}
@@ -872,7 +873,7 @@ func (bsc *BlipSyncContext) getKnownRevs(ctx context.Context, docID string, know
 	// revtree clients. For HLV clients, use the cv as deltaSrc
 	if bsc.useDeltas && len(knownRevsArray) > 0 {
 		if revID, ok := knownRevsArray[0].(string); ok {
-			if bsc.useHLV() {
+			if bsc.useHLV() && !base.IsRevTreeID(revID) {
 				// extract cv from the known revs array
 				msgHLV, _, deltaSrcErr := extractHLVFromBlipString(revID)
 				if deltaSrcErr != nil {

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -727,6 +727,13 @@ func (value *revCacheValue) load(ctx context.Context, backingStore RevisionCache
 			if hlv != nil {
 				value.cv = *hlv.ExtractCurrentVersionFromHLV()
 				value.hlvHistory = hlv.ToHistoryForHLV()
+			} else if value.err == nil {
+				// if hlv is nil its a legacy rev, we need to create a CV from the revID
+				encodedCV, err := LegacyRevToRevTreeEncodedVersion(value.revID)
+				if err != nil {
+					return docRev, false, err
+				}
+				value.cv = encodedCV
 			}
 		}
 	}

--- a/rest/replicatortest/replicator_test_legacy_rev_test.go
+++ b/rest/replicatortest/replicator_test_legacy_rev_test.go
@@ -1094,3 +1094,184 @@ func TestActiveReplicatorConflictPreUpgradedVersionOneSide(t *testing.T) {
 		})
 	}
 }
+
+func TestActiveReplicatorDeltaSyncWhenBothSidesLegacy(t *testing.T) {
+	base.RequireNumTestBuckets(t, 2)
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+
+	if !base.IsEnterpriseEdition() {
+		t.Skip("Delta sync only supported in EE")
+	}
+
+	const username = "alice"
+
+	// Passive (SGW2 in diagram above)
+	rt2 := rest.NewRestTester(t,
+		&rest.RestTesterConfig{
+			SyncFn: channels.DocChannelsSyncFunction,
+			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+				Name: "passivedb",
+				DeltaSync: &rest.DeltaSyncConfig{
+					Enabled: base.Ptr(true),
+				},
+			}},
+		})
+	defer rt2.Close()
+
+	rt2.CreateUser(username, []string{username})
+
+	// Active (SGW1 in diagram above)
+	rt1 := rest.NewRestTester(t,
+		&rest.RestTesterConfig{
+			SyncFn: channels.DocChannelsSyncFunction,
+			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+				Name: "activedb",
+				DeltaSync: &rest.DeltaSyncConfig{
+					Enabled: base.Ptr(true),
+				},
+			}},
+		})
+	defer rt1.Close()
+	ctx1 := rt1.Context()
+
+	docIDToPush := rest.SafeDocumentName(t, t.Name()+"_push")
+
+	// create doc on rt1 with one revision
+	bodyRT1 := db.Body{"channels": []string{username}, "source": "rt1"}
+	rt1InitDoc := rt1.CreateDocNoHLV(docIDToPush, bodyRT1)
+	legacyInitRevRt1 := rt1InitDoc.GetRevTreeID()
+	// create another rev to ensure we have a rev to delta from
+	bodyRT1 = db.Body{db.BodyRev: legacyInitRevRt1, "channels": []string{username}, "source": "rt1"}
+	rt1InitDoc = rt1.CreateDocNoHLV(docIDToPush, bodyRT1)
+	legacyRevRt1 := rt1InitDoc.GetRevTreeID()
+
+	// create rev on rt2 that will resolve to same revID as rev one above simulating the following:
+	// 1. doc created on rt1, pushed to rt2
+	// 2. doc updated on rt1 to create rev2, but upgrade happens before being pushed to rt2
+	// 3. doc is pushed post upgrade to rt2 and the delta from rev1 to rev2 is sent
+	bodyRT2 := db.Body{"channels": []string{username}, "source": "rt1"}
+	rt2InitDoc := rt2.CreateDocNoHLV(docIDToPush, bodyRT2)
+	legacyRevRt2 := rt2InitDoc.GetRevTreeID()
+
+	require.Equal(t, legacyInitRevRt1, legacyRevRt2)
+
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	require.NoError(t, err)
+	replicationStats, err := stats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
+
+	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+		ID:          t.Name(),
+		Direction:   db.ActiveReplicatorTypePush,
+		RemoteDBURL: userDBURL(rt2, username),
+		ActiveDB: &db.Database{
+			DatabaseContext: rt1.GetDatabase(),
+		},
+		ChangesBatchSize:    200,
+		Continuous:          true,
+		ReplicationStatsMap: replicationStats,
+		CollectionsEnabled:  !rt1.GetDatabase().OnlyDefaultCollection(),
+		DeltasEnabled:       true,
+	})
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, ar.Stop())
+	}()
+
+	// Start the replicator
+	require.NoError(t, ar.Start(ctx1))
+
+	rt2.WaitForLegacyRev(docIDToPush, legacyRevRt1, []byte(`{"source":"rt1","channels":["alice"]}`))
+
+	base.RequireWaitForStat(t, func() int64 {
+		return replicationStats.PushDeltaSentCount.Value()
+	}, 1)
+}
+
+func TestDeltaSyncWhenOneSideHasEncodedCV(t *testing.T) {
+	base.RequireNumTestBuckets(t, 2)
+
+	if !base.IsEnterpriseEdition() {
+		t.Skip("Delta sync only supported in EE")
+	}
+
+	const username = "alice"
+
+	// Passive (SGW2 in diagram above)
+	rt2 := rest.NewRestTester(t,
+		&rest.RestTesterConfig{
+			SyncFn: channels.DocChannelsSyncFunction,
+			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+				Name: "passivedb",
+				DeltaSync: &rest.DeltaSyncConfig{
+					Enabled: base.Ptr(true),
+				},
+			}},
+		})
+	defer rt2.Close()
+
+	rt2.CreateUser(username, []string{username})
+
+	// Active (SGW1 in diagram above)
+	rt1 := rest.NewRestTester(t,
+		&rest.RestTesterConfig{
+			SyncFn: channels.DocChannelsSyncFunction,
+			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+				Name: "activedb",
+				DeltaSync: &rest.DeltaSyncConfig{
+					Enabled: base.Ptr(true),
+				},
+			}},
+		})
+	defer rt1.Close()
+	ctx1 := rt1.Context()
+
+	docIDToPush := rest.SafeDocumentName(t, t.Name()+"_push")
+
+	// create doc on rt1 with one revision
+	bodyRT1 := db.Body{"channels": []string{username}, "source": "rt1"}
+	rt1InitDoc := rt1.CreateDocNoHLV(docIDToPush, bodyRT1)
+	legacyInitRevRt1 := rt1InitDoc.GetRevTreeID()
+
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	require.NoError(t, err)
+	replicationStats, err := stats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
+
+	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+		ID:          t.Name(),
+		Direction:   db.ActiveReplicatorTypePush,
+		RemoteDBURL: userDBURL(rt2, username),
+		ActiveDB: &db.Database{
+			DatabaseContext: rt1.GetDatabase(),
+		},
+		ChangesBatchSize:    200,
+		Continuous:          true,
+		ReplicationStatsMap: replicationStats,
+		CollectionsEnabled:  !rt1.GetDatabase().OnlyDefaultCollection(),
+		DeltasEnabled:       true,
+	})
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, ar.Stop())
+	}()
+
+	// Start the replicator
+	require.NoError(t, ar.Start(ctx1))
+
+	rt2.WaitForLegacyRev(docIDToPush, legacyInitRevRt1, []byte(`{"source":"rt1","channels":["alice"]}`))
+
+	// flush revision cache to remove old reference to rev 1 in rev cache
+	rt1.GetDatabase().FlushRevisionCacheForTest()
+
+	// update doc on rt1 to create a second revision with HLV
+	// This should:
+	// 1. update doc on rt1 to give HLV based of rt1 sourceID
+	// 2. push doc to rt2 with delta from rev1 to rev2
+	upgradeVersion := rt1.UpdateDoc(docIDToPush, db.DocVersion{RevTreeID: legacyInitRevRt1}, `{"channels": ["alice"], "source": "rt1-updated"}`)
+	rt1.WaitForVersion(docIDToPush, upgradeVersion)
+
+	base.RequireWaitForStat(t, func() int64 {
+		return replicationStats.PushDeltaSentCount.Value()
+	}, 1)
+}


### PR DESCRIPTION
CBG-4886

Backports: https://github.com/couchbase/sync_gateway/pull/7780

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/132/
