### PR TITLE
CBG-5262 fix missing changes with active_only=true and limit=

### DIFF
--- a/db/changes_view.go
+++ b/db/changes_view.go
@@ -97,6 +97,7 @@ func (c *DatabaseCollection) getChangesInChannelFromQuery(ctx context.Context, c
 	start := time.Now()
 	usingViews := c.useViews()
 	entries := make(LogEntries, 0)
+	activeEntryCount := 0
 
 	base.InfofCtx(ctx, base.KeyCache, "  Querying 'channels' for %q (start=#%d, end=#%d, limit=%d)", base.UD(channelName), startSeq, endSeq, limit)
 
@@ -129,12 +130,16 @@ func (c *DatabaseCollection) getChangesInChannelFromQuery(ctx context.Context, c
 			}
 
 			queryRowCount++
-			highSeq = entry.Sequence
 
-			if activeOnly && (!entry.IsActive() || len(entries) >= limit) {
-				continue
+			// If active-only, track the number of non-removal, non-deleted revisions we've seen in the view results
+			// for limit calculation below.
+			if activeOnly {
+				if entry.IsActive() {
+					activeEntryCount++
+				}
 			}
 			entries = append(entries, entry)
+			highSeq = entry.Sequence
 		}
 
 		// Close query results
@@ -151,10 +156,11 @@ func (c *DatabaseCollection) getChangesInChannelFromQuery(ctx context.Context, c
 			return nil, nil
 		}
 
-		// If active-only, loop until either retrieve (limit) active entries, or reach endSeq.
+		// If active-only, loop until either retrieve (limit) active entries, or reach endSeq.  Non-active entries are still
+		// included in the result set for potential cache prepend
 		if activeOnly {
 			// If we've reached limit, we're done
-			if len(entries) >= limit || limit == 0 {
+			if activeEntryCount >= limit || limit == 0 {
 				break
 			}
 			// If we've reached endSeq, we're done

--- a/db/changes_view.go
+++ b/db/changes_view.go
@@ -97,7 +97,6 @@ func (c *DatabaseCollection) getChangesInChannelFromQuery(ctx context.Context, c
 	start := time.Now()
 	usingViews := c.useViews()
 	entries := make(LogEntries, 0)
-	activeEntryCount := 0
 
 	base.InfofCtx(ctx, base.KeyCache, "  Querying 'channels' for %q (start=#%d, end=#%d, limit=%d)", base.UD(channelName), startSeq, endSeq, limit)
 
@@ -130,16 +129,14 @@ func (c *DatabaseCollection) getChangesInChannelFromQuery(ctx context.Context, c
 			}
 
 			queryRowCount++
+			highSeq = entry.Sequence
 
 			// If active-only, track the number of non-removal, non-deleted revisions we've seen in the view results
 			// for limit calculation below.
-			if activeOnly {
-				if entry.IsActive() {
-					activeEntryCount++
-				}
+			if activeOnly && !entry.IsActive() {
+				continue
 			}
 			entries = append(entries, entry)
-			highSeq = entry.Sequence
 		}
 
 		// Close query results
@@ -156,11 +153,10 @@ func (c *DatabaseCollection) getChangesInChannelFromQuery(ctx context.Context, c
 			return nil, nil
 		}
 
-		// If active-only, loop until either retrieve (limit) active entries, or reach endSeq.  Non-active entries are still
-		// included in the result set for potential cache prepend
+		// If active-only, loop until either retrieve (limit) active entries, or reach endSeq.
 		if activeOnly {
 			// If we've reached limit, we're done
-			if activeEntryCount >= limit || limit == 0 {
+			if len(entries) >= limit || limit == 0 {
 				break
 			}
 			// If we've reached endSeq, we're done

--- a/db/changes_view.go
+++ b/db/changes_view.go
@@ -131,7 +131,7 @@ func (c *DatabaseCollection) getChangesInChannelFromQuery(ctx context.Context, c
 			queryRowCount++
 			highSeq = entry.Sequence
 
-			if activeOnly && !entry.IsActive() {
+			if activeOnly && (!entry.IsActive() || len(entries) >= limit) {
 				continue
 			}
 			entries = append(entries, entry)

--- a/db/changes_view.go
+++ b/db/changes_view.go
@@ -131,8 +131,6 @@ func (c *DatabaseCollection) getChangesInChannelFromQuery(ctx context.Context, c
 			queryRowCount++
 			highSeq = entry.Sequence
 
-			// If active-only, track the number of non-removal, non-deleted revisions we've seen in the view results
-			// for limit calculation below.
 			if activeOnly && !entry.IsActive() {
 				continue
 			}

--- a/db/channel_cache_single.go
+++ b/db/channel_cache_single.go
@@ -440,31 +440,19 @@ func (c *singleChannelCacheImpl) GetChanges(ctx context.Context, options Changes
 
 	result := resultFromQuery
 	room := options.Limit - len(result)
-	if (options.Limit == 0 || room > 0) && len(resultFromCache) > 0 {
+	if (options.Limit == 0 || room > 0 || options.ActiveOnly) && len(resultFromCache) > 0 {
 		// Concatenate the view & cache results:
 		if len(result) > 0 && resultFromCache[0].Sequence == result[len(result)-1].Sequence {
 			resultFromCache = resultFromCache[1:]
 		}
 		n := len(resultFromCache)
-		if options.Limit > 0 && room > 0 && room < n {
-			n = room
-		}
-		if !options.ActiveOnly || options.Limit == 0 || len(resultFromQuery)+len(resultFromCache) <= options.Limit {
-			result = append(result, resultFromCache[0:n]...)
-		} else {
-			totalEntries := len(result)
-			for _, entry := range resultFromCache {
-				if totalEntries >= options.Limit {
-					break
-				}
-				if !entry.IsActive() {
-					continue
-				}
-				result = append(result, entry)
-				totalEntries++
+		// Limit evaluation only valid when not activeOnly, since view and cache results don't apply activeOnly filtering
+		if !options.ActiveOnly {
+			if options.Limit > 0 && room > 0 && room < n {
+				n = room
 			}
-
 		}
+		result = append(result, resultFromCache[0:n]...)
 	}
 	base.InfofCtx(ctx, base.KeyCache, "GetChangesInChannel(%q) --> %d rows", base.UD(c.channelID), len(result))
 

--- a/db/channel_cache_single.go
+++ b/db/channel_cache_single.go
@@ -449,7 +449,22 @@ func (c *singleChannelCacheImpl) GetChanges(ctx context.Context, options Changes
 		if options.Limit > 0 && room > 0 && room < n {
 			n = room
 		}
-		result = append(result, resultFromCache[0:n]...)
+		if !options.ActiveOnly || len(resultFromQuery)+len(resultFromCache) <= options.Limit {
+			result = append(result, resultFromCache[0:n]...)
+		} else {
+			totalEntries := len(result)
+			for _, entry := range resultFromCache {
+				if totalEntries >= options.Limit {
+					break
+				}
+				if !entry.IsActive() {
+					continue
+				}
+				result = append(result, entry)
+				totalEntries++
+			}
+
+		}
 	}
 	base.InfofCtx(ctx, base.KeyCache, "GetChangesInChannel(%q) --> %d rows", base.UD(c.channelID), len(result))
 

--- a/db/channel_cache_single.go
+++ b/db/channel_cache_single.go
@@ -449,7 +449,7 @@ func (c *singleChannelCacheImpl) GetChanges(ctx context.Context, options Changes
 		if options.Limit > 0 && room > 0 && room < n {
 			n = room
 		}
-		if !options.ActiveOnly || len(resultFromQuery)+len(resultFromCache) <= options.Limit {
+		if !options.ActiveOnly || options.Limit == 0 || len(resultFromQuery)+len(resultFromCache) <= options.Limit {
 			result = append(result, resultFromCache[0:n]...)
 		} else {
 			totalEntries := len(result)

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -624,11 +624,11 @@ func TestChannelCacheActiveOnlyAndLimit(t *testing.T) {
 	// doc3 rev1: channel active
 	revID, _, err := collection.Put(ctx, doc1, Body{"channels": activeChannel})
 	require.NoError(t, err)
-	_, _, err = collection.Put(ctx, doc1, Body{"channel": inactiveChannel, "_rev": revID})
+	_, _, err = collection.Put(ctx, doc1, Body{"channels": inactiveChannel, "_rev": revID})
 	require.NoError(t, err)
 	revID, _, err = collection.Put(ctx, doc2, Body{"channels": activeChannel})
 	require.NoError(t, err)
-	_, _, err = collection.Put(ctx, doc2, Body{"channel": inactiveChannel, "_rev": revID})
+	_, _, err = collection.Put(ctx, doc2, Body{"channels": inactiveChannel, "_rev": revID})
 	require.NoError(t, err)
 
 	_, _, err = collection.Put(ctx, doc3, Body{"channels": activeChannel})
@@ -645,11 +645,15 @@ func TestChannelCacheActiveOnlyAndLimit(t *testing.T) {
 	require.Len(t, getChanges(t, collection, base.SetOf(activeChannel), changesOptions), 3)
 
 	// whether limit or no limit, should only be 1 active entry
-	changesOptions = ChangesOptions{
-		Since:      SequenceID{Seq: 0},
-		ActiveOnly: true,
-		ChangesCtx: base.TestCtx(t),
-		Limit:      1,
+	for _, limit := range []int{0, 1} {
+		t.Run("limit="+fmt.Sprint(limit), func(t *testing.T) {
+			changesOptions = ChangesOptions{
+				Since:      SequenceID{Seq: 0},
+				ActiveOnly: true,
+				ChangesCtx: base.TestCtx(t),
+				Limit:      limit,
+			}
+			require.Len(t, getChanges(t, collection, base.SetOf(activeChannel), changesOptions), 1)
+		})
 	}
-	require.Len(t, getChanges(t, collection, base.SetOf(activeChannel), changesOptions), 1)
 }

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -599,15 +599,11 @@ func TestChannelCacheBackgroundTaskWithIllegalTimeInterval(t *testing.T) {
 	assert.Equal(t, options.ChannelCacheAge, backgroundTaskError.Interval)
 }
 
+// - The channel cache is validFrom sequence n, with one active mutation resident in the cache
+// - There are channel removals (only) in the bucket with m < sequence < n
+// - Client issues a GetChanges request with since=m
 func TestChannelCacheActiveOnlyAndLimit(t *testing.T) {
-	cacheOptions := DefaultCacheOptions()
-	cacheOptions.ChannelCacheMaxLength = 2
-	db, ctx := setupTestDBWithCacheOptions(t, cacheOptions)
-	defer db.Close(ctx)
-	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
-
-	_, err := collection.UpdateSyncFun(ctx, channels.DocChannelsSyncFunction)
-	require.NoError(t, err)
+	ctx, db, collection := setupDBWithChannelCacheSize(t, 2)
 
 	const (
 		activeChannel   = "active"
@@ -656,4 +652,118 @@ func TestChannelCacheActiveOnlyAndLimit(t *testing.T) {
 			require.Len(t, getChanges(t, collection, base.SetOf(activeChannel), changesOptions), 1)
 		})
 	}
+}
+
+func TestChannelCacheActiveOnlyScenarios(t *testing.T) {
+	const activeChannel = "active"
+
+	t.Run("query returns an active rev, cache is all removals", func(t *testing.T) {
+		ctx, db, collection := setupDBWithChannelCacheSize(t, 2)
+
+		// doc1: active (seq 1) - will be in backing store, not cache
+		_, _, _ = collection.Put(ctx, "doc1", Body{"channels": activeChannel})
+
+		// doc2: active (seq 2) -> inactive (seq 3) - seq 3 in cache
+		revID2, _, _ := collection.Put(ctx, "doc2", Body{"channels": activeChannel})
+		_, _, _ = collection.Put(ctx, "doc2", Body{"channels": "other", "_rev": revID2})
+
+		// doc3: active (seq 4) -> inactive (seq 5) - seq 5 in cache
+		revID3, _, _ := collection.Put(ctx, "doc3", Body{"channels": activeChannel})
+		_, _, _ = collection.Put(ctx, "doc3", Body{"channels": "other", "_rev": revID3})
+
+		db.WaitForPendingChanges(t)
+
+		// With limit 1 (before)
+		changesOptions := ChangesOptions{Since: SequenceID{Seq: 0}, ActiveOnly: true, Limit: 1, ChangesCtx: base.TestCtx(t)}
+		changes := getChanges(t, collection, base.SetOf(activeChannel), changesOptions)
+		require.Len(t, changes, 1)
+		assert.Equal(t, "doc1", changes[0].ID)
+
+		// No limit
+		changesOptions.Limit = 0
+		changes = getChanges(t, collection, base.SetOf(activeChannel), changesOptions)
+		require.Len(t, changes, 1)
+		assert.Equal(t, "doc1", changes[0].ID)
+
+		// With limit 1 (after)
+		changesOptions.Limit = 1
+		changes = getChanges(t, collection, base.SetOf(activeChannel), changesOptions)
+		require.Len(t, changes, 1)
+		assert.Equal(t, "doc1", changes[0].ID)
+	})
+
+	t.Run("query returns an active rev, cache also has an active rev", func(t *testing.T) {
+		ctx, db, collection := setupDBWithChannelCacheSize(t, 2)
+
+		// doc1: active (seq 1) - backing store
+		_, _, _ = collection.Put(ctx, "doc1", Body{"channels": activeChannel})
+
+		// doc2: active (seq 2) -> inactive (seq 3) - cache
+		revID2, _, _ := collection.Put(ctx, "doc2", Body{"channels": activeChannel})
+		_, _, _ = collection.Put(ctx, "doc2", Body{"channels": "other", "_rev": revID2})
+
+		// doc3: active (seq 4) - cache
+		_, _, _ = collection.Put(ctx, "doc3", Body{"channels": activeChannel})
+
+		db.WaitForPendingChanges(t)
+
+		// With limit 1 (before)
+		changesOptions := ChangesOptions{Since: SequenceID{Seq: 0}, ActiveOnly: true, Limit: 1, ChangesCtx: base.TestCtx(t)}
+		changes := getChanges(t, collection, base.SetOf(activeChannel), changesOptions)
+		require.Len(t, changes, 1)
+		assert.Equal(t, "doc1", changes[0].ID)
+
+		// No limit: should get doc1 and doc3
+		changesOptions.Limit = 0
+		changes = getChanges(t, collection, base.SetOf(activeChannel), changesOptions)
+		require.Len(t, changes, 2)
+		assert.Equal(t, "doc1", changes[0].ID)
+		assert.Equal(t, "doc3", changes[1].ID)
+
+		// With limit 1 (after)
+		changesOptions.Limit = 1
+		changes = getChanges(t, collection, base.SetOf(activeChannel), changesOptions)
+		require.Len(t, changes, 1)
+		assert.Equal(t, "doc1", changes[0].ID)
+	})
+
+	t.Run("query has no active revs, cache has no active revs", func(t *testing.T) {
+		ctx, db, collection := setupDBWithChannelCacheSize(t, 2)
+
+		// doc1: active (seq 1) -> inactive (seq 2)
+		revID1, _, _ := collection.Put(ctx, "doc1", Body{"channels": activeChannel})
+		_, _, _ = collection.Put(ctx, "doc1", Body{"channels": "other", "_rev": revID1})
+
+		// doc2: active (seq 3) -> inactive (seq 4)
+		revID2, _, _ := collection.Put(ctx, "doc2", Body{"channels": activeChannel})
+		_, _, _ = collection.Put(ctx, "doc2", Body{"channels": "other", "_rev": revID2})
+
+		db.WaitForPendingChanges(t)
+
+		// With limit 1 (before)
+		changesOptions := ChangesOptions{Since: SequenceID{Seq: 0}, ActiveOnly: true, Limit: 1, ChangesCtx: base.TestCtx(t)}
+		changes := getChanges(t, collection, base.SetOf(activeChannel), changesOptions)
+		require.Len(t, changes, 0)
+
+		// No limit: should get nothing
+		changesOptions.Limit = 0
+		changes = getChanges(t, collection, base.SetOf(activeChannel), changesOptions)
+		require.Len(t, changes, 0)
+
+		// With limit 1 (after)
+		changesOptions.Limit = 1
+		changes = getChanges(t, collection, base.SetOf(activeChannel), changesOptions)
+		require.Len(t, changes, 0)
+	})
+}
+
+func setupDBWithChannelCacheSize(t *testing.T, maxLength int) (context.Context, *Database, *DatabaseCollectionWithUser) {
+	cacheOptions := DefaultCacheOptions()
+	cacheOptions.ChannelCacheMaxLength = maxLength
+	db, ctx := setupTestDBWithCacheOptions(t, cacheOptions)
+	t.Cleanup(func() { db.Close(ctx) })
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+	_, err := collection.UpdateSyncFun(ctx, channels.DocChannelsSyncFunction)
+	require.NoError(t, err)
+	return ctx, db, collection
 }

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -598,3 +598,58 @@ func TestChannelCacheBackgroundTaskWithIllegalTimeInterval(t *testing.T) {
 	assert.Equal(t, "CleanAgedItems", backgroundTaskError.TaskName)
 	assert.Equal(t, options.ChannelCacheAge, backgroundTaskError.Interval)
 }
+
+func TestChannelCacheActiveOnlyAndLimit(t *testing.T) {
+	cacheOptions := DefaultCacheOptions()
+	cacheOptions.ChannelCacheMaxLength = 2
+	db, ctx := setupTestDBWithCacheOptions(t, cacheOptions)
+	defer db.Close(ctx)
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+
+	_, err := collection.UpdateSyncFun(ctx, channels.DocChannelsSyncFunction)
+	require.NoError(t, err)
+
+	const (
+		activeChannel   = "active"
+		inactiveChannel = "inactive"
+		doc1            = "doc1"
+		doc2            = "doc2"
+		doc3            = "doc3"
+	)
+
+	// doc1 rev1: channel active
+	// doc1 rev2: channel inactive
+	// doc2 rev1: channel active
+	// doc2 rev2: channel inactive
+	// doc3 rev1: channel active
+	revID, _, err := collection.Put(ctx, doc1, Body{"channels": activeChannel})
+	require.NoError(t, err)
+	_, _, err = collection.Put(ctx, doc1, Body{"channel": inactiveChannel, "_rev": revID})
+	require.NoError(t, err)
+	revID, _, err = collection.Put(ctx, doc2, Body{"channels": activeChannel})
+	require.NoError(t, err)
+	_, _, err = collection.Put(ctx, doc2, Body{"channel": inactiveChannel, "_rev": revID})
+	require.NoError(t, err)
+
+	_, _, err = collection.Put(ctx, doc3, Body{"channels": activeChannel})
+	require.NoError(t, err)
+
+	db.WaitForPendingChanges(t)
+
+	// prime channel cache, doc2 and doc3 should be in cache
+	changesOptions := ChangesOptions{
+		Since:      SequenceID{Seq: 0},
+		ActiveOnly: false,
+		ChangesCtx: base.TestCtx(t),
+	}
+	require.Len(t, getChanges(t, collection, base.SetOf(activeChannel), changesOptions), 3)
+
+	// whether limit or no limit, should only be 1 active entry
+	changesOptions = ChangesOptions{
+		Since:      SequenceID{Seq: 0},
+		ActiveOnly: true,
+		ChangesCtx: base.TestCtx(t),
+		Limit:      1,
+	}
+	require.Len(t, getChanges(t, collection, base.SetOf(activeChannel), changesOptions), 1)
+}


### PR DESCRIPTION
CBG-5262 fix missing changes with active_only=true and limit=

When ActiveOnly is set, the N1QL query will filtered tombstoned documents but not documents which have undergone a channel filter. In this case, active only and limit were compatible. In the case of a channel removal, the limit 

To make sure this works in cases of mixed active/inactive documents and channel backfill:

- Filter non active entries from getChangesInChannelFromQuery that are not caught by N1QL (channel removals)
- Fill the active entries from the cache, which could involve parsing a greater number of cached entries than limit has

When `activeOnly` is set, that doesn't populate channel cache, so it isn't a problem to filter the entries for `getChangesInChannelFromQuery`. 

- Are there test cases I should be covering that are missing?
- Is there a more efficient way to avoid the extra loop in `GetChanges`?

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/5262/ (known unrelated flake)
