### PR TITLE
CBG-5232: cache memory managment

### DIFF
--- a/base/stats_descriptions.go
+++ b/base/stats_descriptions.go
@@ -138,7 +138,7 @@ const (
 	RevCacheMissesDesc = "The total number of revision cache misses. This metric can be used to calculate the ratio of revision cache misses: " +
 		"Rev Cache Miss Ratio = rev_cache_misses / (rev_cache_hits + rev_cache_misses)"
 
-	RevCacheMemoryDesc = "The approximation of total memory taken up by rev cache for documents. This is measured by the raw document body, the channels allocated to a document and its revision history."
+	RevCacheMemoryDesc = "The approximation of total memory taken up by rev cache and delta cache for documents. This is measured by the raw document body, the channels allocated to a document and its revision history."
 
 	SkippedSeqLengthDesc = "The current length of the pending skipped sequence slice."
 

--- a/db/cache_memory_controller.go
+++ b/db/cache_memory_controller.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2026-Present Couchbase, Inc.
+
+Use of this software is governed by the Business Source License included in
+the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+file, in accordance with the Business Source License, use of this software will
+be governed by the Apache License, Version 2.0, included in the file
+licenses/APL2.txt.
+*/
+
+package db
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/couchbase/sync_gateway/base"
+)
+
+// CacheMemoryController manages a single memory budget shared between a revision cache and
+// its associated delta cache. All accounting is done via atomic operations so the hot-path
+// capacity check (IsOverCapacity) is entirely lock-free.
+type CacheMemoryController struct {
+	capacity       int64            // total byte limit; 0 = unlimited
+	currBytesCount atomic.Int64     // bytes held by the revision cache + delta cache shard
+	totalBytesStat *base.SgwIntStat // shared observable stat. Overall footprint of the caches combined.
+}
+
+// globalCacheAccessCounter is a monotonically increasing counter stamped onto every
+// cache item on insert and on access. It provides a total ordering across both the
+// revision and delta caches for cross-cache LRU eviction decisions.
+// Using a counter rather than time.Now() keeps the hot-path cost to a single
+// atomic increment (~1–2 ns vs ~25 ns for a clock read).
+var globalCacheAccessCounter atomic.Uint64
+
+func nextAccessOrder() uint64 {
+	return globalCacheAccessCounter.Add(1)
+}
+
+func newCacheMemoryController(capacityBytes int64, totalBytesStat *base.SgwIntStat) *CacheMemoryController {
+	return &CacheMemoryController{
+		capacity:       capacityBytes,
+		totalBytesStat: totalBytesStat,
+	}
+}
+
+// IsOverCapacity will check if overall memory footprint is over the configured for this shard/cache.
+func (mc *CacheMemoryController) IsOverCapacity() bool {
+	if mc.capacity == 0 {
+		return false
+	}
+	return mc.currBytesCount.Load() > mc.capacity
+}
+
+func (mc *CacheMemoryController) bytesToEvict() int64 {
+	excess := mc.currBytesCount.Load() - mc.capacity
+	if excess < 0 {
+		return 0
+	}
+	return excess
+}
+
+func (mc *CacheMemoryController) incrementBytesCount(ctx context.Context, n int64) {
+	mc.currBytesCount.Add(n)
+	mc.totalBytesStat.Add(n)
+}
+
+func (mc *CacheMemoryController) decrementBytesCount(ctx context.Context, n int64) {
+	mc.currBytesCount.Add(-n)
+	mc.totalBytesStat.Add(-n)
+}

--- a/db/cache_memory_controller.go
+++ b/db/cache_memory_controller.go
@@ -11,7 +11,6 @@ licenses/APL2.txt.
 package db
 
 import (
-	"context"
 	"sync/atomic"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -60,12 +59,12 @@ func (mc *CacheMemoryController) bytesToEvict() int64 {
 	return excess
 }
 
-func (mc *CacheMemoryController) incrementBytesCount(ctx context.Context, n int64) {
+func (mc *CacheMemoryController) incrementBytesCount(n int64) {
 	mc.currBytesCount.Add(n)
 	mc.totalBytesStat.Add(n)
 }
 
-func (mc *CacheMemoryController) decrementBytesCount(ctx context.Context, n int64) {
+func (mc *CacheMemoryController) decrementBytesCount(n int64) {
 	mc.currBytesCount.Add(-n)
 	mc.totalBytesStat.Add(-n)
 }

--- a/db/cache_memory_controller.go
+++ b/db/cache_memory_controller.go
@@ -37,6 +37,8 @@ func (mc *CacheMemoryController) IsOverCapacity() bool {
 	if mc.capacity == 0 {
 		return false
 	}
+	// IsOverCapacity returns true only when usage strictly exceeds the limit,
+	// so a cache exactly at capacity is not evicted.
 	return mc.currBytesCount.Load() > mc.capacity
 }
 

--- a/db/cache_memory_controller.go
+++ b/db/cache_memory_controller.go
@@ -20,15 +20,15 @@ import (
 // its associated delta cache. All accounting is done via atomic operations so the hot-path
 // capacity check (IsOverCapacity) is entirely lock-free.
 type CacheMemoryController struct {
-	capacity       int64            // total byte limit; 0 = unlimited
-	currBytesCount atomic.Int64     // bytes held by the revision cache + delta cache shard
-	totalBytesStat *base.SgwIntStat // shared observable stat. Overall footprint of the caches combined.
+	capacity           int64            // total byte limit; 0 = unlimited
+	bytesInUseForShard atomic.Int64     // bytes held by the revision cache + delta cache shard
+	globalUsageStat    *base.SgwIntStat // shared observable stat. Overall footprint of the caches combined.
 }
 
 func newCacheMemoryController(capacityBytes int64, totalBytesStat *base.SgwIntStat) *CacheMemoryController {
 	return &CacheMemoryController{
-		capacity:       capacityBytes,
-		totalBytesStat: totalBytesStat,
+		capacity:        capacityBytes,
+		globalUsageStat: totalBytesStat,
 	}
 }
 
@@ -39,11 +39,11 @@ func (mc *CacheMemoryController) IsOverCapacity() bool {
 	}
 	// IsOverCapacity returns true only when usage strictly exceeds the limit,
 	// so a cache exactly at capacity is not evicted.
-	return mc.currBytesCount.Load() > mc.capacity
+	return mc.bytesInUseForShard.Load() > mc.capacity
 }
 
 func (mc *CacheMemoryController) bytesToEvict() int64 {
-	excess := mc.currBytesCount.Load() - mc.capacity
+	excess := mc.bytesInUseForShard.Load() - mc.capacity
 	if excess < 0 {
 		return 0
 	}
@@ -51,11 +51,11 @@ func (mc *CacheMemoryController) bytesToEvict() int64 {
 }
 
 func (mc *CacheMemoryController) incrementBytesCount(n int64) {
-	mc.currBytesCount.Add(n)
-	mc.totalBytesStat.Add(n)
+	mc.bytesInUseForShard.Add(n)
+	mc.globalUsageStat.Add(n)
 }
 
 func (mc *CacheMemoryController) decrementBytesCount(n int64) {
-	mc.currBytesCount.Add(-n)
-	mc.totalBytesStat.Add(-n)
+	mc.bytesInUseForShard.Add(-n)
+	mc.globalUsageStat.Add(-n)
 }

--- a/db/cache_memory_controller.go
+++ b/db/cache_memory_controller.go
@@ -25,17 +25,6 @@ type CacheMemoryController struct {
 	totalBytesStat *base.SgwIntStat // shared observable stat. Overall footprint of the caches combined.
 }
 
-// globalCacheAccessCounter is a monotonically increasing counter stamped onto every
-// cache item on insert and on access. It provides a total ordering across both the
-// revision and delta caches for cross-cache LRU eviction decisions.
-// Using a counter rather than time.Now() keeps the hot-path cost to a single
-// atomic increment (~1–2 ns vs ~25 ns for a clock read).
-var globalCacheAccessCounter atomic.Uint64
-
-func nextAccessOrder() uint64 {
-	return globalCacheAccessCounter.Add(1)
-}
-
 func newCacheMemoryController(capacityBytes int64, totalBytesStat *base.SgwIntStat) *CacheMemoryController {
 	return &CacheMemoryController{
 		capacity:       capacityBytes,

--- a/db/delta_cache_lru.go
+++ b/db/delta_cache_lru.go
@@ -146,7 +146,7 @@ func (c *LRUDeltaCache) peekLRUTailAccessOrder() uint64 {
 }
 
 // evictLRUTail removes the LRU item and notifies the memory controller.
-// Returns false if the cache was empty.
+// Returns 0 bytes if the cache was empty.
 func (dc *LRUDeltaCache) evictLRUTail() int64 {
 	dc.lock.Lock()
 	defer dc.lock.Unlock()

--- a/db/delta_cache_lru.go
+++ b/db/delta_cache_lru.go
@@ -100,6 +100,7 @@ func (dc *LRUDeltaCache) _numberCapacityEviction() (numItemsEvicted int64, bytes
 		// delete item from lookup map
 		delete(dc.cache, deltaValue.itemKey)
 		numItemsEvicted++
+		bytesEvicted += deltaValue.delta.totalDeltaBytes
 	}
 	return numItemsEvicted, bytesEvicted
 }

--- a/db/delta_cache_lru.go
+++ b/db/delta_cache_lru.go
@@ -155,7 +155,6 @@ type RevisionDelta struct {
 	ToCV                  string                  // Target CV for the delta
 	DeltaBytes            []byte                  // The actual delta
 	AttachmentStorageMeta []AttachmentStorageMeta // Storage metadata of all attachments present on ToRevID
-	ToChannels            base.Set                // Full list of channels for the to revision
 	RevisionHistory       []string                // Revision history from parent of ToRevID to source revID, in descending order
 	HlvHistory            string                  // HLV History in CBL format
 	ToDeleted             bool                    // Flag if ToRevID is a tombstone
@@ -167,7 +166,6 @@ func newRevCacheDelta(deltaBytes []byte, fromRevID string, toRevision DocumentRe
 		ToRevID:               toRevision.RevID,
 		DeltaBytes:            deltaBytes,
 		AttachmentStorageMeta: toRevAttStorageMeta,
-		ToChannels:            toRevision.Channels,
 		RevisionHistory:       toRevision.History.parseAncestorRevisions(fromRevID),
 		HlvHistory:            toRevision.HlvHistory,
 		ToDeleted:             deleted,

--- a/db/delta_cache_lru.go
+++ b/db/delta_cache_lru.go
@@ -14,7 +14,6 @@ import (
 	"container/list"
 	"context"
 	"sync"
-	"sync/atomic"
 
 	"github.com/couchbase/sync_gateway/base"
 )
@@ -30,9 +29,8 @@ type LRUDeltaCache struct {
 
 // deltaCacheValue is the delta cache payload data. Stored as the Value of a list Element.
 type deltaCacheValue struct {
-	delta       *RevisionDelta
-	itemKey     deltaCacheKey
-	accessOrder atomic.Uint64 // stamped on insert; used for cross-cache eviction ordering
+	delta   *RevisionDelta
+	itemKey deltaCacheKey
 }
 
 // deltaCacheKey is used to key the lookup map to delta cache items
@@ -73,7 +71,6 @@ func (dc *LRUDeltaCache) addDelta(ctx context.Context, docID, fromVersionString,
 	elem := dc.lruList.PushFront(value)
 	dc.cache[key] = elem
 	dc.cacheNumDeltas.Add(1)
-	value.accessOrder.Store(nextAccessOrder()) // stamp on insert
 	numItemsRemoved, bytesEvicted := dc._numberCapacityEviction()
 	if numItemsRemoved > 0 {
 		dc.cacheNumDeltas.Add(-numItemsRemoved)
@@ -135,30 +132,21 @@ func (delta *RevisionDelta) CalculateDeltaBytes() {
 	delta.totalDeltaBytes = int64(totalBytes)
 }
 
-// peekLRUTailAccessOrder returns the accessOrder of the LRU item, or 0 if the cache is empty.
-func (c *LRUDeltaCache) peekLRUTailAccessOrder() uint64 {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-	if elem := c.lruList.Back(); elem != nil {
-		return elem.Value.(*deltaCacheValue).accessOrder.Load()
-	}
-	return 0
-}
-
 // evictLRUTail removes the LRU item and notifies the memory controller.
 // Returns 0 bytes if the cache was empty.
-func (dc *LRUDeltaCache) evictLRUTail() int64 {
+// Returns true if an item was evicted.
+func (dc *LRUDeltaCache) evictLRUTail() (int64, bool) {
 	dc.lock.Lock()
 	defer dc.lock.Unlock()
 	elem := dc.lruList.Back()
 	if elem == nil {
-		return 0
+		return 0, false
 	}
 	val := elem.Value.(*deltaCacheValue)
 	dc.lruList.Remove(elem)
 	delete(dc.cache, val.itemKey)
 	dc.cacheNumDeltas.Add(-1)
-	return val.delta.totalDeltaBytes
+	return val.delta.totalDeltaBytes, true
 }
 
 // RevisionDelta stores data about a delta between a revision and ToRevID.

--- a/db/delta_cache_lru.go
+++ b/db/delta_cache_lru.go
@@ -108,7 +108,7 @@ func (dc *LRUDeltaCache) getCachedDelta(ctx context.Context, docID, fromVersionS
 		return nil
 	}
 	key := createDeltaCacheKey(docID, fromVersionString, toVersionString, collectionID)
-	dc.lock.Lock()
+	dc.lock.Lock() // exclusive lock needed for read given it moves the item to front of list
 	defer dc.lock.Unlock()
 	var deltaValue *RevisionDelta
 	if elem := dc.cache[key]; elem != nil {

--- a/db/delta_cache_lru.go
+++ b/db/delta_cache_lru.go
@@ -14,27 +14,28 @@ import (
 	"container/list"
 	"context"
 	"sync"
+	"sync/atomic"
 
 	"github.com/couchbase/sync_gateway/base"
 )
 
 type LRUDeltaCache struct {
-	backingStores  map[uint32]RevisionCacheBackingStore
-	cache          map[deltaCacheKey]*list.Element
-	lruList        *list.List
-	cacheHits      *base.SgwIntStat
-	cacheMisses    *base.SgwIntStat
-	cacheNumDeltas *base.SgwIntStat
-	lock           sync.Mutex
-	capacity       uint32 // Max number of items capacity of LRUDeltaCache
+	cache            map[deltaCacheKey]*list.Element
+	memoryController *CacheMemoryController // used to control memory usage of revision cache and delta cache combined
+	lruList          *list.List
+	cacheNumDeltas   *base.SgwIntStat
+	lock             sync.Mutex
+	capacity         uint32 // Max number of items capacity of LRUDeltaCache
 }
 
 // deltaCacheValue is the delta cache payload data. Stored as the Value of a list Element.
 type deltaCacheValue struct {
-	delta   *RevisionDelta
-	itemKey deltaCacheKey
+	delta       *RevisionDelta
+	itemKey     deltaCacheKey
+	accessOrder atomic.Uint64 // stamped on insert; used for cross-cache eviction ordering
 }
 
+// deltaCacheKey is used to key the lookup map to delta cache items
 type deltaCacheKey struct {
 	docID          string
 	toDocVersion   string
@@ -46,15 +47,13 @@ func createDeltaCacheKey(docID string, fromVersionString, toVersionString string
 	return deltaCacheKey{docID: docID, fromDocVersion: fromVersionString, toDocVersion: toVersionString, collectionID: collectionID}
 }
 
-func NewLRUDeltaCache(revCacheOptions *RevisionCacheOptions, deltaSyncStats *base.DeltaSyncStats, backingStores map[uint32]RevisionCacheBackingStore) *LRUDeltaCache {
+func NewLRUDeltaCache(revCacheOptions *RevisionCacheOptions, deltaSyncStats *base.DeltaSyncStats, memoryController *CacheMemoryController) *LRUDeltaCache {
 	return &LRUDeltaCache{
-		cache:          map[deltaCacheKey]*list.Element{},
-		lruList:        list.New(),
-		capacity:       revCacheOptions.MaxItemCount,
-		backingStores:  backingStores,
-		cacheHits:      deltaSyncStats.DeltaCacheHit,
-		cacheMisses:    deltaSyncStats.DeltaCacheMiss,
-		cacheNumDeltas: deltaSyncStats.DeltaCacheNumItems,
+		cache:            map[deltaCacheKey]*list.Element{},
+		lruList:          list.New(),
+		capacity:         revCacheOptions.MaxItemCount,
+		cacheNumDeltas:   deltaSyncStats.DeltaCacheNumItems,
+		memoryController: memoryController,
 	}
 }
 
@@ -74,15 +73,22 @@ func (dc *LRUDeltaCache) addDelta(ctx context.Context, docID, fromVersionString,
 	elem := dc.lruList.PushFront(value)
 	dc.cache[key] = elem
 	dc.cacheNumDeltas.Add(1)
-	numItemsRemoved := dc._numberCapacityEviction()
+	value.accessOrder.Store(nextAccessOrder()) // stamp on insert
+	numItemsRemoved, bytesEvicted := dc._numberCapacityEviction()
 	if numItemsRemoved > 0 {
 		dc.cacheNumDeltas.Add(-numItemsRemoved)
+	}
+	if dc.memoryController != nil {
+		dc.memoryController.incrementBytesCount(nil, value.delta.totalDeltaBytes)
+		if bytesEvicted > 0 {
+			dc.memoryController.decrementBytesCount(nil, bytesEvicted)
+		}
 	}
 }
 
 // _numberCapacityEviction will iterate removing the last element in cache til we fall below the maximum number of items
 // threshold for this shard, returning the number of items evicted
-func (dc *LRUDeltaCache) _numberCapacityEviction() (numItemsEvicted int64) {
+func (dc *LRUDeltaCache) _numberCapacityEviction() (numItemsEvicted int64, bytesEvicted int64) {
 	for dc.lruList.Len() > int(dc.capacity) {
 		value := dc.lruList.Back()
 		if value == nil {
@@ -95,7 +101,7 @@ func (dc *LRUDeltaCache) _numberCapacityEviction() (numItemsEvicted int64) {
 		delete(dc.cache, deltaValue.itemKey)
 		numItemsEvicted++
 	}
-	return numItemsEvicted
+	return numItemsEvicted, bytesEvicted
 }
 
 // getCachedDelta will retrieve a delta if cached
@@ -126,4 +132,44 @@ func (delta *RevisionDelta) CalculateDeltaBytes() {
 	totalBytes += len(delta.DeltaBytes)
 
 	delta.totalDeltaBytes = int64(totalBytes)
+}
+
+// peekLRUTailAccessOrder returns the accessOrder of the LRU item, or 0 if the cache is empty.
+func (c *LRUDeltaCache) peekLRUTailAccessOrder() uint64 {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if elem := c.lruList.Back(); elem != nil {
+		return elem.Value.(*deltaCacheValue).accessOrder.Load()
+	}
+	return 0
+}
+
+// RevisionDelta stores data about a delta between a revision and ToRevID.
+type RevisionDelta struct {
+	ToRevID               string                  // Target revID for the delta
+	ToCV                  string                  // Target CV for the delta
+	DeltaBytes            []byte                  // The actual delta
+	AttachmentStorageMeta []AttachmentStorageMeta // Storage metadata of all attachments present on ToRevID
+	ToChannels            base.Set                // Full list of channels for the to revision
+	RevisionHistory       []string                // Revision history from parent of ToRevID to source revID, in descending order
+	HlvHistory            string                  // HLV History in CBL format
+	ToDeleted             bool                    // Flag if ToRevID is a tombstone
+	totalDeltaBytes       int64                   // totalDeltaBytes is the total bytes for channels, revisions and body on the delta itself
+}
+
+func newRevCacheDelta(deltaBytes []byte, fromRevID string, toRevision DocumentRevision, deleted bool, toRevAttStorageMeta []AttachmentStorageMeta) RevisionDelta {
+	revDelta := RevisionDelta{
+		ToRevID:               toRevision.RevID,
+		DeltaBytes:            deltaBytes,
+		AttachmentStorageMeta: toRevAttStorageMeta,
+		ToChannels:            toRevision.Channels,
+		RevisionHistory:       toRevision.History.parseAncestorRevisions(fromRevID),
+		HlvHistory:            toRevision.HlvHistory,
+		ToDeleted:             deleted,
+	}
+	if toRevision.CV != nil {
+		revDelta.ToCV = toRevision.CV.String()
+	}
+	revDelta.CalculateDeltaBytes()
+	return revDelta
 }

--- a/db/delta_cache_lru.go
+++ b/db/delta_cache_lru.go
@@ -79,9 +79,9 @@ func (dc *LRUDeltaCache) addDelta(ctx context.Context, docID, fromVersionString,
 		dc.cacheNumDeltas.Add(-numItemsRemoved)
 	}
 	if dc.memoryController != nil {
-		dc.memoryController.incrementBytesCount(nil, value.delta.totalDeltaBytes)
+		dc.memoryController.incrementBytesCount(value.delta.totalDeltaBytes)
 		if bytesEvicted > 0 {
-			dc.memoryController.decrementBytesCount(nil, bytesEvicted)
+			dc.memoryController.decrementBytesCount(bytesEvicted)
 		}
 	}
 }
@@ -142,6 +142,22 @@ func (c *LRUDeltaCache) peekLRUTailAccessOrder() uint64 {
 		return elem.Value.(*deltaCacheValue).accessOrder.Load()
 	}
 	return 0
+}
+
+// evictLRUTail removes the LRU item and notifies the memory controller.
+// Returns false if the cache was empty.
+func (dc *LRUDeltaCache) evictLRUTail() int64 {
+	dc.lock.Lock()
+	defer dc.lock.Unlock()
+	elem := dc.lruList.Back()
+	if elem == nil {
+		return 0
+	}
+	val := elem.Value.(*deltaCacheValue)
+	dc.lruList.Remove(elem)
+	delete(dc.cache, val.itemKey)
+	dc.cacheNumDeltas.Add(-1)
+	return val.delta.totalDeltaBytes
 }
 
 // RevisionDelta stores data about a delta between a revision and ToRevID.

--- a/db/delta_cache_test.go
+++ b/db/delta_cache_test.go
@@ -208,7 +208,7 @@ func TestUpdateDeltaWhenNoDeltaCacheInit(t *testing.T) {
 	_, doc2, err := collection.Put(ctx, docID, Body{"foo": "baz", BodyRev: rev1ID})
 	require.NoError(t, err)
 	rev2CV := doc2.HLV.GetCurrentVersionString()
-	docRev, err := db.revisionCache.Get(ctx, docID, doc2.HLV.GetCurrentVersionString(), collection.GetCollectionID(), RevCacheDontLoadBackupRev)
+	docRev, _, err := db.revisionCache.Get(ctx, docID, doc2.HLV.GetCurrentVersionString(), collection.GetCollectionID(), RevCacheDontLoadBackupRev)
 	require.NoError(t, err)
 
 	// try adding delta when delta sync is off

--- a/db/delta_cache_test.go
+++ b/db/delta_cache_test.go
@@ -174,7 +174,7 @@ func TestNumberBasedEvictionForDeltaCache(t *testing.T) {
 	}
 	// assert that num items in delta is 5
 	assert.Equal(t, int64(5), db.DbStats.DeltaSync().DeltaCacheNumItems.Value())
-	// attempt to add a delta version that already exsits in the cache
+	// attempt to add a delta version that already exists in the cache
 	db.revisionCache.UpdateDelta(ctx, docID, fromCV.String(), toCV.String(), collection.GetCollectionID(), testDelta)
 	// assert that num items in delta is still 5
 	assert.Equal(t, int64(5), db.DbStats.DeltaSync().DeltaCacheNumItems.Value())
@@ -448,4 +448,104 @@ func TestAccessCheckOnNonCurrentRevision(t *testing.T) {
 	// should return missing error given rev2 is no longer current revision
 	_, _, err = collection.GetDelta(ctx, docID, rev1CV, rev2CV)
 	require.ErrorContains(t, err, "404 missing")
+}
+
+// TestDeltaNumberBasedEvictionDecrementsMemoryBytes verifies that when the delta cache
+// hits its MaxItemCount limit and number-based eviction removes an item, the memory
+// controller correctly decrements the evicted delta's bytes.
+func TestDeltaNumberBasedEvictionDecrementsMemoryBytes(t *testing.T) {
+	if !base.IsEnterpriseEdition() {
+		t.Skip("delta cache is EE only")
+	}
+
+	ctx := base.TestCtx(t)
+
+	revStats := newTestRevCacheStats()
+	deltaStats := newTestDeltaStats()
+
+	var getDocumentCounter, getRevisionCounter base.SgwIntStat
+	bs := &testBackingStore{getDocumentCounter: &getDocumentCounter, getRevisionCounter: &getRevisionCounter}
+
+	// MaxItemCount=2 caps the delta cache at 2 items; MaxBytes=0 so memory-based eviction
+	// never fires — only number-based eviction is exercised here.
+	opts := &RevisionCacheOptions{MaxItemCount: 2, MaxBytes: 0}
+	orchestrator := NewRevisionCacheOrchestrator(
+		opts, CreateTestSingleBackingStoreMap(bs, testCollectionID), revStats, deltaStats, true,
+	)
+
+	const perDeltaBytes = int64(10) // len("0123456789")
+	makeDelta := func() RevisionDelta {
+		d := RevisionDelta{DeltaBytes: []byte("0123456789")}
+		d.CalculateDeltaBytes()
+		return d
+	}
+
+	// Fill the delta cache to its item limit.
+	orchestrator.UpdateDelta(ctx, "doc1", "from1", "to1", testCollectionID, makeDelta())
+	orchestrator.UpdateDelta(ctx, "doc1", "from2", "to2", testCollectionID, makeDelta())
+	assert.Equal(t, int64(2), deltaStats.DeltaCacheNumItems.Value())
+	assert.Equal(t, 2*perDeltaBytes, revStats.cacheMemoryStat.Value(), "both deltas should be counted")
+
+	// Adding a third delta triggers number-based eviction of the oldest (from1→to1).
+	// Before the fix, bytesEvicted was never set so the stat remained at 30 instead of 20.
+	orchestrator.UpdateDelta(ctx, "doc1", "from3", "to3", testCollectionID, makeDelta())
+
+	assert.Equal(t, int64(2), deltaStats.DeltaCacheNumItems.Value(), "only 2 deltas should remain")
+	assert.Equal(t, 2*perDeltaBytes, revStats.cacheMemoryStat.Value(),
+		"evicted delta's bytes must be decremented; stat should equal 2 deltas not 3")
+}
+
+// TestGetWithDeltaTriggersMemoryEvictionOnMiss verifies that a backing-store load
+// triggered by GetWithDelta (revision cache miss) calls triggerMemoryEviction so that
+// memory pressure is relieved.
+func TestGetWithDeltaTriggersMemoryEvictionOnMiss(t *testing.T) {
+	if !base.IsEnterpriseEdition() {
+		t.Skip("delta sync and delta cache are EE only")
+	}
+
+	ctx := base.TestCtx(t)
+	// testBackingStore serves any docID at cv{Value:123, SourceID:"test"}.
+	rev1CV := Version{Value: 123, SourceID: "test"}
+	rev2CV := Version{Value: 456, SourceID: "test"}
+
+	// testBackingStore produces 118 bytes for a 4-char docID like "doc1".
+	const expectedRevBytes = int64(118)
+	const expectedDeltaBytes = int64(10) // len("delta12345")
+	// maxBytes=118: rev alone just fits (118 NOT > 118); together (128 > 118) they trigger eviction.
+	const maxBytes = expectedRevBytes
+
+	revStats := newTestRevCacheStats()
+	deltaStats := newTestDeltaStats()
+
+	var getDocumentCounter, getRevisionCounter base.SgwIntStat
+	bs := &testBackingStore{getDocumentCounter: &getDocumentCounter, getRevisionCounter: &getRevisionCounter}
+
+	opts := &RevisionCacheOptions{MaxItemCount: 100, MaxBytes: maxBytes}
+	orchestrator := NewRevisionCacheOrchestrator(
+		opts, CreateTestSingleBackingStoreMap(bs, testCollectionID), revStats, deltaStats, true,
+	)
+
+	// Add the delta first so it carries the older access order.
+	delta := RevisionDelta{DeltaBytes: []byte("delta12345")}
+	delta.CalculateDeltaBytes()
+	orchestrator.UpdateDelta(ctx, "doc1", rev1CV.String(), rev2CV.String(), testCollectionID, delta)
+	assert.Equal(t, int64(1), deltaStats.DeltaCacheNumItems.Value())
+	assert.Equal(t, expectedDeltaBytes, revStats.cacheMemoryStat.Value(), "only delta bytes counted so far")
+
+	// GetWithDelta causes a revision backing-store miss, adding 118 bytes.
+	// Total (128) exceeds maxBytes (118) → triggerMemoryEviction must fire and evict the
+	// delta (older access order), leaving only the revision in memory.
+	docRev, err := orchestrator.GetWithDelta(ctx, "doc1", rev1CV.String(), rev2CV.String(), testCollectionID)
+	require.NoError(t, err)
+	require.NotNil(t, docRev.BodyBytes, "revision should be loaded from backing store")
+
+	_, revInCache := orchestrator.Peek(ctx, "doc1", rev1CV.String(), testCollectionID)
+	assert.True(t, revInCache, "revision should remain in cache")
+
+	cachedDelta := orchestrator.deltaCache.getCachedDelta(ctx, "doc1", rev1CV.String(), rev2CV.String(), testCollectionID)
+	assert.Nil(t, cachedDelta, "delta should have been evicted by memory pressure from GetWithDelta")
+
+	assert.Equal(t, int64(1), revStats.cacheNumItemsStat.Value())
+	assert.Equal(t, int64(0), deltaStats.DeltaCacheNumItems.Value())
+	assert.Equal(t, expectedRevBytes, revStats.cacheMemoryStat.Value(), "memory stat should equal revision bytes only")
 }

--- a/db/delta_cache_test.go
+++ b/db/delta_cache_test.go
@@ -12,6 +12,7 @@ package db
 
 import (
 	"bytes"
+	"sync"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -538,6 +539,7 @@ func TestGetWithDeltaTriggersMemoryEvictionOnMiss(t *testing.T) {
 	docRev, err := orchestrator.GetWithDelta(ctx, "doc1", rev1CV.String(), rev2CV.String(), testCollectionID)
 	require.NoError(t, err)
 	require.NotNil(t, docRev.BodyBytes, "revision should be loaded from backing store")
+	require.NotNil(t, docRev.Delta)
 
 	_, revInCache := orchestrator.Peek(ctx, "doc1", rev1CV.String(), testCollectionID)
 	assert.True(t, revInCache, "revision should remain in cache")
@@ -548,4 +550,220 @@ func TestGetWithDeltaTriggersMemoryEvictionOnMiss(t *testing.T) {
 	assert.Equal(t, int64(1), revStats.cacheNumItemsStat.Value())
 	assert.Equal(t, int64(0), deltaStats.DeltaCacheNumItems.Value())
 	assert.Equal(t, expectedRevBytes, revStats.cacheMemoryStat.Value(), "memory stat should equal revision bytes only")
+}
+
+// TestConcurrentPutAndUpdateDeltaMemoryEvictsFirstEntry verifies that when Put and
+// UpdateDelta race under a MaxBytes limit that fits exactly one item, the operation
+// with the lower accessOrder (whichever landed first) is evicted by the one that
+// follows, and the memory stat reflects only the surviving item's bytes.
+func TestConcurrentPutAndUpdateDeltaMemoryEvictsFirstEntry(t *testing.T) {
+	if !base.IsEnterpriseEdition() {
+		t.Skip("delta cache is EE only")
+	}
+
+	ctx := base.TestCtx(t)
+
+	revStats := newTestRevCacheStats()
+	deltaStats := newTestDeltaStats()
+
+	var getDocumentCounter, getRevisionCounter base.SgwIntStat
+	bs := &testBackingStore{getDocumentCounter: &getDocumentCounter, getRevisionCounter: &getRevisionCounter}
+
+	// Both the revision and the delta are crafted to occupy exactly itemBytes each.
+	//
+	// With MaxBytes=itemBytes the first item to land fits exactly (itemBytes NOT >
+	// itemBytes, so IsOverCapacity is false). When the second arrives the total
+	// becomes 2*itemBytes > itemBytes, triggerMemoryEviction fires, and the item with
+	// the lower accessOrder — whichever landed first — is evicted.
+	const itemBytes = int64(32)
+	opts := &RevisionCacheOptions{MaxItemCount: 100, MaxBytes: itemBytes}
+	orchestrator := NewRevisionCacheOrchestrator(
+		opts, CreateTestSingleBackingStoreMap(bs, testCollectionID), revStats, deltaStats, true,
+	)
+
+	cv := Version{SourceID: "src", Value: 1}
+	toCV := Version{SourceID: "src", Value: 2}
+
+	// One digest in History → 32 bytes (32 × 1); no channels; empty body → total = 32.
+	docRev := DocumentRevision{
+		DocID:     "doc1",
+		RevID:     "1-x",
+		BodyBytes: []byte{},
+		Channels:  nil,
+		History:   Revisions{RevisionsIds: []string{"x"}, RevisionsStart: 1},
+		CV:        &cv,
+	}
+	docRev.CalculateBytes()
+	require.Equal(t, itemBytes, docRev.MemoryBytes, "revision byte count must equal MaxBytes")
+
+	// 32 DeltaBytes; no ToChannels; no RevisionHistory → totalDeltaBytes = 32.
+	delta := RevisionDelta{DeltaBytes: make([]byte, int(itemBytes))}
+	delta.CalculateDeltaBytes()
+	require.Equal(t, itemBytes, delta.totalDeltaBytes, "delta byte count must equal MaxBytes")
+
+	// ready is a starting pistol that releases both goroutines simultaneously.
+	ready := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		<-ready
+		orchestrator.Put(ctx, docRev, testCollectionID)
+	}()
+
+	go func() {
+		defer wg.Done()
+		<-ready
+		orchestrator.UpdateDelta(ctx, "doc1", cv.String(), toCV.String(), testCollectionID, delta)
+	}()
+
+	close(ready)
+	wg.Wait()
+
+	// The winner (higher accessOrder) survives; the loser (lower accessOrder) is evicted.
+	// Regardless of scheduling, exactly one item — worth itemBytes — must remain.
+	assert.Equal(t, itemBytes, revStats.cacheMemoryStat.Value(),
+		"memory stat must equal one item's bytes: the first-landed entry was evicted")
+
+	_, revInCache := orchestrator.Peek(ctx, "doc1", cv.String(), testCollectionID)
+	cachedDelta := orchestrator.deltaCache.getCachedDelta(ctx, "doc1", cv.String(), toCV.String(), testCollectionID)
+
+	assert.True(t, revInCache != (cachedDelta != nil),
+		"exactly one of the revision or delta should survive after memory eviction")
+}
+
+// TestImmediateDeltaCacheEviction tests adding an item to delta cache and that item immediately being
+// evicted through either memory eviction or number based eviction.
+func TestImmediateDeltaCacheEviction(t *testing.T) {
+	testCases := []struct {
+		name        string
+		memoryBased bool
+	}{
+		{
+			name:        "memory based",
+			memoryBased: true,
+		},
+		{
+			name:        "number based",
+			memoryBased: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx := base.TestCtx(t)
+
+			revStats := newTestRevCacheStats()
+			deltaStats := newTestDeltaStats()
+			var getDocumentCounter, getRevisionCounter base.SgwIntStat
+			bs := &testBackingStore{getDocumentCounter: &getDocumentCounter, getRevisionCounter: &getRevisionCounter}
+
+			// If we want to test memory eviction set max bytes for cache to one less then delta bytes.
+			// If not set 0 to turn this off and set max number count to 0 for number based eviction.
+			itemBytes := int64(32)
+			maxCacheBytes := int64(31)
+			itemCount := uint32(10)
+			if !testCase.memoryBased {
+				// evict based on number count so set empty
+				maxCacheBytes = 0
+				itemCount = 0
+			}
+			opts := &RevisionCacheOptions{MaxItemCount: itemCount, MaxBytes: maxCacheBytes}
+			orchestrator := NewRevisionCacheOrchestrator(
+				opts, CreateTestSingleBackingStoreMap(bs, testCollectionID), revStats, deltaStats, true,
+			)
+
+			cv := Version{SourceID: "src", Value: 1}
+			toCV := Version{SourceID: "src", Value: 2}
+
+			// 32 DeltaBytes; no ToChannels; no RevisionHistory → totalDeltaBytes = 32.
+			delta := RevisionDelta{DeltaBytes: make([]byte, int(itemBytes))}
+			delta.CalculateDeltaBytes()
+			require.Equal(t, itemBytes, delta.totalDeltaBytes, "delta byte count must equal MaxBytes")
+
+			orchestrator.UpdateDelta(ctx, "doc1", cv.String(), toCV.String(), testCollectionID, delta)
+
+			// assert cache is empty
+			assert.Equal(t, int64(0), revStats.cacheMemoryStat.Value())
+			assert.Equal(t, int64(0), deltaStats.DeltaCacheNumItems.Value())
+		})
+	}
+}
+
+// TestNumberAndMemoryBasedEvictionTriggerOnSameWrite verifies that a single write can
+// trigger both eviction mechanisms in sequence. Number-based eviction fires first inside
+// addDelta, removing the LRU-tail item to bring the item count back within MaxItemCount.
+// If the net memory after that removal is still above MaxBytes, memory-based eviction
+// fires immediately afterwards in triggerMemoryEviction, removing the new LRU tail.
+//
+// Scenario (MaxItemCount=2, MaxBytes=45):
+//
+//	delta1 (10 B) + delta2 (10 B) fill the cache to capacity: 20 B ≤ 45 — no eviction.
+//	delta3 (40 B) added:
+//	  1. Number-based: 3 items > 2 → evict delta1 (oldest). Memory: 10+10+40−10 = 50 B.
+//	  2. Memory-based: 50 B > 45 B → evict delta2 (new LRU tail).   Memory: 40 B.
+//	Only delta3 survives; the final memory stat must equal its 40 B.
+func TestNumberAndMemoryBasedEvictionTriggerOnSameWrite(t *testing.T) {
+	if !base.IsEnterpriseEdition() {
+		t.Skip("delta cache is EE only")
+	}
+
+	ctx := base.TestCtx(t)
+
+	revStats := newTestRevCacheStats()
+	deltaStats := newTestDeltaStats()
+
+	var getDocumentCounter, getRevisionCounter base.SgwIntStat
+	bs := &testBackingStore{getDocumentCounter: &getDocumentCounter, getRevisionCounter: &getRevisionCounter}
+
+	const (
+		smallDeltaBytes = int64(10) // delta1 and delta2 each occupy this many bytes
+		largeDeltaBytes = int64(40) // delta3 occupies this many bytes
+
+		// After number-based eviction removes delta1 (10 B), memory = 10+10+40−10 = 50 B.
+		// 50 > maxBytes(45) so memory-based eviction subsequently fires.
+		// Both small deltas coexist beforehand (20 B ≤ 45 B), so only the third write
+		// triggers both paths.
+		maxBytes = int64(45)
+	)
+
+	opts := &RevisionCacheOptions{MaxItemCount: 2, MaxBytes: maxBytes}
+	orchestrator := NewRevisionCacheOrchestrator(
+		opts, CreateTestSingleBackingStoreMap(bs, testCollectionID), revStats, deltaStats, true,
+	)
+
+	makeDeltaOfSize := func(n int) RevisionDelta {
+		d := RevisionDelta{DeltaBytes: make([]byte, n)}
+		d.CalculateDeltaBytes()
+		return d
+	}
+
+	// Fill the delta cache to its item limit with small deltas.
+	// Neither eviction path should fire: item count is at capacity and memory is well under MaxBytes.
+	orchestrator.UpdateDelta(ctx, "doc1", "from1", "to1", testCollectionID, makeDeltaOfSize(int(smallDeltaBytes)))
+	orchestrator.UpdateDelta(ctx, "doc1", "from2", "to2", testCollectionID, makeDeltaOfSize(int(smallDeltaBytes)))
+	require.Equal(t, int64(2), deltaStats.DeltaCacheNumItems.Value(), "setup: expected 2 deltas in cache")
+	require.Equal(t, 2*smallDeltaBytes, revStats.cacheMemoryStat.Value(), "setup: expected 20 B before large write")
+
+	// Adding delta3 triggers both eviction paths on the same write:
+	//   Number-based (inside addDelta):  3 > MaxItemCount(2) → remove delta1. Memory → 50 B.
+	//   Memory-based (triggerMemoryEviction): 50 > MaxBytes(45) → remove delta2. Memory → 40 B.
+	orchestrator.UpdateDelta(ctx, "doc1", "from3", "to3", testCollectionID, makeDeltaOfSize(int(largeDeltaBytes)))
+
+	// One item remains; its byte count equals delta3's size.
+	assert.Equal(t, int64(1), deltaStats.DeltaCacheNumItems.Value(), "only delta3 should remain after both evictions")
+	assert.Equal(t, largeDeltaBytes, revStats.cacheMemoryStat.Value(), "memory stat should equal delta3's bytes only")
+
+	// delta1 was the LRU tail when delta3 arrived — removed by number-based eviction.
+	assert.Nil(t, orchestrator.deltaCache.getCachedDelta(ctx, "doc1", "from1", "to1", testCollectionID),
+		"delta1 should have been evicted by number-based eviction")
+
+	// delta2 became the new LRU tail once delta1 was removed — removed by memory-based eviction.
+	assert.Nil(t, orchestrator.deltaCache.getCachedDelta(ctx, "doc1", "from2", "to2", testCollectionID),
+		"delta2 should have been evicted by memory-based eviction")
+
+	// delta3 is the most-recently added item and survives both eviction passes.
+	assert.NotNil(t, orchestrator.deltaCache.getCachedDelta(ctx, "doc1", "from3", "to3", testCollectionID),
+		"delta3 should survive as the sole remaining item")
 }

--- a/db/delta_cache_test.go
+++ b/db/delta_cache_test.go
@@ -542,14 +542,14 @@ func TestGetWithDeltaTriggersMemoryEvictionOnMiss(t *testing.T) {
 	require.NotNil(t, docRev.Delta)
 
 	_, revInCache := orchestrator.Peek(ctx, "doc1", rev1CV.String(), testCollectionID)
-	assert.True(t, revInCache, "revision should remain in cache")
+	assert.False(t, revInCache, "revision be immediately evicted after GetWithDelta miss")
 
 	cachedDelta := orchestrator.deltaCache.getCachedDelta(ctx, "doc1", rev1CV.String(), rev2CV.String(), testCollectionID)
-	assert.Nil(t, cachedDelta, "delta should have been evicted by memory pressure from GetWithDelta")
+	assert.NotNil(t, cachedDelta, "delta should still be present in cache")
 
-	assert.Equal(t, int64(1), revStats.cacheNumItemsStat.Value())
-	assert.Equal(t, int64(0), deltaStats.DeltaCacheNumItems.Value())
-	assert.Equal(t, expectedRevBytes, revStats.cacheMemoryStat.Value(), "memory stat should equal revision bytes only")
+	assert.Equal(t, int64(0), revStats.cacheNumItemsStat.Value())
+	assert.Equal(t, int64(1), deltaStats.DeltaCacheNumItems.Value())
+	assert.Equal(t, expectedDeltaBytes, revStats.cacheMemoryStat.Value(), "memory stat should equal revision bytes only")
 }
 
 // TestConcurrentPutAndUpdateDeltaMemoryEvictsFirstEntry verifies that when Put and

--- a/db/delta_cache_test.go
+++ b/db/delta_cache_test.go
@@ -526,7 +526,7 @@ func TestGetWithDeltaTriggersMemoryEvictionOnMiss(t *testing.T) {
 		opts, CreateTestSingleBackingStoreMap(bs, testCollectionID), revStats, deltaStats, true,
 	)
 
-	// Add the delta first so it carries the older access order.
+	// Add the delta first so will be evicted by GetWithDelta.
 	delta := RevisionDelta{DeltaBytes: []byte("delta12345")}
 	delta.CalculateDeltaBytes()
 	orchestrator.UpdateDelta(ctx, "doc1", rev1CV.String(), rev2CV.String(), testCollectionID, delta)
@@ -535,7 +535,7 @@ func TestGetWithDeltaTriggersMemoryEvictionOnMiss(t *testing.T) {
 
 	// GetWithDelta causes a revision backing-store miss, adding 118 bytes.
 	// Total (128) exceeds maxBytes (118) → triggerMemoryEviction must fire and evict the
-	// delta (older access order), leaving only the revision in memory.
+	// delta, leaving only the revision in memory.
 	docRev, err := orchestrator.GetWithDelta(ctx, "doc1", rev1CV.String(), rev2CV.String(), testCollectionID)
 	require.NoError(t, err)
 	require.NotNil(t, docRev.BodyBytes, "revision should be loaded from backing store")
@@ -553,9 +553,8 @@ func TestGetWithDeltaTriggersMemoryEvictionOnMiss(t *testing.T) {
 }
 
 // TestConcurrentPutAndUpdateDeltaMemoryEvictsFirstEntry verifies that when Put and
-// UpdateDelta race under a MaxBytes limit that fits exactly one item, the operation
-// with the lower accessOrder (whichever landed first) is evicted by the one that
-// follows, and the memory stat reflects only the surviving item's bytes.
+// UpdateDelta race under a MaxBytes limit that fits exactly one item, memory eviction
+// fires and the memory stat reflects only the surviving item's bytes.
 func TestConcurrentPutAndUpdateDeltaMemoryEvictsFirstEntry(t *testing.T) {
 	if !base.IsEnterpriseEdition() {
 		t.Skip("delta cache is EE only")
@@ -573,8 +572,7 @@ func TestConcurrentPutAndUpdateDeltaMemoryEvictsFirstEntry(t *testing.T) {
 	//
 	// With MaxBytes=itemBytes the first item to land fits exactly (itemBytes NOT >
 	// itemBytes, so IsOverCapacity is false). When the second arrives the total
-	// becomes 2*itemBytes > itemBytes, triggerMemoryEviction fires, and the item with
-	// the lower accessOrder — whichever landed first — is evicted.
+	// becomes 2*itemBytes > itemBytes, triggerMemoryEviction fires and evicts one item.
 	const itemBytes = int64(32)
 	opts := &RevisionCacheOptions{MaxItemCount: 100, MaxBytes: itemBytes}
 	orchestrator := NewRevisionCacheOrchestrator(
@@ -621,10 +619,9 @@ func TestConcurrentPutAndUpdateDeltaMemoryEvictsFirstEntry(t *testing.T) {
 	close(ready)
 	wg.Wait()
 
-	// The winner (higher accessOrder) survives; the loser (lower accessOrder) is evicted.
 	// Regardless of scheduling, exactly one item — worth itemBytes — must remain.
 	assert.Equal(t, itemBytes, revStats.cacheMemoryStat.Value(),
-		"memory stat must equal one item's bytes: the first-landed entry was evicted")
+		"memory stat must equal one item's bytes after eviction")
 
 	_, revInCache := orchestrator.Peek(ctx, "doc1", cv.String(), testCollectionID)
 	cachedDelta := orchestrator.deltaCache.getCachedDelta(ctx, "doc1", cv.String(), toCV.String(), testCollectionID)

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -31,7 +31,8 @@ func NewBypassRevisionCache(backingStores map[uint32]RevisionCacheBackingStore, 
 	}
 }
 
-// Get fetches the revision for the given docID and revID immediately from the bucket.
+// Get fetches the revision for the given docID and revID immediately from the bucket. Always returns false for checking
+// for memory based eviction as there is nothing to evict from when using bypass revision cache.
 func (rc *BypassRevisionCache) Get(ctx context.Context, docID, versionString string, collectionID uint32, loadBackup bool) (docRev DocumentRevision, b bool, err error) {
 	doc, err := rc.backingStores[collectionID].GetDocument(ctx, docID, DocUnmarshalSync)
 	if err != nil {
@@ -70,11 +71,11 @@ func (rc *BypassRevisionCache) Get(ctx context.Context, docID, versionString str
 }
 
 // GetActive fetches the active revision for the given docID immediately from the bucket.
-func (rc *BypassRevisionCache) GetActive(ctx context.Context, docID string, collectionID uint32) (docRev DocumentRevision, cacheHit bool, err error) {
+func (rc *BypassRevisionCache) GetActive(ctx context.Context, docID string, collectionID uint32) (docRev DocumentRevision, checkForMemoryEviction bool, err error) {
 
 	doc, err := rc.backingStores[collectionID].GetDocument(ctx, docID, DocUnmarshalSync)
 	if err != nil {
-		return DocumentRevision{}, cacheHit, err
+		return DocumentRevision{}, checkForMemoryEviction, err
 	}
 
 	docRev = DocumentRevision{
@@ -88,7 +89,7 @@ func (rc *BypassRevisionCache) GetActive(ctx context.Context, docID string, coll
 	var hlv *HybridLogicalVector
 	docRev.BodyBytes, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, hlv, err = revCacheLoaderForDocument(ctx, rc.backingStores[collectionID], doc, doc.SyncData.GetRevTreeID())
 	if err != nil {
-		return DocumentRevision{}, cacheHit, err
+		return DocumentRevision{}, checkForMemoryEviction, err
 	}
 	if hlv != nil {
 		docRev.CV = hlv.ExtractCurrentVersionFromHLV()
@@ -97,7 +98,7 @@ func (rc *BypassRevisionCache) GetActive(ctx context.Context, docID string, coll
 
 	rc.bypassStat.Add(1)
 
-	return docRev, cacheHit, nil
+	return docRev, checkForMemoryEviction, nil
 }
 
 // Peek is a no-op for a BypassRevisionCache, and always returns a false 'found' value.

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -71,14 +71,14 @@ func (rc *BypassRevisionCache) Get(ctx context.Context, docID, versionString str
 }
 
 // GetActive fetches the active revision for the given docID immediately from the bucket.
-func (rc *BypassRevisionCache) GetActive(ctx context.Context, docID string, collectionID uint32) (docRev DocumentRevision, checkForMemoryEviction bool, err error) {
+func (rc *BypassRevisionCache) GetActive(ctx context.Context, docID string, collectionID uint32) (DocumentRevision, bool, error) {
 
 	doc, err := rc.backingStores[collectionID].GetDocument(ctx, docID, DocUnmarshalSync)
 	if err != nil {
-		return DocumentRevision{}, checkForMemoryEviction, err
+		return DocumentRevision{}, false, err
 	}
 
-	docRev = DocumentRevision{
+	docRev := DocumentRevision{
 		RevID:                  doc.GetRevTreeID(),
 		DocID:                  docID,
 		RevCacheValueDeltaLock: &sync.Mutex{}, // initialize the mutex for delta updates
@@ -89,7 +89,7 @@ func (rc *BypassRevisionCache) GetActive(ctx context.Context, docID string, coll
 	var hlv *HybridLogicalVector
 	docRev.BodyBytes, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, hlv, err = revCacheLoaderForDocument(ctx, rc.backingStores[collectionID], doc, doc.SyncData.GetRevTreeID())
 	if err != nil {
-		return DocumentRevision{}, checkForMemoryEviction, err
+		return DocumentRevision{}, false, err
 	}
 	if hlv != nil {
 		docRev.CV = hlv.ExtractCurrentVersionFromHLV()
@@ -98,7 +98,7 @@ func (rc *BypassRevisionCache) GetActive(ctx context.Context, docID string, coll
 
 	rc.bypassStat.Add(1)
 
-	return docRev, checkForMemoryEviction, nil
+	return docRev, false, nil
 }
 
 // Peek is a no-op for a BypassRevisionCache, and always returns a false 'found' value.

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -32,10 +32,10 @@ func NewBypassRevisionCache(backingStores map[uint32]RevisionCacheBackingStore, 
 }
 
 // Get fetches the revision for the given docID and revID immediately from the bucket.
-func (rc *BypassRevisionCache) Get(ctx context.Context, docID, versionString string, collectionID uint32, loadBackup bool) (docRev DocumentRevision, err error) {
+func (rc *BypassRevisionCache) Get(ctx context.Context, docID, versionString string, collectionID uint32, loadBackup bool) (docRev DocumentRevision, b bool, err error) {
 	doc, err := rc.backingStores[collectionID].GetDocument(ctx, docID, DocUnmarshalSync)
 	if err != nil {
-		return DocumentRevision{}, err
+		return DocumentRevision{}, false, err
 	}
 
 	docRev = DocumentRevision{
@@ -55,7 +55,7 @@ func (rc *BypassRevisionCache) Get(ctx context.Context, docID, versionString str
 		docRev.BodyBytes, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, docRev.RevID, hlv, err = revCacheLoaderForDocumentCV(ctx, rc.backingStores[collectionID], doc, *docRev.CV, loadBackup)
 	}
 	if err != nil {
-		return DocumentRevision{}, err
+		return DocumentRevision{}, false, err
 	}
 	if hlv != nil {
 		if docRev.CV == nil {
@@ -66,15 +66,15 @@ func (rc *BypassRevisionCache) Get(ctx context.Context, docID, versionString str
 
 	rc.bypassStat.Add(1)
 
-	return docRev, nil
+	return docRev, false, nil
 }
 
 // GetActive fetches the active revision for the given docID immediately from the bucket.
-func (rc *BypassRevisionCache) GetActive(ctx context.Context, docID string, collectionID uint32) (docRev DocumentRevision, err error) {
+func (rc *BypassRevisionCache) GetActive(ctx context.Context, docID string, collectionID uint32) (docRev DocumentRevision, cacheHit bool, err error) {
 
 	doc, err := rc.backingStores[collectionID].GetDocument(ctx, docID, DocUnmarshalSync)
 	if err != nil {
-		return DocumentRevision{}, err
+		return DocumentRevision{}, cacheHit, err
 	}
 
 	docRev = DocumentRevision{
@@ -88,7 +88,7 @@ func (rc *BypassRevisionCache) GetActive(ctx context.Context, docID string, coll
 	var hlv *HybridLogicalVector
 	docRev.BodyBytes, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, hlv, err = revCacheLoaderForDocument(ctx, rc.backingStores[collectionID], doc, doc.SyncData.GetRevTreeID())
 	if err != nil {
-		return DocumentRevision{}, err
+		return DocumentRevision{}, cacheHit, err
 	}
 	if hlv != nil {
 		docRev.CV = hlv.ExtractCurrentVersionFromHLV()
@@ -97,7 +97,7 @@ func (rc *BypassRevisionCache) GetActive(ctx context.Context, docID string, coll
 
 	rc.bypassStat.Add(1)
 
-	return docRev, nil
+	return docRev, cacheHit, nil
 }
 
 // Peek is a no-op for a BypassRevisionCache, and always returns a false 'found' value.
@@ -125,7 +125,7 @@ func (rc *BypassRevisionCache) UpdateDelta(ctx context.Context, docID, fromVersi
 }
 
 func (rc *BypassRevisionCache) GetWithDelta(ctx context.Context, docID, fromVersionString, toVersionString string, collectionID uint32) (DocumentRevision, error) {
-	docRev, err := rc.Get(ctx, docID, fromVersionString, collectionID, true)
+	docRev, _, err := rc.Get(ctx, docID, fromVersionString, collectionID, true)
 	if err != nil {
 		return DocumentRevision{}, err
 	}

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -31,10 +31,10 @@ type RevisionCache interface {
 
 	// Get returns the given revision, and stores if not already cached.
 	// When includeDelta=true, the returned DocumentRevision will include delta - requires additional locking during retrieval.
-	Get(ctx context.Context, docID, versionString string, collectionID uint32, loadBackup bool) (DocumentRevision, error)
+	Get(ctx context.Context, docID, versionString string, collectionID uint32, loadBackup bool) (DocumentRevision, bool, error)
 
 	// GetActive returns the current revision for the given doc ID, and stores if not already cached.
-	GetActive(ctx context.Context, docID string, collectionID uint32) (docRev DocumentRevision, err error)
+	GetActive(ctx context.Context, docID string, collectionID uint32) (docRev DocumentRevision, cacheHit bool, err error)
 
 	// Peek returns the given revision if present in the cache
 	Peek(ctx context.Context, docID string, versionString string, collectionID uint32) (docRev DocumentRevision, found bool)
@@ -108,11 +108,11 @@ func NewRevisionCache(cacheOptions *RevisionCacheOptions, backingStores map[uint
 	}
 
 	var deltaCache *LRUDeltaCache
+	memoryController := newCacheMemoryController(cacheOptions.MaxBytes, revCacheStats.cacheMemoryStat)
 	if initDeltaCache {
-		deltaCache = NewLRUDeltaCache(cacheOptions, deltaSyncStats, backingStores)
+		deltaCache = NewLRUDeltaCache(cacheOptions, deltaSyncStats, memoryController)
 	}
-
-	return NewRevisionCacheOrchestrator(NewLRURevisionCache(cacheOptions, backingStores, revCacheStats), deltaCache)
+	return NewRevisionCacheOrchestrator(NewLRURevisionCache(cacheOptions, backingStores, revCacheStats, memoryController), deltaCache, memoryController)
 }
 
 type RevisionCacheOptions struct {
@@ -152,12 +152,14 @@ func newCollectionRevisionCache(revCache *RevisionCache, collectionID uint32) co
 
 // Get is for per collection access to Get method
 func (c *collectionRevisionCache) Get(ctx context.Context, docID, versionString string, loadBackup bool) (DocumentRevision, error) {
-	return (*c.revCache).Get(ctx, docID, versionString, c.collectionID, loadBackup)
+	docRev, _, err := (*c.revCache).Get(ctx, docID, versionString, c.collectionID, loadBackup)
+	return docRev, err
 }
 
 // GetActive is for per collection access to GetActive method
 func (c *collectionRevisionCache) GetActive(ctx context.Context, docID string) (DocumentRevision, error) {
-	return (*c.revCache).GetActive(ctx, docID, c.collectionID)
+	docRev, _, err := (*c.revCache).GetActive(ctx, docID, c.collectionID)
+	return docRev, err
 }
 
 // Peek is for per collection access to Peek method
@@ -363,34 +365,6 @@ type IDandCV struct {
 	Version      uint64
 	Source       string
 	CollectionID uint32
-}
-
-// RevisionDelta stores data about a delta between a revision and ToRevID.
-type RevisionDelta struct {
-	ToRevID               string                  // Target revID for the delta
-	ToCV                  string                  // Target CV for the delta
-	DeltaBytes            []byte                  // The actual delta
-	AttachmentStorageMeta []AttachmentStorageMeta // Storage metadata of all attachments present on ToRevID
-	RevisionHistory       []string                // Revision history from parent of ToRevID to source revID, in descending order
-	HlvHistory            string                  // HLV History in CBL format
-	ToDeleted             bool                    // Flag if ToRevID is a tombstone
-	totalDeltaBytes       int64                   // totalDeltaBytes is the total bytes for channels, revisions and body on the delta itself
-}
-
-func newRevCacheDelta(deltaBytes []byte, fromRevID string, toRevision DocumentRevision, deleted bool, toRevAttStorageMeta []AttachmentStorageMeta) RevisionDelta {
-	revDelta := RevisionDelta{
-		ToRevID:               toRevision.RevID,
-		DeltaBytes:            deltaBytes,
-		AttachmentStorageMeta: toRevAttStorageMeta,
-		RevisionHistory:       toRevision.History.parseAncestorRevisions(fromRevID),
-		HlvHistory:            toRevision.HlvHistory,
-		ToDeleted:             deleted,
-	}
-	if toRevision.CV != nil {
-		revDelta.ToCV = toRevision.CV.String()
-	}
-	revDelta.CalculateDeltaBytes()
-	return revDelta
 }
 
 // This is the RevisionCacheLoaderFunc callback for the context's RevisionCache.

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -29,12 +29,13 @@ const (
 // RevisionCache is an interface that can be used to fetch a DocumentRevision for a Doc ID and Rev ID pair.
 type RevisionCache interface {
 
-	// Get returns the given revision, and stores if not already cached.
-	// When includeDelta=true, the returned DocumentRevision will include delta - requires additional locking during retrieval.
+	// Get returns the given revision, and stores if not already cached. Will return true if Get results in successful
+	// load to check for memory eviction.
 	Get(ctx context.Context, docID, versionString string, collectionID uint32, loadBackup bool) (DocumentRevision, bool, error)
 
-	// GetActive returns the current revision for the given doc ID, and stores if not already cached.
-	GetActive(ctx context.Context, docID string, collectionID uint32) (docRev DocumentRevision, cacheHit bool, err error)
+	// GetActive returns the current revision for the given doc ID, and stores if not already cached. Will return true
+	// if GetActive results in successful load to check for memory eviction.
+	GetActive(ctx context.Context, docID string, collectionID uint32) (docRev DocumentRevision, checkForMemoryEviction bool, err error)
 
 	// Peek returns the given revision if present in the cache
 	Peek(ctx context.Context, docID string, versionString string, collectionID uint32) (docRev DocumentRevision, found bool)

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -106,13 +106,7 @@ func NewRevisionCache(cacheOptions *RevisionCacheOptions, backingStores map[uint
 	if cacheOptions.ShardCount > 1 {
 		return NewShardedLRURevisionCache(cacheOptions, backingStores, revCacheStats, deltaSyncStats, initDeltaCache)
 	}
-
-	var deltaCache *LRUDeltaCache
-	memoryController := newCacheMemoryController(cacheOptions.MaxBytes, revCacheStats.cacheMemoryStat)
-	if initDeltaCache {
-		deltaCache = NewLRUDeltaCache(cacheOptions, deltaSyncStats, memoryController)
-	}
-	return NewRevisionCacheOrchestrator(NewLRURevisionCache(cacheOptions, backingStores, revCacheStats, memoryController), deltaCache, memoryController)
+	return NewRevisionCacheOrchestrator(cacheOptions, backingStores, revCacheStats, deltaSyncStats, initDeltaCache)
 }
 
 type RevisionCacheOptions struct {

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -53,7 +53,7 @@ func (sc *ShardedLRURevisionCache) getShard(docID string) *RevisionCacheOrchestr
 	return sc.caches[sgbucket.VBHash(docID, sc.numShards)]
 }
 
-func (sc *ShardedLRURevisionCache) Get(ctx context.Context, docID, versionString string, collectionID uint32, loadBackup bool) (docRev DocumentRevision, b bool, err error) {
+func (sc *ShardedLRURevisionCache) Get(ctx context.Context, docID, versionString string, collectionID uint32, loadBackup bool) (docRev DocumentRevision, checkForMemoryEviction bool, err error) {
 	return sc.getShard(docID).Get(ctx, docID, versionString, collectionID, loadBackup)
 }
 

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -40,13 +40,7 @@ func NewShardedLRURevisionCache(revCacheOptions *RevisionCacheOptions, backingSt
 		revCacheOptions.MaxBytes = int64(perCacheMemoryCapacity)
 	}
 	for i := 0; i < int(revCacheOptions.ShardCount); i++ {
-		memoryController := newCacheMemoryController(revCacheOptions.MaxBytes, revCacheStats.cacheMemoryStat)
-		cacheForShard := NewLRURevisionCache(revCacheOptions, backingStores, revCacheStats, memoryController)
-		var deltaCacheForShard *LRUDeltaCache
-		if initDeltaCache {
-			deltaCacheForShard = NewLRUDeltaCache(revCacheOptions, deltaSyncStats, memoryController)
-		}
-		caches[i] = NewRevisionCacheOrchestrator(cacheForShard, deltaCacheForShard, memoryController)
+		caches[i] = NewRevisionCacheOrchestrator(revCacheOptions, backingStores, revCacheStats, deltaSyncStats, initDeltaCache)
 	}
 
 	return &ShardedLRURevisionCache{

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -128,9 +128,8 @@ type revCacheValue struct {
 	removed      bool
 	itemBytes    atomic.Int64
 	collectionID uint32
-	memState     atomic.Int32  // memory accounting lifecycle; see memStateXxx constants
-	deltaLock    sync.Mutex    // synchronizes GetDelta across multiple clients for each fromRevision
-	accessOrder  atomic.Uint64 // stamped on insert; used for cross-cache eviction ordering
+	memState     atomic.Int32 // memory accounting lifecycle; see memStateXxx constants
+	deltaLock    sync.Mutex   // synchronizes GetDelta across multiple clients for each fromRevision
 }
 
 // Creates a revision cache with the given capacity and an optional loader function.
@@ -325,7 +324,6 @@ func (rc *LRURevisionCache) upsertDocToCache(ctx context.Context, cvKey revCache
 	// also ensure we add to rev id lookup map too
 	cvValue := &revCacheValue{id: docRev.DocID, cv: *docRev.CV, collectionID: collectionID, itemKey: cvKey}
 	elem := rc.lruList.PushFront(cvValue)
-	cvValue.accessOrder.Store(nextAccessOrder()) // stamp on insert
 	rc.cache[cvKey] = elem
 
 	// only increment if we are inserting new item to cache
@@ -368,7 +366,6 @@ func (rc *LRURevisionCache) getValue(ctx context.Context, docID, docVersionStrin
 		} else {
 			value.cv = currentVersion
 		}
-		value.accessOrder.Store(nextAccessOrder()) // stamp on insert
 		rc.cache[key] = rc.lruList.PushFront(value)
 		rc.cacheNumItems.Add(1)
 
@@ -633,34 +630,21 @@ func (rc *LRURevisionCache) _findEvictionValue() *revCacheValue {
 	return revItem
 }
 
-// peekLRUTailAccessOrder returns the accessOrder of the least-recently-used item,
-// or 0 if the cache is empty.
-// Called by the orchestrator to compare against the delta cache tail before deciding which to evict.
-func (rc *LRURevisionCache) peekLRUTailAccessOrder() uint64 {
-	rc.lock.Lock()
-	defer rc.lock.Unlock()
-	if elem := rc.lruList.Back(); elem != nil {
-		if v, ok := elem.Value.(*revCacheValue); ok {
-			return v.accessOrder.Load()
-		}
-	}
-	return 0
-}
-
 // evictLRUTail removes the LRU loaded item and returns the bytes to decrement from the memory
 // controller, or 0 if there was nothing eligible to evict or the item's bytes were not yet
 // accounted (in which case the in-flight CAS in Get will fail, so no decrement is needed).
-func (rc *LRURevisionCache) evictLRUTail() int64 {
+// Returns true if an item was evicted.
+func (rc *LRURevisionCache) evictLRUTail() (int64, bool) {
 	rc.lock.Lock()
 	defer rc.lock.Unlock()
 	value := rc._findEvictionValue()
 	if value == nil {
-		return 0
+		return 0, false
 	}
 	delete(rc.cache, value.itemKey)
 	rc.cacheNumItems.Add(-1)
 	if value.memState.Swap(memStateRemoved) == memStateSized {
-		return value.getItemBytes()
+		return value.getItemBytes(), true
 	}
-	return 0
+	return 0, true
 }

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -98,6 +98,18 @@ type LRURevisionCache struct {
 	capacity         uint32 // Max number of items capacity of LRURevisionCache
 }
 
+// Memory accounting lifecycle states for revCacheValue.
+// The transitions are:
+//
+//	memStateLoading → memStateSized  (CAS in Get/Put after bytes are known and stat incremented)
+//	memStateLoading → memStateRemoved (Swap in Remove/eviction before increment happened)
+//	memStateSized   → memStateRemoved (Swap in Remove/eviction after stat was incremented)
+const (
+	memStateLoading = int32(0) // item is in the cache but bytes have not yet been accounted in the memory stat
+	memStateSized   = int32(1) // bytes have been accounted; a future Remove/eviction must decrement
+	memStateRemoved = int32(2) // item has been removed; any in-flight CAS to memStateSized will fail
+)
+
 // The cache payload data. Stored as the Value of a list Element.
 type revCacheValue struct {
 	err          error
@@ -116,7 +128,7 @@ type revCacheValue struct {
 	removed      bool
 	itemBytes    atomic.Int64
 	collectionID uint32
-	itemLoaded   atomic.Bool
+	memState     atomic.Int32  // memory accounting lifecycle; see memStateXxx constants
 	deltaLock    sync.Mutex    // synchronizes GetDelta across multiple clients for each fromRevision
 	accessOrder  atomic.Uint64 // stamped on insert; used for cross-cache eviction ordering
 }
@@ -151,8 +163,15 @@ func (rc *LRURevisionCache) Get(ctx context.Context, docID, versionString string
 
 	incrementStatEvent := !cacheHit && err == nil
 	if incrementStatEvent {
-		// cache miss so we had to load doc, increment memory count
-		rc.memoryController.incrementBytesCount(ctx, value.getItemBytes())
+		// Transition to memStateSized under a CAS so that a concurrent Remove that ran before
+		// the load completed (reading itemBytes=0) cannot result in a permanently inflated stat.
+		// If Remove already set memStateRemoved the CAS fails and we skip the increment — the
+		// item is gone and its bytes were never decremented, so no increment is needed either.
+		if !value.memState.CompareAndSwap(memStateLoading, memStateSized) {
+			incrementStatEvent = false
+		} else {
+			rc.memoryController.incrementBytesCount(value.getItemBytes())
+		}
 	}
 
 	if err != nil {
@@ -213,8 +232,15 @@ func (rc *LRURevisionCache) GetActive(ctx context.Context, docID string, collect
 
 	incrementStatEvent := !statEvent && err == nil
 	if incrementStatEvent {
-		// cache miss so we had to load doc, increment memory count
-		rc.memoryController.incrementBytesCount(ctx, value.getItemBytes())
+		// Transition to memStateSized under a CAS so that a concurrent Remove that ran before
+		// the load completed (reading itemBytes=0) cannot result in a permanently inflated stat.
+		// If Remove already set memStateRemoved the CAS fails and we skip the increment — the
+		// item is gone and its bytes were never decremented, so no increment is needed either.
+		if !value.memState.CompareAndSwap(memStateLoading, memStateSized) {
+			incrementStatEvent = false
+		} else {
+			rc.memoryController.incrementBytesCount(value.getItemBytes())
+		}
 	}
 
 	if err != nil {
@@ -243,7 +269,14 @@ func (rc *LRURevisionCache) Put(ctx context.Context, docRev DocumentRevision, co
 	value := rc.getValue(ctx, docRev.DocID, docRev.CV.String(), collectionID, true)
 	// increment incoming bytes
 	docRev.CalculateBytes()
-	rc.memoryController.incrementBytesCount(ctx, docRev.MemoryBytes)
+	// Store itemBytes on the value before the CAS so that a concurrent Remove or eviction
+	// that wins the Swap to memStateRemoved will read the correct size.
+	value.itemBytes.Store(docRev.MemoryBytes)
+	// CAS guards against double-counting if this key already exists and is memStateSized,
+	// and against incrementing for an item that was concurrently removed (memStateRemoved).
+	if value.memState.CompareAndSwap(memStateLoading, memStateSized) {
+		rc.memoryController.incrementBytesCount(docRev.MemoryBytes)
+	}
 	value.store(docRev)
 }
 
@@ -257,8 +290,12 @@ func (rc *LRURevisionCache) Upsert(ctx context.Context, docRev DocumentRevision,
 	}
 
 	docRev.CalculateBytes()
-	// add new item bytes to overall count
-	rc.memoryController.incrementBytesCount(ctx, docRev.MemoryBytes)
+	// Store itemBytes before the CAS for the same reason as in Put.
+	cvValue.itemBytes.Store(docRev.MemoryBytes)
+	// CAS guards against incrementing for a value that was concurrently removed.
+	if cvValue.memState.CompareAndSwap(memStateLoading, memStateSized) {
+		rc.memoryController.incrementBytesCount(docRev.MemoryBytes)
+	}
 	cvValue.store(docRev)
 }
 
@@ -273,8 +310,11 @@ func (rc *LRURevisionCache) upsertDocToCache(ctx context.Context, cvKey revCache
 	existingElem, found = rc.cache[cvKey]
 	if found {
 		revItem := existingElem.Value.(*revCacheValue)
-		// decrement item bytes by the removed item
-		rc.memoryController.decrementBytesCount(ctx, revItem.getItemBytes())
+		// Swap to removed and only decrement if bytes were already accounted (memStateSized).
+		// If the old item was still loading its increment CAS will now fail, so no decrement needed.
+		if revItem.memState.Swap(memStateRemoved) == memStateSized {
+			rc.memoryController.decrementBytesCount(revItem.getItemBytes())
+		}
 		rc.lruList.Remove(existingElem)
 		newItem = false
 	}
@@ -294,7 +334,7 @@ func (rc *LRURevisionCache) upsertDocToCache(ctx context.Context, cvKey revCache
 	// Purge oldest item if over number capacity
 	numItemsRemoved, numBytesEvicted := rc._numberCapacityEviction()
 	if numBytesEvicted > 0 {
-		rc.memoryController.decrementBytesCount(ctx, numBytesEvicted)
+		rc.memoryController.decrementBytesCount(numBytesEvicted)
 	}
 	return numItemsRemoved, cvValue
 }
@@ -326,14 +366,13 @@ func (rc *LRURevisionCache) getValue(ctx context.Context, docID, docVersionStrin
 		} else {
 			value.cv = currentVersion
 		}
-		value.itemLoaded.Store(false)
 		value.accessOrder.Store(nextAccessOrder()) // stamp on insert
 		rc.cache[key] = rc.lruList.PushFront(value)
 		rc.cacheNumItems.Add(1)
 
 		numItemsRemoved, numBytesEvicted := rc._numberCapacityEviction()
 		if numBytesEvicted > 0 {
-			rc.memoryController.decrementBytesCount(ctx, numBytesEvicted)
+			rc.memoryController.decrementBytesCount(numBytesEvicted)
 		}
 		if numItemsRemoved > 0 {
 			rc.cacheNumItems.Add(-numItemsRemoved)
@@ -355,15 +394,24 @@ func (rc *LRURevisionCache) Remove(ctx context.Context, docID, versionString str
 	if !ok {
 		return
 	}
-	rc.memoryController.decrementBytesCount(ctx, revValue.getItemBytes())
 	rc.lruList.Remove(elem)
 	rc.cacheNumItems.Add(-1)
 	delete(rc.cache, key)
+	// Swap to removed after the map/list are already updated.
+	// Only decrement if bytes were already accounted (memStateSized); if the item was still
+	// loading (memStateLoading) the in-flight CAS in Get/Put will fail and skip the increment.
+	if revValue.memState.Swap(memStateRemoved) == memStateSized {
+		rc.memoryController.decrementBytesCount(revValue.getItemBytes())
+	}
 }
 
-// removeValueForFailedLoad removes a value from after a failed load. NOTE this mist only be called for failed load, rto remove an item from the rev cache you must call Remove.
-// No decrement of memory stats needed as failed loads don't increment memory stats.
+// removeValueForFailedLoad removes a value after a failed load. Must only be called for failed loads;
+// to remove a cached item use Remove. No memory decrement is needed because failed loads never reach
+// the CAS that transitions to memStateSized, but we store memStateRemoved as a safety guard.
 func (rc *LRURevisionCache) removeValueForFailedLoad(value *revCacheValue) {
+	// Mark removed before acquiring the lock so any concurrent CAS-based increment sees the
+	// terminal state and skips, even if it races with this function.
+	value.memState.Store(memStateRemoved)
 	rc.lock.Lock()
 	defer rc.lock.Unlock()
 	var itemRemoved bool
@@ -378,7 +426,7 @@ func (rc *LRURevisionCache) removeValueForFailedLoad(value *revCacheValue) {
 }
 
 // _numberCapacityEviction will iterate removing the last element in cache til we fall below the maximum number of items
-// threshold for this shard, retuning the bytes evicted and number of items evicted
+// threshold for this shard, returning the bytes evicted and number of items evicted.
 func (rc *LRURevisionCache) _numberCapacityEviction() (numItemsEvicted int64, numBytesEvicted int64) {
 	for rc.lruList.Len() > int(rc.capacity) {
 		value := rc._findEvictionValue()
@@ -386,10 +434,14 @@ func (rc *LRURevisionCache) _numberCapacityEviction() (numItemsEvicted int64, nu
 			// no more ready for eviction
 			break
 		}
-		// delete item from lookup map
 		delete(rc.cache, value.itemKey)
 		numItemsEvicted++
-		numBytesEvicted += value.getItemBytes()
+		// Only count bytes if they were already accounted in the stat (memStateSized).
+		// If the item was still in memStateLoading the in-flight CAS will fail and skip
+		// the increment, so there is nothing to decrement.
+		if value.memState.Swap(memStateRemoved) == memStateSized {
+			numBytesEvicted += value.getItemBytes()
+		}
 	}
 	return numItemsEvicted, numBytesEvicted
 }
@@ -421,12 +473,6 @@ func (value *revCacheValue) load(ctx context.Context, backingStore RevisionCache
 	if value.bodyBytes != nil || value.err != nil {
 		cacheHit = true
 	} else {
-		// we only want to set can evict if we are having to load the doc from the bucket into value,
-		// avoiding setting this value multiple times in the case other goroutines are loading the same value
-		defer func() {
-			value.itemLoaded.Store(true) // once done loading doc we can set the value to be ready for eviction
-		}()
-
 		cacheHit = false
 		hlv := &HybridLogicalVector{}
 		if value.revID == "" {
@@ -452,7 +498,7 @@ func (value *revCacheValue) load(ctx context.Context, backingStore RevisionCache
 
 	docRev, err = value.asDocumentRevision(delta)
 	// if not cache hit, we loaded from bucket. Calculate doc rev size and assign to rev cache value
-	if !cacheHit {
+	if !cacheHit && err == nil {
 		docRev.CalculateBytes()
 		value.itemBytes.Store(docRev.MemoryBytes)
 	}
@@ -506,12 +552,6 @@ func (value *revCacheValue) loadForDoc(ctx context.Context, backingStore Revisio
 	if value.bodyBytes != nil || value.err != nil {
 		cacheHit = true
 	} else {
-		// we only want to set can evict if we are having to load the doc from the bucket into value,
-		// avoiding setting this value multiple times in the case other goroutines are loading the same value
-		defer func() {
-			value.itemLoaded.Store(true) // once done loading doc we can set the value to be ready for eviction
-		}()
-
 		cacheHit = false
 		hlv := &HybridLogicalVector{}
 		if value.revID == "" {
@@ -529,7 +569,7 @@ func (value *revCacheValue) loadForDoc(ctx context.Context, backingStore Revisio
 	}
 	docRev, err = value.asDocumentRevision(nil)
 	// if not cache hit, we loaded from bucket. Calculate doc rev size and assign to rev cache value
-	if !cacheHit {
+	if !cacheHit && err == nil {
 		docRev.CalculateBytes()
 		value.itemBytes.Store(docRev.MemoryBytes)
 	}
@@ -553,7 +593,6 @@ func (value *revCacheValue) store(docRev DocumentRevision) {
 		value.itemBytes.Store(docRev.MemoryBytes)
 		value.hlvHistory = docRev.HlvHistory
 	}
-	value.itemLoaded.Store(true) // now we have stored the doc revision in the cache, we can allow eviction
 }
 
 // getItemBytes atomically retrieves the rev cache items overall memory footprint
@@ -588,51 +627,38 @@ func (rc *LRURevisionCache) _findEvictionValue() *revCacheValue {
 	if !ok {
 		return nil
 	}
-
-	if revItem.itemLoaded.Load() {
-		rc.lruList.Remove(evictionCandidate)
-		return revItem
-	}
-
-	// iterate through list backwards to find value ready for eviction
-	evictionCandidate = evictionCandidate.Prev()
-	for evictionCandidate != nil {
-		revItem = evictionCandidate.Value.(*revCacheValue)
-		if revItem.itemLoaded.Load() {
-			rc.lruList.Remove(evictionCandidate)
-			return revItem
-		}
-		// check prev value
-		evictionCandidate = evictionCandidate.Prev()
-	}
-	return nil
+	rc.lruList.Remove(evictionCandidate)
+	return revItem
 }
 
-// peekLRUTailAccessOrder returns the accessOrder of the least-recently-used loaded item,
-// or 0 if the cache is empty or has no loaded items ready for eviction.
+// peekLRUTailAccessOrder returns the accessOrder of the least-recently-used item,
+// or 0 if the cache is empty.
 // Called by the orchestrator to compare against the delta cache tail before deciding which to evict.
 func (rc *LRURevisionCache) peekLRUTailAccessOrder() uint64 {
 	rc.lock.Lock()
 	defer rc.lock.Unlock()
-	// Walk backwards to find a loaded item — mirrors _findEvictionValue but without removing.
-	for elem := rc.lruList.Back(); elem != nil; elem = elem.Prev() {
-		if v, ok := elem.Value.(*revCacheValue); ok && v.itemLoaded.Load() {
+	if elem := rc.lruList.Back(); elem != nil {
+		if v, ok := elem.Value.(*revCacheValue); ok {
 			return v.accessOrder.Load()
 		}
 	}
 	return 0
 }
 
-// evictLRUTail removes the LRU loaded item and notifies the memory controller.
-// Returns false if there was nothing eligible to evict.
-func (rc *LRURevisionCache) evictLRUTail(ctx context.Context) int64 {
+// evictLRUTail removes the LRU loaded item and returns the bytes to decrement from the memory
+// controller, or 0 if there was nothing eligible to evict or the item's bytes were not yet
+// accounted (in which case the in-flight CAS in Get will fail, so no decrement is needed).
+func (rc *LRURevisionCache) evictLRUTail() int64 {
 	rc.lock.Lock()
 	defer rc.lock.Unlock()
-	value := rc._findEvictionValue() // already walks back to find a loaded item
+	value := rc._findEvictionValue()
 	if value == nil {
 		return 0
 	}
 	delete(rc.cache, value.itemKey)
 	rc.cacheNumItems.Add(-1)
-	return value.getItemBytes()
+	if value.memState.Swap(memStateRemoved) == memStateSized {
+		return value.getItemBytes()
+	}
+	return 0
 }

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -65,7 +65,7 @@ func (sc *ShardedLRURevisionCache) UpdateDelta(ctx context.Context, docID, fromV
 	sc.getShard(docID).UpdateDelta(ctx, docID, fromVersionString, toVersionString, collectionID, toDelta)
 }
 
-func (sc *ShardedLRURevisionCache) GetActive(ctx context.Context, docID string, collectionID uint32) (docRev DocumentRevision, cacheHit bool, err error) {
+func (sc *ShardedLRURevisionCache) GetActive(ctx context.Context, docID string, collectionID uint32) (docRev DocumentRevision, checkForMemoryEviction bool, err error) {
 	return sc.getShard(docID).GetActive(ctx, docID, collectionID)
 }
 
@@ -151,7 +151,8 @@ func NewLRURevisionCache(revCacheOptions *RevisionCacheOptions, backingStores ma
 // Looks up a revision from the cache.
 // Returns the body of the revision, its history, and the set of channels it's in.
 // If the cache has a loaderFunction, it will be called if the revision isn't in the cache;
-// any error returned by the loaderFunction will be returned from Get.
+// any error returned by the loaderFunction will be returned from Get. Any successful load will return true for
+// flag to check for memory based eviction.
 func (rc *LRURevisionCache) Get(ctx context.Context, docID, versionString string, collectionID uint32, loadBackup bool) (DocumentRevision, bool, error) {
 	value := rc.getValue(ctx, docID, versionString, collectionID, true)
 	if value == nil {
@@ -209,7 +210,8 @@ func (rc *LRURevisionCache) UpdateDelta(ctx context.Context, docID, fromVersionS
 // of the document from the bucket to guarantee the current active revision, but does minimal unmarshalling
 // of the retrieved document to get the current rev from _sync metadata.  If active rev is already in the
 // rev cache, will use it.  Otherwise will add to the rev cache using the raw document obtained in the
-// initial retrieval.
+// initial retrieval. Returns document revision, bool to indicate to caller whether we should check for memory based
+// eviction or not, and any error.
 func (rc *LRURevisionCache) GetActive(ctx context.Context, docID string, collectionID uint32) (DocumentRevision, bool, error) {
 
 	// Look up active rev for doc.  Note - can't rely on DocUnmarshalAll here when includeBody=true, because for a
@@ -227,10 +229,10 @@ func (rc *LRURevisionCache) GetActive(ctx context.Context, docID string, collect
 	// have a HLV assigned to it.
 	value := rc.getValue(ctx, docID, bucketDoc.GetRevTreeID(), collectionID, true)
 
-	docRev, statEvent, err := value.loadForDoc(ctx, rc.backingStores[collectionID], bucketDoc)
-	rc.statsRecorderFunc(statEvent)
+	docRev, cacheHit, err := value.loadForDoc(ctx, rc.backingStores[collectionID], bucketDoc)
+	rc.statsRecorderFunc(cacheHit)
 
-	incrementStatEvent := !statEvent && err == nil
+	incrementStatEvent := !cacheHit && err == nil
 	if incrementStatEvent {
 		// Transition to memStateSized under a CAS so that a concurrent Remove that ran before
 		// the load completed (reading itemBytes=0) cannot result in a permanently inflated stat.

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -39,14 +39,14 @@ func NewShardedLRURevisionCache(revCacheOptions *RevisionCacheOptions, backingSt
 		perCacheMemoryCapacity = float32(revCacheOptions.MaxBytes) / float32(revCacheOptions.ShardCount)
 		revCacheOptions.MaxBytes = int64(perCacheMemoryCapacity)
 	}
-
 	for i := 0; i < int(revCacheOptions.ShardCount); i++ {
-		cacheForShard := NewLRURevisionCache(revCacheOptions, backingStores, revCacheStats)
+		memoryController := newCacheMemoryController(revCacheOptions.MaxBytes, revCacheStats.cacheMemoryStat)
+		cacheForShard := NewLRURevisionCache(revCacheOptions, backingStores, revCacheStats, memoryController)
 		var deltaCacheForShard *LRUDeltaCache
 		if initDeltaCache {
-			deltaCacheForShard = NewLRUDeltaCache(revCacheOptions, deltaSyncStats, backingStores)
+			deltaCacheForShard = NewLRUDeltaCache(revCacheOptions, deltaSyncStats, memoryController)
 		}
-		caches[i] = NewRevisionCacheOrchestrator(cacheForShard, deltaCacheForShard)
+		caches[i] = NewRevisionCacheOrchestrator(cacheForShard, deltaCacheForShard, memoryController)
 	}
 
 	return &ShardedLRURevisionCache{
@@ -59,7 +59,7 @@ func (sc *ShardedLRURevisionCache) getShard(docID string) *RevisionCacheOrchestr
 	return sc.caches[sgbucket.VBHash(docID, sc.numShards)]
 }
 
-func (sc *ShardedLRURevisionCache) Get(ctx context.Context, docID, versionString string, collectionID uint32, loadBackup bool) (docRev DocumentRevision, err error) {
+func (sc *ShardedLRURevisionCache) Get(ctx context.Context, docID, versionString string, collectionID uint32, loadBackup bool) (docRev DocumentRevision, b bool, err error) {
 	return sc.getShard(docID).Get(ctx, docID, versionString, collectionID, loadBackup)
 }
 
@@ -71,7 +71,7 @@ func (sc *ShardedLRURevisionCache) UpdateDelta(ctx context.Context, docID, fromV
 	sc.getShard(docID).UpdateDelta(ctx, docID, fromVersionString, toVersionString, collectionID, toDelta)
 }
 
-func (sc *ShardedLRURevisionCache) GetActive(ctx context.Context, docID string, collectionID uint32) (docRev DocumentRevision, err error) {
+func (sc *ShardedLRURevisionCache) GetActive(ctx context.Context, docID string, collectionID uint32) (docRev DocumentRevision, cacheHit bool, err error) {
 	return sc.getShard(docID).GetActive(ctx, docID, collectionID)
 }
 
@@ -93,17 +93,15 @@ func (sc *ShardedLRURevisionCache) GetWithDelta(ctx context.Context, docID, from
 
 // An LRU cache of document revision bodies, together with their channel access.
 type LRURevisionCache struct {
-	backingStores        map[uint32]RevisionCacheBackingStore
-	cache                map[revCacheKey]*list.Element
-	lruList              *list.List
-	cacheHits            *base.SgwIntStat
-	cacheMisses          *base.SgwIntStat
-	cacheNumItems        *base.SgwIntStat
-	lock                 sync.Mutex
-	capacity             uint32           // Max number of items capacity of LRURevisionCache
-	memoryCapacity       int64            // Max memory capacity of LRURevisionCache
-	currMemoryUsage      base.AtomicInt   // count of number of bytes used currently in the LRURevisionCache
-	cacheMemoryBytesStat *base.SgwIntStat // stat for overall revision cache memory usage in bytes.  When using sharded cache, will be shared by all shards.
+	backingStores    map[uint32]RevisionCacheBackingStore
+	cache            map[revCacheKey]*list.Element
+	memoryController *CacheMemoryController // used to control memory usage of revision cache and delta cache combined
+	lruList          *list.List
+	cacheHits        *base.SgwIntStat
+	cacheMisses      *base.SgwIntStat
+	cacheNumItems    *base.SgwIntStat
+	lock             sync.Mutex
+	capacity         uint32 // Max number of items capacity of LRURevisionCache
 }
 
 // The cache payload data. Stored as the Value of a list Element.
@@ -125,22 +123,22 @@ type revCacheValue struct {
 	itemBytes    atomic.Int64
 	collectionID uint32
 	itemLoaded   atomic.Bool
-	deltaLock    sync.Mutex // synchronizes GetDelta across multiple clients for each fromRevision
+	deltaLock    sync.Mutex    // synchronizes GetDelta across multiple clients for each fromRevision
+	accessOrder  atomic.Uint64 // stamped on insert; used for cross-cache eviction ordering
 }
 
 // Creates a revision cache with the given capacity and an optional loader function.
-func NewLRURevisionCache(revCacheOptions *RevisionCacheOptions, backingStores map[uint32]RevisionCacheBackingStore, revCacheStats revisionCacheStats) *LRURevisionCache {
+func NewLRURevisionCache(revCacheOptions *RevisionCacheOptions, backingStores map[uint32]RevisionCacheBackingStore, revCacheStats revisionCacheStats, memoryController *CacheMemoryController) *LRURevisionCache {
 
 	return &LRURevisionCache{
-		cache:                map[revCacheKey]*list.Element{},
-		lruList:              list.New(),
-		capacity:             revCacheOptions.MaxItemCount,
-		backingStores:        backingStores,
-		cacheHits:            revCacheStats.cacheHitStat,
-		cacheMisses:          revCacheStats.cacheMissStat,
-		cacheNumItems:        revCacheStats.cacheNumItemsStat,
-		cacheMemoryBytesStat: revCacheStats.cacheMemoryStat,
-		memoryCapacity:       revCacheOptions.MaxBytes,
+		cache:            map[revCacheKey]*list.Element{},
+		lruList:          list.New(),
+		capacity:         revCacheOptions.MaxItemCount,
+		backingStores:    backingStores,
+		cacheHits:        revCacheStats.cacheHitStat,
+		cacheMisses:      revCacheStats.cacheMissStat,
+		cacheNumItems:    revCacheStats.cacheNumItemsStat,
+		memoryController: memoryController,
 	}
 }
 
@@ -148,27 +146,26 @@ func NewLRURevisionCache(revCacheOptions *RevisionCacheOptions, backingStores ma
 // Returns the body of the revision, its history, and the set of channels it's in.
 // If the cache has a loaderFunction, it will be called if the revision isn't in the cache;
 // any error returned by the loaderFunction will be returned from Get.
-func (rc *LRURevisionCache) Get(ctx context.Context, docID, versionString string, collectionID uint32, loadBackup bool) (DocumentRevision, error) {
+func (rc *LRURevisionCache) Get(ctx context.Context, docID, versionString string, collectionID uint32, loadBackup bool) (DocumentRevision, bool, error) {
 	value := rc.getValue(ctx, docID, versionString, collectionID, true)
 	if value == nil {
-		return DocumentRevision{}, nil
+		return DocumentRevision{}, false, nil
 	}
 
 	docRev, cacheHit, err := value.load(ctx, rc.backingStores[collectionID], loadBackup)
 	rc.statsRecorderFunc(cacheHit)
 
-	if !cacheHit && err == nil {
+	incrementStatEvent := !cacheHit && err == nil
+	if incrementStatEvent {
 		// cache miss so we had to load doc, increment memory count
-		rc.incrRevCacheMemoryUsage(ctx, value.getItemBytes())
-		// check for memory based eviction
-		rc.revCacheMemoryBasedEviction(ctx)
+		rc.memoryController.incrementBytesCount(ctx, value.getItemBytes())
 	}
 
 	if err != nil {
 		rc.removeValueForFailedLoad(value) // don't keep failed loads in the cache
 	}
 
-	return docRev, err
+	return docRev, incrementStatEvent, err
 }
 
 func (rc *LRURevisionCache) GetWithDelta(ctx context.Context, docID, fromVersionString, toVersionString string, collectionID uint32) (DocumentRevision, error) {
@@ -200,16 +197,16 @@ func (rc *LRURevisionCache) UpdateDelta(ctx context.Context, docID, fromVersionS
 // of the retrieved document to get the current rev from _sync metadata.  If active rev is already in the
 // rev cache, will use it.  Otherwise will add to the rev cache using the raw document obtained in the
 // initial retrieval.
-func (rc *LRURevisionCache) GetActive(ctx context.Context, docID string, collectionID uint32) (DocumentRevision, error) {
+func (rc *LRURevisionCache) GetActive(ctx context.Context, docID string, collectionID uint32) (DocumentRevision, bool, error) {
 
 	// Look up active rev for doc.  Note - can't rely on DocUnmarshalAll here when includeBody=true, because for a
 	// cache hit we don't want to do that work (yet).
 	bucketDoc, getErr := rc.backingStores[collectionID].GetDocument(ctx, docID, DocUnmarshalSync)
 	if getErr != nil {
-		return DocumentRevision{}, getErr
+		return DocumentRevision{}, false, getErr
 	}
 	if bucketDoc == nil {
-		return DocumentRevision{}, nil
+		return DocumentRevision{}, false, nil
 	}
 
 	// Retrieve from or add to rev cache
@@ -220,18 +217,17 @@ func (rc *LRURevisionCache) GetActive(ctx context.Context, docID string, collect
 	docRev, statEvent, err := value.loadForDoc(ctx, rc.backingStores[collectionID], bucketDoc)
 	rc.statsRecorderFunc(statEvent)
 
-	if !statEvent && err == nil {
+	incrementStatEvent := !statEvent && err == nil
+	if incrementStatEvent {
 		// cache miss so we had to load doc, increment memory count
-		rc.incrRevCacheMemoryUsage(ctx, value.getItemBytes())
-		// check for rev cache memory based eviction
-		rc.revCacheMemoryBasedEviction(ctx)
+		rc.memoryController.incrementBytesCount(ctx, value.getItemBytes())
 	}
 
 	if err != nil {
 		rc.removeValueForFailedLoad(value) // don't keep failed loads in the cache
 	}
 
-	return docRev, err
+	return docRev, incrementStatEvent, err
 }
 
 func (rc *LRURevisionCache) statsRecorderFunc(cacheHit bool) {
@@ -253,11 +249,8 @@ func (rc *LRURevisionCache) Put(ctx context.Context, docRev DocumentRevision, co
 	value := rc.getValue(ctx, docRev.DocID, docRev.CV.String(), collectionID, true)
 	// increment incoming bytes
 	docRev.CalculateBytes()
-	rc.incrRevCacheMemoryUsage(ctx, docRev.MemoryBytes)
+	rc.memoryController.incrementBytesCount(ctx, docRev.MemoryBytes)
 	value.store(docRev)
-
-	// check for rev cache memory based eviction
-	rc.revCacheMemoryBasedEviction(ctx)
 }
 
 // Upsert a revision in the cache. This function only upserts for CV key
@@ -271,11 +264,8 @@ func (rc *LRURevisionCache) Upsert(ctx context.Context, docRev DocumentRevision,
 
 	docRev.CalculateBytes()
 	// add new item bytes to overall count
-	rc.incrRevCacheMemoryUsage(ctx, docRev.MemoryBytes)
+	rc.memoryController.incrementBytesCount(ctx, docRev.MemoryBytes)
 	cvValue.store(docRev)
-
-	// check we aren't over memory capacity, if so perform eviction
-	rc.revCacheMemoryBasedEviction(ctx)
 }
 
 func (rc *LRURevisionCache) upsertDocToCache(ctx context.Context, cvKey revCacheKey, docRev DocumentRevision, collectionID uint32) (int64, *revCacheValue) {
@@ -290,7 +280,7 @@ func (rc *LRURevisionCache) upsertDocToCache(ctx context.Context, cvKey revCache
 	if found {
 		revItem := existingElem.Value.(*revCacheValue)
 		// decrement item bytes by the removed item
-		rc._decrRevCacheMemoryUsage(ctx, -revItem.getItemBytes())
+		rc.memoryController.decrementBytesCount(ctx, revItem.getItemBytes())
 		rc.lruList.Remove(existingElem)
 		newItem = false
 	}
@@ -299,6 +289,7 @@ func (rc *LRURevisionCache) upsertDocToCache(ctx context.Context, cvKey revCache
 	// also ensure we add to rev id lookup map too
 	cvValue := &revCacheValue{id: docRev.DocID, cv: *docRev.CV, collectionID: collectionID, itemKey: cvKey}
 	elem := rc.lruList.PushFront(cvValue)
+	cvValue.accessOrder.Store(nextAccessOrder()) // stamp on insert
 	rc.cache[cvKey] = elem
 
 	// only increment if we are inserting new item to cache
@@ -309,7 +300,7 @@ func (rc *LRURevisionCache) upsertDocToCache(ctx context.Context, cvKey revCache
 	// Purge oldest item if over number capacity
 	numItemsRemoved, numBytesEvicted := rc._numberCapacityEviction()
 	if numBytesEvicted > 0 {
-		rc._decrRevCacheMemoryUsage(ctx, -numBytesEvicted)
+		rc.memoryController.decrementBytesCount(ctx, numBytesEvicted)
 	}
 	return numItemsRemoved, cvValue
 }
@@ -342,12 +333,13 @@ func (rc *LRURevisionCache) getValue(ctx context.Context, docID, docVersionStrin
 			value.cv = currentVersion
 		}
 		value.itemLoaded.Store(false)
+		value.accessOrder.Store(nextAccessOrder()) // stamp on insert
 		rc.cache[key] = rc.lruList.PushFront(value)
 		rc.cacheNumItems.Add(1)
 
 		numItemsRemoved, numBytesEvicted := rc._numberCapacityEviction()
 		if numBytesEvicted > 0 {
-			rc._decrRevCacheMemoryUsage(ctx, -numBytesEvicted)
+			rc.memoryController.decrementBytesCount(ctx, numBytesEvicted)
 		}
 		if numItemsRemoved > 0 {
 			rc.cacheNumItems.Add(-numItemsRemoved)
@@ -369,7 +361,7 @@ func (rc *LRURevisionCache) Remove(ctx context.Context, docID, versionString str
 	if !ok {
 		return
 	}
-	rc._decrRevCacheMemoryUsage(ctx, -revValue.getItemBytes())
+	rc.memoryController.decrementBytesCount(ctx, revValue.getItemBytes())
 	rc.lruList.Remove(elem)
 	rc.cacheNumItems.Add(-1)
 	delete(rc.cache, key)
@@ -593,86 +585,6 @@ func (rev *DocumentRevision) CalculateBytes() {
 	rev.MemoryBytes = int64(totalBytes)
 }
 
-// revCacheMemoryBasedEviction checks for rev cache eviction, if required calls performEviction which will acquire lock to evict
-func (rc *LRURevisionCache) revCacheMemoryBasedEviction(ctx context.Context) {
-	// if memory capacity is not set, don't check for eviction this way
-	if rc.memoryCapacity > 0 && rc.currMemoryUsage.Value() > rc.memoryCapacity {
-		rc.performEviction(ctx)
-	}
-}
-
-// performEviction will evict the oldest items in the cache till we are below the memory threshold
-func (rc *LRURevisionCache) performEviction(ctx context.Context) {
-	numItemsRemoved := rc.evictBasedOffMemoryUsage(ctx)
-	rc.cacheNumItems.Add(-numItemsRemoved)
-}
-
-func (rc *LRURevisionCache) evictBasedOffMemoryUsage(ctx context.Context) int64 {
-	var numItemsRemoved, numBytesRemoved int64
-	rc.lock.Lock()
-	defer rc.lock.Unlock()
-	// check if we are over memory capacity after holding rev cache mutex (protect against another goroutine evicting whilst waiting for mutex above)
-	if currMemoryUsage := rc.currMemoryUsage.Value(); currMemoryUsage > rc.memoryCapacity {
-		// find amount of bytes needed to evict till below threshold
-		bytesNeededToRemove := currMemoryUsage - rc.memoryCapacity
-		for bytesNeededToRemove > numBytesRemoved {
-			value := rc._findEvictionValue()
-			if value == nil {
-				if rc.lruList.Len() > 0 {
-					// no more values ready for eviction
-					break
-				} else {
-					// list is empty, nothing more to evict but stats are wrong so zero stats and return
-					base.DebugfCtx(ctx, base.KeyCache, "Revision cache memory stats inconsistent for this shard, resetting to zero")
-					correctionVal := rc.currMemoryUsage.Value()
-					// Correct overall memory stat across shards to remove this shards memory usage, and set this shard to zero
-					rc.cacheMemoryBytesStat.Add(-correctionVal)
-					rc.currMemoryUsage.Set(0)
-					return numItemsRemoved
-				}
-			}
-			delete(rc.cache, value.itemKey)
-			numItemsRemoved++
-			valueBytes := value.getItemBytes()
-			numBytesRemoved += valueBytes
-		}
-	}
-	rc._decrRevCacheMemoryUsage(ctx, -numBytesRemoved) // need update rev cache memory stats before release lock to stop other goroutines evicting based on outdated stats
-	return numItemsRemoved
-}
-
-// _decrRevCacheMemoryUsage atomically decreases overall memory usage for cache and the actual rev cache objects usage.
-// You should be holding rev cache lock in using this function to avoid eviction processes over evicting items
-func (rc *LRURevisionCache) _decrRevCacheMemoryUsage(ctx context.Context, bytesCount int64) {
-	// We need to keep track of the current LRURevisionCache memory usage AND the overall usage of the cache. We need
-	// overall memory usage for the stat added to show rev cache usage plus we need the current rev cache capacity of the
-	// LRURevisionCache object for sharding the rev cache. This way we can perform eviction on per shard basis much like
-	// we do with the number of items capacity eviction
-	if bytesCount > 0 {
-		// function is for decrementing memory usage, so return if incrementing
-		base.AssertfCtx(ctx, "Attempting to increment memory stats with inside decrement function, should use incrRevCacheMemoryUsage instead")
-		return
-	}
-	rc.currMemoryUsage.Add(bytesCount)
-	rc.cacheMemoryBytesStat.Add(bytesCount)
-}
-
-// incrRevCacheMemoryUsage atomically increases overall memory usage for cache and the actual rev cache objects usage.
-// You do not need to hold rev cache lock when using this function
-func (rc *LRURevisionCache) incrRevCacheMemoryUsage(ctx context.Context, bytesCount int64) {
-	// We need to keep track of the current LRURevisionCache memory usage AND the overall usage of the cache. We need
-	// overall memory usage for the stat added to show rev cache usage plus we need the current rev cache capacity of the
-	// LRURevisionCache object for sharding the rev cache. This way we can perform eviction on per shard basis much like
-	// we do with the number of items capacity eviction
-	if bytesCount < 0 {
-		// function is for incrementing memory usage, so return if decrementing
-		base.AssertfCtx(ctx, "Attempting to decrement memory stats with inside increment function, should use _decrRevCacheMemoryUsage instead whilst holding rev cache lock")
-		return
-	}
-	rc.currMemoryUsage.Add(bytesCount)
-	rc.cacheMemoryBytesStat.Add(bytesCount)
-}
-
 func (rc *LRURevisionCache) _findEvictionValue() *revCacheValue {
 	evictionCandidate := rc.lruList.Back()
 	if evictionCandidate == nil {
@@ -700,4 +612,33 @@ func (rc *LRURevisionCache) _findEvictionValue() *revCacheValue {
 		evictionCandidate = evictionCandidate.Prev()
 	}
 	return nil
+}
+
+// peekLRUTailAccessOrder returns the accessOrder of the least-recently-used loaded item,
+// or 0 if the cache is empty or has no loaded items ready for eviction.
+// Called by the orchestrator to compare against the delta cache tail before deciding which to evict.
+func (rc *LRURevisionCache) peekLRUTailAccessOrder() uint64 {
+	rc.lock.Lock()
+	defer rc.lock.Unlock()
+	// Walk backwards to find a loaded item — mirrors _findEvictionValue but without removing.
+	for elem := rc.lruList.Back(); elem != nil; elem = elem.Prev() {
+		if v, ok := elem.Value.(*revCacheValue); ok && v.itemLoaded.Load() {
+			return v.accessOrder.Load()
+		}
+	}
+	return 0
+}
+
+// evictLRUTail removes the LRU loaded item and notifies the memory controller.
+// Returns false if there was nothing eligible to evict.
+func (rc *LRURevisionCache) evictLRUTail(ctx context.Context) int64 {
+	rc.lock.Lock()
+	defer rc.lock.Unlock()
+	value := rc._findEvictionValue() // already walks back to find a loaded item
+	if value == nil {
+		return 0
+	}
+	delete(rc.cache, value.itemKey)
+	rc.cacheNumItems.Add(-1)
+	return value.getItemBytes()
 }

--- a/db/revision_cache_orchestrator.go
+++ b/db/revision_cache_orchestrator.go
@@ -39,19 +39,19 @@ func NewRevisionCacheOrchestrator(cacheOptions *RevisionCacheOptions, backingSto
 }
 
 func (c *RevisionCacheOrchestrator) Get(ctx context.Context, docID, versionString string, collectionID uint32, loadBackup bool) (DocumentRevision, bool, error) {
-	docRev, cacheHit, err := c.revisionCache.Get(ctx, docID, versionString, collectionID, loadBackup)
-	if cacheHit {
+	docRev, cacheMiss, err := c.revisionCache.Get(ctx, docID, versionString, collectionID, loadBackup)
+	if cacheMiss {
 		c.triggerMemoryEviction()
 	}
-	return docRev, cacheHit, err
+	return docRev, cacheMiss, err
 }
 
-func (c *RevisionCacheOrchestrator) GetActive(ctx context.Context, docID string, collectionID uint32) (docRev DocumentRevision, cacheHit bool, err error) {
-	docRev, cacheHit, err = c.revisionCache.GetActive(ctx, docID, collectionID)
-	if cacheHit {
+func (c *RevisionCacheOrchestrator) GetActive(ctx context.Context, docID string, collectionID uint32) (docRev DocumentRevision, cacheMiss bool, err error) {
+	docRev, cacheMiss, err = c.revisionCache.GetActive(ctx, docID, collectionID)
+	if cacheMiss {
 		c.triggerMemoryEviction()
 	}
-	return docRev, cacheHit, err
+	return docRev, cacheMiss, err
 }
 
 func (c *RevisionCacheOrchestrator) Peek(ctx context.Context, docID, versionString string, collectionID uint32) (docRev DocumentRevision, found bool) {
@@ -90,6 +90,8 @@ func (c *RevisionCacheOrchestrator) GetWithDelta(ctx context.Context, docID, fro
 		cachedDelta := c.deltaCache.getCachedDelta(ctx, docID, fromVersionString, toVersionString, collectionID)
 		docRev.Delta = cachedDelta
 	}
+	// check for memory based eviction
+	c.triggerMemoryEviction()
 	return docRev, nil
 }
 
@@ -128,16 +130,6 @@ func (c *RevisionCacheOrchestrator) triggerMemoryEviction() {
 			bytesRemoved = c.deltaCache.evictLRUTail()
 		}
 		numBytesRemoved += bytesRemoved
-		if bytesRemoved == 0 {
-			// Nothing evictable in the chosen cache (e.g. all items still loading).
-			// Try the other cache before giving up.
-			if evictFromRev && c.deltaCache != nil {
-				c.deltaCache.evictLRUTail()
-			} else {
-				c.revisionCache.evictLRUTail()
-			}
-			break
-		}
 	}
 	c.memoryController.decrementBytesCount(numBytesRemoved)
 }

--- a/db/revision_cache_orchestrator.go
+++ b/db/revision_cache_orchestrator.go
@@ -12,6 +12,9 @@ package db
 
 import (
 	"context"
+	"sync"
+
+	"github.com/couchbase/sync_gateway/base"
 )
 
 // RevisionCacheOrchestrator orchestrates between the revisionCache and a deltaCache.
@@ -19,15 +22,20 @@ type RevisionCacheOrchestrator struct {
 	revisionCache    *LRURevisionCache      // holds document revisions
 	deltaCache       *LRUDeltaCache         // holds computed deltas, only initialed when delta sync is enabled
 	memoryController *CacheMemoryController // used to control memory usage of revision cache and delta cache combined
+	evictionLock     sync.Mutex             // This is to synchronise the eviction process so we don;t have multiple goroutines fighting to evict
 }
 
 // NewRevisionCacheOrchestrator creates a new RevisionCacheOrchestrator.
-func NewRevisionCacheOrchestrator(revisionCache *LRURevisionCache, deltaCache *LRUDeltaCache, memoryController *CacheMemoryController) *RevisionCacheOrchestrator {
-	return &RevisionCacheOrchestrator{
-		revisionCache:    revisionCache,
-		deltaCache:       deltaCache,
-		memoryController: memoryController,
+func NewRevisionCacheOrchestrator(cacheOptions *RevisionCacheOptions, backingStores map[uint32]RevisionCacheBackingStore, revCacheStats revisionCacheStats, deltaSyncStats *base.DeltaSyncStats, initDeltaCache bool) *RevisionCacheOrchestrator {
+	mc := newCacheMemoryController(cacheOptions.MaxBytes, revCacheStats.cacheMemoryStat)
+	revOrchestrator := &RevisionCacheOrchestrator{
+		revisionCache:    NewLRURevisionCache(cacheOptions, backingStores, revCacheStats, mc),
+		memoryController: mc,
 	}
+	if initDeltaCache {
+		revOrchestrator.deltaCache = NewLRUDeltaCache(cacheOptions, deltaSyncStats, mc)
+	}
+	return revOrchestrator
 }
 
 func (c *RevisionCacheOrchestrator) Get(ctx context.Context, docID, versionString string, collectionID uint32, loadBackup bool) (DocumentRevision, bool, error) {
@@ -91,11 +99,18 @@ func (c *RevisionCacheOrchestrator) triggerMemoryEviction(ctx context.Context) {
 		// no eviction to take place
 		return
 	}
-	// do we need to syncdhirnise this????
+	// Acquire lock till eviction is done. This is to protect against multiple goroutines attempting to
+	// perform this at the same time on the shard.
+	c.evictionLock.Lock()
+	defer c.evictionLock.Unlock()
 
 	var numBytesRemoved int64
 	var deltaCandidateOrder uint64
 	bytesNeededToEvict := c.memoryController.bytesToEvict()
+	if bytesNeededToEvict == 0 {
+		// a different goroutine has evicted enough already
+		return
+	}
 	for bytesNeededToEvict > numBytesRemoved {
 		if c.deltaCache != nil {
 			deltaCandidateOrder = c.deltaCache.peekLRUTailAccessOrder()
@@ -103,7 +118,6 @@ func (c *RevisionCacheOrchestrator) triggerMemoryEviction(ctx context.Context) {
 		revCandidateOrder := c.revisionCache.peekLRUTailAccessOrder()
 		if revCandidateOrder == 0 && deltaCandidateOrder == 0 {
 			// Both caches are empty — nothing more to evict.
-			//base.AssertfCtx(ctx, "memory")
 			break
 		}
 		var bytesRemoved int64

--- a/db/revision_cache_orchestrator.go
+++ b/db/revision_cache_orchestrator.go
@@ -22,7 +22,7 @@ type RevisionCacheOrchestrator struct {
 	revisionCache    *LRURevisionCache      // holds document revisions
 	deltaCache       *LRUDeltaCache         // holds computed deltas, only initialized when delta sync is enabled
 	memoryController *CacheMemoryController // used to control memory usage of revision cache and delta cache combined
-	evictionLock     sync.Mutex             // This is to synchronise the eviction process so we don;t have multiple goroutines fighting to evict
+	evictionLock     sync.Mutex             // This is to synchronise the eviction process so we don't have multiple goroutines fighting to evict
 	evictNextFromRev bool                   // round-robin flag: alternates which cache is tried first on each eviction
 }
 
@@ -137,7 +137,7 @@ func (c *RevisionCacheOrchestrator) evictOneItem() (int64, bool) {
 	}
 
 	tryRevFirst := c.evictNextFromRev
-	// flip boolean to evict from opposite sode nect time around
+	// flip flag to try the other cache first on the next eviction
 	c.evictNextFromRev = !c.evictNextFromRev
 
 	if tryRevFirst {

--- a/db/revision_cache_orchestrator.go
+++ b/db/revision_cache_orchestrator.go
@@ -23,6 +23,7 @@ type RevisionCacheOrchestrator struct {
 	deltaCache       *LRUDeltaCache         // holds computed deltas, only initialized when delta sync is enabled
 	memoryController *CacheMemoryController // used to control memory usage of revision cache and delta cache combined
 	evictionLock     sync.Mutex             // This is to synchronise the eviction process so we don;t have multiple goroutines fighting to evict
+	evictNextFromRev bool                   // round-robin flag: alternates which cache is tried first on each eviction
 }
 
 // NewRevisionCacheOrchestrator creates a new RevisionCacheOrchestrator.
@@ -82,7 +83,7 @@ func (c *RevisionCacheOrchestrator) UpdateDelta(ctx context.Context, docID, from
 }
 
 func (c *RevisionCacheOrchestrator) GetWithDelta(ctx context.Context, docID, fromVersionString, toVersionString string, collectionID uint32) (DocumentRevision, error) {
-	docRev, _, err := c.revisionCache.Get(ctx, docID, fromVersionString, collectionID, RevCacheLoadBackupRev)
+	docRev, checkForMemoryEviction, err := c.revisionCache.Get(ctx, docID, fromVersionString, collectionID, RevCacheLoadBackupRev)
 	if err != nil {
 		return docRev, err
 	}
@@ -91,7 +92,9 @@ func (c *RevisionCacheOrchestrator) GetWithDelta(ctx context.Context, docID, fro
 		docRev.Delta = cachedDelta
 	}
 	// check for memory based eviction
-	c.triggerMemoryEviction()
+	if checkForMemoryEviction {
+		c.triggerMemoryEviction()
+	}
 	return docRev, nil
 }
 
@@ -107,29 +110,47 @@ func (c *RevisionCacheOrchestrator) triggerMemoryEviction() {
 	defer c.evictionLock.Unlock()
 
 	var numBytesRemoved int64
-	var deltaCandidateOrder uint64
 	bytesNeededToEvict := c.memoryController.bytesToEvict()
 	if bytesNeededToEvict == 0 {
 		// a different goroutine has evicted enough already
 		return
 	}
-	for bytesNeededToEvict > numBytesRemoved {
-		if c.deltaCache != nil {
-			deltaCandidateOrder = c.deltaCache.peekLRUTailAccessOrder()
-		}
-		revCandidateOrder := c.revisionCache.peekLRUTailAccessOrder()
-		if revCandidateOrder == 0 && deltaCandidateOrder == 0 {
-			// Both caches are empty — nothing more to evict.
+	for numBytesRemoved < bytesNeededToEvict {
+		bytes, evicted := c.evictOneItem()
+		if !evicted {
+			// both caches exhausted
 			break
 		}
-		var bytesRemoved int64
-		evictFromRev := deltaCandidateOrder == 0 || (revCandidateOrder != 0 && revCandidateOrder < deltaCandidateOrder)
-		if evictFromRev {
-			bytesRemoved = c.revisionCache.evictLRUTail()
-		} else {
-			bytesRemoved = c.deltaCache.evictLRUTail()
-		}
-		numBytesRemoved += bytesRemoved
+		numBytesRemoved += bytes
 	}
 	c.memoryController.decrementBytesCount(numBytesRemoved)
+}
+
+// evictOneItem removes one item from either the revision or delta cache using round-robin
+// selection. If the primary cache is empty, it immediately falls back to the other cache.
+// Returns (bytes freed, true) when an item was removed, or (0, false) when both are empty.
+// Must only be called while holding evictionLock.
+func (c *RevisionCacheOrchestrator) evictOneItem() (int64, bool) {
+	// When the delta cache is not enabled, always evict from the revision cache.
+	if c.deltaCache == nil {
+		return c.revisionCache.evictLRUTail()
+	}
+
+	tryRevFirst := c.evictNextFromRev
+	// flip boolean to evict from opposite sode nect time around
+	c.evictNextFromRev = !c.evictNextFromRev
+
+	if tryRevFirst {
+		if bytes, evicted := c.revisionCache.evictLRUTail(); evicted {
+			return bytes, true
+		}
+		// Rev cache exhausted — fall back to delta immediately without burning a loop iteration.
+		return c.deltaCache.evictLRUTail()
+	}
+
+	if bytes, evicted := c.deltaCache.evictLRUTail(); evicted {
+		return bytes, true
+	}
+	// Delta cache exhausted — fall back to rev immediately without burning a loop iteration.
+	return c.revisionCache.evictLRUTail()
 }

--- a/db/revision_cache_orchestrator.go
+++ b/db/revision_cache_orchestrator.go
@@ -20,7 +20,7 @@ import (
 // RevisionCacheOrchestrator orchestrates between the revisionCache and a deltaCache.
 type RevisionCacheOrchestrator struct {
 	revisionCache    *LRURevisionCache      // holds document revisions
-	deltaCache       *LRUDeltaCache         // holds computed deltas, only initialed when delta sync is enabled
+	deltaCache       *LRUDeltaCache         // holds computed deltas, only initialized when delta sync is enabled
 	memoryController *CacheMemoryController // used to control memory usage of revision cache and delta cache combined
 	evictionLock     sync.Mutex             // This is to synchronise the eviction process so we don;t have multiple goroutines fighting to evict
 }
@@ -39,19 +39,19 @@ func NewRevisionCacheOrchestrator(cacheOptions *RevisionCacheOptions, backingSto
 }
 
 func (c *RevisionCacheOrchestrator) Get(ctx context.Context, docID, versionString string, collectionID uint32, loadBackup bool) (DocumentRevision, bool, error) {
-	docRev, cacheMiss, err := c.revisionCache.Get(ctx, docID, versionString, collectionID, loadBackup)
-	if cacheMiss {
+	docRev, checkForMemoryEviction, err := c.revisionCache.Get(ctx, docID, versionString, collectionID, loadBackup)
+	if checkForMemoryEviction {
 		c.triggerMemoryEviction()
 	}
-	return docRev, cacheMiss, err
+	return docRev, checkForMemoryEviction, err
 }
 
-func (c *RevisionCacheOrchestrator) GetActive(ctx context.Context, docID string, collectionID uint32) (docRev DocumentRevision, cacheMiss bool, err error) {
-	docRev, cacheMiss, err = c.revisionCache.GetActive(ctx, docID, collectionID)
-	if cacheMiss {
+func (c *RevisionCacheOrchestrator) GetActive(ctx context.Context, docID string, collectionID uint32) (docRev DocumentRevision, checkForMemoryEviction bool, err error) {
+	docRev, checkForMemoryEviction, err = c.revisionCache.GetActive(ctx, docID, collectionID)
+	if checkForMemoryEviction {
 		c.triggerMemoryEviction()
 	}
-	return docRev, cacheMiss, err
+	return docRev, checkForMemoryEviction, err
 }
 
 func (c *RevisionCacheOrchestrator) Peek(ctx context.Context, docID, versionString string, collectionID uint32) (docRev DocumentRevision, found bool) {

--- a/db/revision_cache_orchestrator.go
+++ b/db/revision_cache_orchestrator.go
@@ -116,7 +116,7 @@ func (c *RevisionCacheOrchestrator) triggerMemoryEviction() {
 		return
 	}
 	for numBytesRemoved < bytesNeededToEvict {
-		bytes, evicted := c.evictOneItem()
+		bytes, evicted := c._evictOneItem()
 		if !evicted {
 			// both caches exhausted
 			break
@@ -126,31 +126,24 @@ func (c *RevisionCacheOrchestrator) triggerMemoryEviction() {
 	c.memoryController.decrementBytesCount(numBytesRemoved)
 }
 
-// evictOneItem removes one item from either the revision or delta cache using round-robin
+// _evictOneItem removes one item from either the revision or delta cache using round-robin
 // selection. If the primary cache is empty, it immediately falls back to the other cache.
 // Returns (bytes freed, true) when an item was removed, or (0, false) when both are empty.
 // Must only be called while holding evictionLock.
-func (c *RevisionCacheOrchestrator) evictOneItem() (int64, bool) {
+func (c *RevisionCacheOrchestrator) _evictOneItem() (int64, bool) {
 	// When the delta cache is not enabled, always evict from the revision cache.
 	if c.deltaCache == nil {
 		return c.revisionCache.evictLRUTail()
 	}
 
-	tryRevFirst := c.evictNextFromRev
-	// flip flag to try the other cache first on the next eviction
+	// flip eviction toggle
 	c.evictNextFromRev = !c.evictNextFromRev
-
-	if tryRevFirst {
-		if bytes, evicted := c.revisionCache.evictLRUTail(); evicted {
-			return bytes, true
-		}
-		// Rev cache exhausted — fall back to delta immediately without burning a loop iteration.
-		return c.deltaCache.evictLRUTail()
+	first, second := c.revisionCache.evictLRUTail, c.deltaCache.evictLRUTail
+	if !c.evictNextFromRev {
+		first, second = second, first
 	}
-
-	if bytes, evicted := c.deltaCache.evictLRUTail(); evicted {
+	if bytes, evicted := first(); evicted {
 		return bytes, true
 	}
-	// Delta cache exhausted — fall back to rev immediately without burning a loop iteration.
-	return c.revisionCache.evictLRUTail()
+	return second()
 }

--- a/db/revision_cache_orchestrator.go
+++ b/db/revision_cache_orchestrator.go
@@ -41,7 +41,7 @@ func NewRevisionCacheOrchestrator(cacheOptions *RevisionCacheOptions, backingSto
 func (c *RevisionCacheOrchestrator) Get(ctx context.Context, docID, versionString string, collectionID uint32, loadBackup bool) (DocumentRevision, bool, error) {
 	docRev, cacheHit, err := c.revisionCache.Get(ctx, docID, versionString, collectionID, loadBackup)
 	if cacheHit {
-		c.triggerMemoryEviction(ctx)
+		c.triggerMemoryEviction()
 	}
 	return docRev, cacheHit, err
 }
@@ -49,7 +49,7 @@ func (c *RevisionCacheOrchestrator) Get(ctx context.Context, docID, versionStrin
 func (c *RevisionCacheOrchestrator) GetActive(ctx context.Context, docID string, collectionID uint32) (docRev DocumentRevision, cacheHit bool, err error) {
 	docRev, cacheHit, err = c.revisionCache.GetActive(ctx, docID, collectionID)
 	if cacheHit {
-		c.triggerMemoryEviction(ctx)
+		c.triggerMemoryEviction()
 	}
 	return docRev, cacheHit, err
 }
@@ -60,12 +60,12 @@ func (c *RevisionCacheOrchestrator) Peek(ctx context.Context, docID, versionStri
 
 func (c *RevisionCacheOrchestrator) Put(ctx context.Context, docRev DocumentRevision, collectionID uint32) {
 	c.revisionCache.Put(ctx, docRev, collectionID)
-	c.triggerMemoryEviction(ctx)
+	c.triggerMemoryEviction()
 }
 
 func (c *RevisionCacheOrchestrator) Upsert(ctx context.Context, docRev DocumentRevision, collectionID uint32) {
 	c.revisionCache.Upsert(ctx, docRev, collectionID)
-	c.triggerMemoryEviction(ctx)
+	c.triggerMemoryEviction()
 }
 
 func (c *RevisionCacheOrchestrator) Remove(ctx context.Context, docID, versionString string, collectionID uint32) {
@@ -78,7 +78,7 @@ func (c *RevisionCacheOrchestrator) UpdateDelta(ctx context.Context, docID, from
 	}
 	c.deltaCache.addDelta(ctx, docID, fromVersionString, toVersionString, collectionID, toDelta)
 	// check for memory based eviction
-	c.triggerMemoryEviction(ctx)
+	c.triggerMemoryEviction()
 }
 
 func (c *RevisionCacheOrchestrator) GetWithDelta(ctx context.Context, docID, fromVersionString, toVersionString string, collectionID uint32) (DocumentRevision, error) {
@@ -94,7 +94,7 @@ func (c *RevisionCacheOrchestrator) GetWithDelta(ctx context.Context, docID, fro
 }
 
 // triggerMemoryEviction is called after any write to either sub-cache.
-func (c *RevisionCacheOrchestrator) triggerMemoryEviction(ctx context.Context) {
+func (c *RevisionCacheOrchestrator) triggerMemoryEviction() {
 	if c.memoryController == nil || !c.memoryController.IsOverCapacity() {
 		// no eviction to take place
 		return
@@ -123,37 +123,21 @@ func (c *RevisionCacheOrchestrator) triggerMemoryEviction(ctx context.Context) {
 		var bytesRemoved int64
 		evictFromRev := deltaCandidateOrder == 0 || (revCandidateOrder != 0 && revCandidateOrder < deltaCandidateOrder)
 		if evictFromRev {
-			bytesRemoved = c.revisionCache.evictLRUTail(ctx)
+			bytesRemoved = c.revisionCache.evictLRUTail()
 		} else {
-			bytesRemoved = c.deltaCache.evictLRUTail(ctx)
+			bytesRemoved = c.deltaCache.evictLRUTail()
 		}
 		numBytesRemoved += bytesRemoved
 		if bytesRemoved == 0 {
 			// Nothing evictable in the chosen cache (e.g. all items still loading).
 			// Try the other cache before giving up.
 			if evictFromRev && c.deltaCache != nil {
-				c.deltaCache.evictLRUTail(ctx)
+				c.deltaCache.evictLRUTail()
 			} else {
-				c.revisionCache.evictLRUTail(ctx)
+				c.revisionCache.evictLRUTail()
 			}
 			break
 		}
 	}
-	c.memoryController.decrementBytesCount(ctx, numBytesRemoved)
-}
-
-// evictLRUTail removes the LRU item and notifies the memory controller.
-// Returns false if the cache was empty.
-func (dc *LRUDeltaCache) evictLRUTail(ctx context.Context) int64 {
-	dc.lock.Lock()
-	defer dc.lock.Unlock()
-	elem := dc.lruList.Back()
-	if elem == nil {
-		return 0
-	}
-	val := elem.Value.(*deltaCacheValue)
-	dc.lruList.Remove(elem)
-	delete(dc.cache, val.itemKey)
-	dc.cacheNumDeltas.Add(-1)
-	return val.delta.totalDeltaBytes
+	c.memoryController.decrementBytesCount(numBytesRemoved)
 }

--- a/db/revision_cache_orchestrator.go
+++ b/db/revision_cache_orchestrator.go
@@ -10,28 +10,40 @@ licenses/APL2.txt.
 
 package db
 
-import "context"
+import (
+	"context"
+)
 
 // RevisionCacheOrchestrator orchestrates between the revisionCache and a deltaCache.
 type RevisionCacheOrchestrator struct {
-	revisionCache *LRURevisionCache
-	deltaCache    *LRUDeltaCache
+	revisionCache    *LRURevisionCache      // holds document revisions
+	deltaCache       *LRUDeltaCache         // holds computed deltas, only initialed when delta sync is enabled
+	memoryController *CacheMemoryController // used to control memory usage of revision cache and delta cache combined
 }
 
 // NewRevisionCacheOrchestrator creates a new RevisionCacheOrchestrator.
-func NewRevisionCacheOrchestrator(revisionCache *LRURevisionCache, deltaCache *LRUDeltaCache) *RevisionCacheOrchestrator {
+func NewRevisionCacheOrchestrator(revisionCache *LRURevisionCache, deltaCache *LRUDeltaCache, memoryController *CacheMemoryController) *RevisionCacheOrchestrator {
 	return &RevisionCacheOrchestrator{
-		revisionCache: revisionCache,
-		deltaCache:    deltaCache,
+		revisionCache:    revisionCache,
+		deltaCache:       deltaCache,
+		memoryController: memoryController,
 	}
 }
 
-func (c *RevisionCacheOrchestrator) Get(ctx context.Context, docID, versionString string, collectionID uint32, loadBackup bool) (DocumentRevision, error) {
-	return c.revisionCache.Get(ctx, docID, versionString, collectionID, loadBackup)
+func (c *RevisionCacheOrchestrator) Get(ctx context.Context, docID, versionString string, collectionID uint32, loadBackup bool) (DocumentRevision, bool, error) {
+	docRev, cacheHit, err := c.revisionCache.Get(ctx, docID, versionString, collectionID, loadBackup)
+	if cacheHit {
+		c.triggerMemoryEviction(ctx)
+	}
+	return docRev, cacheHit, err
 }
 
-func (c *RevisionCacheOrchestrator) GetActive(ctx context.Context, docID string, collectionID uint32) (docRev DocumentRevision, err error) {
-	return c.revisionCache.GetActive(ctx, docID, collectionID)
+func (c *RevisionCacheOrchestrator) GetActive(ctx context.Context, docID string, collectionID uint32) (docRev DocumentRevision, cacheHit bool, err error) {
+	docRev, cacheHit, err = c.revisionCache.GetActive(ctx, docID, collectionID)
+	if cacheHit {
+		c.triggerMemoryEviction(ctx)
+	}
+	return docRev, cacheHit, err
 }
 
 func (c *RevisionCacheOrchestrator) Peek(ctx context.Context, docID, versionString string, collectionID uint32) (docRev DocumentRevision, found bool) {
@@ -40,10 +52,12 @@ func (c *RevisionCacheOrchestrator) Peek(ctx context.Context, docID, versionStri
 
 func (c *RevisionCacheOrchestrator) Put(ctx context.Context, docRev DocumentRevision, collectionID uint32) {
 	c.revisionCache.Put(ctx, docRev, collectionID)
+	c.triggerMemoryEviction(ctx)
 }
 
 func (c *RevisionCacheOrchestrator) Upsert(ctx context.Context, docRev DocumentRevision, collectionID uint32) {
 	c.revisionCache.Upsert(ctx, docRev, collectionID)
+	c.triggerMemoryEviction(ctx)
 }
 
 func (c *RevisionCacheOrchestrator) Remove(ctx context.Context, docID, versionString string, collectionID uint32) {
@@ -55,10 +69,12 @@ func (c *RevisionCacheOrchestrator) UpdateDelta(ctx context.Context, docID, from
 		return
 	}
 	c.deltaCache.addDelta(ctx, docID, fromVersionString, toVersionString, collectionID, toDelta)
+	// check for memory based eviction
+	c.triggerMemoryEviction(ctx)
 }
 
 func (c *RevisionCacheOrchestrator) GetWithDelta(ctx context.Context, docID, fromVersionString, toVersionString string, collectionID uint32) (DocumentRevision, error) {
-	docRev, err := c.revisionCache.Get(ctx, docID, fromVersionString, collectionID, RevCacheLoadBackupRev)
+	docRev, _, err := c.revisionCache.Get(ctx, docID, fromVersionString, collectionID, RevCacheLoadBackupRev)
 	if err != nil {
 		return docRev, err
 	}
@@ -67,4 +83,63 @@ func (c *RevisionCacheOrchestrator) GetWithDelta(ctx context.Context, docID, fro
 		docRev.Delta = cachedDelta
 	}
 	return docRev, nil
+}
+
+// triggerMemoryEviction is called after any write to either sub-cache.
+func (c *RevisionCacheOrchestrator) triggerMemoryEviction(ctx context.Context) {
+	if c.memoryController == nil || !c.memoryController.IsOverCapacity() {
+		// no eviction to take place
+		return
+	}
+	// do we need to syncdhirnise this????
+
+	var numBytesRemoved int64
+	var deltaCandidateOrder uint64
+	bytesNeededToEvict := c.memoryController.bytesToEvict()
+	for bytesNeededToEvict > numBytesRemoved {
+		if c.deltaCache != nil {
+			deltaCandidateOrder = c.deltaCache.peekLRUTailAccessOrder()
+		}
+		revCandidateOrder := c.revisionCache.peekLRUTailAccessOrder()
+		if revCandidateOrder == 0 && deltaCandidateOrder == 0 {
+			// Both caches are empty — nothing more to evict.
+			//base.AssertfCtx(ctx, "memory")
+			break
+		}
+		var bytesRemoved int64
+		evictFromRev := deltaCandidateOrder == 0 || (revCandidateOrder != 0 && revCandidateOrder < deltaCandidateOrder)
+		if evictFromRev {
+			bytesRemoved = c.revisionCache.evictLRUTail(ctx)
+		} else {
+			bytesRemoved = c.deltaCache.evictLRUTail(ctx)
+		}
+		numBytesRemoved += bytesRemoved
+		if bytesRemoved == 0 {
+			// Nothing evictable in the chosen cache (e.g. all items still loading).
+			// Try the other cache before giving up.
+			if evictFromRev && c.deltaCache != nil {
+				c.deltaCache.evictLRUTail(ctx)
+			} else {
+				c.revisionCache.evictLRUTail(ctx)
+			}
+			break
+		}
+	}
+	c.memoryController.decrementBytesCount(ctx, numBytesRemoved)
+}
+
+// evictLRUTail removes the LRU item and notifies the memory controller.
+// Returns false if the cache was empty.
+func (dc *LRUDeltaCache) evictLRUTail(ctx context.Context) int64 {
+	dc.lock.Lock()
+	defer dc.lock.Unlock()
+	elem := dc.lruList.Back()
+	if elem == nil {
+		return 0
+	}
+	val := elem.Value.(*deltaCacheValue)
+	dc.lruList.Remove(elem)
+	delete(dc.cache, val.itemKey)
+	dc.cacheNumDeltas.Add(-1)
+	return val.delta.totalDeltaBytes
 }

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -157,7 +157,7 @@ func TestLRURevisionCacheEviction(t *testing.T) {
 				cacheNumItemsStat: &cacheNumItems,
 				cacheMemoryStat:   &memoryBytesCounted,
 			}
-			cache := NewLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats)
+			cache := NewLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats, newCacheMemoryController(0, revCacheStats.cacheMemoryStat))
 
 			ctx := base.TestCtx(t)
 
@@ -169,7 +169,7 @@ func TestLRURevisionCacheEviction(t *testing.T) {
 			// Fill up the rev cache with the first 10 docs
 			for docID := range 10 {
 				id := strconv.Itoa(docID)
-				_, err := cache.Get(ctx, id, revOrCV, testCollectionID, RevCacheDontLoadBackupRev)
+				_, _, err := cache.Get(ctx, id, revOrCV, testCollectionID, RevCacheDontLoadBackupRev)
 				require.NoError(t, err)
 			}
 			assert.Equal(t, int64(10), cacheNumItems.Value())
@@ -179,7 +179,7 @@ func TestLRURevisionCacheEviction(t *testing.T) {
 			// Get them back out
 			for i := range 10 {
 				docID := strconv.Itoa(i)
-				docRev, err := cache.Get(ctx, docID, revOrCV, testCollectionID, RevCacheDontLoadBackupRev)
+				docRev, _, err := cache.Get(ctx, docID, revOrCV, testCollectionID, RevCacheDontLoadBackupRev)
 				assert.NoError(t, err)
 				assert.NotNil(t, docRev.BodyBytes, "nil body for %s", docID)
 				assert.Equal(t, docID, docRev.DocID)
@@ -191,7 +191,7 @@ func TestLRURevisionCacheEviction(t *testing.T) {
 			// Add 3 more docs to the now full revcache
 			for i := 10; i < 13; i++ {
 				docID := strconv.Itoa(i)
-				_, err := cache.Get(ctx, docID, revOrCV, testCollectionID, RevCacheDontLoadBackupRev)
+				_, _, err := cache.Get(ctx, docID, revOrCV, testCollectionID, RevCacheDontLoadBackupRev)
 				require.NoError(t, err)
 			}
 			assert.Equal(t, int64(10), cacheNumItems.Value())
@@ -216,7 +216,7 @@ func TestLRURevisionCacheEviction(t *testing.T) {
 			// and check we can Get up to and including the last 3 we put in
 			for i := range 10 {
 				id := strconv.Itoa(i + 3)
-				docRev, err := cache.Get(ctx, id, revOrCV, testCollectionID, RevCacheDontLoadBackupRev)
+				docRev, _, err := cache.Get(ctx, id, revOrCV, testCollectionID, RevCacheDontLoadBackupRev)
 				assert.NoError(t, err)
 				assert.NotNil(t, docRev.BodyBytes, "nil body for %s", id)
 				assert.Equal(t, id, docRev.DocID)
@@ -285,7 +285,7 @@ func TestLRURevisionCacheEvictionMemoryBased(t *testing.T) {
 			expValue -= revZeroSize // for doc being evicted
 			docSize, rev, docVersion := createDocAndReturnSizeAndRev(t, ctx, "11", collection, smallBody, testCase.useCVKey)
 			// load into cache
-			_, err := db.revisionCache.Get(ctx, "11", versionKey(docVersion, rev), collection.GetCollectionID(), RevCacheDontLoadBackupRev)
+			_, _, err := db.revisionCache.Get(ctx, "11", versionKey(docVersion, rev), collection.GetCollectionID(), RevCacheDontLoadBackupRev)
 			require.NoError(t, err)
 			expValue += int64(docSize)
 			// assert doc 0 been evicted
@@ -321,12 +321,12 @@ func TestLRURevisionCacheEvictionMemoryBased(t *testing.T) {
 			require.NoError(t, err)
 
 			// load into cache
-			_, err = db.revisionCache.Get(ctx, "12", versionKey(doc.HLV.ExtractCurrentVersionFromHLV(), revID), collection.GetCollectionID(), RevCacheDontLoadBackupRev)
+			_, _, err = db.revisionCache.Get(ctx, "12", versionKey(doc.HLV.ExtractCurrentVersionFromHLV(), revID), collection.GetCollectionID(), RevCacheDontLoadBackupRev)
 			require.NoError(t, err)
 
 			// assert doc "2" has been evicted even though we only have 9 items in cache with capacity of 10, so memory based
 			// eviction took place
-			docRev, ok = db.revisionCache.Peek(ctx, "2", versionKey(versions[2], rev), collection.GetCollectionID())
+			docRev, _, ok = db.revisionCache.Peek(ctx, "2", versionKey(versions[2], rev), collection.GetCollectionID())
 			assert.False(t, ok)
 			assert.Nil(t, docRev.BodyBytes)
 
@@ -366,7 +366,9 @@ func TestBackingStoreMemoryCalculation(t *testing.T) {
 				cacheNumItemsStat: &cacheNumItems,
 				cacheMemoryStat:   &memoryBytesCounted,
 			}
-			cache := NewLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats)
+			mc := newCacheMemoryController(cacheOptions.MaxBytes, revCacheStats.cacheMemoryStat)
+			lruCache := NewLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats, mc)
+			cache := NewRevisionCacheOrchestrator(lruCache, nil, mc)
 			ctx := base.TestCtx(t)
 			var err error
 
@@ -376,7 +378,7 @@ func TestBackingStoreMemoryCalculation(t *testing.T) {
 			}
 
 			var docRev DocumentRevision
-			docRev, err = cache.Get(ctx, "doc1", revOrCV, testCollectionID, RevCacheDontLoadBackupRev)
+			docRev, _, err = cache.Get(ctx, "doc1", revOrCV, testCollectionID, RevCacheDontLoadBackupRev)
 			require.NoError(t, err)
 			assert.Equal(t, "doc1", docRev.DocID)
 			assert.NotNil(t, docRev.History)
@@ -387,7 +389,7 @@ func TestBackingStoreMemoryCalculation(t *testing.T) {
 			assert.Equal(t, docRev.MemoryBytes, currMemStat)
 
 			// Test get active code pathway of a load from bucket
-			docRev, err = cache.GetActive(ctx, "doc", testCollectionID)
+			docRev, _, err = cache.GetActive(ctx, "doc", testCollectionID)
 			require.NoError(t, err)
 			assert.Equal(t, "doc", docRev.DocID)
 			assert.NotNil(t, docRev.History)
@@ -398,24 +400,24 @@ func TestBackingStoreMemoryCalculation(t *testing.T) {
 			assert.Equal(t, newMemStat, memoryBytesCounted.Value())
 
 			// test fail load event doesn't increment memory stat
-			docRev, err = cache.Get(ctx, "doc2", revOrCV, testCollectionID, RevCacheDontLoadBackupRev)
+			docRev, _, err = cache.Get(ctx, "doc2", revOrCV, testCollectionID, RevCacheDontLoadBackupRev)
 			assertHTTPError(t, err, 404)
 			assert.Nil(t, docRev.BodyBytes)
 			assert.Equal(t, newMemStat, memoryBytesCounted.Value())
 
 			// assert length is 2 as expected
-			assert.Equal(t, 2, cache.lruList.Len())
+			assert.Equal(t, 2, cache.revisionCache.lruList.Len())
 
 			memStatBeforeThirdLoad := memoryBytesCounted.Value()
 			// test another load from bucket but doing so should trigger memory based eviction
-			docRev, err = cache.Get(ctx, "doc3", revOrCV, testCollectionID, RevCacheDontLoadBackupRev)
+			docRev, _, err = cache.Get(ctx, "doc3", revOrCV, testCollectionID, RevCacheDontLoadBackupRev)
 			require.NoError(t, err)
 			assert.Equal(t, "doc3", docRev.DocID)
 			assert.NotNil(t, docRev.History)
 			assert.NotNil(t, docRev.Channels)
 
 			// assert length is still 2 (eviction took place) + test Peek for first added doc is failure
-			assert.Equal(t, 2, cache.lruList.Len())
+			assert.Equal(t, 2, cache.revisionCache.lruList.Len())
 			memStatAfterEviction := (memStatBeforeThirdLoad + docRev.MemoryBytes) - currMemStat
 			assert.Equal(t, memStatAfterEviction, memoryBytesCounted.Value())
 			_, ok := cache.Peek(ctx, "doc1", revOrCV, testCollectionID)
@@ -438,10 +440,10 @@ func TestBackingStore(t *testing.T) {
 		cacheNumItemsStat: &cacheNumItems,
 		cacheMemoryStat:   &memoryBytesCounted,
 	}
-	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats)
+	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats, newCacheMemoryController(cacheOptions.MaxBytes, revCacheStats.cacheMemoryStat))
 
 	// Get Rev for the first time - miss cache, but fetch the doc and revision to store
-	docRev, err := cache.Get(base.TestCtx(t), "Jens", "1-abc", testCollectionID, RevCacheDontLoadBackupRev)
+	docRev, _, err := cache.Get(base.TestCtx(t), "Jens", "1-abc", testCollectionID, RevCacheDontLoadBackupRev)
 	assert.NoError(t, err)
 	assert.Equal(t, "Jens", docRev.DocID)
 	assert.NotNil(t, docRev.History)
@@ -452,7 +454,7 @@ func TestBackingStore(t *testing.T) {
 	assert.Equal(t, int64(1), getRevisionCounter.Value())
 
 	// Doc doesn't exist, so miss the cache, and fail when getting the doc
-	docRev, err = cache.Get(base.TestCtx(t), "Peter", "1-abc", testCollectionID, RevCacheDontLoadBackupRev)
+	docRev, _, err = cache.Get(base.TestCtx(t), "Peter", "1-abc", testCollectionID, RevCacheDontLoadBackupRev)
 	assertHTTPError(t, err, 404)
 	assert.Nil(t, docRev.BodyBytes)
 	assert.Equal(t, int64(0), cacheHitCounter.Value())
@@ -461,7 +463,7 @@ func TestBackingStore(t *testing.T) {
 	assert.Equal(t, int64(1), getRevisionCounter.Value())
 
 	// Rev is already resident, but still issue GetDocument to check for later revisions
-	docRev, err = cache.Get(base.TestCtx(t), "Jens", "1-abc", testCollectionID, RevCacheDontLoadBackupRev)
+	docRev, _, err = cache.Get(base.TestCtx(t), "Jens", "1-abc", testCollectionID, RevCacheDontLoadBackupRev)
 	assert.NoError(t, err)
 	assert.Equal(t, "Jens", docRev.DocID)
 	assert.NotNil(t, docRev.History)
@@ -472,7 +474,7 @@ func TestBackingStore(t *testing.T) {
 	assert.Equal(t, int64(1), getRevisionCounter.Value())
 
 	// Rev still doesn't exist, make sure it wasn't cached
-	docRev, err = cache.Get(base.TestCtx(t), "Peter", "1-abc", testCollectionID, RevCacheDontLoadBackupRev)
+	docRev, _, err = cache.Get(base.TestCtx(t), "Peter", "1-abc", testCollectionID, RevCacheDontLoadBackupRev)
 	assertHTTPError(t, err, 404)
 	assert.Nil(t, docRev.BodyBytes)
 	assert.Equal(t, int64(1), cacheHitCounter.Value())
@@ -500,11 +502,11 @@ func TestBackingStoreCV(t *testing.T) {
 		cacheNumItemsStat: &cacheNumItems,
 		cacheMemoryStat:   &memoryBytesCounted,
 	}
-	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats)
+	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats, newCacheMemoryController(cacheOptions.MaxBytes, revCacheStats.cacheMemoryStat))
 
 	// Get Rev for the first time - miss cache, but fetch the doc and revision to store
 	cv := Version{SourceID: "test", Value: 123}
-	docRev, err := cache.Get(base.TestCtx(t), "doc1", cv.String(), testCollectionID, RevCacheDontLoadBackupRev)
+	docRev, _, err := cache.Get(base.TestCtx(t), "doc1", cv.String(), testCollectionID, RevCacheDontLoadBackupRev)
 	assert.NoError(t, err)
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.NotNil(t, docRev.Channels)
@@ -516,7 +518,7 @@ func TestBackingStoreCV(t *testing.T) {
 	assert.Equal(t, int64(1), getRevisionCounter.Value())
 
 	// Perform a get on the same doc as above, check that we get cache hit
-	docRev, err = cache.Get(base.TestCtx(t), "doc1", cv.String(), testCollectionID, RevCacheDontLoadBackupRev)
+	docRev, _, err = cache.Get(base.TestCtx(t), "doc1", cv.String(), testCollectionID, RevCacheDontLoadBackupRev)
 	assert.NoError(t, err)
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.Equal(t, "test", docRev.CV.SourceID)
@@ -528,7 +530,7 @@ func TestBackingStoreCV(t *testing.T) {
 
 	// Doc doesn't exist, so miss the cache, and fail when getting the doc
 	cv = Version{SourceID: "test11", Value: 100}
-	docRev, err = cache.Get(base.TestCtx(t), "not_found", cv.String(), testCollectionID, RevCacheDontLoadBackupRev)
+	docRev, _, err = cache.Get(base.TestCtx(t), "not_found", cv.String(), testCollectionID, RevCacheDontLoadBackupRev)
 
 	assertHTTPError(t, err, 404)
 	assert.Nil(t, docRev.BodyBytes)
@@ -538,7 +540,7 @@ func TestBackingStoreCV(t *testing.T) {
 	assert.Equal(t, int64(1), getRevisionCounter.Value())
 
 	// Rev still doesn't exist, make sure it wasn't cached
-	docRev, err = cache.Get(base.TestCtx(t), "not_found", cv.String(), testCollectionID, RevCacheDontLoadBackupRev)
+	docRev, _, err = cache.Get(base.TestCtx(t), "not_found", cv.String(), testCollectionID, RevCacheDontLoadBackupRev)
 	assertHTTPError(t, err, 404)
 	assert.Nil(t, docRev.BodyBytes)
 	assert.Equal(t, int64(1), cacheHitCounter.Value())
@@ -631,15 +633,15 @@ func TestBypassRevisionCache(t *testing.T) {
 	assert.False(t, ok)
 
 	// Get non-existing doc
-	_, err = rc.Get(base.TestCtx(t), "invalid", rev1, collection.GetCollectionID(), RevCacheDontLoadBackupRev)
+	_, _, err = rc.Get(base.TestCtx(t), "invalid", rev1, collection.GetCollectionID(), RevCacheDontLoadBackupRev)
 	assert.True(t, base.IsDocNotFoundError(err))
 
 	// Get non-existing revision
-	_, err = rc.Get(base.TestCtx(t), key, "3-abc", collection.GetCollectionID(), RevCacheDontLoadBackupRev)
+	_, _, err = rc.Get(base.TestCtx(t), key, "3-abc", collection.GetCollectionID(), RevCacheDontLoadBackupRev)
 	assertHTTPError(t, err, 404)
 
 	// Get specific revision
-	doc, err := rc.Get(base.TestCtx(t), key, rev1, collection.GetCollectionID(), RevCacheDontLoadBackupRev)
+	doc, _, err := rc.Get(base.TestCtx(t), key, rev1, collection.GetCollectionID(), RevCacheDontLoadBackupRev)
 	assert.NoError(t, err)
 	require.NotNil(t, doc)
 	assert.Equal(t, `{"value":1234}`, string(doc.BodyBytes))
@@ -656,7 +658,7 @@ func TestBypassRevisionCache(t *testing.T) {
 	assert.False(t, ok)
 
 	// Get active revision
-	doc, err = rc.GetActive(ctx, key, collection.GetCollectionID())
+	doc, _, err = rc.GetActive(ctx, key, collection.GetCollectionID())
 	assert.NoError(t, err)
 	assert.Equal(t, `{"value":5678}`, string(doc.BodyBytes))
 
@@ -781,15 +783,16 @@ func TestRevisionImmutableDelta(t *testing.T) {
 		DeltaCacheHit:      &deltaCacheHit,
 		DeltaCacheNumItems: &deltaCacheCount,
 	}
-	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats)
-	deltaCache := NewLRUDeltaCache(cacheOptions, deltaStats, backingStoreMap)
-	orchestrator := NewRevisionCacheOrchestrator(cache, deltaCache)
+	mc := newCacheMemoryController(cacheOptions.MaxBytes, &memoryBytesCounted)
+	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats, mc)
+	deltaCache := NewLRUDeltaCache(cacheOptions, deltaStats, mc)
+	orchestrator := NewRevisionCacheOrchestrator(cache, deltaCache, mc)
 
 	firstDelta := []byte("delta")
 	secondDelta := []byte("modified delta")
 
 	// Trigger load into cache
-	_, err := orchestrator.Get(base.TestCtx(t), "doc1", "1-abc", testCollectionID, false)
+	_, _, err := orchestrator.Get(base.TestCtx(t), "doc1", "1-abc", testCollectionID, false)
 	assert.NoError(t, err, "Error adding to cache")
 	orchestrator.UpdateDelta(base.TestCtx(t), "doc1", "1-abc", "rev2", testCollectionID, RevisionDelta{ToRevID: "rev2", DeltaBytes: firstDelta})
 
@@ -845,7 +848,7 @@ func TestUpdateDeltaRevCacheMemoryStat(t *testing.T) {
 				cacheNumItemsStat: &cacheNumItems,
 				cacheMemoryStat:   &memoryBytesCounted,
 			}
-			cache := NewLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats)
+			cache := NewLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats, newCacheMemoryController(cacheOptions.MaxBytes, revCacheStats.cacheMemoryStat))
 
 			firstDelta := []byte("delta")
 			secondDelta := []byte("modified delta")
@@ -867,7 +870,7 @@ func TestUpdateDeltaRevCacheMemoryStat(t *testing.T) {
 			// Trigger load into cache
 			var docRev DocumentRevision
 			var err error
-			docRev, err = cache.Get(ctx, "doc1", revOrCV, testCollectionID, RevCacheDontLoadBackupRev)
+			docRev, _, err = cache.Get(ctx, "doc1", revOrCV, testCollectionID, RevCacheDontLoadBackupRev)
 			require.NoError(t, err, "Error adding to cache")
 
 			revCacheMem := memoryBytesCounted.Value()
@@ -926,7 +929,8 @@ func TestImmediateRevCacheMemoryBasedEviction(t *testing.T) {
 			}
 			ctx := base.TestCtx(t)
 			var err error
-			cache := NewLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats)
+			lruCache := NewLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats, newCacheMemoryController(cacheOptions.MaxBytes, revCacheStats.cacheMemoryStat))
+			cache := NewRevisionCacheOrchestrator(lruCache, nil, lruCache.memoryController)
 
 			revOrCV := "1-abc"
 			if testCase.useCVKey {
@@ -942,9 +946,9 @@ func TestImmediateRevCacheMemoryBasedEviction(t *testing.T) {
 
 			if !testCase.useCVKey {
 				// fetch each doc added to load into cache
-				_, err = cache.Get(ctx, "doc1", revOrCV, testCollectionID, RevCacheDontLoadBackupRev)
+				_, _, err = cache.Get(ctx, "doc1", revOrCV, testCollectionID, RevCacheDontLoadBackupRev)
 				require.NoError(t, err)
-				_, err = cache.Get(ctx, "doc2", revOrCV, testCollectionID, RevCacheDontLoadBackupRev)
+				_, _, err = cache.Get(ctx, "doc2", revOrCV, testCollectionID, RevCacheDontLoadBackupRev)
 				require.NoError(t, err)
 			}
 
@@ -953,7 +957,7 @@ func TestImmediateRevCacheMemoryBasedEviction(t *testing.T) {
 
 			// assert we can still fetch this upsert doc
 			var docRev DocumentRevision
-			docRev, err = cache.Get(ctx, "doc2", revOrCV, testCollectionID, RevCacheDontLoadBackupRev)
+			docRev, _, err = cache.Get(ctx, "doc2", revOrCV, testCollectionID, RevCacheDontLoadBackupRev)
 			require.NoError(t, err)
 			assert.Equal(t, "doc2", docRev.DocID)
 			assert.Equal(t, int64(118), docRev.MemoryBytes)
@@ -961,14 +965,14 @@ func TestImmediateRevCacheMemoryBasedEviction(t *testing.T) {
 			assert.Equal(t, int64(0), memoryBytesCounted.Value())
 			assert.Equal(t, int64(0), cacheNumItems.Value())
 
-			docRev, err = cache.Get(ctx, "doc1", revOrCV, testCollectionID, RevCacheDontLoadBackupRev)
+			docRev, _, err = cache.Get(ctx, "doc1", revOrCV, testCollectionID, RevCacheDontLoadBackupRev)
 			require.NoError(t, err)
 			assert.NotNil(t, docRev.BodyBytes)
 
 			assert.Equal(t, int64(0), memoryBytesCounted.Value())
 			assert.Equal(t, int64(0), cacheNumItems.Value())
 
-			docRev, err = cache.GetActive(ctx, "doc1", testCollectionID)
+			docRev, _, err = cache.GetActive(ctx, "doc1", testCollectionID)
 			require.NoError(t, err)
 			assert.NotNil(t, docRev.BodyBytes)
 
@@ -1010,12 +1014,12 @@ func TestShardedMemoryEviction(t *testing.T) {
 	// grab this particular shard + assert that the shard memory usage is as expected
 	shardedCache := db.revisionCache.(*ShardedLRURevisionCache)
 	doc1Shard := shardedCache.getShard("doc1")
-	assert.Equal(t, int64(size), doc1Shard.revisionCache.currMemoryUsage.Value())
+	assert.Equal(t, int64(size), doc1Shard.memoryController.currBytesCount.Load())
 
 	// add new doc in diff shard + assert that the shard memory usage is as expected
 	size, _, _ = createDocAndReturnSizeAndRev(t, ctx, "doc2", collection, docBody, false)
 	doc2Shard := shardedCache.getShard("doc2")
-	assert.Equal(t, int64(size), doc2Shard.revisionCache.currMemoryUsage.Value())
+	assert.Equal(t, int64(size), doc2Shard.memoryController.currBytesCount.Load())
 	// overall mem usage should be combination oif the two added docs
 	assert.Equal(t, int64(size*2), cacheStats.RevisionCacheTotalMemory.Value())
 
@@ -1029,7 +1033,7 @@ func TestShardedMemoryEviction(t *testing.T) {
 	// add new doc to trigger eviction and assert stats are as expected
 	newDocSize, _, _ := createDocAndReturnSizeAndRev(t, ctx, "doc3", collection, docBody, false)
 	doc3Shard := shardedCache.getShard("doc3")
-	assert.Equal(t, int64(newDocSize), doc3Shard.revisionCache.currMemoryUsage.Value())
+	assert.Equal(t, int64(newDocSize), doc3Shard.memoryController.currBytesCount.Load())
 	assert.Equal(t, int64(2), cacheStats.RevisionCacheNumItems.Value())
 	assert.Equal(t, int64(size+newDocSize), cacheStats.RevisionCacheTotalMemory.Value())
 }
@@ -1065,7 +1069,7 @@ func TestShardedMemoryEvictionWhenShardEmpty(t *testing.T) {
 
 	// assert that doc was not added to cache as it's too large
 	doc1Shard := shardedCache.getShard("doc1")
-	assert.Equal(t, int64(0), doc1Shard.revisionCache.currMemoryUsage.Value())
+	assert.Equal(t, int64(0), doc1Shard.memoryController.currBytesCount.Load())
 	assert.Equal(t, int64(0), cacheStats.RevisionCacheNumItems.Value())
 	assert.Equal(t, int64(0), cacheStats.RevisionCacheTotalMemory.Value())
 
@@ -1076,7 +1080,7 @@ func TestShardedMemoryEvictionWhenShardEmpty(t *testing.T) {
 	assert.NotNil(t, docRev.BodyBytes)
 
 	// assert rev cache is still empty
-	assert.Equal(t, int64(0), doc1Shard.revisionCache.currMemoryUsage.Value())
+	assert.Equal(t, int64(0), doc1Shard.memoryController.currBytesCount.Load())
 	assert.Equal(t, int64(0), cacheStats.RevisionCacheNumItems.Value())
 	assert.Equal(t, int64(0), cacheStats.RevisionCacheTotalMemory.Value())
 }
@@ -1114,7 +1118,7 @@ func TestImmediateRevCacheItemBasedEviction(t *testing.T) {
 				cacheMemoryStat:   &memoryBytesCounted,
 			}
 
-			cache := NewLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats)
+			cache := NewLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats, newCacheMemoryController(cacheOptions.MaxBytes, revCacheStats.cacheMemoryStat))
 			revOrCV := "1-abc"
 			if testCase.useCVKey {
 				revOrCV = Version{Value: 123, SourceID: "test"}.String()
@@ -1134,14 +1138,14 @@ func TestImmediateRevCacheItemBasedEviction(t *testing.T) {
 			assert.Equal(t, int64(1), cacheNumItems.Value())
 
 			var docRev DocumentRevision
-			docRev, err = cache.Get(ctx, "doc3", revOrCV, testCollectionID, RevCacheDontLoadBackupRev)
+			docRev, _, err = cache.Get(ctx, "doc3", revOrCV, testCollectionID, RevCacheDontLoadBackupRev)
 			require.NoError(t, err)
 			assert.NotNil(t, docRev.BodyBytes)
 
 			assert.Equal(t, int64(118), memoryBytesCounted.Value())
 			assert.Equal(t, int64(1), cacheNumItems.Value())
 
-			docRev, err = cache.GetActive(ctx, "doc4", testCollectionID)
+			docRev, _, err = cache.GetActive(ctx, "doc4", testCollectionID)
 			require.NoError(t, err)
 			assert.NotNil(t, docRev.BodyBytes)
 
@@ -1225,7 +1229,7 @@ func TestBasicOperationsOnCacheWithMemoryStat(t *testing.T) {
 
 			// Test Get with item in the cache
 			var docRev DocumentRevision
-			docRev, err = db.revisionCache.Get(ctx, "doc1", versionKey(docCV, revID), collectionID, RevCacheDontLoadBackupRev)
+			docRev, _, err = db.revisionCache.Get(ctx, "doc1", versionKey(docCV, revID), collectionID, RevCacheDontLoadBackupRev)
 			require.NoError(t, err)
 			assert.NotNil(t, docRev.BodyBytes)
 			assert.Equal(t, int64(docSize), cacheStats.RevisionCacheTotalMemory.Value())
@@ -1233,7 +1237,7 @@ func TestBasicOperationsOnCacheWithMemoryStat(t *testing.T) {
 			cvDoc1 := docRev.CV
 
 			// get again and ensure memory stat doesn't change
-			docRev, err = db.revisionCache.Get(ctx, "doc1", versionKey(docCV, revID), collectionID, RevCacheDontLoadBackupRev)
+			docRev, _, err = db.revisionCache.Get(ctx, "doc1", versionKey(docCV, revID), collectionID, RevCacheDontLoadBackupRev)
 			require.NoError(t, err)
 			assert.Equal(t, int64(docSize), cacheStats.RevisionCacheTotalMemory.Value())
 
@@ -1241,7 +1245,7 @@ func TestBasicOperationsOnCacheWithMemoryStat(t *testing.T) {
 			prevMemStat := cacheStats.RevisionCacheTotalMemory.Value()
 			revDoc2 := createThenRemoveFromRevCache(t, ctx, "doc2", db, collection)
 			// load from doc from bucket
-			docRev, err = db.revisionCache.Get(ctx, "doc2", versionKey(&revDoc2.CV, revDoc2.RevTreeID), collectionID, RevCacheDontLoadBackupRev)
+			docRev, _, err = db.revisionCache.Get(ctx, "doc2", versionKey(&revDoc2.CV, revDoc2.RevTreeID), collectionID, RevCacheDontLoadBackupRev)
 			require.NoError(t, err)
 			assert.NotNil(t, docRev.BodyBytes)
 			assert.Equal(t, "doc2", docRev.DocID)
@@ -1249,7 +1253,7 @@ func TestBasicOperationsOnCacheWithMemoryStat(t *testing.T) {
 
 			// Test Get active with item resident in cache
 			prevMemStat = cacheStats.RevisionCacheTotalMemory.Value()
-			docRev, err = db.revisionCache.GetActive(ctx, "doc2", collectionID)
+			docRev, _, err = db.revisionCache.GetActive(ctx, "doc2", collectionID)
 			require.NoError(t, err)
 			var doc2RevID string
 			if testCase.useCVKey {
@@ -1266,7 +1270,7 @@ func TestBasicOperationsOnCacheWithMemoryStat(t *testing.T) {
 			// Test Get active with item to be loaded from bucket, need to first create and remove from rev cache
 			prevMemStat = cacheStats.RevisionCacheTotalMemory.Value()
 			revDoc3 := createThenRemoveFromRevCache(t, ctx, "doc3", db, collection)
-			docRev, err = db.revisionCache.GetActive(ctx, "doc3", collectionID)
+			docRev, _, err = db.revisionCache.GetActive(ctx, "doc3", collectionID)
 			require.NoError(t, err)
 			assert.Equal(t, "doc3", docRev.DocID)
 			assert.Greater(t, cacheStats.RevisionCacheTotalMemory.Value(), prevMemStat)
@@ -1329,10 +1333,10 @@ func TestSingleLoad(t *testing.T) {
 		cacheNumItemsStat: &cacheNumItems,
 		cacheMemoryStat:   &memoryBytesCounted,
 	}
-	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats)
+	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats, newCacheMemoryController(cacheOptions.MaxBytes, revCacheStats.cacheMemoryStat))
 
 	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc123", RevID: "1-abc", CV: &Version{Value: 123, SourceID: "test"}, History: Revisions{"start": 1}}, testCollectionID)
-	_, err := cache.Get(base.TestCtx(t), "doc123", "1-abc", testCollectionID, false)
+	_, _, err := cache.Get(base.TestCtx(t), "doc123", "1-abc", testCollectionID, false)
 
 	assert.NoError(t, err)
 }
@@ -1352,7 +1356,7 @@ func TestConcurrentLoad(t *testing.T) {
 		cacheNumItemsStat: &cacheNumItems,
 		cacheMemoryStat:   &memoryBytesCounted,
 	}
-	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats)
+	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats, newCacheMemoryController(cacheOptions.MaxBytes, revCacheStats.cacheMemoryStat))
 
 	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc1", RevID: "1-abc", CV: &Version{Value: 1234, SourceID: "test"}, History: Revisions{"start": 1}}, testCollectionID)
 
@@ -1361,7 +1365,7 @@ func TestConcurrentLoad(t *testing.T) {
 	wg.Add(20)
 	for range 20 {
 		go func() {
-			_, err := cache.Get(base.TestCtx(t), "doc1", "1-abc", testCollectionID, false)
+			_, _, err := cache.Get(base.TestCtx(t), "doc1", "1-abc", testCollectionID, false)
 			assert.NoError(t, err)
 			wg.Done()
 		}()
@@ -1561,7 +1565,7 @@ func TestRevCacheCapacityStat(t *testing.T) {
 				cacheNumItemsStat: &cacheNumItems,
 				cacheMemoryStat:   &cacheMemoryStat,
 			}
-			cache := NewLRURevisionCache(&RevisionCacheOptions{MaxItemCount: 5, MaxBytes: 0}, backingStoreMap, revCacheStats)
+			cache := NewLRURevisionCache(&RevisionCacheOptions{MaxItemCount: 5, MaxBytes: 0}, backingStoreMap, revCacheStats, newCacheMemoryController(0, revCacheStats.cacheMemoryStat))
 			ctx := base.TestCtx(t)
 			cv := &Version{SourceID: "test", Value: 123}
 			const revID = "1-abc"
@@ -1576,9 +1580,11 @@ func TestRevCacheCapacityStat(t *testing.T) {
 			// getDoc abstracts over the two lookup pathways under test.
 			getDoc := func(docID string) (DocumentRevision, error) {
 				if tc.useCVCache {
-					return cache.Get(ctx, docID, cv.String(), testCollectionID, RevCacheDontLoadBackupRev)
+					docRev, _, err := cache.Get(ctx, docID, cv.String(), testCollectionID, RevCacheDontLoadBackupRev)
+					return docRev, err
 				}
-				return cache.Get(ctx, docID, revID, testCollectionID, RevCacheLoadBackupRev)
+				docRev, _, err := cache.Get(ctx, docID, revID, testCollectionID, RevCacheLoadBackupRev)
+				return docRev, err
 			}
 
 			// removeDoc removes an entry using the key type appropriate to the pathway under test.
@@ -1614,13 +1620,13 @@ func TestRevCacheCapacityStat(t *testing.T) {
 			assertItems(2)
 
 			// GetActive cache miss: loads from backing store via a revID key.
-			docRev, err = cache.GetActive(ctx, "doc3", testCollectionID)
+			docRev, _, err = cache.GetActive(ctx, "doc3", testCollectionID)
 			require.NoError(t, err)
 			assert.Equal(t, "doc3", docRev.DocID)
 			assertItems(3)
 
 			// GetActive cache hit: count is unchanged.
-			docRev, err = cache.GetActive(ctx, "doc3", testCollectionID)
+			docRev, _, err = cache.GetActive(ctx, "doc3", testCollectionID)
 			require.NoError(t, err)
 			assert.Equal(t, "doc3", docRev.DocID)
 			assertItems(3)
@@ -1706,7 +1712,7 @@ func TestRevCacheOnDemand(t *testing.T) {
 				case <-testCtx.Done():
 					return
 				default:
-					_, err = db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheDontLoadBackupRev) //nolint:errcheck
+					_, _, err = db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheDontLoadBackupRev) //nolint:errcheck
 				}
 			}
 		}()
@@ -1759,7 +1765,7 @@ func TestRevCacheOperationsCV(t *testing.T) {
 		cacheNumItemsStat: &cacheNumItems,
 		cacheMemoryStat:   &memoryBytesCounted,
 	}
-	cache := NewLRURevisionCache(cacheOptions, CreateTestSingleBackingStoreMap(&testBackingStore{[]string{"test_doc"}, &getDocumentCounter, &getRevisionCounter}, testCollectionID), revCacheStats)
+	cache := NewLRURevisionCache(cacheOptions, CreateTestSingleBackingStoreMap(&testBackingStore{[]string{"test_doc"}, &getDocumentCounter, &getRevisionCounter}, testCollectionID), revCacheStats, newCacheMemoryController(cacheOptions.MaxBytes, revCacheStats.cacheMemoryStat))
 
 	cv := Version{SourceID: "test", Value: 123}
 	documentRevision := DocumentRevision{
@@ -1772,7 +1778,7 @@ func TestRevCacheOperationsCV(t *testing.T) {
 	}
 	cache.Put(base.TestCtx(t), documentRevision, testCollectionID)
 
-	docRev, err := cache.Get(base.TestCtx(t), "doc1", cv.String(), testCollectionID, RevCacheDontLoadBackupRev)
+	docRev, _, err := cache.Get(base.TestCtx(t), "doc1", cv.String(), testCollectionID, RevCacheDontLoadBackupRev)
 	require.NoError(t, err)
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.Equal(t, base.SetOf("chan1"), docRev.Channels)
@@ -1785,7 +1791,7 @@ func TestRevCacheOperationsCV(t *testing.T) {
 
 	cache.Upsert(base.TestCtx(t), documentRevision, testCollectionID)
 
-	docRev, err = cache.Get(base.TestCtx(t), "doc1", cv.String(), testCollectionID, RevCacheDontLoadBackupRev)
+	docRev, _, err = cache.Get(base.TestCtx(t), "doc1", cv.String(), testCollectionID, RevCacheDontLoadBackupRev)
 	require.NoError(t, err)
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.Equal(t, base.SetOf("chan1"), docRev.Channels)
@@ -1816,13 +1822,13 @@ func BenchmarkRevisionCacheRead(b *testing.B) {
 		cacheNumItemsStat: &cacheNumItems,
 		cacheMemoryStat:   &memoryBytesCounted,
 	}
-	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats)
+	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats, newCacheMemoryController(cacheOptions.MaxBytes, revCacheStats.cacheMemoryStat))
 
 	ctx := base.TestCtx(b)
 
 	// trigger load into cache
 	for i := range 5000 {
-		_, _ = cache.Get(ctx, fmt.Sprintf("doc%d", i), "1-abc", testCollectionID, RevCacheDontLoadBackupRev)
+		_, _, _ = cache.Get(ctx, fmt.Sprintf("doc%d", i), "1-abc", testCollectionID, RevCacheDontLoadBackupRev)
 	}
 
 	b.ResetTimer()
@@ -1830,7 +1836,7 @@ func BenchmarkRevisionCacheRead(b *testing.B) {
 		// GET the document until test run has completed
 		for pb.Next() {
 			docId := fmt.Sprintf("doc%d", rand.Intn(5000))
-			_, _ = cache.Get(ctx, docId, "1-abc", testCollectionID, RevCacheDontLoadBackupRev)
+			_, _, _ = cache.Get(ctx, docId, "1-abc", testCollectionID, RevCacheDontLoadBackupRev)
 		}
 	})
 }
@@ -1915,7 +1921,7 @@ func TestRevCacheOnDemandImport(t *testing.T) {
 				case <-ctx.Done():
 					return
 				default:
-					_, err = db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheDontLoadBackupRev) //nolint:errcheck
+					_, _, err = db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheDontLoadBackupRev) //nolint:errcheck
 				}
 			}
 		}()
@@ -1963,7 +1969,7 @@ func TestRevCacheOnDemandMemoryEviction(t *testing.T) {
 				case <-testCtx.Done():
 					return
 				default:
-					_, err = db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheDontLoadBackupRev) //nolint:errcheck
+					_, _, err = db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheDontLoadBackupRev) //nolint:errcheck
 				}
 			}
 		}()
@@ -1994,12 +2000,12 @@ func TestLoaderMismatchInCV(t *testing.T) {
 		cacheNumItemsStat: &cacheNumItems,
 		cacheMemoryStat:   &memoryBytesCounted,
 	}
-	cache := NewLRURevisionCache(cacheOptions, CreateTestSingleBackingStoreMap(&testBackingStore{[]string{"test_doc"}, &getDocumentCounter, &getRevisionCounter}, testCollectionID), revCacheStats)
+	cache := NewLRURevisionCache(cacheOptions, CreateTestSingleBackingStoreMap(&testBackingStore{[]string{"test_doc"}, &getDocumentCounter, &getRevisionCounter}, testCollectionID), revCacheStats, newCacheMemoryController(cacheOptions.MaxBytes, revCacheStats.cacheMemoryStat))
 
 	// create cv with incorrect version to the one stored in backing store
 	cv := Version{SourceID: "test", Value: 1234}
 
-	_, err := cache.Get(base.TestCtx(t), "doc1", cv.String(), testCollectionID, RevCacheDontLoadBackupRev)
+	_, _, err := cache.Get(base.TestCtx(t), "doc1", cv.String(), testCollectionID, RevCacheDontLoadBackupRev)
 	require.Error(t, err)
 	require.Error(t, err, base.ErrNotFound)
 	assert.Equal(t, int64(0), cacheHitCounter.Value())
@@ -2025,7 +2031,7 @@ func TestConcurrentLoadByCVAndRevOnCache(t *testing.T) {
 		cacheNumItemsStat: &cacheNumItems,
 		cacheMemoryStat:   &memoryBytesCounted,
 	}
-	cache := NewLRURevisionCache(cacheOptions, CreateTestSingleBackingStoreMap(&testBackingStore{[]string{"test_doc"}, &getDocumentCounter, &getRevisionCounter}, testCollectionID), revCacheStats)
+	cache := NewLRURevisionCache(cacheOptions, CreateTestSingleBackingStoreMap(&testBackingStore{[]string{"test_doc"}, &getDocumentCounter, &getRevisionCounter}, testCollectionID), revCacheStats, newCacheMemoryController(cacheOptions.MaxBytes, revCacheStats.cacheMemoryStat))
 
 	ctx := base.TestCtx(t)
 
@@ -2034,13 +2040,13 @@ func TestConcurrentLoadByCVAndRevOnCache(t *testing.T) {
 
 	cv := Version{SourceID: "test", Value: 123}
 	go func() {
-		_, err := cache.Get(ctx, "doc1", "1-abc", testCollectionID, RevCacheDontLoadBackupRev)
+		_, _, err := cache.Get(ctx, "doc1", "1-abc", testCollectionID, RevCacheDontLoadBackupRev)
 		require.NoError(t, err)
 		wg.Done()
 	}()
 
 	go func() {
-		_, err := cache.Get(ctx, "doc1", cv.String(), testCollectionID, RevCacheDontLoadBackupRev)
+		_, _, err := cache.Get(ctx, "doc1", cv.String(), testCollectionID, RevCacheDontLoadBackupRev)
 		require.NoError(t, err)
 		wg.Done()
 	}()
@@ -2102,7 +2108,7 @@ func TestConcurrentPutAndGetOnRevCache(t *testing.T) {
 		cacheNumItemsStat: &cacheNumItems,
 		cacheMemoryStat:   &memoryBytesCounted,
 	}
-	cache := NewLRURevisionCache(cacheOptions, CreateTestSingleBackingStoreMap(&testBackingStore{[]string{"test_doc"}, &getDocumentCounter, &getRevisionCounter}, testCollectionID), revCacheStats)
+	cache := NewLRURevisionCache(cacheOptions, CreateTestSingleBackingStoreMap(&testBackingStore{[]string{"test_doc"}, &getDocumentCounter, &getRevisionCounter}, testCollectionID), revCacheStats, newCacheMemoryController(cacheOptions.MaxBytes, revCacheStats.cacheMemoryStat))
 
 	ctx := base.TestCtx(t)
 
@@ -2120,7 +2126,7 @@ func TestConcurrentPutAndGetOnRevCache(t *testing.T) {
 	}
 
 	go func() {
-		_, err := cache.Get(ctx, "doc1", cv.String(), testCollectionID, RevCacheDontLoadBackupRev)
+		_, _, err := cache.Get(ctx, "doc1", cv.String(), testCollectionID, RevCacheDontLoadBackupRev)
 		require.NoError(t, err)
 		wg.Done()
 	}()
@@ -2184,7 +2190,7 @@ func TestLoadActiveDocFromBucketRevCacheChurn(t *testing.T) {
 				case <-testCtx.Done():
 					return
 				default:
-					_, err = db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheDontLoadBackupRev) //nolint:errcheck
+					_, _, err = db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheDontLoadBackupRev) //nolint:errcheck
 				}
 			}
 		}()
@@ -2194,7 +2200,7 @@ func TestLoadActiveDocFromBucketRevCacheChurn(t *testing.T) {
 		for i := range 100 {
 			err = collection.dataStore.Set(docID, 0, nil, fmt.Appendf(nil, `{"ver": "%d"}`, i))
 			require.NoError(t, err)
-			_, err := db.revisionCache.GetActive(ctx, docID, collection.GetCollectionID())
+			_, _, err := db.revisionCache.GetActive(ctx, docID, collection.GetCollectionID())
 			if err != nil {
 				break
 			}
@@ -2239,7 +2245,7 @@ func TestLoadRequestedRevFromBucketHighChurn(t *testing.T) {
 				case <-testCtx.Done():
 					return
 				default:
-					_, err = db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheDontLoadBackupRev) //nolint:errcheck
+					_, _, err = db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheDontLoadBackupRev) //nolint:errcheck
 				}
 			}
 		}()
@@ -2248,7 +2254,7 @@ func TestLoadRequestedRevFromBucketHighChurn(t *testing.T) {
 	var getErr error
 	go func() {
 		for range 100 {
-			_, getErr = db.revisionCache.Get(ctx, docID, rev1ID, collection.GetCollectionID(), RevCacheDontLoadBackupRev)
+			_, _, getErr = db.revisionCache.Get(ctx, docID, rev1ID, collection.GetCollectionID(), RevCacheDontLoadBackupRev)
 			if getErr != nil {
 				break
 			}
@@ -2290,7 +2296,7 @@ func TestPutRevHighRevCacheChurn(t *testing.T) {
 				case <-testCtx.Done():
 					return
 				default:
-					_, err = db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheDontLoadBackupRev) //nolint:errcheck
+					_, _, err = db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheDontLoadBackupRev) //nolint:errcheck
 				}
 			}
 		}()
@@ -2503,7 +2509,7 @@ func TestRaceRemovingStaleCVValue(t *testing.T) {
 		cacheNumItemsStat: &cacheNumItems,
 		cacheMemoryStat:   &memoryBytesCounted,
 	}
-	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats)
+	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats, newCacheMemoryController(cacheOptions.MaxBytes, revCacheStats.cacheMemoryStat))
 
 	ctx := base.TestCtx(t)
 

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -366,9 +366,7 @@ func TestBackingStoreMemoryCalculation(t *testing.T) {
 				cacheNumItemsStat: &cacheNumItems,
 				cacheMemoryStat:   &memoryBytesCounted,
 			}
-			mc := newCacheMemoryController(cacheOptions.MaxBytes, revCacheStats.cacheMemoryStat)
-			lruCache := NewLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats, mc)
-			cache := NewRevisionCacheOrchestrator(lruCache, nil, mc)
+			cache := NewRevisionCacheOrchestrator(cacheOptions, backingStoreMap, revCacheStats, nil, false)
 			ctx := base.TestCtx(t)
 			var err error
 
@@ -783,10 +781,7 @@ func TestRevisionImmutableDelta(t *testing.T) {
 		DeltaCacheHit:      &deltaCacheHit,
 		DeltaCacheNumItems: &deltaCacheCount,
 	}
-	mc := newCacheMemoryController(cacheOptions.MaxBytes, &memoryBytesCounted)
-	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats, mc)
-	deltaCache := NewLRUDeltaCache(cacheOptions, deltaStats, mc)
-	orchestrator := NewRevisionCacheOrchestrator(cache, deltaCache, mc)
+	orchestrator := NewRevisionCacheOrchestrator(cacheOptions, backingStoreMap, revCacheStats, deltaStats, true)
 
 	firstDelta := []byte("delta")
 	secondDelta := []byte("modified delta")
@@ -929,8 +924,7 @@ func TestImmediateRevCacheMemoryBasedEviction(t *testing.T) {
 			}
 			ctx := base.TestCtx(t)
 			var err error
-			lruCache := NewLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats, newCacheMemoryController(cacheOptions.MaxBytes, revCacheStats.cacheMemoryStat))
-			cache := NewRevisionCacheOrchestrator(lruCache, nil, lruCache.memoryController)
+			cache := NewRevisionCacheOrchestrator(cacheOptions, backingStoreMap, revCacheStats, nil, false)
 
 			revOrCV := "1-abc"
 			if testCase.useCVKey {

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -2765,42 +2765,39 @@ func TestMemoryBasedEvictionBetweenRevAndDeltaCache(t *testing.T) {
 
 	// -----------------------------------------------------------------------
 	// Step 2: Add delta rev1→rev2 via UpdateDelta.
-	// Total (121+10=131) exceeds maxBytes (121).  rev1 carries the older access
-	// order, so it is evicted from the revision cache, leaving only the delta.
+	// Total (121+10=131) exceeds maxBytes (121).  Delta is evicted due to round-
+	// robin eviction approach
 	// -----------------------------------------------------------------------
 	delta := RevisionDelta{DeltaBytes: deltaBodyBytes}
 	delta.CalculateDeltaBytes()
 	orchestrator.UpdateDelta(ctx, docID, rev1CV.String(), rev2CV.String(), testCollectionID, delta)
 
 	_, rev1InCacheAfterDelta := orchestrator.Peek(ctx, docID, rev1CV.String(), testCollectionID)
-	assert.False(t, rev1InCacheAfterDelta, "rev1 should have been evicted from revision cache by memory pressure")
+	assert.True(t, rev1InCacheAfterDelta, "rev1 should still be present")
 
 	cachedDelta := orchestrator.deltaCache.getCachedDelta(ctx, docID, rev1CV.String(), rev2CV.String(), testCollectionID)
-	assert.NotNil(t, cachedDelta, "delta should remain in delta cache after evicting rev1")
+	assert.Nil(t, cachedDelta, "delta should have been evicted")
 
-	assert.Equal(t, int64(0), cacheNumItems.Value(), "revision cache should be empty after evicting rev1")
-	assert.Equal(t, int64(1), deltaCacheNumItems.Value(), "delta cache should have one entry")
-	assert.Equal(t, expectedDeltaBytes, cacheMemoryBytes.Value(), "memory stat should equal delta bytes only after eviction")
+	assert.Equal(t, int64(1), cacheNumItems.Value(), "revision cache should not be empty after evicting rev1")
+	assert.Equal(t, int64(0), deltaCacheNumItems.Value(), "delta cache should be empty")
+	assert.Equal(t, expectedRev1Bytes, cacheMemoryBytes.Value(), "memory stat should equal rev1 bytes only after eviction")
 
 	// -----------------------------------------------------------------------
-	// Step 3: Load rev1 again via Get (cache miss — it was evicted in step 2).
-	// Total (10+121=131) exceeds maxBytes again.  The delta now carries the older
-	// access order, so it is evicted from the delta cache, leaving only rev1.
+	// Step 3: Add delta rev1→rev2 via UpdateDelta again.
+	// Total (10+121=131) exceeds maxBytes again.  rev1 turn to be evicted.
 	// -----------------------------------------------------------------------
-	_, wasMiss2, err := orchestrator.Get(ctx, docID, rev1CV.String(), testCollectionID, false)
-	require.NoError(t, err)
-	require.True(t, wasMiss2, "second Get should be a cache miss (rev1 was evicted)")
+	orchestrator.UpdateDelta(ctx, docID, rev1CV.String(), rev2CV.String(), testCollectionID, delta)
 
-	_, rev1BackInCache := orchestrator.Peek(ctx, docID, rev1CV.String(), testCollectionID)
-	assert.True(t, rev1BackInCache, "rev1 should be back in revision cache after second Get")
+	_, rev1InCacheAfterDelta = orchestrator.Peek(ctx, docID, rev1CV.String(), testCollectionID)
+	assert.False(t, rev1InCacheAfterDelta, "rev1 should have been evicted after delta update")
 
 	cachedDeltaAfter := orchestrator.deltaCache.getCachedDelta(ctx, docID, rev1CV.String(), rev2CV.String(), testCollectionID)
-	assert.Nil(t, cachedDeltaAfter, "delta should have been evicted from delta cache by memory pressure")
+	assert.NotNil(t, cachedDeltaAfter, "delta should be present")
 
-	assert.Equal(t, int64(1), cacheNumItems.Value(), "revision cache should have rev1 again")
-	assert.Equal(t, int64(0), deltaCacheNumItems.Value(), "delta cache should be empty after eviction")
-	assert.Equal(t, expectedRev1Bytes, cacheMemoryBytes.Value(), "memory stat should equal rev1 bytes only after delta evicted")
-	assert.Equal(t, int64(2), cacheMisses.Value(), "both Gets were cache misses")
+	assert.Equal(t, int64(0), cacheNumItems.Value(), "revision cache should be empty")
+	assert.Equal(t, int64(1), deltaCacheNumItems.Value(), "delta cache should have one item")
+	assert.Equal(t, expectedDeltaBytes, cacheMemoryBytes.Value(), "memory stat should equal delta bytes only after rev1 evicted")
+	assert.Equal(t, int64(1), cacheMisses.Value(), "Get was a cache miss")
 	assert.Equal(t, int64(0), cacheHits.Value())
 }
 
@@ -2940,7 +2937,8 @@ func TestEvictLRUTailOnLoadingItemReturnsZeroBytes(t *testing.T) {
 	assert.Equal(t, int64(1), revStats.cacheNumItemsStat.Value())
 
 	// Evict the still-loading item — must return 0 bytes, not inflate or deflate the stat.
-	bytesReturned := rc.evictLRUTail()
+	bytesReturned, evicted := rc.evictLRUTail()
+	assert.True(t, evicted)
 	assert.Equal(t, int64(0), bytesReturned, "evicting a loading item must return 0 bytes")
 	assert.Equal(t, int64(0), revStats.cacheMemoryStat.Value(), "memory stat must not go negative")
 	assert.Equal(t, memStateRemoved, value.memState.Load(), "evicted item should be in Removed state")
@@ -3027,12 +3025,12 @@ func TestCombinedNumberAndMemoryEviction(t *testing.T) {
 	assert.Equal(t, int64(1), revStats.cacheNumItemsStat.Value())
 	assert.Equal(t, int64(15), revStats.cacheMemoryStat.Value())
 
-	// UpdateDelta A: total = 15+10 = 25 > 20 → memory eviction fires and evicts the revision
-	// (older access order).  After eviction: only delta A in memory (10 bytes).
+	// UpdateDelta A: total = 15+10 = 25 > 20 → memory eviction fires and evicts the revision delta immediately
+	// After eviction: only delta doc1 in memory (15 bytes).
 	orchestrator.UpdateDelta(ctx, "doc1", "from1", "to1", testCollectionID, makeDelta())
-	assert.Equal(t, int64(0), revStats.cacheNumItemsStat.Value(), "revision evicted by memory pressure")
-	assert.Equal(t, int64(1), deltaStats.DeltaCacheNumItems.Value())
-	assert.Equal(t, int64(10), revStats.cacheMemoryStat.Value(), "only delta A bytes should remain")
+	assert.Equal(t, int64(1), revStats.cacheNumItemsStat.Value())
+	assert.Equal(t, int64(0), deltaStats.DeltaCacheNumItems.Value())
+	assert.Equal(t, int64(15), revStats.cacheMemoryStat.Value(), "only doc1 bytes should remain")
 
 	// UpdateDelta B: number-based eviction (MaxItemCount=1) removes delta A and decrements
 	// its 10 bytes, then delta B is added and its 10 bytes incremented.  Net = 10 bytes.
@@ -3087,4 +3085,221 @@ func TestMemoryStatTracksUsageWithUnlimitedCapacity(t *testing.T) {
 	orchestrator.Remove(ctx, "doc2", cv2.String(), testCollectionID)
 	assert.Equal(t, int64(0), revStats.cacheMemoryStat.Value(), "all items removed — stat must be 0")
 	assert.Equal(t, int64(0), revStats.cacheNumItemsStat.Value())
+}
+
+// TestConcurrentPutAndRemoveRace exercises the Put/Remove race with many goroutines to ensure
+// memory stats stay consistent under the race detector. After all goroutines finish, every item
+// must either be in the cache with its bytes counted, or absent with its bytes not counted.
+func TestConcurrentPutAndRemoveRace(t *testing.T) {
+	ctx := base.TestCtx(t)
+
+	revStats := newTestRevCacheStats()
+	opts := &RevisionCacheOptions{MaxItemCount: 1000, MaxBytes: 0}
+	orchestrator := NewRevisionCacheOrchestrator(
+		opts, CreateTestSingleBackingStoreMap(&noopBackingStore{}, testCollectionID),
+		revStats, &base.DeltaSyncStats{}, false,
+	)
+
+	const numDocs = 50
+	const iterations = 20
+
+	for iter := range iterations {
+		var wg sync.WaitGroup
+		for i := range numDocs {
+			docID := fmt.Sprintf("doc-%d-%d", iter, i)
+			cv := Version{Value: uint64(iter*numDocs + i + 1), SourceID: "test"}
+			body := fmt.Sprintf(`{"iter":%d,"i":%d}`, iter, i)
+
+			wg.Add(2)
+			go func() {
+				defer wg.Done()
+				orchestrator.Put(ctx, makeTestRevision(docID, cv, body), testCollectionID)
+			}()
+			go func() {
+				defer wg.Done()
+				orchestrator.Remove(ctx, docID, cv.String(), testCollectionID)
+			}()
+		}
+		wg.Wait()
+	}
+
+	// Verify stat consistency: the memory stat must equal the sum of bytes of items
+	// actually resident in the cache.
+	var expectedBytes int64
+	for iter := range iterations {
+		for i := range numDocs {
+			docID := fmt.Sprintf("doc-%d-%d", iter, i)
+			cv := Version{Value: uint64(iter*numDocs + i + 1), SourceID: "test"}
+			docRev, found := orchestrator.Peek(ctx, docID, cv.String(), testCollectionID)
+			if found {
+				docRev.CalculateBytes()
+				expectedBytes += docRev.MemoryBytes
+			}
+		}
+	}
+	assert.Equal(t, expectedBytes, revStats.cacheMemoryStat.Value(),
+		"memory stat must equal the sum of bytes of items actually in the cache")
+	assert.True(t, revStats.cacheMemoryStat.Value() >= 0, "memory stat must never go negative")
+}
+
+// TestConcurrentGetAndRemoveRace exercises the Get (cache-miss load)/Remove race. A backing store
+// with a delay would make the race more likely, but even without delays the race detector can
+// catch unsynchronized access. After all goroutines finish, memory stats must be consistent.
+func TestConcurrentGetAndRemoveRace(t *testing.T) {
+	ctx := base.TestCtx(t)
+
+	var getDocCounter, getRevCounter base.SgwIntStat
+	backingStore := &testBackingStore{nil, &getDocCounter, &getRevCounter}
+	revStats := newTestRevCacheStats()
+	opts := &RevisionCacheOptions{MaxItemCount: 1000, MaxBytes: 0}
+	orchestrator := NewRevisionCacheOrchestrator(
+		opts, CreateTestSingleBackingStoreMap(backingStore, testCollectionID),
+		revStats, &base.DeltaSyncStats{}, false,
+	)
+
+	const numDocs = 50
+
+	var wg sync.WaitGroup
+	for i := range numDocs {
+		docID := fmt.Sprintf("doc-%d", i)
+		// testBackingStore always returns docs at rev "1-abc" with HLV SourceID=test Version=123
+		cv := Version{Value: 123, SourceID: "test"}
+
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			// Get triggers a cache-miss load from the backing store
+			_, _, _ = orchestrator.Get(ctx, docID, cv.String(), testCollectionID, false)
+		}()
+		go func() {
+			defer wg.Done()
+			orchestrator.Remove(ctx, docID, cv.String(), testCollectionID)
+		}()
+	}
+	wg.Wait()
+
+	// Memory stat must be non-negative and consistent with what's in the cache.
+	assert.True(t, revStats.cacheMemoryStat.Value() >= 0, "memory stat must never go negative")
+}
+
+// TestRemoveDuringNumberBasedEviction verifies that when a Put triggers number-based eviction
+// of an unsized item, and a concurrent Remove targets the same item, the memory stat remains
+// consistent — no double-decrement, no negative stat.
+func TestRemoveDuringNumberBasedEviction(t *testing.T) {
+	ctx := base.TestCtx(t)
+
+	revStats := newTestRevCacheStats()
+	// MaxItemCount=1: every Put evicts the previous tail.
+	opts := &RevisionCacheOptions{MaxItemCount: 1, MaxBytes: 0}
+	orchestrator := NewRevisionCacheOrchestrator(
+		opts, CreateTestSingleBackingStoreMap(&noopBackingStore{}, testCollectionID),
+		revStats, &base.DeltaSyncStats{}, false,
+	)
+
+	const numDocs = 100
+
+	var wg sync.WaitGroup
+	for i := range numDocs {
+		cv := Version{Value: uint64(i + 1), SourceID: "test"}
+		docID := fmt.Sprintf("doc-%d", i)
+		body := fmt.Sprintf(`{"i":%d}`, i)
+
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			orchestrator.Put(ctx, makeTestRevision(docID, cv, body), testCollectionID)
+		}()
+		go func() {
+			defer wg.Done()
+			orchestrator.Remove(ctx, docID, cv.String(), testCollectionID)
+		}()
+	}
+	wg.Wait()
+
+	// With MaxItemCount=1, at most 1 item should remain.
+	assert.True(t, revStats.cacheNumItemsStat.Value() <= 1,
+		"with MaxItemCount=1, at most 1 item should remain in cache")
+	assert.True(t, revStats.cacheMemoryStat.Value() >= 0, "memory stat must never go negative")
+}
+
+// TestConcurrentUpsertAndRemoveRace exercises the Upsert/Remove race. Upsert replaces an
+// existing entry (decrement old bytes, increment new bytes); a concurrent Remove must not
+// cause double-decrement.
+func TestConcurrentUpsertAndRemoveRace(t *testing.T) {
+	ctx := base.TestCtx(t)
+
+	revStats := newTestRevCacheStats()
+	opts := &RevisionCacheOptions{MaxItemCount: 1000, MaxBytes: 0}
+	orchestrator := NewRevisionCacheOrchestrator(
+		opts, CreateTestSingleBackingStoreMap(&noopBackingStore{}, testCollectionID),
+		revStats, &base.DeltaSyncStats{}, false,
+	)
+
+	const numDocs = 50
+	const upsertRounds = 10
+
+	// Seed the cache with initial versions.
+	for i := range numDocs {
+		cv := Version{Value: 1, SourceID: "test"}
+		docID := fmt.Sprintf("doc-%d", i)
+		orchestrator.Put(ctx, makeTestRevision(docID, cv, `{"v":1}`), testCollectionID)
+	}
+
+	// Concurrently Upsert new versions and Remove entries.
+	var wg sync.WaitGroup
+	for round := range upsertRounds {
+		for i := range numDocs {
+			cv := Version{Value: 1, SourceID: "test"}
+			docID := fmt.Sprintf("doc-%d", i)
+			body := fmt.Sprintf(`{"v":%d,"round":%d}`, round+2, round)
+
+			wg.Add(2)
+			go func() {
+				defer wg.Done()
+				orchestrator.Upsert(ctx, makeTestRevision(docID, cv, body), testCollectionID)
+			}()
+			go func() {
+				defer wg.Done()
+				orchestrator.Remove(ctx, docID, cv.String(), testCollectionID)
+			}()
+		}
+	}
+	wg.Wait()
+
+	assert.True(t, revStats.cacheMemoryStat.Value() >= 0, "memory stat must never go negative")
+}
+
+// TestMemoryEvictionDuringConcurrentPuts verifies that when memory-based eviction fires during
+// concurrent Puts, the memory stat remains consistent and eventually falls at or below capacity.
+func TestMemoryEvictionDuringConcurrentPuts(t *testing.T) {
+	ctx := base.TestCtx(t)
+
+	revStats := newTestRevCacheStats()
+	// Each body is 10 bytes; maxBytes=50 means at most ~5 items before eviction.
+	const maxBytes = int64(50)
+	opts := &RevisionCacheOptions{MaxItemCount: 1000, MaxBytes: maxBytes}
+	orchestrator := NewRevisionCacheOrchestrator(
+		opts, CreateTestSingleBackingStoreMap(&noopBackingStore{}, testCollectionID),
+		revStats, &base.DeltaSyncStats{}, false,
+	)
+
+	const numDocs = 30
+
+	var wg sync.WaitGroup
+	for i := range numDocs {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cv := Version{Value: uint64(i + 1), SourceID: "test"}
+			docID := fmt.Sprintf("doc-%d", i)
+			orchestrator.Put(ctx, makeTestRevision(docID, cv, `{"k":"val"}`), testCollectionID)
+		}()
+	}
+	wg.Wait()
+
+	// After all concurrent Puts and evictions settle, the memory stat should be at or below capacity.
+	assert.True(t, revStats.cacheMemoryStat.Value() >= 0, "memory stat must never go negative")
+	assert.True(t, revStats.cacheMemoryStat.Value() <= maxBytes,
+		"memory stat (%d) should be at or below capacity (%d) after eviction settles",
+		revStats.cacheMemoryStat.Value(), maxBytes)
 }

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -2507,11 +2507,20 @@ func TestRaceRemovingStaleCVValue(t *testing.T) {
 
 	ctx := base.TestCtx(t)
 
+	docRev := DocumentRevision{
+		BodyBytes: []byte(`{"some":"data"}`),
+		DocID:     "doc1",
+		RevID:     "1-abc",
+		CV:        &Version{Value: 123, SourceID: "test"},
+		History:   Revisions{"start": 1},
+	}
+	docRev.CalculateBytes()
+
 	var wg sync.WaitGroup
 	wg.Add(2)
 
 	go func() {
-		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{"some":"data"}`), DocID: "doc1", RevID: "1-abc", CV: &Version{Value: 123, SourceID: "test"}, History: Revisions{"start": 1}}, testCollectionID)
+		cache.Put(ctx, docRev, testCollectionID)
 		wg.Done()
 	}()
 
@@ -2522,6 +2531,18 @@ func TestRaceRemovingStaleCVValue(t *testing.T) {
 
 	wg.Wait()
 
+	// Two valid outcomes depending on goroutine scheduling:
+	//   - Remove ran before Put inserted the item (Remove was a no-op): item is still in the
+	//     cache and the stat reflects its bytes.
+	//   - Remove ran after Put's getValue (our memState fix handles the race): the item has
+	//     been removed and the stat must be 0.
+	// In either case the stat must be consistent with what is actually in the cache.
+	_, inCache := cache.Peek(ctx, "doc1", Version{Value: 123, SourceID: "test"}.String(), testCollectionID)
+	if inCache {
+		assert.Equal(t, docRev.MemoryBytes, memoryBytesCounted.Value(), "item is in cache so stat should equal item bytes")
+	} else {
+		assert.Equal(t, int64(0), memoryBytesCounted.Value(), "item was removed so stat should be 0")
+	}
 }
 
 func TestItemResidentInCacheBackupRevLoaded(t *testing.T) {

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -1008,12 +1008,12 @@ func TestShardedMemoryEviction(t *testing.T) {
 	// grab this particular shard + assert that the shard memory usage is as expected
 	shardedCache := db.revisionCache.(*ShardedLRURevisionCache)
 	doc1Shard := shardedCache.getShard("doc1")
-	assert.Equal(t, int64(size), doc1Shard.memoryController.currBytesCount.Load())
+	assert.Equal(t, int64(size), doc1Shard.memoryController.bytesInUseForShard.Load())
 
 	// add new doc in diff shard + assert that the shard memory usage is as expected
 	size, _, _ = createDocAndReturnSizeAndRev(t, ctx, "doc2", collection, docBody, false)
 	doc2Shard := shardedCache.getShard("doc2")
-	assert.Equal(t, int64(size), doc2Shard.memoryController.currBytesCount.Load())
+	assert.Equal(t, int64(size), doc2Shard.memoryController.bytesInUseForShard.Load())
 	// overall mem usage should be combination oif the two added docs
 	assert.Equal(t, int64(size*2), cacheStats.RevisionCacheTotalMemory.Value())
 
@@ -1027,7 +1027,7 @@ func TestShardedMemoryEviction(t *testing.T) {
 	// add new doc to trigger eviction and assert stats are as expected
 	newDocSize, _, _ := createDocAndReturnSizeAndRev(t, ctx, "doc3", collection, docBody, false)
 	doc3Shard := shardedCache.getShard("doc3")
-	assert.Equal(t, int64(newDocSize), doc3Shard.memoryController.currBytesCount.Load())
+	assert.Equal(t, int64(newDocSize), doc3Shard.memoryController.bytesInUseForShard.Load())
 	assert.Equal(t, int64(2), cacheStats.RevisionCacheNumItems.Value())
 	assert.Equal(t, int64(size+newDocSize), cacheStats.RevisionCacheTotalMemory.Value())
 }
@@ -1063,7 +1063,7 @@ func TestShardedMemoryEvictionWhenShardEmpty(t *testing.T) {
 
 	// assert that doc was not added to cache as it's too large
 	doc1Shard := shardedCache.getShard("doc1")
-	assert.Equal(t, int64(0), doc1Shard.memoryController.currBytesCount.Load())
+	assert.Equal(t, int64(0), doc1Shard.memoryController.bytesInUseForShard.Load())
 	assert.Equal(t, int64(0), cacheStats.RevisionCacheNumItems.Value())
 	assert.Equal(t, int64(0), cacheStats.RevisionCacheTotalMemory.Value())
 
@@ -1074,7 +1074,7 @@ func TestShardedMemoryEvictionWhenShardEmpty(t *testing.T) {
 	assert.NotNil(t, docRev.BodyBytes)
 
 	// assert rev cache is still empty
-	assert.Equal(t, int64(0), doc1Shard.memoryController.currBytesCount.Load())
+	assert.Equal(t, int64(0), doc1Shard.memoryController.bytesInUseForShard.Load())
 	assert.Equal(t, int64(0), cacheStats.RevisionCacheNumItems.Value())
 	assert.Equal(t, int64(0), cacheStats.RevisionCacheTotalMemory.Value())
 }
@@ -2765,7 +2765,7 @@ func TestMemoryBasedEvictionBetweenRevAndDeltaCache(t *testing.T) {
 
 	// -----------------------------------------------------------------------
 	// Step 2: Add delta rev1→rev2 via UpdateDelta.
-	// Total (121+10=131) exceeds maxBytes (121).  Delta is evicted due to round-
+	// Total (121+10=131) exceeds maxBytes (121).  Revision 1 is evicted due to round-
 	// robin eviction approach
 	// -----------------------------------------------------------------------
 	delta := RevisionDelta{DeltaBytes: deltaBodyBytes}
@@ -2773,31 +2773,33 @@ func TestMemoryBasedEvictionBetweenRevAndDeltaCache(t *testing.T) {
 	orchestrator.UpdateDelta(ctx, docID, rev1CV.String(), rev2CV.String(), testCollectionID, delta)
 
 	_, rev1InCacheAfterDelta := orchestrator.Peek(ctx, docID, rev1CV.String(), testCollectionID)
-	assert.True(t, rev1InCacheAfterDelta, "rev1 should still be present")
+	assert.False(t, rev1InCacheAfterDelta, "rev1 should have been evicted")
 
 	cachedDelta := orchestrator.deltaCache.getCachedDelta(ctx, docID, rev1CV.String(), rev2CV.String(), testCollectionID)
-	assert.Nil(t, cachedDelta, "delta should have been evicted")
+	assert.NotNil(t, cachedDelta, "delta still be present")
 
-	assert.Equal(t, int64(1), cacheNumItems.Value(), "revision cache should not be empty after evicting rev1")
-	assert.Equal(t, int64(0), deltaCacheNumItems.Value(), "delta cache should be empty")
-	assert.Equal(t, expectedRev1Bytes, cacheMemoryBytes.Value(), "memory stat should equal rev1 bytes only after eviction")
+	assert.Equal(t, int64(0), cacheNumItems.Value(), "revision cache should not be empty after evicting rev1")
+	assert.Equal(t, int64(1), deltaCacheNumItems.Value(), "delta cache should be empty")
+	assert.Equal(t, expectedDeltaBytes, cacheMemoryBytes.Value(), "memory stat should equal rev1 bytes only after eviction")
 
 	// -----------------------------------------------------------------------
-	// Step 3: Add delta rev1→rev2 via UpdateDelta again.
-	// Total (10+121=131) exceeds maxBytes again.  rev1 turn to be evicted.
+	// Step 3: Load rev1 again via Get (cache miss — it was evicted in step 2).
+	// Total (10+121=131) exceeds maxBytes again.  Deltas turn to be evicted.
 	// -----------------------------------------------------------------------
-	orchestrator.UpdateDelta(ctx, docID, rev1CV.String(), rev2CV.String(), testCollectionID, delta)
+	_, wasMiss2, err := orchestrator.Get(ctx, docID, rev1CV.String(), testCollectionID, false)
+	require.NoError(t, err)
+	require.True(t, wasMiss2, "second Get should be a cache miss (rev1 was evicted)")
 
-	_, rev1InCacheAfterDelta = orchestrator.Peek(ctx, docID, rev1CV.String(), testCollectionID)
-	assert.False(t, rev1InCacheAfterDelta, "rev1 should have been evicted after delta update")
+	_, rev1BackInCache := orchestrator.Peek(ctx, docID, rev1CV.String(), testCollectionID)
+	assert.True(t, rev1BackInCache, "rev1 should be back in revision cache after second Get")
 
 	cachedDeltaAfter := orchestrator.deltaCache.getCachedDelta(ctx, docID, rev1CV.String(), rev2CV.String(), testCollectionID)
-	assert.NotNil(t, cachedDeltaAfter, "delta should be present")
+	assert.Nil(t, cachedDeltaAfter, "delta should've been evicted")
 
-	assert.Equal(t, int64(0), cacheNumItems.Value(), "revision cache should be empty")
-	assert.Equal(t, int64(1), deltaCacheNumItems.Value(), "delta cache should have one item")
-	assert.Equal(t, expectedDeltaBytes, cacheMemoryBytes.Value(), "memory stat should equal delta bytes only after rev1 evicted")
-	assert.Equal(t, int64(1), cacheMisses.Value(), "Get was a cache miss")
+	assert.Equal(t, int64(1), cacheNumItems.Value(), "revision cache should be empty")
+	assert.Equal(t, int64(0), deltaCacheNumItems.Value(), "delta cache should have one item")
+	assert.Equal(t, expectedRev1Bytes, cacheMemoryBytes.Value(), "memory stat should equal delta bytes only after rev1 evicted")
+	assert.Equal(t, int64(2), cacheMisses.Value(), "Two Get's were a cache miss")
 	assert.Equal(t, int64(0), cacheHits.Value())
 }
 
@@ -3025,12 +3027,12 @@ func TestCombinedNumberAndMemoryEviction(t *testing.T) {
 	assert.Equal(t, int64(1), revStats.cacheNumItemsStat.Value())
 	assert.Equal(t, int64(15), revStats.cacheMemoryStat.Value())
 
-	// UpdateDelta A: total = 15+10 = 25 > 20 → memory eviction fires and evicts the revision delta immediately
+	// UpdateDelta A: total = 15+10 = 25 > 20 → memory eviction fires and evicts the revision immediately
 	// After eviction: only delta doc1 in memory (15 bytes).
 	orchestrator.UpdateDelta(ctx, "doc1", "from1", "to1", testCollectionID, makeDelta())
-	assert.Equal(t, int64(1), revStats.cacheNumItemsStat.Value())
-	assert.Equal(t, int64(0), deltaStats.DeltaCacheNumItems.Value())
-	assert.Equal(t, int64(15), revStats.cacheMemoryStat.Value(), "only doc1 bytes should remain")
+	assert.Equal(t, int64(0), revStats.cacheNumItemsStat.Value())
+	assert.Equal(t, int64(1), deltaStats.DeltaCacheNumItems.Value())
+	assert.Equal(t, int64(10), revStats.cacheMemoryStat.Value(), "only doc1 bytes should remain")
 
 	// UpdateDelta B: number-based eviction (MaxItemCount=1) removes delta A and decrements
 	// its 10 bytes, then delta B is added and its 10 bytes incremented.  Net = 10 bytes.
@@ -3231,8 +3233,8 @@ func TestRemoveDuringNumberBasedEviction(t *testing.T) {
 	}
 	wg.Wait()
 
-	// With MaxItemCount=1, 1 item should remain.
-	// get copilot to suggest assertion here
+	// With MaxItemCount=1, 1 item should remain, assert on item that exists and
+	// ensure memory stat equals that item's bytes
 	var expectedBytes, numFound int64
 	for i := range numDocs {
 		cv := Version{Value: uint64(i + 1), SourceID: "test"}
@@ -3338,4 +3340,152 @@ func TestMemoryEvictionDuringConcurrentPuts(t *testing.T) {
 	// After all concurrent Puts and evictions settle, the memory stat should be at or below capacity.
 	assert.Equal(t, int64(44), revStats.cacheMemoryStat.Value(), "we should have 4 items worth of memory")
 	assert.Equal(t, int64(4), revStats.cacheNumItemsStat.Value(), "we should have 4 items in cache")
+}
+
+// TestMemoryStatLongTermConsistency runs a high-concurrency mixed workload (Put, Upsert,
+// Get, UpdateDelta, GetWithDelta, Remove) against an orchestrator with both rev and delta
+// caches enabled and a memory limit that forces frequent memory-based eviction. After the
+// workload settles, it audits the full internal state of both caches against the published
+// memory stat and the controller's internal counter — catching any divergence between the
+// stat and reality across all operation types and eviction paths.
+//
+// Mirrors the production invariant that any given CV maps to exactly one body: Put/Upsert
+// use a writer-side CV, Get/GetWithDelta use the backing-store's CV, and the body bytes for
+// each (docID, CV) pair are deterministic. Without this, the "Put-on-existing-Sized" path
+// is reached (different bodies for the same cache key) which is impossible in production.
+func TestMemoryStatLongTermConsistency(t *testing.T) {
+	if !base.IsEnterpriseEdition() {
+		t.Skip("delta cache is EE only")
+	}
+
+	ctx := base.TestCtx(t)
+
+	revStats := newTestRevCacheStats()
+	deltaStats := newTestDeltaStats()
+
+	var docCounter, revCounter base.SgwIntStat
+	bs := &testBackingStore{getDocumentCounter: &docCounter, getRevisionCounter: &revCounter}
+
+	// MaxBytes deliberately small so memory-based eviction fires constantly throughout the run.
+	// MaxItemCount large so number-based eviction stays out of the way (covered by other tests).
+	const maxBytes = int64(2000)
+	opts := &RevisionCacheOptions{MaxItemCount: 10000, MaxBytes: maxBytes}
+	orchestrator := NewRevisionCacheOrchestrator(
+		opts, CreateTestSingleBackingStoreMap(bs, testCollectionID),
+		revStats, deltaStats, true,
+	)
+
+	// loadedCV is what the backing store returns for any doc — Get/GetWithDelta cache under this key.
+	// writeCV is what Put/Upsert cache under — distinct from loadedCV so the two paths never collide
+	// on the same cache key (production invariant: each write produces a fresh CV).
+	loadedCV := Version{Value: 123, SourceID: "test"}
+	writeCV := Version{Value: 999, SourceID: "writer"}
+
+	const numDocs = 100
+	const opsPerWorker = 1000
+	const numWorkers = 250
+
+	docID := func(i int) string { return fmt.Sprintf("doc-%d", i) }
+	// bodyForDoc is deterministic per docID so any Put or Upsert on (docID, writeCV) produces the
+	// same byte count — upholding the "one CV ⇒ one body" invariant.
+	bodyForDoc := func(i int) string {
+		return fmt.Sprintf(`{"docID":%d,"payload":"abcdefghijklmnop"}`, i)
+	}
+
+	put := func(i int) {
+		orchestrator.Put(ctx, makeTestRevision(docID(i), writeCV, bodyForDoc(i)), testCollectionID)
+	}
+	upsert := func(i int) {
+		orchestrator.Upsert(ctx, makeTestRevision(docID(i), writeCV, bodyForDoc(i)), testCollectionID)
+	}
+	get := func(i int) {
+		_, _, _ = orchestrator.Get(ctx, docID(i), loadedCV.String(), testCollectionID, false)
+	}
+	updateDelta := func(i int) {
+		toCV := Version{Value: uint64(1000 + i), SourceID: "test"}.String()
+		d := RevisionDelta{DeltaBytes: []byte(fmt.Sprintf("delta-payload-for-doc-%d", i))}
+		d.CalculateDeltaBytes()
+		orchestrator.UpdateDelta(ctx, docID(i), loadedCV.String(), toCV, testCollectionID, d)
+	}
+	getWithDelta := func(i int) {
+		toCV := Version{Value: uint64(1000 + i), SourceID: "test"}.String()
+		_, _ = orchestrator.GetWithDelta(ctx, docID(i), loadedCV.String(), toCV, testCollectionID)
+	}
+	removeWriter := func(i int) {
+		orchestrator.Remove(ctx, docID(i), writeCV.String(), testCollectionID)
+	}
+	removeLoaded := func(i int) {
+		orchestrator.Remove(ctx, docID(i), loadedCV.String(), testCollectionID)
+	}
+
+	ops := []func(int){put, upsert, get, updateDelta, getWithDelta, removeWriter, removeLoaded}
+
+	var wg sync.WaitGroup
+	for w := range numWorkers {
+		wg.Add(1)
+		go func(seed int) {
+			defer wg.Done()
+			r := rand.New(rand.NewSource(int64(seed)))
+			for range opsPerWorker {
+				op := ops[r.Intn(len(ops))]
+				op(r.Intn(numDocs))
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	// Audit: walk both caches under their own locks and sum the bytes that should be
+	// reflected in the memory stat. Items in memStateLoading must not be counted (their
+	// bytes were never added). Items in memStateRemoved must not be present in the map at all.
+	var revBytes, deltaBytes, revCount, deltaCount int64
+
+	orchestrator.revisionCache.lock.Lock()
+	for _, elem := range orchestrator.revisionCache.cache {
+		val := elem.Value.(*revCacheValue)
+		switch val.memState.Load() {
+		case memStateSized:
+			revBytes += val.itemBytes.Load()
+		case memStateRemoved:
+			t.Errorf("rev cache map still contains a removed entry for key %+v", val.itemKey)
+		}
+		revCount++
+	}
+	revListLen := int64(orchestrator.revisionCache.lruList.Len())
+	orchestrator.revisionCache.lock.Unlock()
+
+	orchestrator.deltaCache.lock.Lock()
+	for _, elem := range orchestrator.deltaCache.cache {
+		val := elem.Value.(*deltaCacheValue)
+		deltaBytes += val.delta.totalDeltaBytes
+		deltaCount++
+	}
+	deltaListLen := int64(orchestrator.deltaCache.lruList.Len())
+	orchestrator.deltaCache.lock.Unlock()
+
+	totalBytes := revBytes + deltaBytes
+
+	// Stat published to the rest of the system must match the bytes actually held.
+	assert.Equal(t, totalBytes, revStats.cacheMemoryStat.Value(),
+		"published memory stat must equal sum of bytes in rev cache (%d) + delta cache (%d)", revBytes, deltaBytes)
+
+	// Internal controller counter must agree with the published stat — they are mutated
+	// together in incrementBytesCount/decrementBytesCount, so any drift between them
+	// indicates a missed write site.
+	assert.Equal(t, revStats.cacheMemoryStat.Value(), orchestrator.memoryController.bytesInUseForShard.Load(),
+		"internal controller counter must equal published memory stat")
+
+	// Item-count stats must match the actual number of entries in each cache.
+	assert.Equal(t, revCount, revStats.cacheNumItemsStat.Value(),
+		"rev cache num-items stat must equal number of map entries")
+	assert.Equal(t, deltaCount, deltaStats.DeltaCacheNumItems.Value(),
+		"delta cache num-items stat must equal number of map entries")
+
+	// Map size and list length must agree (no orphaned list entries or leaked map keys).
+	assert.Equal(t, revCount, revListLen, "rev cache map size must equal LRU list length")
+	assert.Equal(t, deltaCount, deltaListLen, "delta cache map size must equal LRU list length")
+
+	// Memory must remain at or below the configured limit (eviction may briefly go over, but
+	// the controller drives back to <= maxBytes once triggerMemoryEviction completes).
+	assert.LessOrEqual(t, revStats.cacheMemoryStat.Value(), maxBytes,
+		"after workload settles, memory stat must be at or below maxBytes — eviction failed to keep up")
 }

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -2678,3 +2678,413 @@ func TestMultipleRevCacheItemsForSameDocs(t *testing.T) {
 	// assert four items now in cache
 	assert.Equal(t, int64(4), db.DbStats.Cache().RevisionCacheNumItems.Value())
 }
+
+// TestMemoryBasedEvictionBetweenRevAndDeltaCache verifies that the shared CacheMemoryController
+// evicts across both LRURevisionCache and LRUDeltaCache, always choosing the globally oldest item
+// (by access order). The test drives two round-trips:
+//
+//  1. Get rev1  → loaded from backing store, memory at capacity (no eviction).
+//  2. UpdateDelta(rev1→rev2) → total exceeds limit; rev1 (older access order) is evicted from
+//     the revision cache.
+//  3. Get rev1 again → loaded from backing store, total exceeds limit again; the delta (now the
+//     oldest item) is evicted from the delta cache.
+//
+// At each step the cache item counts and shared memory byte stat are asserted for consistency.
+func TestMemoryBasedEvictionBetweenRevAndDeltaCache(t *testing.T) {
+	if !base.IsEnterpriseEdition() {
+		t.Skip("delta sync and delta cache are EE only")
+	}
+
+	ctx := base.TestCtx(t)
+	const docID = "testDoc"
+
+	// testBackingStore always serves docID at cv{Value:123, SourceID:"test"}.
+	rev1CV := Version{Value: 123, SourceID: "test"}
+	rev2CV := Version{Value: 456, SourceID: "test"} // only used as the delta's toVersion key
+
+	// Delta body bytes.  With no channels or revision history, totalDeltaBytes = len(DeltaBytes).
+	deltaBodyBytes := []byte("delta_data") // 10 bytes
+	const expectedDeltaBytes = int64(10)
+
+	// testBackingStore produces 121 bytes for "testDoc" (verified empirically: body JSON + 1
+	// history digest at 32 bytes + 1 channel byte "*").
+	const expectedRev1Bytes = int64(121)
+
+	// maxBytes=121: rev1 alone just fits (121 is NOT > 121), delta alone fits (10 < 121), but
+	// together (131 > 121) they trigger memory-based eviction.
+	const maxBytes = expectedRev1Bytes
+
+	// Revision cache stats.
+	var cacheHits, cacheMisses, cacheNumItems, cacheMemoryBytes base.SgwIntStat
+	revCacheStats := revisionCacheStats{
+		cacheHitStat:      &cacheHits,
+		cacheMissStat:     &cacheMisses,
+		cacheNumItemsStat: &cacheNumItems,
+		cacheMemoryStat:   &cacheMemoryBytes,
+	}
+
+	// Delta cache stats.
+	var deltaCacheHit, deltaCacheMiss, deltaCacheNumItems base.SgwIntStat
+	deltaStats := &base.DeltaSyncStats{
+		DeltaCacheHit:      &deltaCacheHit,
+		DeltaCacheMiss:     &deltaCacheMiss,
+		DeltaCacheNumItems: &deltaCacheNumItems,
+	}
+
+	var docCounter, revCounter base.SgwIntStat
+	bs := &testBackingStore{getDocumentCounter: &docCounter, getRevisionCounter: &revCounter}
+
+	cacheOptions := &RevisionCacheOptions{
+		MaxItemCount: 100, // high enough that number-based eviction never fires
+		MaxBytes:     maxBytes,
+	}
+	orchestrator := NewRevisionCacheOrchestrator(
+		cacheOptions,
+		CreateTestSingleBackingStoreMap(bs, testCollectionID),
+		revCacheStats,
+		deltaStats,
+		true, // initDeltaCache
+	)
+
+	// -----------------------------------------------------------------------
+	// Step 1: Load rev1 via Get (cache miss — loaded from backing store).
+	// Memory reaches the limit exactly; IsOverCapacity returns false (> not >=),
+	// so no eviction occurs.
+	// -----------------------------------------------------------------------
+	_, wasMiss, err := orchestrator.Get(ctx, docID, rev1CV.String(), testCollectionID, false)
+	require.NoError(t, err)
+	require.True(t, wasMiss, "first Get should be a cache miss triggering a backing-store load")
+
+	_, rev1InCache := orchestrator.Peek(ctx, docID, rev1CV.String(), testCollectionID)
+	assert.True(t, rev1InCache, "rev1 should be in revision cache after Get")
+	assert.Equal(t, int64(1), cacheNumItems.Value(), "revision cache should have one item")
+	assert.Equal(t, int64(0), deltaCacheNumItems.Value(), "delta cache should be empty")
+	assert.Equal(t, expectedRev1Bytes, cacheMemoryBytes.Value(), "memory stat should equal rev1 bytes")
+	assert.Equal(t, int64(1), cacheMisses.Value())
+	assert.Equal(t, int64(0), cacheHits.Value())
+
+	// -----------------------------------------------------------------------
+	// Step 2: Add delta rev1→rev2 via UpdateDelta.
+	// Total (121+10=131) exceeds maxBytes (121).  rev1 carries the older access
+	// order, so it is evicted from the revision cache, leaving only the delta.
+	// -----------------------------------------------------------------------
+	delta := RevisionDelta{DeltaBytes: deltaBodyBytes}
+	delta.CalculateDeltaBytes()
+	orchestrator.UpdateDelta(ctx, docID, rev1CV.String(), rev2CV.String(), testCollectionID, delta)
+
+	_, rev1InCacheAfterDelta := orchestrator.Peek(ctx, docID, rev1CV.String(), testCollectionID)
+	assert.False(t, rev1InCacheAfterDelta, "rev1 should have been evicted from revision cache by memory pressure")
+
+	cachedDelta := orchestrator.deltaCache.getCachedDelta(ctx, docID, rev1CV.String(), rev2CV.String(), testCollectionID)
+	assert.NotNil(t, cachedDelta, "delta should remain in delta cache after evicting rev1")
+
+	assert.Equal(t, int64(0), cacheNumItems.Value(), "revision cache should be empty after evicting rev1")
+	assert.Equal(t, int64(1), deltaCacheNumItems.Value(), "delta cache should have one entry")
+	assert.Equal(t, expectedDeltaBytes, cacheMemoryBytes.Value(), "memory stat should equal delta bytes only after eviction")
+
+	// -----------------------------------------------------------------------
+	// Step 3: Load rev1 again via Get (cache miss — it was evicted in step 2).
+	// Total (10+121=131) exceeds maxBytes again.  The delta now carries the older
+	// access order, so it is evicted from the delta cache, leaving only rev1.
+	// -----------------------------------------------------------------------
+	_, wasMiss2, err := orchestrator.Get(ctx, docID, rev1CV.String(), testCollectionID, false)
+	require.NoError(t, err)
+	require.True(t, wasMiss2, "second Get should be a cache miss (rev1 was evicted)")
+
+	_, rev1BackInCache := orchestrator.Peek(ctx, docID, rev1CV.String(), testCollectionID)
+	assert.True(t, rev1BackInCache, "rev1 should be back in revision cache after second Get")
+
+	cachedDeltaAfter := orchestrator.deltaCache.getCachedDelta(ctx, docID, rev1CV.String(), rev2CV.String(), testCollectionID)
+	assert.Nil(t, cachedDeltaAfter, "delta should have been evicted from delta cache by memory pressure")
+
+	assert.Equal(t, int64(1), cacheNumItems.Value(), "revision cache should have rev1 again")
+	assert.Equal(t, int64(0), deltaCacheNumItems.Value(), "delta cache should be empty after eviction")
+	assert.Equal(t, expectedRev1Bytes, cacheMemoryBytes.Value(), "memory stat should equal rev1 bytes only after delta evicted")
+	assert.Equal(t, int64(2), cacheMisses.Value(), "both Gets were cache misses")
+	assert.Equal(t, int64(0), cacheHits.Value())
+}
+
+// TestMemoryBasedEvictionRevisionCacheOnly verifies memory-based eviction when the delta cache
+// is disabled (delta sync off).  Two documents are loaded sequentially; each fits within the
+// memory limit on its own, but together they exceed it, so the older document must be evicted
+// when the second is loaded.
+func TestMemoryBasedEvictionRevisionCacheOnly(t *testing.T) {
+	ctx := base.TestCtx(t)
+
+	// testBackingStore serves any docID at cv{Value:123, SourceID:"test"}.
+	rev1CV := Version{Value: 123, SourceID: "test"}
+
+	// testBackingStore produces 118 bytes for a 4-char docID (verified empirically: body JSON
+	// + 1 history digest at 32 bytes + 1 channel byte "*").
+	const expectedBytesPerDoc = int64(118)
+
+	// maxBytes=118: one document just fits (118 is NOT > 118); two together (236 > 118)
+	// trigger memory-based eviction of the older document.
+	const maxBytes = expectedBytesPerDoc
+
+	var cacheHits, cacheMisses, cacheNumItems, cacheMemoryBytes base.SgwIntStat
+	revCacheStats := revisionCacheStats{
+		cacheHitStat:      &cacheHits,
+		cacheMissStat:     &cacheMisses,
+		cacheNumItemsStat: &cacheNumItems,
+		cacheMemoryStat:   &cacheMemoryBytes,
+	}
+
+	var docCounter, revCounter base.SgwIntStat
+	bs := &testBackingStore{getDocumentCounter: &docCounter, getRevisionCounter: &revCounter}
+
+	cacheOptions := &RevisionCacheOptions{
+		MaxItemCount: 100, // number-based eviction disabled
+		MaxBytes:     maxBytes,
+	}
+	// initDeltaCache=false mirrors the configuration when delta sync is disabled.
+	orchestrator := NewRevisionCacheOrchestrator(
+		cacheOptions,
+		CreateTestSingleBackingStoreMap(bs, testCollectionID),
+		revCacheStats,
+		&base.DeltaSyncStats{},
+		false,
+	)
+
+	// -----------------------------------------------------------------------
+	// Step 1: Load doc1 via Get (cache miss).
+	// Memory reaches the limit exactly; no eviction occurs.
+	// -----------------------------------------------------------------------
+	_, wasMiss, err := orchestrator.Get(ctx, "doc1", rev1CV.String(), testCollectionID, false)
+	require.NoError(t, err)
+	require.True(t, wasMiss, "first Get should be a cache miss")
+
+	_, doc1InCache := orchestrator.Peek(ctx, "doc1", rev1CV.String(), testCollectionID)
+	assert.True(t, doc1InCache, "doc1 should be in revision cache after Get")
+	assert.Equal(t, int64(1), cacheNumItems.Value())
+	assert.Equal(t, expectedBytesPerDoc, cacheMemoryBytes.Value(), "memory stat should equal doc1 bytes")
+	assert.Equal(t, int64(1), cacheMisses.Value())
+	assert.Equal(t, int64(0), cacheHits.Value())
+
+	// -----------------------------------------------------------------------
+	// Step 2: Load doc2 via Get (cache miss).
+	// Total (118+118=236) exceeds maxBytes (118).  doc1 carries the older access
+	// order, so it is evicted, leaving only doc2 in the revision cache.
+	// -----------------------------------------------------------------------
+	_, wasMiss2, err := orchestrator.Get(ctx, "doc2", rev1CV.String(), testCollectionID, false)
+	require.NoError(t, err)
+	require.True(t, wasMiss2, "second Get should be a cache miss")
+
+	_, doc1InCacheAfter := orchestrator.Peek(ctx, "doc1", rev1CV.String(), testCollectionID)
+	assert.False(t, doc1InCacheAfter, "doc1 should have been evicted from revision cache by memory pressure")
+
+	_, doc2InCache := orchestrator.Peek(ctx, "doc2", rev1CV.String(), testCollectionID)
+	assert.True(t, doc2InCache, "doc2 should be in revision cache")
+
+	assert.Equal(t, int64(1), cacheNumItems.Value(), "only doc2 should remain in revision cache")
+	assert.Equal(t, expectedBytesPerDoc, cacheMemoryBytes.Value(), "memory stat should equal doc2 bytes only after eviction")
+	assert.Equal(t, int64(2), cacheMisses.Value(), "both Gets were cache misses")
+	assert.Equal(t, int64(0), cacheHits.Value())
+}
+
+// makeTestRevision creates a minimal DocumentRevision for memory-accounting tests.
+// MemoryBytes = len(body) because History is an empty (but non-nil) Revisions map
+// and there are no channels, so CalculateBytes contributes 0 history/channel overhead.
+func makeTestRevision(docID string, cv Version, body string) DocumentRevision {
+	return DocumentRevision{
+		DocID:     docID,
+		CV:        &cv,
+		BodyBytes: []byte(body),
+		History:   Revisions{}, // non-nil satisfies Put's nil-history guard; contributes 0 bytes
+	}
+}
+
+// newTestRevCacheStats returns zero-value stats for standalone cache tests.
+func newTestRevCacheStats() revisionCacheStats {
+	var hits, misses, numItems, cacheMemoryStat base.SgwIntStat
+	return revisionCacheStats{
+		cacheHitStat:      &hits,
+		cacheMissStat:     &misses,
+		cacheNumItemsStat: &numItems,
+		cacheMemoryStat:   &cacheMemoryStat,
+	}
+}
+
+// newTestDeltaStats returns zero-value delta stats for standalone cache tests.
+func newTestDeltaStats() *base.DeltaSyncStats {
+	var hit, miss, numItems base.SgwIntStat
+	return &base.DeltaSyncStats{
+		DeltaCacheHit:      &hit,
+		DeltaCacheMiss:     &miss,
+		DeltaCacheNumItems: &numItems,
+	}
+}
+
+// TestEvictLRUTailOnLoadingItemReturnsZeroBytes verifies that evicting an item still in
+// memStateLoading (bytes not yet accounted) returns 0 bytes and does not corrupt the
+// memory stat.  It also verifies that the CAS Loading→Sized, which would normally
+// follow a backing-store load, correctly fails after eviction — preventing a double-count.
+func TestEvictLRUTailOnLoadingItemReturnsZeroBytes(t *testing.T) {
+	ctx := base.TestCtx(t)
+
+	revStats := newTestRevCacheStats()
+
+	opts := &RevisionCacheOptions{MaxItemCount: 100, MaxBytes: 0}
+	mc := newCacheMemoryController(0, revStats.cacheMemoryStat)
+	rc := NewLRURevisionCache(
+		opts, CreateTestSingleBackingStoreMap(&noopBackingStore{}, testCollectionID), revStats, mc,
+	)
+
+	docCV := Version{Value: 123, SourceID: "test"}
+
+	// getValue(create=true) inserts a shell entry in memStateLoading with itemBytes=0.
+	value := rc.getValue(ctx, "doc1", docCV.String(), testCollectionID, true)
+	require.NotNil(t, value)
+	assert.Equal(t, memStateLoading, value.memState.Load(), "item should start in Loading state")
+	assert.Equal(t, int64(0), revStats.cacheMemoryStat.Value(), "no bytes counted while item is still loading")
+	assert.Equal(t, int64(1), revStats.cacheNumItemsStat.Value())
+
+	// Evict the still-loading item — must return 0 bytes, not inflate or deflate the stat.
+	bytesReturned := rc.evictLRUTail()
+	assert.Equal(t, int64(0), bytesReturned, "evicting a loading item must return 0 bytes")
+	assert.Equal(t, int64(0), revStats.cacheMemoryStat.Value(), "memory stat must not go negative")
+	assert.Equal(t, memStateRemoved, value.memState.Load(), "evicted item should be in Removed state")
+	assert.Equal(t, int64(0), revStats.cacheNumItemsStat.Value())
+
+	// Simulate the backing-store load completing after eviction: store bytes then attempt
+	// the CAS that Get would perform.  The CAS must fail (state is already Removed),
+	// preventing any bytes from being counted for a no-longer-cached item.
+	value.itemBytes.Store(int64(50))
+	casSucceeded := value.memState.CompareAndSwap(memStateLoading, memStateSized)
+	assert.False(t, casSucceeded, "CAS Loading→Sized must fail on an already-evicted item")
+	assert.Equal(t, int64(0), revStats.cacheMemoryStat.Value(), "memory stat must stay at 0 after the failed CAS")
+}
+
+// TestUpsertReplacesItemMemoryBytes verifies that Upserting a document with a different
+// body size correctly decrements the old bytes and increments the new bytes, so the stat
+// always reflects the current item's size only — no double-counting, no stale bytes.
+func TestUpsertReplacesItemMemoryBytes(t *testing.T) {
+	ctx := base.TestCtx(t)
+
+	revStats := newTestRevCacheStats()
+
+	opts := &RevisionCacheOptions{MaxItemCount: 100, MaxBytes: 0}
+	orchestrator := NewRevisionCacheOrchestrator(
+		opts, CreateTestSingleBackingStoreMap(&noopBackingStore{}, testCollectionID),
+		revStats, &base.DeltaSyncStats{}, false,
+	)
+
+	docCV := Version{Value: 1, SourceID: "test"}
+
+	// First Upsert: small body — MemoryBytes = len(`{"v":1}`) = 7.
+	orchestrator.Upsert(ctx, makeTestRevision("doc1", docCV, `{"v":1}`), testCollectionID)
+	assert.Equal(t, int64(1), revStats.cacheNumItemsStat.Value())
+	assert.Equal(t, int64(7), revStats.cacheMemoryStat.Value(), "first upsert should count 7 bytes")
+
+	// Second Upsert: same doc/CV, larger body — MemoryBytes = 22.
+	// Old bytes (7) must be decremented and new bytes (22) incremented; stat = 22, not 29.
+	orchestrator.Upsert(ctx, makeTestRevision("doc1", docCV, `{"v":2,"extra":"data"}`), testCollectionID)
+	assert.Equal(t, int64(1), revStats.cacheNumItemsStat.Value(), "upsert replaces in-place — still 1 item")
+	assert.Equal(t, int64(22), revStats.cacheMemoryStat.Value(),
+		"stat must equal new body size only — no double-counting of old bytes")
+
+	// Third Upsert: smaller body — MemoryBytes = 7.  Stat must shrink, not accumulate.
+	orchestrator.Upsert(ctx, makeTestRevision("doc1", docCV, `{"v":3}`), testCollectionID)
+	assert.Equal(t, int64(1), revStats.cacheNumItemsStat.Value())
+	assert.Equal(t, int64(7), revStats.cacheMemoryStat.Value(), "stat must shrink when the replacement body is smaller")
+}
+
+// TestCombinedNumberAndMemoryEviction verifies that when both MaxItemCount and MaxBytes
+// are configured, number-based eviction (inside addDelta) and memory-based eviction
+// (triggerMemoryEviction) interact correctly, leaving consistent item-count and memory stats.
+func TestCombinedNumberAndMemoryEviction(t *testing.T) {
+	if !base.IsEnterpriseEdition() {
+		t.Skip("delta cache is EE only")
+	}
+
+	ctx := base.TestCtx(t)
+
+	revStats := newTestRevCacheStats()
+	deltaStats := newTestDeltaStats()
+
+	// rev body = 15 bytes; each delta body = 10 bytes.
+	// maxBytes=20: rev(15) fits alone; delta(10) fits alone; rev+delta(25) triggers memory
+	// eviction; two deltas(20) exactly at the limit — NOT > 20 — so no memory eviction fires
+	// after the second delta is added via number-based eviction.
+	const maxBytes = int64(20)
+
+	// MaxItemCount=1 caps both rev and delta caches at 1 item, ensuring number-based
+	// eviction fires when the second delta is added.
+	opts := &RevisionCacheOptions{MaxItemCount: 1, MaxBytes: maxBytes}
+	orchestrator := NewRevisionCacheOrchestrator(
+		opts, CreateTestSingleBackingStoreMap(&noopBackingStore{}, testCollectionID),
+		revStats, deltaStats, true,
+	)
+
+	makeDelta := func() RevisionDelta {
+		d := RevisionDelta{DeltaBytes: []byte("0123456789")} // 10 bytes
+		d.CalculateDeltaBytes()
+		return d
+	}
+
+	// Put a revision (15 bytes) — fits within maxBytes, no eviction.
+	orchestrator.Put(ctx, makeTestRevision("doc1", Version{Value: 1, SourceID: "src"}, `{"key":"value"}`), testCollectionID)
+	assert.Equal(t, int64(1), revStats.cacheNumItemsStat.Value())
+	assert.Equal(t, int64(15), revStats.cacheMemoryStat.Value())
+
+	// UpdateDelta A: total = 15+10 = 25 > 20 → memory eviction fires and evicts the revision
+	// (older access order).  After eviction: only delta A in memory (10 bytes).
+	orchestrator.UpdateDelta(ctx, "doc1", "from1", "to1", testCollectionID, makeDelta())
+	assert.Equal(t, int64(0), revStats.cacheNumItemsStat.Value(), "revision evicted by memory pressure")
+	assert.Equal(t, int64(1), deltaStats.DeltaCacheNumItems.Value())
+	assert.Equal(t, int64(10), revStats.cacheMemoryStat.Value(), "only delta A bytes should remain")
+
+	// UpdateDelta B: number-based eviction (MaxItemCount=1) removes delta A and decrements
+	// its 10 bytes, then delta B is added and its 10 bytes incremented.  Net = 10 bytes.
+	// Memory (10) is NOT > maxBytes (20) so memory-based eviction does not fire.
+	orchestrator.UpdateDelta(ctx, "doc1", "from2", "to2", testCollectionID, makeDelta())
+	assert.Equal(t, int64(0), revStats.cacheNumItemsStat.Value(), "revision cache still empty")
+	assert.Equal(t, int64(1), deltaStats.DeltaCacheNumItems.Value(), "only delta B should remain")
+	assert.Equal(t, int64(10), revStats.cacheMemoryStat.Value(),
+		"number eviction of delta A must have decremented bytes; stat should equal delta B only")
+}
+
+// TestMemoryStatTracksUsageWithUnlimitedCapacity verifies that with MaxBytes=0 (no memory
+// limit), the shared stat still accurately tracks the sum of bytes in the revision cache
+// as items are added and removed, and never goes negative.
+func TestMemoryStatTracksUsageWithUnlimitedCapacity(t *testing.T) {
+	ctx := base.TestCtx(t)
+
+	revStats := newTestRevCacheStats()
+
+	// MaxBytes=0: IsOverCapacity() always false — eviction never fires, only accounting.
+	opts := &RevisionCacheOptions{MaxItemCount: 100, MaxBytes: 0}
+	orchestrator := NewRevisionCacheOrchestrator(
+		opts, CreateTestSingleBackingStoreMap(&noopBackingStore{}, testCollectionID),
+		revStats, &base.DeltaSyncStats{}, false,
+	)
+
+	cv1 := Version{Value: 1, SourceID: "test"}
+	cv2 := Version{Value: 2, SourceID: "test"}
+
+	// Put two revisions with different bodies.
+	// rev1: len(`{"v":1}`) = 7 bytes; rev2: len(`{"v":2,"x":"y"}`) = 15 bytes.
+	orchestrator.Put(ctx, makeTestRevision("doc1", cv1, `{"v":1}`), testCollectionID)
+	assert.Equal(t, int64(7), revStats.cacheMemoryStat.Value())
+	assert.Equal(t, int64(1), revStats.cacheNumItemsStat.Value())
+
+	orchestrator.Put(ctx, makeTestRevision("doc2", cv2, `{"v":2,"x":"y"}`), testCollectionID)
+	assert.Equal(t, int64(22), revStats.cacheMemoryStat.Value(), "stat should be the sum of both revision bodies")
+	assert.Equal(t, int64(2), revStats.cacheNumItemsStat.Value())
+
+	// Remove rev1 — stat must decrease by exactly rev1's bytes.
+	orchestrator.Remove(ctx, "doc1", cv1.String(), testCollectionID)
+	assert.Equal(t, int64(15), revStats.cacheMemoryStat.Value(), "stat should reflect only rev2 after removing rev1")
+	assert.Equal(t, int64(1), revStats.cacheNumItemsStat.Value())
+	assert.True(t, revStats.cacheMemoryStat.Value() >= 0, "memory stat must never go negative")
+
+	// Remove rev2 — stat must reach exactly zero.
+	orchestrator.Remove(ctx, "doc2", cv2.String(), testCollectionID)
+	assert.Equal(t, int64(0), revStats.cacheMemoryStat.Value(), "all items removed — stat must be 0")
+	assert.Equal(t, int64(0), revStats.cacheNumItemsStat.Value())
+
+	// Remove rev2 - item doesn't exist, stats stay same
+	orchestrator.Remove(ctx, "doc2", cv2.String(), testCollectionID)
+	assert.Equal(t, int64(0), revStats.cacheMemoryStat.Value(), "all items removed — stat must be 0")
+	assert.Equal(t, int64(0), revStats.cacheNumItemsStat.Value())
+}

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -3125,7 +3125,7 @@ func TestConcurrentPutAndRemoveRace(t *testing.T) {
 
 	// Verify stat consistency: the memory stat must equal the sum of bytes of items
 	// actually resident in the cache.
-	var expectedBytes int64
+	var expectedBytes, numFound int64
 	for iter := range iterations {
 		for i := range numDocs {
 			docID := fmt.Sprintf("doc-%d-%d", iter, i)
@@ -3134,12 +3134,13 @@ func TestConcurrentPutAndRemoveRace(t *testing.T) {
 			if found {
 				docRev.CalculateBytes()
 				expectedBytes += docRev.MemoryBytes
+				numFound++
 			}
 		}
 	}
 	assert.Equal(t, expectedBytes, revStats.cacheMemoryStat.Value(),
 		"memory stat must equal the sum of bytes of items actually in the cache")
-	assert.True(t, revStats.cacheMemoryStat.Value() >= 0, "memory stat must never go negative")
+	assert.Equal(t, numFound, revStats.cacheNumItemsStat.Value())
 }
 
 // TestConcurrentGetAndRemoveRace exercises the Get (cache-miss load)/Remove race. A backing store
@@ -3179,7 +3180,21 @@ func TestConcurrentGetAndRemoveRace(t *testing.T) {
 	wg.Wait()
 
 	// Memory stat must be non-negative and consistent with what's in the cache.
-	assert.True(t, revStats.cacheMemoryStat.Value() >= 0, "memory stat must never go negative")
+	// Verify stat consistency: the memory stat must equal the sum of bytes of items
+	// actually resident in the cache.
+	var expectedBytes, numFound int64
+	for i := range numDocs {
+		docID := fmt.Sprintf("doc-%d", i)
+		cv := Version{Value: 123, SourceID: "test"}
+		docRev, found := orchestrator.Peek(ctx, docID, cv.String(), testCollectionID)
+		if found {
+			docRev.CalculateBytes()
+			expectedBytes += docRev.MemoryBytes
+			numFound++
+		}
+	}
+	assert.Equal(t, expectedBytes, revStats.cacheMemoryStat.Value())
+	assert.Equal(t, numFound, revStats.cacheNumItemsStat.Value())
 }
 
 // TestRemoveDuringNumberBasedEviction verifies that when a Put triggers number-based eviction
@@ -3216,10 +3231,21 @@ func TestRemoveDuringNumberBasedEviction(t *testing.T) {
 	}
 	wg.Wait()
 
-	// With MaxItemCount=1, at most 1 item should remain.
-	assert.True(t, revStats.cacheNumItemsStat.Value() <= 1,
-		"with MaxItemCount=1, at most 1 item should remain in cache")
-	assert.True(t, revStats.cacheMemoryStat.Value() >= 0, "memory stat must never go negative")
+	// With MaxItemCount=1, 1 item should remain.
+	// get copilot to suggest assertion here
+	var expectedBytes, numFound int64
+	for i := range numDocs {
+		cv := Version{Value: uint64(i + 1), SourceID: "test"}
+		docID := fmt.Sprintf("doc-%d", i)
+		docRev, found := orchestrator.Peek(ctx, docID, cv.String(), testCollectionID)
+		if found {
+			docRev.CalculateBytes()
+			expectedBytes += docRev.MemoryBytes
+			numFound++
+		}
+	}
+	assert.Equal(t, expectedBytes, revStats.cacheMemoryStat.Value())
+	assert.Equal(t, numFound, revStats.cacheNumItemsStat.Value())
 }
 
 // TestConcurrentUpsertAndRemoveRace exercises the Upsert/Remove race. Upsert replaces an
@@ -3266,7 +3292,19 @@ func TestConcurrentUpsertAndRemoveRace(t *testing.T) {
 	}
 	wg.Wait()
 
-	assert.True(t, revStats.cacheMemoryStat.Value() >= 0, "memory stat must never go negative")
+	var expectedBytes, numFound int64
+	for i := range numDocs {
+		docID := fmt.Sprintf("doc-%d", i)
+		cv := Version{Value: 1, SourceID: "test"}
+		docRev, found := orchestrator.Peek(ctx, docID, cv.String(), testCollectionID)
+		if found {
+			docRev.CalculateBytes()
+			expectedBytes += docRev.MemoryBytes
+			numFound++
+		}
+	}
+	assert.Equal(t, expectedBytes, revStats.cacheMemoryStat.Value())
+	assert.Equal(t, numFound, revStats.cacheNumItemsStat.Value())
 }
 
 // TestMemoryEvictionDuringConcurrentPuts verifies that when memory-based eviction fires during
@@ -3298,8 +3336,6 @@ func TestMemoryEvictionDuringConcurrentPuts(t *testing.T) {
 	wg.Wait()
 
 	// After all concurrent Puts and evictions settle, the memory stat should be at or below capacity.
-	assert.True(t, revStats.cacheMemoryStat.Value() >= 0, "memory stat must never go negative")
-	assert.True(t, revStats.cacheMemoryStat.Value() <= maxBytes,
-		"memory stat (%d) should be at or below capacity (%d) after eviction settles",
-		revStats.cacheMemoryStat.Value(), maxBytes)
+	assert.Equal(t, int64(44), revStats.cacheMemoryStat.Value(), "we should have 4 items worth of memory")
+	assert.Equal(t, int64(4), revStats.cacheNumItemsStat.Value(), "we should have 4 items in cache")
 }

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -326,7 +326,7 @@ func TestLRURevisionCacheEvictionMemoryBased(t *testing.T) {
 
 			// assert doc "2" has been evicted even though we only have 9 items in cache with capacity of 10, so memory based
 			// eviction took place
-			docRev, _, ok = db.revisionCache.Peek(ctx, "2", versionKey(versions[2], rev), collection.GetCollectionID())
+			docRev, ok = db.revisionCache.Peek(ctx, "2", versionKey(versions[2], rev), collection.GetCollectionID())
 			assert.False(t, ok)
 			assert.Nil(t, docRev.BodyBytes)
 

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -1098,9 +1098,16 @@ func (c *collectionRevisionCache) PutRevEntry(t *testing.T, ctx context.Context,
 	} else {
 		cache = (*c.revCache).(*RevisionCacheOrchestrator)
 	}
+	val := cache.revisionCache.getValue(ctx, docRev.DocID, docRev.RevID, c.collectionID, false)
 	// Remove any existing entry so that store() below is not a no-op.
 	cache.Remove(ctx, docRev.DocID, docRev.RevID, c.collectionID)
+	if val.memState.Swap(memStateRemoved) == memStateSized {
+		cache.memoryController.decrementBytesCount(val.itemBytes.Load())
+	}
 	value := cache.revisionCache.getValue(ctx, docRev.DocID, docRev.RevID, c.collectionID, true)
 	docRev.CalculateBytes()
 	value.store(docRev)
+	if value.memState.CompareAndSwap(memStateLoading, memStateSized) {
+		cache.memoryController.incrementBytesCount(docRev.MemoryBytes)
+	}
 }

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -1101,7 +1101,7 @@ func (c *collectionRevisionCache) PutRevEntry(t *testing.T, ctx context.Context,
 	val := cache.revisionCache.getValue(ctx, docRev.DocID, docRev.RevID, c.collectionID, false)
 	// Remove any existing entry so that store() below is not a no-op.
 	cache.Remove(ctx, docRev.DocID, docRev.RevID, c.collectionID)
-	if val.memState.Swap(memStateRemoved) == memStateSized {
+	if val != nil && val.memState.Swap(memStateRemoved) == memStateSized {
 		cache.memoryController.decrementBytesCount(val.itemBytes.Load())
 	}
 	value := cache.revisionCache.getValue(ctx, docRev.DocID, docRev.RevID, c.collectionID, true)

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -1102,7 +1102,5 @@ func (c *collectionRevisionCache) PutRevEntry(t *testing.T, ctx context.Context,
 	cache.Remove(ctx, docRev.DocID, docRev.RevID, c.collectionID)
 	value := cache.revisionCache.getValue(ctx, docRev.DocID, docRev.RevID, c.collectionID, true)
 	docRev.CalculateBytes()
-	cache.revisionCache.incrRevCacheMemoryUsage(ctx, docRev.MemoryBytes)
 	value.store(docRev)
-	cache.revisionCache.revCacheMemoryBasedEviction(ctx)
 }


### PR DESCRIPTION
CBG-5232

Memory based eviction for delta cache and revision cache. 
Slight difference to original design, Original design was that a memory controller would control the eviction process, when implementing I felt it was cleaner for the orchestrator to do this given it.s job is to orchestrator between the caches. So memory controller simply sits on each shard and counts memory for that shard and lets the orchestrator know when its over capacity. 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/433/
- [x] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/434/ (disable rev cache)
