### PR TITLE
CBG-5190: Add node poller for shardedDCPFeedListener

### DIFF
--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -566,7 +566,7 @@ func registerHeartbeatListener(ctx context.Context, heartbeater Heartbeater, cbg
 		return nil, errors.New("Unable to register heartbeat listener with nil manager, cfg or heartbeater")
 	}
 
-	// Register listener for import, uses cfg and manager to manage set of participating nodes
+	// Register listener for shardedDCP, uses cfg and manager to manage set of participating nodes
 	shardedDCPHeartbeatListener, err := NewShardedDCPHeartbeatListener(ctx, cbgtContext)
 	if err != nil {
 		return nil, err
@@ -582,7 +582,7 @@ func registerHeartbeatListener(ctx context.Context, heartbeater Heartbeater, cbg
 
 // shardedDCPHeartbeatListener uses cbgt's cfg to manage node list
 type shardedDCPHeartbeatListener struct {
-	cfg        cbgt.Cfg      // cbgt cfg being used for import
+	cfg        cbgt.Cfg      // cbgt cfg being used for shardedDCP
 	mgr        *cbgt.Manager // cbgt manager associated with this import node
 	ctx        *CbgtContext
 	terminator chan struct{} // close cfg subscription on close

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -37,13 +37,6 @@ const (
 	CBGTIndexTypeSyncGatewayResync    = "syncGateway-resync"
 )
 
-type ShardedDCPFeedType string
-
-const (
-	ShardedDCPFeedTypeImport ShardedDCPFeedType = "import"
-	ShardedDCPFeedTypeResync ShardedDCPFeedType = "resync"
-)
-
 // firstVersionToSupportCollections represents the earliest Sync Gateway release that supports collections.
 var firstVersionToSupportCollections = &ComparableBuildVersion{
 	epoch: 0,
@@ -63,7 +56,7 @@ type CbgtContext struct {
 	Manager           *cbgt.Manager                // Manager is main entry point for initialization, registering indexes
 	Cfg               cbgt.Cfg                     // Cfg manages storage of the current pindex set and node assignment
 	heartbeater       Heartbeater                  // Heartbeater used for failed node detection
-	heartbeatListener *shardedDCPHeartbeatListener // Listener subscribed to failed node alerts from heartbeater
+	heartbeatListener *shardedDCPHeartBeatListener // Listener subscribed to failed node alerts from heartbeater
 	eventHandlers     *sgMgrEventHandlers          // Event handler callbacks
 	dbName            string                       // Database name
 	sourceName        string                       // cbgt source name. Store on CbgtContext for access during teardown
@@ -183,14 +176,14 @@ func StartShardedDCPFeed(ctx context.Context, opts ShardedDCPOptions) (*CbgtCont
 
 // GenerateCBGTIndexName creates an index name for cbgt using the database name suitable for the distributed DCP feed.
 // Given a dbName and feedType, generate a unique and length-constrained index name for CBGT to use as part of their DCP name.
-func GenerateCBGTIndexName(dbName string, feedType ShardedDCPFeedType) (string, error) {
+func GenerateCBGTIndexName(dbName string, feedType string) (string, error) {
 	// Index names *must* start with a letter, so we'll prepend 'db' before the per-database checksum (which starts with '0x')
 	// Don't use Crc32cHashString here because this is intentionally non zero padded to match
 	// existing values.
 	var indexName string
-	if feedType == ShardedDCPFeedTypeImport {
+	if feedType == CBGTIndexTypeSyncGatewayImport {
 		indexName = fmt.Sprintf("db0x%x_index", Crc32cHash([]byte(dbName)))
-	} else if feedType == ShardedDCPFeedTypeResync {
+	} else if feedType == CBGTIndexTypeSyncGatewayResync {
 		indexName = fmt.Sprintf("db0x%x_resync_index", Crc32cHash([]byte(dbName)))
 	} else {
 		return "", fmt.Errorf("unknown index type %s", feedType)
@@ -366,7 +359,7 @@ func initCBGTManager(ctx context.Context, bucket Bucket, spec BucketSpec, cfgSG 
 	//   avoids file system usage, in conjunction with managerLoadDataDir=false in options.
 	dataDir := ""
 
-	eventHandlersCtx, eventHandlersCancel := context.WithCancelCause(ctx)
+	eventHandlersCtx, eventHandlersCancel := context.WithCancel(ctx)
 	eventHandlers := &sgMgrEventHandlers{ctx: eventHandlersCtx, ctxCancel: eventHandlersCancel}
 
 	// Specify one feed per pindex
@@ -513,7 +506,7 @@ func getMinNodeVersion(cfg cbgt.Cfg) (*ComparableBuildVersion, error) {
 // Stop unregisters the listener from the heartbeater, and stops it and associated handlers.
 func (c *CbgtContext) Stop(ctx context.Context) {
 	if c.eventHandlers != nil {
-		c.eventHandlers.ctxCancel(errors.New("CbgtContext is stopping, cancelling event handlers"))
+		c.eventHandlers.ctxCancel()
 	}
 
 	if c.heartbeatListener != nil {
@@ -544,7 +537,7 @@ func (c *CbgtContext) RemoveFeedCredentials(dbName string) {
 }
 
 // Format of dest key for retrieval of import dest from cbgtDestFactories
-func DestKey(dbName string, scope string, collections []string, feedType ShardedDCPFeedType) string {
+func DestKey(dbName string, scope string, collections []string, feedType string) string {
 	sort.Strings(collections)
 	collectionString := ""
 	onlyDefault := true
@@ -556,53 +549,54 @@ func DestKey(dbName string, scope string, collections []string, feedType Sharded
 	}
 	var destKey string
 	// format for _default._default
-	if (collectionString == "" || (scope == DefaultScope && onlyDefault)) && feedType == ShardedDCPFeedTypeImport {
+	if (collectionString == "" || (scope == DefaultScope && onlyDefault)) && feedType == CBGTIndexTypeSyncGatewayImport {
 		destKey = fmt.Sprintf("%s_import", dbName)
-	} else if feedType == ShardedDCPFeedTypeImport {
+	} else if feedType == CBGTIndexTypeSyncGatewayImport {
 		destKey = fmt.Sprintf("%s_import_%x", dbName, sha256.Sum256([]byte(collectionString)))
-	} else if feedType == ShardedDCPFeedTypeResync {
+	} else {
+
 		destKey = fmt.Sprintf("%s_resync_%x", dbName, sha256.Sum256([]byte(collectionString)))
 	}
 	return destKey
 }
 
-func registerHeartbeatListener(ctx context.Context, heartbeater Heartbeater, cbgtContext *CbgtContext) (*shardedDCPHeartbeatListener, error) {
+func registerHeartbeatListener(ctx context.Context, heartbeater Heartbeater, cbgtContext *CbgtContext) (*shardedDCPHeartBeatListener, error) {
 
 	if cbgtContext == nil || cbgtContext.Manager == nil || cbgtContext.Cfg == nil || heartbeater == nil {
-		return nil, errors.New("Unable to register heartbeat listener with nil manager, cfg or heartbeater")
+		return nil, errors.New("Unable to register import heartbeat listener with nil manager, cfg or heartbeater")
 	}
 
-	// Register listener for shardedDCP, uses cfg and manager to manage set of participating nodes
-	shardedDCPHeartbeatListener, err := NewShardedDCPHeartbeatListener(ctx, cbgtContext)
+	// Register listener for import, uses cfg and manager to manage set of participating nodes
+	shardedDCPHeartBeatListener, err := NewShardedDCPHeartBeatListener(ctx, cbgtContext)
 	if err != nil {
 		return nil, err
 	}
 
-	err = heartbeater.RegisterListener(shardedDCPHeartbeatListener)
+	err = heartbeater.RegisterListener(shardedDCPHeartBeatListener)
 	if err != nil {
 		return nil, err
 	}
 
-	return shardedDCPHeartbeatListener, nil
+	return shardedDCPHeartBeatListener, nil
 }
 
-// shardedDCPHeartbeatListener uses cbgt's cfg to manage node list
-type shardedDCPHeartbeatListener struct {
-	cfg        cbgt.Cfg      // cbgt cfg being used for shardedDCP
-	mgr        *cbgt.Manager // cbgt manager associated with this node
+// shardedDCPHeartBeatListener uses cbgt's cfg to manage node list
+type shardedDCPHeartBeatListener struct {
+	cfg        cbgt.Cfg      // cbgt cfg being used for import
+	mgr        *cbgt.Manager // cbgt manager associated with this import node
 	ctx        *CbgtContext
 	terminator chan struct{} // close cfg subscription on close
 	nodeIDs    []string      // Set of nodes from the latest retrieval
 	lock       sync.RWMutex  // lock for nodeIDs access
 }
 
-func NewShardedDCPHeartbeatListener(ctx context.Context, cbgtCtx *CbgtContext) (*shardedDCPHeartbeatListener, error) {
+func NewShardedDCPHeartBeatListener(ctx context.Context, cbgtCtx *CbgtContext) (*shardedDCPHeartBeatListener, error) {
 
 	if cbgtCtx == nil {
-		return nil, errors.New("cbgt ctx must not be nil for shardedDCPHeartbeatListener")
+		return nil, errors.New("ctx must not be nil for ImportHeartbeatListener")
 	}
 
-	listener := &shardedDCPHeartbeatListener{
+	listener := &shardedDCPHeartBeatListener{
 		ctx:        cbgtCtx,
 		mgr:        cbgtCtx.Manager,
 		cfg:        cbgtCtx.Cfg,
@@ -624,12 +618,12 @@ func NewShardedDCPHeartbeatListener(ctx context.Context, cbgtCtx *CbgtContext) (
 	return listener, nil
 }
 
-func (l *shardedDCPHeartbeatListener) Name() string {
-	return "shardedDCPHeartbeatListener"
+func (l *shardedDCPHeartBeatListener) Name() string {
+	return "importListener"
 }
 
 // When we detect other nodes have stopped pushing heartbeats, use manager to remove from cfg
-func (l *shardedDCPHeartbeatListener) StaleHeartbeatDetected(ctx context.Context, nodeUUID string) {
+func (l *shardedDCPHeartBeatListener) StaleHeartbeatDetected(ctx context.Context, nodeUUID string) {
 
 	InfofCtx(ctx, KeyCluster, "StaleHeartbeatDetected by import listener for node: %v", nodeUUID)
 	err := cbgt.UnregisterNodes(l.cfg, l.mgr.Version(), []string{nodeUUID})
@@ -640,7 +634,7 @@ func (l *shardedDCPHeartbeatListener) StaleHeartbeatDetected(ctx context.Context
 
 // subscribeNodeChanges registers with the manager's cfg implementation for notifications on changes to the
 // NODE_DEFS_KNOWN key.  When notified, refreshes the handlers nodeIDs.
-func (l *shardedDCPHeartbeatListener) subscribeNodeChanges(ctx context.Context) error {
+func (l *shardedDCPHeartBeatListener) subscribeNodeChanges(ctx context.Context) error {
 
 	cfgEvents := make(chan cbgt.CfgEvent)
 	err := l.cfg.Subscribe(cbgt.CfgNodeDefsKey(cbgt.NODE_DEFS_KNOWN), cfgEvents)
@@ -677,7 +671,7 @@ func (l *shardedDCPHeartbeatListener) subscribeNodeChanges(ctx context.Context) 
 	return nil
 }
 
-func (l *shardedDCPHeartbeatListener) reloadNodes() (localNodePresent bool, err error) {
+func (l *shardedDCPHeartBeatListener) reloadNodes() (localNodePresent bool, err error) {
 
 	nodeUUIDs := make([]string, 0)
 	nodeDefTypes := []string{cbgt.NODE_DEFS_KNOWN, cbgt.NODE_DEFS_WANTED}
@@ -703,7 +697,7 @@ func (l *shardedDCPHeartbeatListener) reloadNodes() (localNodePresent bool, err 
 }
 
 // GetNodes returns a copy of the in-memory node set
-func (l *shardedDCPHeartbeatListener) GetNodes() ([]string, error) {
+func (l *shardedDCPHeartBeatListener) GetNodes() ([]string, error) {
 
 	l.lock.RLock()
 	nodeIDsCopy := make([]string, len(l.nodeIDs))
@@ -712,7 +706,7 @@ func (l *shardedDCPHeartbeatListener) GetNodes() ([]string, error) {
 	return nodeIDsCopy, nil
 }
 
-func (l *shardedDCPHeartbeatListener) Stop() {
+func (l *shardedDCPHeartBeatListener) Stop() {
 	close(l.terminator)
 }
 
@@ -763,7 +757,7 @@ func GetDefaultImportPartitions(serverless bool) uint16 {
 
 type sgMgrEventHandlers struct {
 	ctx       context.Context
-	ctxCancel context.CancelCauseFunc
+	ctxCancel context.CancelFunc
 	manager   *cbgt.Manager
 }
 

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/couchbase/cbgt"
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -72,17 +73,19 @@ type CbgtContext struct {
 
 // ShardedDCPOptions contains options for starting a DCP feed for cbgt.
 type ShardedDCPOptions struct {
-	Bucket            Bucket          // bucket to target
-	Cfg               cbgt.Cfg        // cbgt cfg used to coordinate cbgt documents
-	Collections       CollectionNames // collection names to target
-	DBName            string          // database name is used to look up credentials
-	DestKey           string          // key used in indexParams for this feed, used to look up the feed destination in cbgtDestFactories
-	Heartbeater       Heartbeater     // heartbeater to use to find nodes
-	IndexName         string          // cbgt.Manger.IndexName, used to uniquely identify the index
-	IndexType         string          // cbgt.Manager.IndexType, matches name used by cbgt.RegisterPIndexImplType
-	NumPartitions     uint16          // number of cbgt partitions to use, if 0 will default to DefaultImportPartitions
-	PreviousIndexName string          // previous index name. If specified, marks IndexName as as a replacement for this name.
-	UUID              string          // database uuid, used to uniquely identify nodes
+	Bucket            Bucket             // bucket to target
+	Cfg               cbgt.Cfg           // cbgt cfg used to coordinate cbgt documents
+	Collections       CollectionNames    // collection names to target
+	DBName            string             // database name is used to look up credentials
+	DestKey           string             // key used in indexParams for this feed, used to look up the feed destination in cbgtDestFactories
+	Heartbeater       Heartbeater        // heartbeater to use to find nodes
+	IndexName         string             // cbgt.Manger.IndexName, used to uniquely identify the index
+	IndexType         string             // cbgt.Manager.IndexType, matches name used by cbgt.RegisterPIndexImplType
+	NumPartitions     uint16             // number of cbgt partitions to use, if 0 will default to DefaultImportPartitions
+	PreviousIndexName string             // previous index name. If specified, marks IndexName as as a replacement for this name.
+	UUID              string             // database uuid, used to uniquely identify nodes
+	Datastore         DataStore          // datastore to perform KV ops
+	FeedType          ShardedDCPFeedType // type of sharded DCP feed to start
 }
 
 // Validate makes sure that all options are specified.
@@ -110,6 +113,12 @@ func (opts ShardedDCPOptions) Validate() error {
 	}
 	if opts.DestKey == "" {
 		return fmt.Errorf("destKey must be provided to start sharded DCP feed")
+	}
+	if opts.Datastore == nil {
+		return fmt.Errorf("datastore must be provided to start sharded DCP feed")
+	}
+	if opts.FeedType != ShardedDCPFeedTypeImport && opts.FeedType != ShardedDCPFeedTypeResync {
+		return fmt.Errorf("unknown feed type %s", opts.FeedType)
 	}
 	if len(opts.Collections) == 0 {
 		return fmt.Errorf("at least one collection must be specified to start a sharded DCP feed")
@@ -170,7 +179,7 @@ func StartShardedDCPFeed(ctx context.Context, opts ShardedDCPOptions) (*CbgtCont
 
 	// Register heartbeat listener to trigger removal from cfg when
 	// other SG nodes stop sending heartbeats.
-	listener, err := registerHeartbeatListener(ctx, opts.Heartbeater, cbgtContext)
+	listener, err := registerHeartbeatListener(ctx, opts.Heartbeater, cbgtContext, opts.Datastore, opts.FeedType)
 	if err != nil {
 		return nil, err
 	}
@@ -566,14 +575,14 @@ func DestKey(dbName string, scope string, collections []string, feedType Sharded
 	return destKey
 }
 
-func registerHeartbeatListener(ctx context.Context, heartbeater Heartbeater, cbgtContext *CbgtContext) (*shardedDCPHeartbeatListener, error) {
+func registerHeartbeatListener(ctx context.Context, heartbeater Heartbeater, cbgtContext *CbgtContext, datastore DataStore, feedType ShardedDCPFeedType) (*shardedDCPHeartbeatListener, error) {
 
 	if cbgtContext == nil || cbgtContext.Manager == nil || cbgtContext.Cfg == nil || heartbeater == nil {
 		return nil, errors.New("Unable to register heartbeat listener with nil manager, cfg or heartbeater")
 	}
 
 	// Register listener for shardedDCP, uses cfg and manager to manage set of participating nodes
-	shardedDCPHeartbeatListener, err := NewShardedDCPHeartbeatListener(ctx, cbgtContext)
+	shardedDCPHeartbeatListener, err := NewShardedDCPHeartbeatListener(ctx, cbgtContext, datastore, feedType)
 	if err != nil {
 		return nil, err
 	}
@@ -586,6 +595,69 @@ func registerHeartbeatListener(ctx context.Context, heartbeater Heartbeater, cbg
 	return shardedDCPHeartbeatListener, nil
 }
 
+type cfgNodePoller struct {
+	nodeDefsKnownKey  string
+	nodeDefsWantedKey string
+	nodeDefsKnownCAS  uint64 // to store the last known cas of nodeDefsKnown
+	nodeDefsWantedCAS uint64 // to store the last known cas of nodeDefsWanted
+	datastore         DataStore
+	cfg               *CfgSG
+}
+
+func newCfgNodePoller(datastore DataStore, cfg cbgt.Cfg) (*cfgNodePoller, error) {
+
+	nodeDefsKnownKey := cbgt.CfgNodeDefsKey(cbgt.NODE_DEFS_KNOWN)
+	_, nodeDefsKnownCas, err := datastore.GetRaw(nodeDefsKnownKey)
+	if err != nil {
+		return nil, err
+	}
+
+	nodeDefsWantedKey := cbgt.CfgNodeDefsKey(cbgt.NODE_DEFS_WANTED)
+	_, nodeDefsWantedCas, err := datastore.GetRaw(nodeDefsWantedKey)
+	if err != nil {
+		return nil, err
+	}
+
+	cfgSG, ok := cfg.(*CfgSG)
+	if !ok {
+		return nil, errors.New("cfg is not a CfgSG")
+	}
+
+	return &cfgNodePoller{
+		nodeDefsKnownKey:  nodeDefsKnownKey,
+		nodeDefsWantedKey: nodeDefsWantedKey,
+		nodeDefsKnownCAS:  nodeDefsKnownCas,
+		nodeDefsWantedCAS: nodeDefsWantedCas,
+		datastore:         datastore,
+		cfg:               cfgSG,
+	}, nil
+
+}
+
+func (p *cfgNodePoller) Poll() error {
+
+	_, nodeDefsKnownCas, err := p.datastore.GetRaw(p.nodeDefsKnownKey)
+	if err != nil {
+		return err
+	}
+
+	_, nodeDefsWantedCas, err := p.datastore.GetRaw(p.nodeDefsWantedKey)
+	if err != nil {
+		return err
+	}
+	if nodeDefsKnownCas != p.nodeDefsKnownCAS {
+		p.nodeDefsKnownCAS = nodeDefsKnownCas
+		p.cfg.FireEvent(p.nodeDefsKnownKey, nodeDefsKnownCas, nil)
+		return nil
+	}
+	if nodeDefsWantedCas != p.nodeDefsWantedCAS {
+		p.nodeDefsWantedCAS = nodeDefsWantedCas
+		p.cfg.FireEvent(p.nodeDefsWantedKey, nodeDefsWantedCas, nil)
+		return nil
+	}
+	return nil
+}
+
 // shardedDCPHeartbeatListener uses cbgt's cfg to manage node list
 type shardedDCPHeartbeatListener struct {
 	cfg        cbgt.Cfg      // cbgt cfg being used for shardedDCP
@@ -594,9 +666,12 @@ type shardedDCPHeartbeatListener struct {
 	terminator chan struct{} // close cfg subscription on close
 	nodeIDs    []string      // Set of nodes from the latest retrieval
 	lock       sync.RWMutex  // lock for nodeIDs access
+	datastore  DataStore
+	feedType   ShardedDCPFeedType
+	poller     *cfgNodePoller
 }
 
-func NewShardedDCPHeartbeatListener(ctx context.Context, cbgtCtx *CbgtContext) (*shardedDCPHeartbeatListener, error) {
+func NewShardedDCPHeartbeatListener(ctx context.Context, cbgtCtx *CbgtContext, dataStore DataStore, feedType ShardedDCPFeedType) (*shardedDCPHeartbeatListener, error) {
 
 	if cbgtCtx == nil {
 		return nil, errors.New("cbgt ctx must not be nil for shardedDCPHeartbeatListener")
@@ -607,6 +682,8 @@ func NewShardedDCPHeartbeatListener(ctx context.Context, cbgtCtx *CbgtContext) (
 		mgr:        cbgtCtx.Manager,
 		cfg:        cbgtCtx.Cfg,
 		terminator: make(chan struct{}),
+		datastore:  dataStore,
+		feedType:   feedType,
 	}
 
 	// Initialize the node set
@@ -620,6 +697,16 @@ func NewShardedDCPHeartbeatListener(ctx context.Context, cbgtCtx *CbgtContext) (
 	if err != nil {
 		return nil, err
 	}
+
+	if feedType == ShardedDCPFeedTypeResync {
+		poller, err := newCfgNodePoller(dataStore, cbgtCtx.Cfg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to initialize poller for resync node: %w", err)
+		}
+		listener.poller = poller
+	}
+
+	listener.StartPolling(ctx)
 
 	return listener, nil
 }
@@ -714,6 +801,28 @@ func (l *shardedDCPHeartbeatListener) GetNodes() ([]string, error) {
 
 func (l *shardedDCPHeartbeatListener) Stop() {
 	close(l.terminator)
+}
+
+func (l *shardedDCPHeartbeatListener) StartPolling(ctx context.Context) {
+	if l.feedType == ShardedDCPFeedTypeImport {
+		return
+	}
+	ticker := time.NewTicker(defaultHeartbeatPollInterval)
+	go func() {
+		defer FatalPanicHandler()
+		for {
+			select {
+			case <-l.terminator:
+				ticker.Stop()
+				return
+			case <-ticker.C:
+				err := l.poller.Poll()
+				if err != nil {
+					WarnfCtx(ctx, "Error polling sharded dcp heartbeat: %v", err)
+				}
+			}
+		}
+	}()
 }
 
 // cbgtDestFactories map DCP feed keys (destKey) to a function that will generate cbgt.Dest.  Need to be stored in a

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -37,6 +37,13 @@ const (
 	CBGTIndexTypeSyncGatewayResync    = "syncGateway-resync"
 )
 
+type ShardedDCPFeedType string
+
+const (
+	ShardedDCPFeedTypeImport ShardedDCPFeedType = "import"
+	ShardedDCPFeedTypeResync ShardedDCPFeedType = "resync"
+)
+
 // firstVersionToSupportCollections represents the earliest Sync Gateway release that supports collections.
 var firstVersionToSupportCollections = &ComparableBuildVersion{
 	epoch: 0,
@@ -176,14 +183,14 @@ func StartShardedDCPFeed(ctx context.Context, opts ShardedDCPOptions) (*CbgtCont
 
 // GenerateCBGTIndexName creates an index name for cbgt using the database name suitable for the distributed DCP feed.
 // Given a dbName and feedType, generate a unique and length-constrained index name for CBGT to use as part of their DCP name.
-func GenerateCBGTIndexName(dbName string, feedType string) (string, error) {
+func GenerateCBGTIndexName(dbName string, feedType ShardedDCPFeedType) (string, error) {
 	// Index names *must* start with a letter, so we'll prepend 'db' before the per-database checksum (which starts with '0x')
 	// Don't use Crc32cHashString here because this is intentionally non zero padded to match
 	// existing values.
 	var indexName string
-	if feedType == CBGTIndexTypeSyncGatewayImport {
+	if feedType == ShardedDCPFeedTypeImport {
 		indexName = fmt.Sprintf("db0x%x_index", Crc32cHash([]byte(dbName)))
-	} else if feedType == CBGTIndexTypeSyncGatewayResync {
+	} else if feedType == ShardedDCPFeedTypeResync {
 		indexName = fmt.Sprintf("db0x%x_resync_index", Crc32cHash([]byte(dbName)))
 	} else {
 		return "", fmt.Errorf("unknown index type %s", feedType)
@@ -537,7 +544,7 @@ func (c *CbgtContext) RemoveFeedCredentials(dbName string) {
 }
 
 // Format of dest key for retrieval of import dest from cbgtDestFactories
-func DestKey(dbName string, scope string, collections []string, feedType string) string {
+func DestKey(dbName string, scope string, collections []string, feedType ShardedDCPFeedType) string {
 	sort.Strings(collections)
 	collectionString := ""
 	onlyDefault := true
@@ -549,12 +556,11 @@ func DestKey(dbName string, scope string, collections []string, feedType string)
 	}
 	var destKey string
 	// format for _default._default
-	if (collectionString == "" || (scope == DefaultScope && onlyDefault)) && feedType == CBGTIndexTypeSyncGatewayImport {
+	if (collectionString == "" || (scope == DefaultScope && onlyDefault)) && feedType == ShardedDCPFeedTypeImport {
 		destKey = fmt.Sprintf("%s_import", dbName)
-	} else if feedType == CBGTIndexTypeSyncGatewayImport {
+	} else if feedType == ShardedDCPFeedTypeImport {
 		destKey = fmt.Sprintf("%s_import_%x", dbName, sha256.Sum256([]byte(collectionString)))
-	} else {
-
+	} else if feedType == ShardedDCPFeedTypeResync {
 		destKey = fmt.Sprintf("%s_resync_%x", dbName, sha256.Sum256([]byte(collectionString)))
 	}
 	return destKey

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -375,7 +375,7 @@ func initCBGTManager(ctx context.Context, bucket Bucket, spec BucketSpec, cfgSG 
 	//   avoids file system usage, in conjunction with managerLoadDataDir=false in options.
 	dataDir := ""
 
-	eventHandlersCtx, eventHandlersCancel := context.WithCancel(ctx)
+	eventHandlersCtx, eventHandlersCancel := context.WithCancelCause(ctx)
 	eventHandlers := &sgMgrEventHandlers{ctx: eventHandlersCtx, ctxCancel: eventHandlersCancel}
 
 	// Specify one feed per pindex
@@ -522,7 +522,7 @@ func getMinNodeVersion(cfg cbgt.Cfg) (*ComparableBuildVersion, error) {
 // Stop unregisters the listener from the heartbeater, and stops it and associated handlers.
 func (c *CbgtContext) Stop(ctx context.Context) {
 	if c.eventHandlers != nil {
-		c.eventHandlers.ctxCancel()
+		c.eventHandlers.ctxCancel(errors.New("CbgtContext is stopping, cancelling event handlers"))
 	}
 
 	if c.heartbeatListener != nil {
@@ -628,11 +628,14 @@ func newCfgNodePoller(ctx context.Context, datastore DataStore, fireEvent CfgEve
 func (p *cfgNodePoller) getWatcher() map[string]uint64 {
 	p.lock.Lock()
 	defer p.lock.Unlock()
-	watcher := make(map[string]uint64, len(p.keyWatcher))
-	for key, cas := range p.keyWatcher {
-		watcher[key] = cas
-	}
+	watcher := maps.Clone(p.keyWatcher)
 	return watcher
+}
+
+func (p *cfgNodePoller) updateCas(key string, newCas uint64) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	p.keyWatcher[key] = newCas
 }
 
 // Register adds a key to the poller's watch list. The current CAS value of the key is retrieved from the datastore
@@ -659,20 +662,13 @@ func (p *cfgNodePoller) poll() {
 	for key, oldCas := range watcher {
 		newCas, err := p.datastore.Get(key, nil)
 		if err != nil && !IsDocNotFoundError(err) {
-			WarnfCtx(p.ctx, "error reading doc: %s %v", UD(key), err)
+			WarnfCtx(p.ctx, "cfgNodePoller: error polling doc: %s %v, skipping polling", UD(key), err)
 			continue
 		}
 		if oldCas == newCas {
 			continue
 		}
-		p.lock.Lock()
-		currentCas, ok := p.keyWatcher[key]
-		if !ok || currentCas != oldCas {
-			p.lock.Unlock()
-			continue
-		}
-		p.keyWatcher[key] = newCas
-		p.lock.Unlock()
+		p.updateCas(key, newCas)
 		p.fireEvent(key, newCas, nil)
 	}
 }
@@ -873,7 +869,7 @@ func GetDefaultImportPartitions(serverless bool) uint16 {
 
 type sgMgrEventHandlers struct {
 	ctx       context.Context
-	ctxCancel context.CancelFunc
+	ctxCancel context.CancelCauseFunc
 	manager   *cbgt.Manager
 }
 

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -595,6 +595,10 @@ func registerHeartbeatListener(ctx context.Context, heartbeater Heartbeater, cbg
 	return shardedDCPHeartbeatListener, nil
 }
 
+// cfgNodePoller is a companion to a cbgt.Cfg instance that polls a datastore for changes to selected document keys.
+//
+// cfgNodePoller.Register is used to listen for changes to keys.
+// fireEvent is called whenever a document's cas value changes. This should map to cbgt.Cfg.FireEvent function.
 type cfgNodePoller struct {
 	ctx          context.Context
 	keyWatcher   map[string]uint64
@@ -604,6 +608,7 @@ type cfgNodePoller struct {
 	pollInterval time.Duration
 }
 
+// newCfgNodePoller constructs a poller instance on the datastore. fireEvent is a cbgt.Cfg.FireEvent function called whenever a document cas changes.
 func newCfgNodePoller(ctx context.Context, datastore DataStore, fireEvent CfgEventNotifyFunc, pollInterval time.Duration) *cfgNodePoller {
 
 	p := &cfgNodePoller{
@@ -614,10 +619,24 @@ func newCfgNodePoller(ctx context.Context, datastore DataStore, fireEvent CfgEve
 		pollInterval: pollInterval,
 	}
 
-	p.StartPolling(ctx)
+	p.startPolling(ctx)
 	return p
 }
 
+// getWatcher returns a copy of the keyWatcher map containing the current CAS values for all registered keys.
+// This method is thread-safe and creates a new map to avoid external modifications to the internal state.
+func (p *cfgNodePoller) getWatcher() map[string]uint64 {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	watcher := make(map[string]uint64, len(p.keyWatcher))
+	for key, cas := range p.keyWatcher {
+		watcher[key] = cas
+	}
+	return watcher
+}
+
+// Register adds a key to the poller's watch list. The current CAS value of the key is retrieved from the datastore
+// and stored. If the key does not exist, it is registered with a CAS value of 0. This method is thread-safe.
 func (p *cfgNodePoller) Register(key string) error {
 	p.lock.Lock()
 	defer p.lock.Unlock()
@@ -630,25 +649,38 @@ func (p *cfgNodePoller) Register(key string) error {
 	return nil
 }
 
-func (p *cfgNodePoller) Poll() {
+// poll checks all registered keys for CAS changes. For each key whose CAS value has changed since the last check,
+// the fireEvent callback is invoked with the key, new CAS value, and nil error. The keyWatcher is updated with
+// the new CAS values. This method is thread-safe and uses optimistic locking to avoid blocking during I/O operations.
+func (p *cfgNodePoller) poll() {
 
-	for key, oldCas := range p.keyWatcher {
+	watcher := p.getWatcher()
+
+	for key, oldCas := range watcher {
 		newCas, err := p.datastore.Get(key, nil)
 		if err != nil && !IsDocNotFoundError(err) {
-			WarnfCtx(p.ctx, "error reading doc: %s %v", key, err)
+			WarnfCtx(p.ctx, "error reading doc: %s %v", UD(key), err)
 			continue
 		}
-		if oldCas != newCas {
-			p.lock.Lock()
-			defer p.lock.Unlock()
-			p.keyWatcher[key] = newCas
-
-			p.fireEvent(key, newCas, nil)
+		if oldCas == newCas {
+			continue
 		}
+		p.lock.Lock()
+		currentCas, ok := p.keyWatcher[key]
+		if !ok || currentCas != oldCas {
+			p.lock.Unlock()
+			continue
+		}
+		p.keyWatcher[key] = newCas
+		p.lock.Unlock()
+		p.fireEvent(key, newCas, nil)
 	}
 }
 
-func (p *cfgNodePoller) StartPolling(ctx context.Context) {
+// startPolling begins periodic polling for changes to registered keys at the configured poll interval.
+// Polling continues until the provided context is cancelled. This method starts a goroutine that calls
+// Poll() on each tick of the interval timer.
+func (p *cfgNodePoller) startPolling(ctx context.Context) {
 	ticker := time.NewTicker(p.pollInterval)
 	go func() {
 		defer FatalPanicHandler()
@@ -658,7 +690,7 @@ func (p *cfgNodePoller) StartPolling(ctx context.Context) {
 				ticker.Stop()
 				return
 			case <-ticker.C:
-				p.Poll()
+				p.poll()
 			}
 		}
 	}()

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -582,7 +582,7 @@ func registerHeartbeatListener(ctx context.Context, heartbeater Heartbeater, cbg
 	}
 
 	// Register listener for shardedDCP, uses cfg and manager to manage set of participating nodes
-	shardedDCPHeartbeatListener, err := NewShardedDCPHeartbeatListener(ctx, cbgtContext, datastore, feedType)
+	shardedDCPHeartbeatListener, err := NewShardedDCPHeartbeatListener(ctx, cbgtContext)
 	if err != nil {
 		return nil, err
 	}
@@ -596,66 +596,72 @@ func registerHeartbeatListener(ctx context.Context, heartbeater Heartbeater, cbg
 }
 
 type cfgNodePoller struct {
-	nodeDefsKnownKey  string
-	nodeDefsWantedKey string
-	nodeDefsKnownCAS  uint64 // to store the last known cas of nodeDefsKnown
-	nodeDefsWantedCAS uint64 // to store the last known cas of nodeDefsWanted
-	datastore         DataStore
-	cfg               *CfgSG
+	ctx          context.Context
+	keyWatcher   map[string]uint64
+	datastore    DataStore
+	fireEvent    CfgEventNotifyFunc
+	lock         sync.Mutex
+	pollInterval time.Duration
 }
 
-func newCfgNodePoller(datastore DataStore, cfg cbgt.Cfg) (*cfgNodePoller, error) {
+func newCfgNodePoller(ctx context.Context, datastore DataStore, fireEvent CfgEventNotifyFunc, pollInterval time.Duration) *cfgNodePoller {
 
-	nodeDefsKnownKey := cbgt.CfgNodeDefsKey(cbgt.NODE_DEFS_KNOWN)
-	_, nodeDefsKnownCas, err := datastore.GetRaw(nodeDefsKnownKey)
-	if err != nil {
-		return nil, err
+	p := &cfgNodePoller{
+		ctx:          ctx,
+		keyWatcher:   make(map[string]uint64),
+		datastore:    datastore,
+		fireEvent:    fireEvent,
+		pollInterval: pollInterval,
 	}
 
-	nodeDefsWantedKey := cbgt.CfgNodeDefsKey(cbgt.NODE_DEFS_WANTED)
-	_, nodeDefsWantedCas, err := datastore.GetRaw(nodeDefsWantedKey)
-	if err != nil {
-		return nil, err
-	}
-
-	cfgSG, ok := cfg.(*CfgSG)
-	if !ok {
-		return nil, errors.New("cfg is not a CfgSG")
-	}
-
-	return &cfgNodePoller{
-		nodeDefsKnownKey:  nodeDefsKnownKey,
-		nodeDefsWantedKey: nodeDefsWantedKey,
-		nodeDefsKnownCAS:  nodeDefsKnownCas,
-		nodeDefsWantedCAS: nodeDefsWantedCas,
-		datastore:         datastore,
-		cfg:               cfgSG,
-	}, nil
-
+	p.StartPolling(ctx)
+	return p
 }
 
-func (p *cfgNodePoller) Poll() error {
+func (p *cfgNodePoller) Register(key string) error {
+	p.lock.Lock()
+	defer p.lock.Unlock()
 
-	_, nodeDefsKnownCas, err := p.datastore.GetRaw(p.nodeDefsKnownKey)
-	if err != nil {
+	cas, err := p.datastore.Get(key, nil)
+	if err != nil && !IsDocNotFoundError(err) {
 		return err
 	}
-
-	_, nodeDefsWantedCas, err := p.datastore.GetRaw(p.nodeDefsWantedKey)
-	if err != nil {
-		return err
-	}
-	if nodeDefsKnownCas != p.nodeDefsKnownCAS {
-		p.nodeDefsKnownCAS = nodeDefsKnownCas
-		p.cfg.FireEvent(p.nodeDefsKnownKey, nodeDefsKnownCas, nil)
-		return nil
-	}
-	if nodeDefsWantedCas != p.nodeDefsWantedCAS {
-		p.nodeDefsWantedCAS = nodeDefsWantedCas
-		p.cfg.FireEvent(p.nodeDefsWantedKey, nodeDefsWantedCas, nil)
-		return nil
-	}
+	p.keyWatcher[key] = cas
 	return nil
+}
+
+func (p *cfgNodePoller) Poll() {
+
+	for key, oldCas := range p.keyWatcher {
+		newCas, err := p.datastore.Get(key, nil)
+		if err != nil && !IsDocNotFoundError(err) {
+			WarnfCtx(p.ctx, "error reading doc: %s %v", key, err)
+			continue
+		}
+		if oldCas != newCas {
+			p.lock.Lock()
+			defer p.lock.Unlock()
+			p.keyWatcher[key] = newCas
+
+			p.fireEvent(key, newCas, nil)
+		}
+	}
+}
+
+func (p *cfgNodePoller) StartPolling(ctx context.Context) {
+	ticker := time.NewTicker(p.pollInterval)
+	go func() {
+		defer FatalPanicHandler()
+		for {
+			select {
+			case <-ctx.Done():
+				ticker.Stop()
+				return
+			case <-ticker.C:
+				p.Poll()
+			}
+		}
+	}()
 }
 
 // shardedDCPHeartbeatListener uses cbgt's cfg to manage node list
@@ -666,12 +672,9 @@ type shardedDCPHeartbeatListener struct {
 	terminator chan struct{} // close cfg subscription on close
 	nodeIDs    []string      // Set of nodes from the latest retrieval
 	lock       sync.RWMutex  // lock for nodeIDs access
-	datastore  DataStore
-	feedType   ShardedDCPFeedType
-	poller     *cfgNodePoller
 }
 
-func NewShardedDCPHeartbeatListener(ctx context.Context, cbgtCtx *CbgtContext, dataStore DataStore, feedType ShardedDCPFeedType) (*shardedDCPHeartbeatListener, error) {
+func NewShardedDCPHeartbeatListener(ctx context.Context, cbgtCtx *CbgtContext) (*shardedDCPHeartbeatListener, error) {
 
 	if cbgtCtx == nil {
 		return nil, errors.New("cbgt ctx must not be nil for shardedDCPHeartbeatListener")
@@ -682,8 +685,6 @@ func NewShardedDCPHeartbeatListener(ctx context.Context, cbgtCtx *CbgtContext, d
 		mgr:        cbgtCtx.Manager,
 		cfg:        cbgtCtx.Cfg,
 		terminator: make(chan struct{}),
-		datastore:  dataStore,
-		feedType:   feedType,
 	}
 
 	// Initialize the node set
@@ -697,16 +698,6 @@ func NewShardedDCPHeartbeatListener(ctx context.Context, cbgtCtx *CbgtContext, d
 	if err != nil {
 		return nil, err
 	}
-
-	if feedType == ShardedDCPFeedTypeResync {
-		poller, err := newCfgNodePoller(dataStore, cbgtCtx.Cfg)
-		if err != nil {
-			return nil, fmt.Errorf("failed to initialize poller for resync node: %w", err)
-		}
-		listener.poller = poller
-	}
-
-	listener.StartPolling(ctx)
 
 	return listener, nil
 }
@@ -801,28 +792,6 @@ func (l *shardedDCPHeartbeatListener) GetNodes() ([]string, error) {
 
 func (l *shardedDCPHeartbeatListener) Stop() {
 	close(l.terminator)
-}
-
-func (l *shardedDCPHeartbeatListener) StartPolling(ctx context.Context) {
-	if l.feedType == ShardedDCPFeedTypeImport {
-		return
-	}
-	ticker := time.NewTicker(defaultHeartbeatPollInterval)
-	go func() {
-		defer FatalPanicHandler()
-		for {
-			select {
-			case <-l.terminator:
-				ticker.Stop()
-				return
-			case <-ticker.C:
-				err := l.poller.Poll()
-				if err != nil {
-					WarnfCtx(ctx, "Error polling sharded dcp heartbeat: %v", err)
-				}
-			}
-		}
-	}()
 }
 
 // cbgtDestFactories map DCP feed keys (destKey) to a function that will generate cbgt.Dest.  Need to be stored in a

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -583,7 +583,7 @@ func registerHeartbeatListener(ctx context.Context, heartbeater Heartbeater, cbg
 // shardedDCPHeartbeatListener uses cbgt's cfg to manage node list
 type shardedDCPHeartbeatListener struct {
 	cfg        cbgt.Cfg      // cbgt cfg being used for shardedDCP
-	mgr        *cbgt.Manager // cbgt manager associated with this import node
+	mgr        *cbgt.Manager // cbgt manager associated with this node
 	ctx        *CbgtContext
 	terminator chan struct{} // close cfg subscription on close
 	nodeIDs    []string      // Set of nodes from the latest retrieval

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -56,7 +56,7 @@ type CbgtContext struct {
 	Manager           *cbgt.Manager                // Manager is main entry point for initialization, registering indexes
 	Cfg               cbgt.Cfg                     // Cfg manages storage of the current pindex set and node assignment
 	heartbeater       Heartbeater                  // Heartbeater used for failed node detection
-	heartbeatListener *shardedDCPHeartBeatListener // Listener subscribed to failed node alerts from heartbeater
+	heartbeatListener *shardedDCPHeartbeatListener // Listener subscribed to failed node alerts from heartbeater
 	eventHandlers     *sgMgrEventHandlers          // Event handler callbacks
 	dbName            string                       // Database name
 	sourceName        string                       // cbgt source name. Store on CbgtContext for access during teardown
@@ -560,28 +560,28 @@ func DestKey(dbName string, scope string, collections []string, feedType string)
 	return destKey
 }
 
-func registerHeartbeatListener(ctx context.Context, heartbeater Heartbeater, cbgtContext *CbgtContext) (*shardedDCPHeartBeatListener, error) {
+func registerHeartbeatListener(ctx context.Context, heartbeater Heartbeater, cbgtContext *CbgtContext) (*shardedDCPHeartbeatListener, error) {
 
 	if cbgtContext == nil || cbgtContext.Manager == nil || cbgtContext.Cfg == nil || heartbeater == nil {
-		return nil, errors.New("Unable to register import heartbeat listener with nil manager, cfg or heartbeater")
+		return nil, errors.New("Unable to register heartbeat listener with nil manager, cfg or heartbeater")
 	}
 
 	// Register listener for import, uses cfg and manager to manage set of participating nodes
-	shardedDCPHeartBeatListener, err := NewShardedDCPHeartBeatListener(ctx, cbgtContext)
+	shardedDCPHeartbeatListener, err := NewShardedDCPHeartbeatListener(ctx, cbgtContext)
 	if err != nil {
 		return nil, err
 	}
 
-	err = heartbeater.RegisterListener(shardedDCPHeartBeatListener)
+	err = heartbeater.RegisterListener(shardedDCPHeartbeatListener)
 	if err != nil {
 		return nil, err
 	}
 
-	return shardedDCPHeartBeatListener, nil
+	return shardedDCPHeartbeatListener, nil
 }
 
-// shardedDCPHeartBeatListener uses cbgt's cfg to manage node list
-type shardedDCPHeartBeatListener struct {
+// shardedDCPHeartbeatListener uses cbgt's cfg to manage node list
+type shardedDCPHeartbeatListener struct {
 	cfg        cbgt.Cfg      // cbgt cfg being used for import
 	mgr        *cbgt.Manager // cbgt manager associated with this import node
 	ctx        *CbgtContext
@@ -590,13 +590,13 @@ type shardedDCPHeartBeatListener struct {
 	lock       sync.RWMutex  // lock for nodeIDs access
 }
 
-func NewShardedDCPHeartBeatListener(ctx context.Context, cbgtCtx *CbgtContext) (*shardedDCPHeartBeatListener, error) {
+func NewShardedDCPHeartbeatListener(ctx context.Context, cbgtCtx *CbgtContext) (*shardedDCPHeartbeatListener, error) {
 
 	if cbgtCtx == nil {
-		return nil, errors.New("ctx must not be nil for ImportHeartbeatListener")
+		return nil, errors.New("cbgt ctx must not be nil for shardedDCPHeartbeatListener")
 	}
 
-	listener := &shardedDCPHeartBeatListener{
+	listener := &shardedDCPHeartbeatListener{
 		ctx:        cbgtCtx,
 		mgr:        cbgtCtx.Manager,
 		cfg:        cbgtCtx.Cfg,
@@ -618,12 +618,12 @@ func NewShardedDCPHeartBeatListener(ctx context.Context, cbgtCtx *CbgtContext) (
 	return listener, nil
 }
 
-func (l *shardedDCPHeartBeatListener) Name() string {
-	return "importListener"
+func (l *shardedDCPHeartbeatListener) Name() string {
+	return "shardedDCPHeartbeatListener"
 }
 
 // When we detect other nodes have stopped pushing heartbeats, use manager to remove from cfg
-func (l *shardedDCPHeartBeatListener) StaleHeartbeatDetected(ctx context.Context, nodeUUID string) {
+func (l *shardedDCPHeartbeatListener) StaleHeartbeatDetected(ctx context.Context, nodeUUID string) {
 
 	InfofCtx(ctx, KeyCluster, "StaleHeartbeatDetected by import listener for node: %v", nodeUUID)
 	err := cbgt.UnregisterNodes(l.cfg, l.mgr.Version(), []string{nodeUUID})
@@ -634,7 +634,7 @@ func (l *shardedDCPHeartBeatListener) StaleHeartbeatDetected(ctx context.Context
 
 // subscribeNodeChanges registers with the manager's cfg implementation for notifications on changes to the
 // NODE_DEFS_KNOWN key.  When notified, refreshes the handlers nodeIDs.
-func (l *shardedDCPHeartBeatListener) subscribeNodeChanges(ctx context.Context) error {
+func (l *shardedDCPHeartbeatListener) subscribeNodeChanges(ctx context.Context) error {
 
 	cfgEvents := make(chan cbgt.CfgEvent)
 	err := l.cfg.Subscribe(cbgt.CfgNodeDefsKey(cbgt.NODE_DEFS_KNOWN), cfgEvents)
@@ -671,7 +671,7 @@ func (l *shardedDCPHeartBeatListener) subscribeNodeChanges(ctx context.Context) 
 	return nil
 }
 
-func (l *shardedDCPHeartBeatListener) reloadNodes() (localNodePresent bool, err error) {
+func (l *shardedDCPHeartbeatListener) reloadNodes() (localNodePresent bool, err error) {
 
 	nodeUUIDs := make([]string, 0)
 	nodeDefTypes := []string{cbgt.NODE_DEFS_KNOWN, cbgt.NODE_DEFS_WANTED}
@@ -697,7 +697,7 @@ func (l *shardedDCPHeartBeatListener) reloadNodes() (localNodePresent bool, err 
 }
 
 // GetNodes returns a copy of the in-memory node set
-func (l *shardedDCPHeartBeatListener) GetNodes() ([]string, error) {
+func (l *shardedDCPHeartbeatListener) GetNodes() ([]string, error) {
 
 	l.lock.RLock()
 	nodeIDsCopy := make([]string, len(l.nodeIDs))
@@ -706,7 +706,7 @@ func (l *shardedDCPHeartBeatListener) GetNodes() ([]string, error) {
 	return nodeIDsCopy, nil
 }
 
-func (l *shardedDCPHeartBeatListener) Stop() {
+func (l *shardedDCPHeartbeatListener) Stop() {
 	close(l.terminator)
 }
 

--- a/base/dcp_sharded_test.go
+++ b/base/dcp_sharded_test.go
@@ -9,8 +9,12 @@
 package base
 
 import (
+	"context"
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -199,4 +203,679 @@ func TestDestKey(t *testing.T) {
 			require.Equal(t, test.key, DestKey(test.dbName, test.scopeName, test.collections, test.feedType))
 		})
 	}
+}
+
+func TestCfgNodePoller_Register(t *testing.T) {
+	bucket := GetTestBucket(t)
+	defer bucket.Close(t.Context())
+	datastore := bucket.GetMetadataStore()
+	ctx := t.Context()
+
+	tests := []struct {
+		name            string
+		keysToCreate    []string        // keys to create in datastore before test
+		keysToRegister  []string        // keys to register with poller
+		expectedCasZero map[string]bool // keys expected to have cas=0 after registration
+	}{
+		{
+			name:            "register_non_existent_key",
+			keysToCreate:    []string{},
+			keysToRegister:  []string{"non_existent_key"},
+			expectedCasZero: map[string]bool{"non_existent_key": true},
+		},
+		{
+			name:            "register_existing_key",
+			keysToCreate:    []string{"existing_key"},
+			keysToRegister:  []string{"existing_key"},
+			expectedCasZero: map[string]bool{},
+		},
+		{
+			name:            "register_same_key_twice",
+			keysToCreate:    []string{"duplicate_key"},
+			keysToRegister:  []string{"duplicate_key", "duplicate_key"},
+			expectedCasZero: map[string]bool{},
+		},
+		{
+			name:            "register_multiple_keys_mixed",
+			keysToCreate:    []string{"exists_1", "exists_2"},
+			keysToRegister:  []string{"exists_1", "not_exists", "exists_2"},
+			expectedCasZero: map[string]bool{"not_exists": true},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Create a new poller for each test (without starting polling)
+			poller := &cfgNodePoller{
+				ctx:        ctx,
+				keyWatcher: make(map[string]uint64),
+				datastore:  datastore,
+				fireEvent:  func(docID string, cas uint64, err error) {},
+			}
+
+			// Common setup: create documents
+			createdCas := make(map[string]uint64)
+			for _, key := range test.keysToCreate {
+				added, err := datastore.Add(key, 0, []byte(`{"test": true}`))
+				require.NoError(t, err)
+				require.True(t, added)
+				cas, err := datastore.Get(key, nil)
+				require.NoError(t, err)
+				createdCas[key] = cas
+			}
+
+			// Cleanup created docs after test
+			t.Cleanup(func() {
+				for _, key := range test.keysToCreate {
+					_ = datastore.Delete(key)
+				}
+			})
+
+			// Register all keys
+			for _, key := range test.keysToRegister {
+				err := poller.Register(key)
+				require.NoError(t, err)
+			}
+
+			// Build unique set of registered keys for length check
+			uniqueKeys := make(map[string]bool)
+			for _, key := range test.keysToRegister {
+				uniqueKeys[key] = true
+			}
+
+			// Verify all registered keys
+			poller.lock.Lock()
+			defer poller.lock.Unlock()
+
+			require.Len(t, poller.keyWatcher, len(uniqueKeys), "keyWatcher should have all unique registered keys")
+
+			for key := range uniqueKeys {
+				cas, exists := poller.keyWatcher[key]
+				require.True(t, exists, "key %s should be registered", key)
+
+				if test.expectedCasZero[key] {
+					require.Equal(t, uint64(0), cas, "key %s should have cas=0", key)
+				} else {
+					require.NotEqual(t, uint64(0), cas, "key %s should have non-zero cas", key)
+					require.Equal(t, createdCas[key], cas, "key %s CAS should match datastore", key)
+				}
+			}
+		})
+	}
+
+	// Verify re-registration picks up new CAS after document update
+	t.Run("register_key_after_document_update", func(t *testing.T) {
+		poller := &cfgNodePoller{
+			ctx:        ctx,
+			keyWatcher: make(map[string]uint64),
+			datastore:  datastore,
+			fireEvent:  func(docID string, cas uint64, err error) {},
+		}
+
+		key := "update_then_register"
+
+		// Create initial document
+		added, err := datastore.Add(key, 0, []byte(`{"test": true}`))
+		require.NoError(t, err)
+		require.True(t, added)
+
+		// Cleanup created doc after test
+		t.Cleanup(func() {
+			_ = datastore.Delete(key)
+		})
+
+		// Register first time
+		err = poller.Register(key)
+		require.NoError(t, err)
+
+		poller.lock.Lock()
+		initialCas := poller.keyWatcher[key]
+		poller.lock.Unlock()
+		require.NotEqual(t, uint64(0), initialCas)
+
+		// Update document externally
+		err = datastore.Set(key, 0, nil, []byte(`{"updated": true}`))
+		require.NoError(t, err)
+
+		// Get new CAS from datastore
+		newExpectedCas, err := datastore.Get(key, nil)
+		require.NoError(t, err)
+		require.NotEqual(t, initialCas, newExpectedCas, "document should have new CAS after update")
+
+		// Register again - should pick up new CAS
+		err = poller.Register(key)
+		require.NoError(t, err)
+
+		poller.lock.Lock()
+		updatedCas := poller.keyWatcher[key]
+		poller.lock.Unlock()
+
+		require.Equal(t, newExpectedCas, updatedCas, "keyWatcher should have updated CAS after re-registration")
+	})
+}
+
+func TestCfgNodePoller_Poll(t *testing.T) {
+	bucket := GetTestBucket(t)
+	defer bucket.Close(t.Context())
+	datastore := bucket.GetMetadataStore()
+	ctx := t.Context()
+
+	tests := []struct {
+		name              string
+		keysToCreate      []string        // keys to create in datastore before registration
+		keysToRegister    []string        // keys to register with poller
+		keysToUpdate      []string        // keys to update after registration (before poll)
+		keysToDelete      []string        // keys to delete after registration (before poll)
+		keysToPurge       []string        // keys to purge after registration (before poll)
+		expectedEventKeys map[string]bool // keys expected to trigger events during poll
+		expectedCasZero   map[string]bool // keys expected to have cas=0 after poll
+	}{
+		{
+			name:              "poll_detects_document_creation",
+			keysToCreate:      []string{},
+			keysToRegister:    []string{"created_doc"},
+			keysToUpdate:      []string{"created_doc"}, // creating a doc that didn't exist
+			keysToDelete:      []string{},
+			keysToPurge:       []string{},
+			expectedEventKeys: map[string]bool{"created_doc": true},
+			expectedCasZero:   map[string]bool{},
+		},
+		{
+			name:              "poll_detects_document_update",
+			keysToCreate:      []string{"updated_doc"},
+			keysToRegister:    []string{"updated_doc"},
+			keysToUpdate:      []string{"updated_doc"},
+			keysToDelete:      []string{},
+			keysToPurge:       []string{},
+			expectedEventKeys: map[string]bool{"updated_doc": true},
+			expectedCasZero:   map[string]bool{},
+		},
+		{
+			name:              "poll_no_event_when_cas_unchanged",
+			keysToCreate:      []string{"unchanged_doc"},
+			keysToRegister:    []string{"unchanged_doc"},
+			keysToUpdate:      []string{},
+			keysToDelete:      []string{},
+			keysToPurge:       []string{},
+			expectedEventKeys: map[string]bool{},
+			expectedCasZero:   map[string]bool{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Track fired events
+			firedEvents := make(map[string]uint64)
+			var eventLock sync.Mutex
+
+			// Create a new poller for each test (without starting polling)
+			poller := &cfgNodePoller{
+				ctx:        ctx,
+				keyWatcher: make(map[string]uint64),
+				datastore:  datastore,
+				fireEvent: func(docID string, cas uint64, err error) {
+					eventLock.Lock()
+					firedEvents[docID] = cas
+					eventLock.Unlock()
+				},
+			}
+
+			// Setup: create initial documents
+			for _, key := range test.keysToCreate {
+				added, err := datastore.Add(key, 0, []byte(`{"test": true}`))
+				require.NoError(t, err)
+				require.True(t, added)
+			}
+
+			// Cleanup all potentially created docs after test
+			t.Cleanup(func() {
+				for _, key := range test.keysToCreate {
+					_ = datastore.Delete(key)
+				}
+				for _, key := range test.keysToUpdate {
+					_ = datastore.Delete(key)
+				}
+			})
+
+			// Register all keys
+			for _, key := range test.keysToRegister {
+				err := poller.Register(key)
+				require.NoError(t, err)
+			}
+
+			// Update documents (creates if doesn't exist)
+			for _, key := range test.keysToUpdate {
+				err := datastore.Set(key, 0, nil, []byte(`{"updated": true}`))
+				require.NoError(t, err)
+			}
+
+			// Delete documents (creates tombstone)
+			for _, key := range test.keysToDelete {
+				err := datastore.Delete(key)
+				require.NoError(t, err)
+			}
+
+			// Purge documents (complete removal - no tombstone)
+			for _, key := range test.keysToPurge {
+				cas, err := datastore.Get(key, nil)
+				require.NoError(t, err)
+				_, err = datastore.Remove(key, cas)
+				require.NoError(t, err)
+			}
+
+			// Call Poll
+			poller.Poll()
+
+			// Verify fired events
+			eventLock.Lock()
+			require.Len(t, firedEvents, len(test.expectedEventKeys), "unexpected number of events fired")
+			for key := range test.expectedEventKeys {
+				_, fired := firedEvents[key]
+				require.True(t, fired, "expected event for key %s was not fired", key)
+			}
+			eventLock.Unlock()
+
+			// Verify keyWatcher CAS values were updated
+			poller.lock.Lock()
+			defer poller.lock.Unlock()
+
+			for key := range test.expectedEventKeys {
+				if test.expectedCasZero[key] {
+					require.Equal(t, uint64(0), poller.keyWatcher[key], "key %s should have cas=0 after poll", key)
+				} else {
+					require.NotEqual(t, uint64(0), poller.keyWatcher[key], "key %s should have non-zero cas after poll", key)
+					// Verify CAS matches current datastore value
+					currentCas, err := datastore.Get(key, nil)
+					require.NoError(t, err)
+					require.Equal(t, currentCas, poller.keyWatcher[key], "key %s CAS should match datastore", key)
+				}
+			}
+		})
+	}
+
+	// Verify fireEvent callback receives correct docID, CAS, and nil error
+	t.Run("poll_fireevent_receives_correct_parameters", func(t *testing.T) {
+		var receivedDocID string
+		var receivedCas uint64
+		var receivedErr error
+		eventCalled := false
+
+		poller := &cfgNodePoller{
+			ctx:        ctx,
+			keyWatcher: make(map[string]uint64),
+			datastore:  datastore,
+			fireEvent: func(docID string, cas uint64, err error) {
+				receivedDocID = docID
+				receivedCas = cas
+				receivedErr = err
+				eventCalled = true
+			},
+		}
+
+		key := "event_params_test"
+
+		// Register key (doesn't exist yet, cas=0)
+		err := poller.Register(key)
+		require.NoError(t, err)
+
+		// Create document
+		added, err := datastore.Add(key, 0, []byte(`{"test": true}`))
+		require.NoError(t, err)
+		require.True(t, added)
+
+		t.Cleanup(func() {
+			_ = datastore.Delete(key)
+		})
+
+		// Get expected CAS
+		expectedCas, err := datastore.Get(key, nil)
+		require.NoError(t, err)
+
+		// Call Poll
+		poller.Poll()
+
+		// Verify event parameters
+		require.True(t, eventCalled, "fireEvent should have been called")
+		require.Equal(t, key, receivedDocID, "docID should match")
+		require.Equal(t, expectedCas, receivedCas, "cas should match datastore CAS")
+		require.Nil(t, receivedErr, "err should be nil")
+	})
+
+	// Verify keyWatcher update prevents duplicate events on subsequent polls
+	t.Run("poll_updates_keywatcher_prevents_duplicate_events", func(t *testing.T) {
+		eventCount := 0
+
+		poller := &cfgNodePoller{
+			ctx:        ctx,
+			keyWatcher: make(map[string]uint64),
+			datastore:  datastore,
+			fireEvent: func(docID string, cas uint64, err error) {
+				eventCount++
+			},
+		}
+
+		key := "duplicate_event_test"
+
+		// Create document
+		added, err := datastore.Add(key, 0, []byte(`{"test": true}`))
+		require.NoError(t, err)
+		require.True(t, added)
+
+		t.Cleanup(func() {
+			_ = datastore.Delete(key)
+		})
+
+		// Register key
+		err = poller.Register(key)
+		require.NoError(t, err)
+
+		// Update document
+		err = datastore.Set(key, 0, nil, []byte(`{"updated": true}`))
+		require.NoError(t, err)
+
+		// First poll - should fire event
+		poller.Poll()
+		require.Equal(t, 1, eventCount, "first poll should fire one event")
+
+		// Second poll without changes - should NOT fire event
+		poller.Poll()
+		require.Equal(t, 1, eventCount, "second poll should not fire event since CAS unchanged")
+
+		// Third poll without changes - should still NOT fire event
+		poller.Poll()
+		require.Equal(t, 1, eventCount, "third poll should not fire event since CAS unchanged")
+	})
+
+	// Verify deletion (tombstone) triggers event with cas=0 - Couchbase Server only
+	t.Run("poll_detects_document_deletion", func(t *testing.T) {
+		if UnitTestUrlIsWalrus() {
+			t.Skip("This test requires Couchbase Server - deletion behavior differs in Rosmar")
+		}
+
+		eventFired := false
+		var firedCas uint64
+
+		poller := &cfgNodePoller{
+			ctx:        ctx,
+			keyWatcher: make(map[string]uint64),
+			datastore:  datastore,
+			fireEvent: func(docID string, cas uint64, err error) {
+				eventFired = true
+				firedCas = cas
+			},
+		}
+
+		key := "deleted_doc_test"
+
+		// Create document
+		added, err := datastore.Add(key, 0, []byte(`{"test": true}`))
+		require.NoError(t, err)
+		require.True(t, added)
+
+		t.Cleanup(func() {
+			_ = datastore.Delete(key)
+		})
+
+		// Register key
+		err = poller.Register(key)
+		require.NoError(t, err)
+
+		// Delete document (creates tombstone)
+		err = datastore.Delete(key)
+		require.NoError(t, err)
+
+		// Call Poll
+		poller.Poll()
+
+		// Verify event was fired
+		require.True(t, eventFired, "event should be fired for deleted document")
+		require.Equal(t, uint64(0), firedCas, "cas should be 0 for deleted document")
+
+		// Verify keyWatcher was updated
+		poller.lock.Lock()
+		require.Equal(t, uint64(0), poller.keyWatcher[key], "keyWatcher should have cas=0 after deletion")
+		poller.lock.Unlock()
+	})
+
+	// Verify purge (complete removal) triggers event with cas=0 - Couchbase Server only
+	t.Run("poll_detects_document_purge", func(t *testing.T) {
+		if UnitTestUrlIsWalrus() {
+			t.Skip("This test requires Couchbase Server - purge behavior differs in Rosmar")
+		}
+
+		eventFired := false
+		var firedCas uint64
+
+		poller := &cfgNodePoller{
+			ctx:        ctx,
+			keyWatcher: make(map[string]uint64),
+			datastore:  datastore,
+			fireEvent: func(docID string, cas uint64, err error) {
+				eventFired = true
+				firedCas = cas
+			},
+		}
+
+		key := "purged_doc_test"
+
+		// Create document
+		added, err := datastore.Add(key, 0, []byte(`{"test": true}`))
+		require.NoError(t, err)
+		require.True(t, added)
+
+		t.Cleanup(func() {
+			_ = datastore.Delete(key)
+		})
+
+		err = poller.Register(key)
+		require.NoError(t, err)
+
+		// Get current CAS before purge
+		cas, err := datastore.Get(key, nil)
+		require.NoError(t, err)
+
+		// Purge document (complete removal - no tombstone)
+		_, err = datastore.Remove(key, cas)
+		require.NoError(t, err)
+
+		poller.Poll()
+
+		// Verify event was fired
+		require.True(t, eventFired, "event should be fired for purged document")
+		require.Equal(t, uint64(0), firedCas, "cas should be 0 for purged document")
+
+		// Verify keyWatcher was updated
+		poller.lock.Lock()
+		require.Equal(t, uint64(0), poller.keyWatcher[key], "keyWatcher should have cas=0 after purge")
+		poller.lock.Unlock()
+	})
+}
+
+func TestCfgNodePoller_StartPolling(t *testing.T) {
+	bucket := GetTestBucket(t)
+	defer bucket.Close(t.Context())
+	datastore := bucket.GetMetadataStore()
+
+	// Polling should stop when context is cancelled
+	t.Run("start_polling_stops_on_context_cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+
+		var eventCount atomic.Int32
+		poller := &cfgNodePoller{
+			ctx:          ctx,
+			keyWatcher:   make(map[string]uint64),
+			datastore:    datastore,
+			fireEvent:    func(docID string, cas uint64, err error) { eventCount.Add(1) },
+			pollInterval: 5 * time.Millisecond,
+		}
+
+		key := "stop_on_cancel_test"
+
+		added, err := datastore.Add(key, 0, []byte(`{"test": true}`))
+		require.NoError(t, err)
+		require.True(t, added)
+
+		t.Cleanup(func() {
+			_ = datastore.Delete(key)
+		})
+
+		err = poller.Register(key)
+		require.NoError(t, err)
+
+		poller.StartPolling(ctx)
+
+		// Wait for at least one poll cycle
+		time.Sleep(20 * time.Millisecond)
+
+		// Cancel context to stop polling
+		cancel()
+
+		// Wait for goroutine to stop
+		time.Sleep(20 * time.Millisecond)
+
+		// Update document after cancellation
+		err = datastore.Set(key, 0, nil, []byte(`{"updated": true}`))
+		require.NoError(t, err)
+
+		// Record event count before waiting
+		countBeforeWait := eventCount.Load()
+
+		// Wait to ensure no more polls happen
+		time.Sleep(30 * time.Millisecond)
+
+		// Event count should not have increased after cancellation
+		countAfterWait := eventCount.Load()
+		require.Equal(t, countBeforeWait, countAfterWait, "no events should fire after context cancellation")
+	})
+
+	// Changes should be detected within the poll interval
+	t.Run("start_polling_polls_at_interval", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		var eventCount atomic.Int32
+		poller := &cfgNodePoller{
+			ctx:          ctx,
+			keyWatcher:   make(map[string]uint64),
+			datastore:    datastore,
+			fireEvent:    func(docID string, cas uint64, err error) { eventCount.Add(1) },
+			pollInterval: 10 * time.Millisecond,
+		}
+
+		key := "poll_interval_test"
+
+		err := poller.Register(key)
+		require.NoError(t, err)
+
+		poller.StartPolling(ctx)
+
+		// Create document - should be detected on next poll
+		added, err := datastore.Add(key, 0, []byte(`{"test": true}`))
+		require.NoError(t, err)
+		require.True(t, added)
+
+		t.Cleanup(func() {
+			_ = datastore.Delete(key)
+		})
+
+		// Wait for poll to detect the change
+		require.Eventually(t, func() bool {
+			return eventCount.Load() >= 1
+		}, 100*time.Millisecond, 5*time.Millisecond, "event should be fired within poll interval")
+	})
+
+	// Multiple sequential changes should all be detected over time
+	t.Run("start_polling_detects_changes_over_time", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		var eventCount atomic.Int32
+		poller := &cfgNodePoller{
+			ctx:          ctx,
+			keyWatcher:   make(map[string]uint64),
+			datastore:    datastore,
+			fireEvent:    func(docID string, cas uint64, err error) { eventCount.Add(1) },
+			pollInterval: 10 * time.Millisecond,
+		}
+
+		key := "changes_over_time_test"
+
+		added, err := datastore.Add(key, 0, []byte(`{"version": 1}`))
+		require.NoError(t, err)
+		require.True(t, added)
+
+		t.Cleanup(func() {
+			_ = datastore.Delete(key)
+		})
+
+		err = poller.Register(key)
+		require.NoError(t, err)
+
+		poller.StartPolling(ctx)
+
+		// First update
+		err = datastore.Set(key, 0, nil, []byte(`{"version": 2}`))
+		require.NoError(t, err)
+
+		// Wait for first event
+		require.Eventually(t, func() bool {
+			return eventCount.Load() >= 1
+		}, 100*time.Millisecond, 5*time.Millisecond, "first update should be detected")
+
+		// Second update
+		err = datastore.Set(key, 0, nil, []byte(`{"version": 3}`))
+		require.NoError(t, err)
+
+		// Wait for second event
+		require.Eventually(t, func() bool {
+			return eventCount.Load() >= 2
+		}, 100*time.Millisecond, 5*time.Millisecond, "second update should be detected")
+
+		// Third update
+		err = datastore.Set(key, 0, nil, []byte(`{"version": 4}`))
+		require.NoError(t, err)
+
+		// Wait for third event
+		require.Eventually(t, func() bool {
+			return eventCount.Load() >= 3
+		}, 100*time.Millisecond, 5*time.Millisecond, "third update should be detected")
+	})
+
+	// No polling should occur after context is cancelled
+	t.Run("start_polling_no_poll_after_context_cancelled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+
+		var eventCount atomic.Int32
+		poller := &cfgNodePoller{
+			ctx:          ctx,
+			keyWatcher:   make(map[string]uint64),
+			datastore:    datastore,
+			fireEvent:    func(docID string, cas uint64, err error) { eventCount.Add(1) },
+			pollInterval: 10 * time.Millisecond,
+		}
+
+		key := "no_poll_after_cancel_test"
+
+		err := poller.Register(key)
+		require.NoError(t, err)
+
+		poller.StartPolling(ctx)
+		cancel()
+
+		// Wait for goroutine to stop
+		time.Sleep(20 * time.Millisecond)
+
+		// Now create the document
+		added, err := datastore.Add(key, 0, []byte(`{"test": true}`))
+		require.NoError(t, err)
+		require.True(t, added)
+
+		t.Cleanup(func() {
+			_ = datastore.Delete(key)
+		})
+
+		// Wait and verify no events were fired
+		time.Sleep(50 * time.Millisecond)
+		require.Equal(t, int32(0), eventCount.Load(), "no events should fire after context cancellation")
+	})
 }

--- a/base/dcp_sharded_test.go
+++ b/base/dcp_sharded_test.go
@@ -10,6 +10,7 @@ package base
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -776,7 +777,7 @@ func TestCfgNodePoller_StartPolling(t *testing.T) {
 
 	// Polling should stop when context is cancelled
 	t.Run("start_polling_stops_on_context_cancellation", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(t.Context())
+		ctx, cancel := context.WithCancelCause(t.Context())
 
 		var eventCount atomic.Int32
 		poller := &cfgNodePoller{
@@ -806,7 +807,7 @@ func TestCfgNodePoller_StartPolling(t *testing.T) {
 		time.Sleep(20 * time.Millisecond)
 
 		// Cancel context to stop polling
-		cancel()
+		cancel(errors.New("test: stopping polling"))
 
 		// Wait for goroutine to stop
 		time.Sleep(20 * time.Millisecond)
@@ -828,8 +829,8 @@ func TestCfgNodePoller_StartPolling(t *testing.T) {
 
 	// Changes should be detected within the poll interval
 	t.Run("start_polling_polls_at_interval", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(t.Context())
-		defer cancel()
+		ctx, cancel := context.WithCancelCause(t.Context())
+		defer cancel(nil)
 
 		var eventCount atomic.Int32
 		poller := &cfgNodePoller{
@@ -864,8 +865,8 @@ func TestCfgNodePoller_StartPolling(t *testing.T) {
 
 	// Multiple sequential changes should all be detected over time
 	t.Run("start_polling_detects_changes_over_time", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(t.Context())
-		defer cancel()
+		ctx, cancel := context.WithCancelCause(t.Context())
+		defer cancel(nil)
 
 		var eventCount atomic.Int32
 		poller := &cfgNodePoller{
@@ -921,7 +922,7 @@ func TestCfgNodePoller_StartPolling(t *testing.T) {
 
 	// No polling should occur after context is cancelled
 	t.Run("start_polling_no_poll_after_context_cancelled", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(t.Context())
+		ctx, cancel := context.WithCancelCause(t.Context())
 
 		var eventCount atomic.Int32
 		poller := &cfgNodePoller{
@@ -938,7 +939,7 @@ func TestCfgNodePoller_StartPolling(t *testing.T) {
 		require.NoError(t, err)
 
 		poller.startPolling(ctx)
-		cancel()
+		cancel(errors.New("test: stopping polling"))
 
 		// Wait for goroutine to stop
 		time.Sleep(20 * time.Millisecond)

--- a/base/dcp_sharded_test.go
+++ b/base/dcp_sharded_test.go
@@ -463,8 +463,8 @@ func TestCfgNodePoller_Poll(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			// Call Poll
-			poller.Poll()
+			// Call poll
+			poller.poll()
 
 			// Verify fired events
 			eventLock.Lock()
@@ -532,7 +532,7 @@ func TestCfgNodePoller_Poll(t *testing.T) {
 		require.NoError(t, err)
 
 		// Call Poll
-		poller.Poll()
+		poller.poll()
 
 		// Verify event parameters
 		require.True(t, eventCalled, "fireEvent should have been called")
@@ -574,15 +574,15 @@ func TestCfgNodePoller_Poll(t *testing.T) {
 		require.NoError(t, err)
 
 		// First poll - should fire event
-		poller.Poll()
+		poller.poll()
 		require.Equal(t, 1, eventCount, "first poll should fire one event")
 
 		// Second poll without changes - should NOT fire event
-		poller.Poll()
+		poller.poll()
 		require.Equal(t, 1, eventCount, "second poll should not fire event since CAS unchanged")
 
 		// Third poll without changes - should still NOT fire event
-		poller.Poll()
+		poller.poll()
 		require.Equal(t, 1, eventCount, "third poll should not fire event since CAS unchanged")
 	})
 
@@ -625,7 +625,7 @@ func TestCfgNodePoller_Poll(t *testing.T) {
 		require.NoError(t, err)
 
 		// Call Poll
-		poller.Poll()
+		poller.poll()
 
 		// Verify event was fired
 		require.True(t, eventFired, "event should be fired for deleted document")
@@ -678,7 +678,7 @@ func TestCfgNodePoller_Poll(t *testing.T) {
 		_, err = datastore.Remove(key, cas)
 		require.NoError(t, err)
 
-		poller.Poll()
+		poller.poll()
 
 		// Verify event was fired
 		require.True(t, eventFired, "event should be fired for purged document")
@@ -689,6 +689,84 @@ func TestCfgNodePoller_Poll(t *testing.T) {
 		require.Equal(t, uint64(0), poller.keyWatcher[key], "keyWatcher should have cas=0 after purge")
 		poller.lock.Unlock()
 	})
+
+	// Verify poll handles multiple document changes in a single poll cycle (race condition test)
+	t.Run("poll_detects_multiple_document_changes", func(t *testing.T) {
+		firedEvents := make(map[string]uint64)
+		var eventLock sync.Mutex
+
+		poller := &cfgNodePoller{
+			ctx:        ctx,
+			keyWatcher: make(map[string]uint64),
+			datastore:  datastore,
+			fireEvent: func(docID string, cas uint64, err error) {
+				eventLock.Lock()
+				firedEvents[docID] = cas
+				eventLock.Unlock()
+			},
+		}
+
+		key1 := "race_condition_doc1"
+		key2 := "race_condition_doc2"
+
+		// Create both documents
+		added, err := datastore.Add(key1, 0, []byte(`{"test": true}`))
+		require.NoError(t, err)
+		require.True(t, added)
+
+		added, err = datastore.Add(key2, 0, []byte(`{"test": true}`))
+		require.NoError(t, err)
+		require.True(t, added)
+
+		t.Cleanup(func() {
+			_ = datastore.Delete(key1)
+			_ = datastore.Delete(key2)
+		})
+
+		// Register both keys
+		err = poller.Register(key1)
+		require.NoError(t, err)
+
+		err = poller.Register(key2)
+		require.NoError(t, err)
+
+		// Change first document
+		err = datastore.Set(key1, 0, nil, []byte(`{"updated": true}`))
+		require.NoError(t, err)
+
+		// Change second document
+		err = datastore.Set(key2, 0, nil, []byte(`{"updated": true}`))
+		require.NoError(t, err)
+
+		// Run poll - should detect both changes
+		poller.poll()
+
+		// Verify both events were fired
+		eventLock.Lock()
+		require.Len(t, firedEvents, 2, "both documents should trigger events")
+		_, fired1 := firedEvents[key1]
+		require.True(t, fired1, "event should be fired for first document")
+		_, fired2 := firedEvents[key2]
+		require.True(t, fired2, "event should be fired for second document")
+		eventLock.Unlock()
+
+		// Verify both keyWatcher CAS values were updated
+		poller.lock.Lock()
+		defer poller.lock.Unlock()
+
+		require.NotEqual(t, uint64(0), poller.keyWatcher[key1], "first document should have non-zero cas after poll")
+		require.NotEqual(t, uint64(0), poller.keyWatcher[key2], "second document should have non-zero cas after poll")
+
+		// Verify CAS matches current datastore values
+		currentCas1, err := datastore.Get(key1, nil)
+		require.NoError(t, err)
+		require.Equal(t, currentCas1, poller.keyWatcher[key1], "first document CAS should match datastore")
+
+		currentCas2, err := datastore.Get(key2, nil)
+		require.NoError(t, err)
+		require.Equal(t, currentCas2, poller.keyWatcher[key2], "second document CAS should match datastore")
+	})
+
 }
 
 func TestCfgNodePoller_StartPolling(t *testing.T) {
@@ -722,7 +800,7 @@ func TestCfgNodePoller_StartPolling(t *testing.T) {
 		err = poller.Register(key)
 		require.NoError(t, err)
 
-		poller.StartPolling(ctx)
+		poller.startPolling(ctx)
 
 		// Wait for at least one poll cycle
 		time.Sleep(20 * time.Millisecond)
@@ -767,7 +845,7 @@ func TestCfgNodePoller_StartPolling(t *testing.T) {
 		err := poller.Register(key)
 		require.NoError(t, err)
 
-		poller.StartPolling(ctx)
+		poller.startPolling(ctx)
 
 		// Create document - should be detected on next poll
 		added, err := datastore.Add(key, 0, []byte(`{"test": true}`))
@@ -811,7 +889,7 @@ func TestCfgNodePoller_StartPolling(t *testing.T) {
 		err = poller.Register(key)
 		require.NoError(t, err)
 
-		poller.StartPolling(ctx)
+		poller.startPolling(ctx)
 
 		// First update
 		err = datastore.Set(key, 0, nil, []byte(`{"version": 2}`))
@@ -859,7 +937,7 @@ func TestCfgNodePoller_StartPolling(t *testing.T) {
 		err := poller.Register(key)
 		require.NoError(t, err)
 
-		poller.StartPolling(ctx)
+		poller.startPolling(ctx)
 		cancel()
 
 		// Wait for goroutine to stop

--- a/base/dcp_test.go
+++ b/base/dcp_test.go
@@ -481,8 +481,12 @@ func TestConcurrentCBGTIndexCreation(t *testing.T) {
 
 	for _, feedType := range []ShardedDCPFeedType{ShardedDCPFeedTypeImport, ShardedDCPFeedTypeResync} {
 
+		useNodePoller := false
+		if feedType == ShardedDCPFeedTypeResync {
+			useNodePoller = true
+		}
 		// Use a bucket-backed cfg
-		cfg, err := NewCfgSG(ctx, dataStore, "")
+		cfg, err := NewCfgSG(ctx, dataStore, "", useNodePoller)
 		require.NoError(t, err)
 
 		// Define index type for db name

--- a/base/heartbeat_test.go
+++ b/base/heartbeat_test.go
@@ -354,21 +354,21 @@ func TestCBGTManagerHeartbeater(t *testing.T) {
 	listener1, err := NewShardedDCPHeartbeatListener(ctx, &CbgtContext{
 		Cfg:     cfgCB,
 		Manager: testManager,
-	}, dataStore, ShardedDCPFeedTypeImport)
+	})
 	assert.NoError(t, err)
 	assert.NoError(t, node1.RegisterListener(listener1))
 
 	listener2, err := NewShardedDCPHeartbeatListener(ctx, &CbgtContext{
 		Cfg:     cfgCB,
 		Manager: testManager,
-	}, dataStore, ShardedDCPFeedTypeImport)
+	})
 	assert.NoError(t, err)
 	assert.NoError(t, node2.RegisterListener(listener2))
 
 	listener3, err := NewShardedDCPHeartbeatListener(ctx, &CbgtContext{
 		Cfg:     cfgCB,
 		Manager: testManager,
-	}, dataStore, ShardedDCPFeedTypeImport)
+	})
 	assert.NoError(t, err)
 	assert.NoError(t, node3.RegisterListener(listener3))
 

--- a/base/heartbeat_test.go
+++ b/base/heartbeat_test.go
@@ -354,21 +354,21 @@ func TestCBGTManagerHeartbeater(t *testing.T) {
 	listener1, err := NewShardedDCPHeartbeatListener(ctx, &CbgtContext{
 		Cfg:     cfgCB,
 		Manager: testManager,
-	})
+	}, dataStore, ShardedDCPFeedTypeImport)
 	assert.NoError(t, err)
 	assert.NoError(t, node1.RegisterListener(listener1))
 
 	listener2, err := NewShardedDCPHeartbeatListener(ctx, &CbgtContext{
 		Cfg:     cfgCB,
 		Manager: testManager,
-	})
+	}, dataStore, ShardedDCPFeedTypeImport)
 	assert.NoError(t, err)
 	assert.NoError(t, node2.RegisterListener(listener2))
 
 	listener3, err := NewShardedDCPHeartbeatListener(ctx, &CbgtContext{
 		Cfg:     cfgCB,
 		Manager: testManager,
-	})
+	}, dataStore, ShardedDCPFeedTypeImport)
 	assert.NoError(t, err)
 	assert.NoError(t, node3.RegisterListener(listener3))
 

--- a/base/sg_cluster_cfg.go
+++ b/base/sg_cluster_cfg.go
@@ -145,7 +145,6 @@ func (c *CfgSG) Subscribe(cfgKey string, ch chan cbgt.CfgEvent) error {
 		}
 	}
 
-
 	return nil
 }
 

--- a/base/sg_cluster_cfg.go
+++ b/base/sg_cluster_cfg.go
@@ -40,11 +40,10 @@ type CfgEventNotifyFunc func(docID string, cas uint64, err error)
 var ErrCfgCasError = &cbgt.CfgCASError{}
 
 // NewCfgSG returns a Cfg implementation that reads/writes its entries
-// from/to a couchbase bucket, using DCP streams to subscribe to
-// changes.
+// from/to a couchbase datastore. All document names will start with keyPrefix.
+// If useNodePoller is true, then any document changes are received by node polling. If useNodePoller is not true, then the caller needs to register event changes itself by calling FireEvent.
 //
-// urlStr: single URL or multiple URLs delimited by ';'
-// bucket: couchbase bucket name
+// The caching feed implements FireEvent calls by looking for document changes starting with keyPrefix and calling FireEvent.
 func NewCfgSG(ctx context.Context, datastore sgbucket.DataStore, keyPrefix string, useNodePoller bool) (*CfgSG, error) {
 
 	cfgContextID := MD(datastore.GetName()).Redact() + "-cfgSG"
@@ -59,7 +58,7 @@ func NewCfgSG(ctx context.Context, datastore sgbucket.DataStore, keyPrefix strin
 	}
 
 	if useNodePoller {
-		c.nodePoller = newCfgNodePoller(ctx, datastore, c.FireEvent, defaultHeartbeatPollInterval)
+		c.nodePoller = newCfgNodePoller(loggingCtx, datastore, c.FireEvent, defaultHeartbeatPollInterval)
 	}
 
 	return c, nil
@@ -132,6 +131,7 @@ func (c *CfgSG) Subscribe(cfgKey string, ch chan cbgt.CfgEvent) error {
 
 	DebugfCtx(c.loggingCtx, KeyCluster, "cfg_sg: Subscribe, key: %s", cfgKey)
 	c.lock.Lock()
+	defer c.lock.Unlock()
 	a, exists := c.subscriptions[cfgKey]
 	if !exists || a == nil {
 		a = make([]chan<- cbgt.CfgEvent, 0)
@@ -145,7 +145,6 @@ func (c *CfgSG) Subscribe(cfgKey string, ch chan cbgt.CfgEvent) error {
 		}
 	}
 
-	c.lock.Unlock()
 
 	return nil
 }

--- a/base/sg_cluster_cfg.go
+++ b/base/sg_cluster_cfg.go
@@ -32,6 +32,7 @@ type CfgSG struct {
 	subscriptions map[string][]chan<- cbgt.CfgEvent // Keyed by key
 	lock          sync.Mutex                        // mutex for subscriptions
 	keyPrefix     string                            // Config doc key prefix
+	nodePoller    *cfgNodePoller
 }
 
 type CfgEventNotifyFunc func(docID string, cas uint64, err error)
@@ -44,7 +45,7 @@ var ErrCfgCasError = &cbgt.CfgCASError{}
 //
 // urlStr: single URL or multiple URLs delimited by ';'
 // bucket: couchbase bucket name
-func NewCfgSG(ctx context.Context, datastore sgbucket.DataStore, keyPrefix string) (*CfgSG, error) {
+func NewCfgSG(ctx context.Context, datastore sgbucket.DataStore, keyPrefix string, useNodePoller bool) (*CfgSG, error) {
 
 	cfgContextID := MD(datastore.GetName()).Redact() + "-cfgSG"
 	// should this inherit DB context?
@@ -55,6 +56,10 @@ func NewCfgSG(ctx context.Context, datastore sgbucket.DataStore, keyPrefix strin
 		loggingCtx:    loggingCtx,
 		subscriptions: make(map[string][]chan<- cbgt.CfgEvent),
 		keyPrefix:     keyPrefix,
+	}
+
+	if useNodePoller {
+		c.nodePoller = newCfgNodePoller(ctx, datastore, c.FireEvent, defaultHeartbeatPollInterval)
 	}
 
 	return c, nil
@@ -132,6 +137,10 @@ func (c *CfgSG) Subscribe(cfgKey string, ch chan cbgt.CfgEvent) error {
 		a = make([]chan<- cbgt.CfgEvent, 0)
 	}
 	c.subscriptions[cfgKey] = append(a, ch)
+
+	if c.nodePoller != nil {
+		c.nodePoller.Register(c.sgCfgBucketKey(cfgKey))
+	}
 
 	c.lock.Unlock()
 

--- a/base/sg_cluster_cfg.go
+++ b/base/sg_cluster_cfg.go
@@ -138,14 +138,10 @@ func (c *CfgSG) Subscribe(cfgKey string, ch chan cbgt.CfgEvent) error {
 	}
 	c.subscriptions[cfgKey] = append(a, ch)
 
-	if c.nodePoller != nil {
-		err := c.nodePoller.Register(c.sgCfgBucketKey(cfgKey))
-		if err != nil {
-			return err
-		}
+	if c.nodePoller == nil {
+		return nil
 	}
-
-	return nil
+	return c.nodePoller.Register(c.sgCfgBucketKey(cfgKey))
 }
 
 func (c *CfgSG) FireEvent(docID string, cas uint64, err error) {

--- a/base/sg_cluster_cfg.go
+++ b/base/sg_cluster_cfg.go
@@ -139,7 +139,10 @@ func (c *CfgSG) Subscribe(cfgKey string, ch chan cbgt.CfgEvent) error {
 	c.subscriptions[cfgKey] = append(a, ch)
 
 	if c.nodePoller != nil {
-		c.nodePoller.Register(c.sgCfgBucketKey(cfgKey))
+		err := c.nodePoller.Register(c.sgCfgBucketKey(cfgKey))
+		if err != nil {
+			return err
+		}
 	}
 
 	c.lock.Unlock()

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -249,11 +249,13 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 		ctx, cancel := context.WithCancelCause(ctx)
 		resyncCfg, err := base.NewCfgSG(ctx, db.MetadataStore, db.MetadataKeys.ResyncCfgPrefix(), true)
 		if err != nil {
+			cancel(fmt.Errorf("resync run ended with error: %v", err))
 			return fmt.Errorf("Error creating resync cfg: %v", err)
 		}
 
 		indexName, err := base.GenerateCBGTIndexName(db.Name, base.ShardedDCPFeedTypeResync)
 		if err != nil {
+			cancel(fmt.Errorf("resync run ended with error: %v", err))
 			return fmt.Errorf("Error generating CBGT index name: %v", err)
 		}
 		opts := base.ShardedDCPOptions{
@@ -278,7 +280,7 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 		defer func() {
 			resyncCbgtContext.Stop(ctx)
 			resyncHB.Stop(ctx)
-			cancel(fmt.Errorf("resync run ended"))
+			cancel(fmt.Errorf("resync run ended with error: %v", err))
 		}()
 	} else {
 

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -246,7 +246,8 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 		}
 
 		// CFG creation:
-		resyncCfg, err := base.NewCfgSG(ctx, db.MetadataStore, db.MetadataKeys.ResyncCfgPrefix())
+		ctx, cancel := context.WithCancelCause(ctx)
+		resyncCfg, err := base.NewCfgSG(ctx, db.MetadataStore, db.MetadataKeys.ResyncCfgPrefix(), true)
 		if err != nil {
 			return fmt.Errorf("Error creating resync cfg: %v", err)
 		}
@@ -277,6 +278,7 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 		defer func() {
 			resyncCbgtContext.Stop(ctx)
 			resyncHB.Stop(ctx)
+			cancel(fmt.Errorf("resync run ended"))
 		}()
 	} else {
 

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -266,6 +266,8 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 			IndexType:     base.CBGTIndexTypeSyncGatewayResync,
 			DestKey:       resyncDestKey,
 			IndexName:     indexName,
+			Datastore:     db.MetadataStore,
+			FeedType:      base.ShardedDCPFeedTypeResync,
 		}
 		resyncCbgtContext, err := base.StartShardedDCPFeed(loggingCtx, opts)
 

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -246,16 +246,17 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 		}
 
 		// CFG creation:
-		ctx, cancel := context.WithCancelCause(ctx)
-		resyncCfg, err := base.NewCfgSG(ctx, db.MetadataStore, db.MetadataKeys.ResyncCfgPrefix(), true)
+		resyncCtx, cancelResync := context.WithCancelCause(ctx)
+		defer cancelResync(nil)
+		resyncCfg, err := base.NewCfgSG(resyncCtx, db.MetadataStore, db.MetadataKeys.ResyncCfgPrefix(), true)
 		if err != nil {
-			cancel(fmt.Errorf("resync run ended with error: %v", err))
+			cancelResync(fmt.Errorf("resync run ended with error: %v", err))
 			return fmt.Errorf("Error creating resync cfg: %v", err)
 		}
 
 		indexName, err := base.GenerateCBGTIndexName(db.Name, base.ShardedDCPFeedTypeResync)
 		if err != nil {
-			cancel(fmt.Errorf("resync run ended with error: %v", err))
+			cancelResync(fmt.Errorf("resync run ended with error: %v", err))
 			return fmt.Errorf("Error generating CBGT index name: %v", err)
 		}
 		opts := base.ShardedDCPOptions{
@@ -273,12 +274,9 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 			FeedType:      base.ShardedDCPFeedTypeResync,
 		}
 		resyncCbgtContext, err := base.StartShardedDCPFeed(loggingCtx, opts)
-
 		if err != nil {
-			cancel(fmt.Errorf("resync run function failed: %w", err))
+			cancelResync(fmt.Errorf("resync run function failed: %w", err))
 			return fmt.Errorf("Error starting resync sharded dcp feed: %v", err)
-		} else {
-			cancel(fmt.Errorf("resync run ended with error: %v", err))
 		}
 		defer func() {
 			resyncCbgtContext.Stop(ctx)

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -275,12 +275,14 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 		resyncCbgtContext, err := base.StartShardedDCPFeed(loggingCtx, opts)
 
 		if err != nil {
+			cancel(fmt.Errorf("resync run function failed: %w", err))
 			return fmt.Errorf("Error starting resync sharded dcp feed: %v", err)
+		} else {
+			cancel(fmt.Errorf("resync run ended with error: %v", err))
 		}
 		defer func() {
 			resyncCbgtContext.Stop(ctx)
 			resyncHB.Stop(ctx)
-			cancel(fmt.Errorf("resync run ended with error: %v", err))
 		}()
 	} else {
 

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -113,7 +113,7 @@ func (r *ResyncManagerDCP) Init(ctx context.Context, options map[string]any, clu
 }
 
 // Run starts a DCP feed to process documents for resync.
-func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, persistClusterStatusCallback updateStatusCallbackFunc, terminator *base.SafeTerminator) error {
+func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, persistClusterStatusCallback updateStatusCallbackFunc, terminator *base.SafeTerminator) (err error) {
 	db, ok := options["database"].(*Database)
 	if !ok {
 		return errors.New("database option is required and must be of type *Database")
@@ -244,19 +244,25 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 		if err != nil {
 			return fmt.Errorf("Error starting resync heartbeater: %v", err)
 		}
+		defer resyncHB.Stop(ctx)
 
 		// CFG creation:
 		resyncCtx, cancelResync := context.WithCancelCause(ctx)
+		defer func() {
+			if err != nil {
+				cancelResync(err)
+			} else {
+				cancelResync(errors.New("resync ended normally"))
+			}
+		}()
 		defer cancelResync(nil)
 		resyncCfg, err := base.NewCfgSG(resyncCtx, db.MetadataStore, db.MetadataKeys.ResyncCfgPrefix(), true)
 		if err != nil {
-			cancelResync(fmt.Errorf("resync run ended with error: %v", err))
 			return fmt.Errorf("Error creating resync cfg: %v", err)
 		}
 
 		indexName, err := base.GenerateCBGTIndexName(db.Name, base.ShardedDCPFeedTypeResync)
 		if err != nil {
-			cancelResync(fmt.Errorf("resync run ended with error: %v", err))
 			return fmt.Errorf("Error generating CBGT index name: %v", err)
 		}
 		opts := base.ShardedDCPOptions{
@@ -275,13 +281,9 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 		}
 		resyncCbgtContext, err := base.StartShardedDCPFeed(loggingCtx, opts)
 		if err != nil {
-			cancelResync(fmt.Errorf("resync run function failed: %w", err))
 			return fmt.Errorf("Error starting resync sharded dcp feed: %v", err)
 		}
-		defer func() {
-			resyncCbgtContext.Stop(ctx)
-			resyncHB.Stop(ctx)
-		}()
+		defer resyncCbgtContext.Stop(ctx)
 	} else {
 
 		clientOptions := getResyncDCPClientOptions(db.DatabaseContext, r.ResyncID, r.collectionIDs, false)

--- a/db/database.go
+++ b/db/database.go
@@ -509,7 +509,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 	// Initialize sg cluster config.  Required even if import and sgreplicate are disabled
 	// on this node, to support replication REST API calls
 	if base.IsEnterpriseEdition() {
-		sgCfg, err := base.NewCfgSG(ctx, metadataStore, metaKeys.SGCfgPrefix(dbContext.Options.GroupID))
+		sgCfg, err := base.NewCfgSG(ctx, metadataStore, metaKeys.SGCfgPrefix(dbContext.Options.GroupID), false)
 		if err != nil {
 			return nil, err
 		}

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -108,6 +108,8 @@ func (il *importListener) StartImportFeed(dbContext *DatabaseContext) (err error
 		DestKey:           il.importDestKey,
 		IndexName:         indexName,
 		PreviousIndexName: base.GenerateLegacyImportIndexName(dbContext.Name),
+		Datastore:         dbContext.MetadataStore,
+		FeedType:          base.ShardedDCPFeedTypeImport,
 	}
 	il.cbgtContext, err = base.StartShardedDCPFeed(il.loggingCtx, opts)
 	return err

--- a/db/sg_replicate_cfg_test.go
+++ b/db/sg_replicate_cfg_test.go
@@ -27,7 +27,7 @@ func TestReplicateManagerReplications(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close(ctx)
 
-	testCfg, err := base.NewCfgSG(ctx, testBucket.GetSingleDataStore(), "")
+	testCfg, err := base.NewCfgSG(ctx, testBucket.GetSingleDataStore(), "", false)
 	require.NoError(t, err)
 
 	manager, err := NewSGReplicateManager(ctx, &DatabaseContext{Name: "test"}, testCfg)
@@ -92,7 +92,7 @@ func TestReplicateManagerNodes(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close(ctx)
 
-	testCfg, err := base.NewCfgSG(ctx, testBucket.GetSingleDataStore(), "")
+	testCfg, err := base.NewCfgSG(ctx, testBucket.GetSingleDataStore(), "", false)
 	require.NoError(t, err)
 
 	manager, err := NewSGReplicateManager(ctx, &DatabaseContext{Name: "test"}, testCfg)
@@ -148,7 +148,7 @@ func TestReplicateManagerConcurrentNodeOperations(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close(ctx)
 
-	testCfg, err := base.NewCfgSG(ctx, testBucket.GetSingleDataStore(), "")
+	testCfg, err := base.NewCfgSG(ctx, testBucket.GetSingleDataStore(), "", false)
 	require.NoError(t, err)
 
 	manager, err := NewSGReplicateManager(ctx, &DatabaseContext{Name: "test"}, testCfg)
@@ -193,7 +193,7 @@ func TestReplicateManagerConcurrentReplicationOperations(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close(ctx)
 
-	testCfg, err := base.NewCfgSG(ctx, testBucket.GetSingleDataStore(), "")
+	testCfg, err := base.NewCfgSG(ctx, testBucket.GetSingleDataStore(), "", false)
 	require.NoError(t, err)
 
 	manager, err := NewSGReplicateManager(ctx, &DatabaseContext{Name: "test"}, testCfg)
@@ -645,7 +645,7 @@ func TestIsCfgChanged(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close(ctx)
 
-	testCfg, err := base.NewCfgSG(ctx, testBucket.GetSingleDataStore(), "")
+	testCfg, err := base.NewCfgSG(ctx, testBucket.GetSingleDataStore(), "", false)
 	require.NoError(t, err)
 
 	mgr, err := NewSGReplicateManager(ctx, &DatabaseContext{Name: "test"}, testCfg)


### PR DESCRIPTION
CBG-5190

Describe your PR here...
- Added a node poller that polls for all the CBGT subscribed documents
- This node poller is used only for distributed resync
- Whenever there is a change in any of the documents used by CBGT, an event is fired to reload the nodes
- added test coverage for the node poller

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/445/
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/477/
