### PR TITLE
CBG-5283: proposal to fix stale delta entry

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -631,7 +631,11 @@ func (db *DatabaseCollection) getRevisionChannels(ctx context.Context, docID, re
 	}
 
 	// Rev tree ID: extract channels directly from the revision tree.
-	revChannels, _ := doc.channelsForRevTreeID(rev)
+	revChannels, ok := doc.channelsForRevTreeID(rev)
+	if !ok {
+		// can't find rev (it was either an unknown rev, or an old non-leaf revision that we can't determine channels for)
+		return nil, false, nil
+	}
 	revInfo, revExists := doc.History[rev]
 	if revExists {
 		deleted = revInfo.Deleted

--- a/db/crud.go
+++ b/db/crud.go
@@ -627,14 +627,14 @@ func (db *DatabaseCollection) getRevisionChannels(ctx context.Context, docID, re
 		}
 		// CV does not match the current version; channels cannot be determined without additional
 		// bucket reads. Returning nil channels is safe — access will be denied conservatively.
-		return nil, false, nil
+		return nil, false, ErrMissing
 	}
 
 	// Rev tree ID: extract channels directly from the revision tree.
 	revChannels, ok := doc.channelsForRevTreeID(rev)
 	if !ok {
 		// can't find rev (it was either an unknown rev, or an old non-leaf revision that we can't determine channels for)
-		return nil, false, nil
+		return nil, false, ErrMissing
 	}
 	revInfo, revExists := doc.History[rev]
 	if revExists {

--- a/db/crud.go
+++ b/db/crud.go
@@ -445,7 +445,15 @@ func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromR
 
 	// If delta is found, check whether it is a delta for the toRevID we want.
 	if initialFromRevision.Delta != nil && (initialFromRevision.Delta.ToCV == toRev || initialFromRevision.Delta.ToRevID == toRev) {
-		isAuthorized, redactedBody := db.authorizeUserForChannels(docID, toRev, initialFromRevision.CV, initialFromRevision.Delta.ToChannels, initialFromRevision.Delta.ToDeleted, encodeRevisions(ctx, docID, initialFromRevision.Delta.RevisionHistory))
+		// Fetch fresh channel information for toRev: a user xattr update can change the document's
+		// channels without creating a new revision (createNewRevIDSkipped), which causes DocChanged to
+		// evict the toRevision from the revision cache while leaving the delta cache intact.
+		// Similar situation also for local wins in HLV.
+		toRevChannels, toRevDeleted, err := db.getRevisionChannels(ctx, docID, toRev)
+		if err != nil {
+			return nil, nil, err
+		}
+		isAuthorized, redactedBody := db.authorizeUserForChannels(docID, toRev, initialFromRevision.CV, toRevChannels, toRevDeleted, encodeRevisions(ctx, docID, initialFromRevision.Delta.RevisionHistory))
 		if !isAuthorized {
 			return nil, &redactedBody, nil
 		}
@@ -467,7 +475,12 @@ func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromR
 
 		// Check if another writer beat us to generating the delta and caching it.
 		if fromRevisionForDiff.Delta != nil && (fromRevisionForDiff.Delta.ToCV == toRev || fromRevisionForDiff.Delta.ToRevID == toRev) {
-			isAuthorized, redactedBody := db.authorizeUserForChannels(docID, toRev, fromRevisionForDiff.CV, fromRevisionForDiff.Delta.ToChannels, fromRevisionForDiff.Delta.ToDeleted, encodeRevisions(ctx, docID, fromRevisionForDiff.Delta.RevisionHistory))
+			// Fetch fresh channel information for the same reason as the pre-lock delta cache hit path above.
+			toRevChannels, toRevDeleted, err := db.getRevisionChannels(ctx, docID, toRev)
+			if err != nil {
+				return nil, nil, err
+			}
+			isAuthorized, redactedBody := db.authorizeUserForChannels(docID, toRev, fromRevisionForDiff.CV, toRevChannels, toRevDeleted, encodeRevisions(ctx, docID, fromRevisionForDiff.Delta.RevisionHistory))
 			if !isAuthorized {
 				return nil, &redactedBody, nil
 			}
@@ -575,6 +588,55 @@ func (col *DatabaseCollectionWithUser) authorizeUserForChannels(docID, revID str
 	}
 
 	return true, DocumentRevision{}
+}
+
+// getRevisionChannels returns the current channel set and deletion status for a specific revision.
+// It is used to perform a lightweight, up-to-date access check on a toRevision during a delta cache
+// hit. A user xattr update can change the document's channels without creating a new revision
+// (createNewRevIDSkipped), causing DocChanged to evict the toRevision from the revision cache while
+// leaving the delta cache intact. Fetching fresh channels here ensures authorization is correct.
+//
+// Fast path: if the revision is still present in the revision cache, its channels are returned
+// directly with no backing store I/O.
+//
+// Slow path: if the revision has been evicted from the revision cache (e.g. due to a user xattr
+// update triggering removal in DocChanged), the document is fetched from the backing store using
+// DocUnmarshalSync (sync xattr only, no body) to obtain the current channel information.
+// This avoids the overhead of a full revision cache load cycle.
+func (db *DatabaseCollection) getRevisionChannels(ctx context.Context, docID, rev string) (channels base.Set, deleted bool, err error) {
+	// Fast path: revision is still in the cache, channels are authoritative.
+	if peekedRev, found := db.revisionCache.Peek(ctx, docID, rev); found {
+		return peekedRev.Channels, peekedRev.Deleted, nil
+	}
+
+	// Slow path: fetch sync metadata only from the backing store, without populating the revision cache.
+	doc, err := db.GetDocument(ctx, docID, DocUnmarshalSync)
+	if err != nil {
+		return nil, false, err
+	}
+	if doc == nil {
+		return nil, false, ErrMissing
+	}
+
+	// If revID is a CV string, compare it against the document's current version.
+	// For the stale delta cache scenario, toRev is always the document's current version because
+	// user xattr updates do not create a new revision ID, so the CV will match.
+	if cv, parseErr := ParseVersion(rev); parseErr == nil {
+		if doc.HasCurrentVersion(ctx, cv) == nil {
+			return doc.getCurrentChannels(), doc.Deleted, nil
+		}
+		// CV does not match the current version; channels cannot be determined without additional
+		// bucket reads. Returning nil channels is safe — access will be denied conservatively.
+		return nil, false, nil
+	}
+
+	// Rev tree ID: extract channels directly from the revision tree.
+	revChannels, _ := doc.channelsForRevTreeID(rev)
+	revInfo, revExists := doc.History[rev]
+	if revExists {
+		deleted = revInfo.Deleted
+	}
+	return revChannels, deleted, nil
 }
 
 // Returns the body of a revision of a document, as well as the document's current channels

--- a/db/delta_cache_lru.go
+++ b/db/delta_cache_lru.go
@@ -115,13 +115,9 @@ func (dc *LRUDeltaCache) getCachedDelta(ctx context.Context, docID, fromVersionS
 	return deltaValue
 }
 
-// CalculateDeltaBytes will calculate bytes from delta channels, delta revisions and delta body
+// CalculateDeltaBytes will calculate bytes from delta revisions and delta body
 func (delta *RevisionDelta) CalculateDeltaBytes() {
 	var totalBytes int
-	for v := range delta.ToChannels {
-		bytes := len([]byte(v))
-		totalBytes += bytes
-	}
 	// history calculation
 	historyBytes := 32 * len(delta.RevisionHistory)
 	totalBytes += historyBytes

--- a/db/delta_cache_test.go
+++ b/db/delta_cache_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/channels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -214,4 +215,188 @@ func TestUpdateDeltaWhenNoDeltaCacheInit(t *testing.T) {
 	deltaBytes := make([]byte, 0)
 	testDelta := newRevCacheDelta(bytes.Repeat(deltaBytes, 10), doc1.HLV.GetCurrentVersionString(), docRev, false, nil)
 	db.revisionCache.UpdateDelta(ctx, docID, rev1CV, rev2CV, collection.GetCollectionID(), testDelta)
+}
+
+// TestGetDeltaStaleChannelAfterUserXattrUpdate verifies that GetDelta enforces access control using
+// the current document channels rather than potentially-stale channel data from a cached delta.
+//
+// When a user xattr update changes a document's channels without creating a new revision ID
+// (createNewRevIDSkipped), DocChanged removes the toRevision from the revision cache but leaves any
+// previously-computed delta intact. Without the fix, a user whose access was revoked by the channel
+// change could still receive the delta. With the fix, GetDelta fetches fresh channel information for
+// the toRevision before honouring a cached delta hit. Both the CV-keyed and revID-keyed delta cache
+// paths are exercised.
+func TestGetDeltaStaleChannelAfterUserXattrUpdate(t *testing.T) {
+	if !base.IsEnterpriseEdition() {
+		t.Skip("delta sync requires enterprise edition")
+	}
+	if base.TestDisableRevCache() {
+		t.Skip("test requires delta cache to be in use")
+	}
+
+	const channelOld = "channelOld"
+	const channelNew = "channelNew"
+
+	dbcOptions := DatabaseContextOptions{
+		RevisionCacheOptions: &RevisionCacheOptions{
+			MaxItemCount: 100,
+		},
+		DeltaSyncOptions: DeltaSyncOptions{
+			Enabled:          true,
+			RevMaxAgeSeconds: DefaultDeltaSyncRevMaxAge,
+		},
+	}
+	db, ctx := SetupTestDBWithOptions(t, dbcOptions)
+	defer db.Close(ctx)
+
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+
+	orchestrator, ok := db.revisionCache.(*RevisionCacheOrchestrator)
+	require.True(t, ok, "expected RevisionCacheOrchestrator")
+
+	authenticator := collection.Authenticator(ctx)
+	restrictedUser, err := authenticator.NewUser("restricted", "pass", base.SetOf(channelOld))
+	require.NoError(t, err)
+	authorizedUser, err := authenticator.NewUser("authorized", "pass", base.SetOf(channelNew))
+	require.NoError(t, err)
+
+	restrictedCollection := &DatabaseCollectionWithUser{DatabaseCollection: collection.DatabaseCollection, user: restrictedUser}
+	authorizedCollection := &DatabaseCollectionWithUser{DatabaseCollection: collection.DatabaseCollection, user: authorizedUser}
+
+	// run exercises one delta cache key type (CV or revID) on a fresh document.
+	run := func(t *testing.T, docID, fromRev, toRev string, staleDelta RevisionDelta) {
+		t.Helper()
+		// Inject a stale delta that simulates the state after a user xattr update moved the document
+		// from channelOld to channelNew without creating a new revision.
+		orchestrator.deltaCache.addDelta(ctx, docID, fromRev, toRev, collection.GetCollectionID(), staleDelta)
+
+		// Simulate DocChanged evicting the toRevision from the revision cache.
+		db.revisionCache.Remove(ctx, docID, toRev, collection.GetCollectionID())
+
+		hitsBefore := db.DbStats.DeltaSync().DeltaCacheHit.Value()
+
+		// Restricted user (channelOld only) must be denied — the document is now in channelNew.
+		delta, redactedRev, err := restrictedCollection.GetDelta(ctx, docID, fromRev, toRev)
+		require.NoError(t, err)
+		assert.Nil(t, delta, "restricted user must not receive delta after channel revocation")
+		assert.NotNil(t, redactedRev, "expected a redacted revision for the unauthorized user")
+
+		// Authorized user (channelNew) must still receive the cached delta.
+		delta, redactedRev, err = authorizedCollection.GetDelta(ctx, docID, fromRev, toRev)
+		require.NoError(t, err)
+		assert.NotNil(t, delta, "authorized user must receive delta for the channel they have access to")
+		assert.Nil(t, redactedRev, "expected no redaction for the authorized user")
+		assert.Equal(t, hitsBefore+1, db.DbStats.DeltaSync().DeltaCacheHit.Value(), "expected a delta cache hit for authorized user")
+	}
+
+	t.Run("CV", func(t *testing.T) {
+		docID := SafeDocumentName(t, t.Name()+"CV")
+		rev1ID, doc1, err := collection.Put(ctx, docID, Body{"channels": []string{channelNew}, "foo": "bar"})
+		require.NoError(t, err)
+		rev1CV := doc1.HLV.GetCurrentVersionString()
+
+		_, doc2, err := collection.Put(ctx, docID, Body{"channels": []string{channelNew}, "foo": "baz", BodyRev: rev1ID})
+		require.NoError(t, err)
+		rev2CV := doc2.HLV.GetCurrentVersionString()
+
+		run(t, docID, rev1CV, rev2CV, RevisionDelta{ToCV: rev2CV, DeltaBytes: []byte(`{}`)})
+	})
+
+	t.Run("RevID", func(t *testing.T) {
+		docID := SafeDocumentName(t, t.Name()+"revID")
+		rev1ID, _, err := collection.Put(ctx, docID, Body{"channels": []string{channelNew}, "foo": "bar"})
+		require.NoError(t, err)
+
+		rev2ID, _, err := collection.Put(ctx, docID, Body{"channels": []string{channelNew}, "foo": "baz", BodyRev: rev1ID})
+		require.NoError(t, err)
+
+		run(t, docID, rev1ID, rev2ID, RevisionDelta{ToRevID: rev2ID, DeltaBytes: []byte(`{}`)})
+	})
+}
+
+// TestGetDeltaThreeRevisions verifies that GetDelta returns correct deltas for all three rev-pair
+// combinations of a three-revision document, and that the second request for each pair is served
+// from the delta cache.
+func TestGetDeltaThreeRevisions(t *testing.T) {
+	if !base.IsEnterpriseEdition() {
+		t.Skip("delta sync requires enterprise edition")
+	}
+	if base.TestDisableRevCache() {
+		t.Skip("test requires delta cache to be in use")
+	}
+
+	dbcOptions := DatabaseContextOptions{
+		RevisionCacheOptions: &RevisionCacheOptions{
+			MaxItemCount: 100,
+		},
+		DeltaSyncOptions: DeltaSyncOptions{
+			Enabled:          true,
+			RevMaxAgeSeconds: DefaultDeltaSyncRevMaxAge,
+		},
+	}
+	db, ctx := SetupTestDBWithOptions(t, dbcOptions)
+	defer db.Close(ctx)
+
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+
+	docID := SafeDocumentName(t, t.Name())
+	rev1ID, doc1, err := collection.Put(ctx, docID, Body{"foo": "bar"})
+	require.NoError(t, err)
+	rev1CV := doc1.HLV.GetCurrentVersionString()
+
+	rev2ID, doc2, err := collection.Put(ctx, docID, Body{"foo": "baz", BodyRev: rev1ID})
+	require.NoError(t, err)
+	rev2CV := doc2.HLV.GetCurrentVersionString()
+
+	// assertDeltaTransforms verifies that applying delta.DeltaBytes to fromBody produces toBody.
+	assertDeltaTransforms := func(t *testing.T, delta *RevisionDelta, fromBody, toBody Body) {
+		t.Helper()
+		require.NotNil(t, delta)
+		patched := map[string]interface{}(fromBody)
+		var deltaMap map[string]interface{}
+		require.NoError(t, base.JSONUnmarshal(delta.DeltaBytes, &deltaMap))
+		require.NoError(t, base.Patch(&patched, deltaMap))
+		assert.Equal(t, map[string]interface{}(toBody), patched)
+	}
+
+	// First request for rev1→rev2: delta must be computed (cache miss) and correct.
+	// rev2 is the current document version at this point, so toRev can be loaded directly.
+	delta12, _, err := collection.GetDelta(ctx, docID, rev1CV, rev2CV)
+	require.NoError(t, err)
+	assertDeltaTransforms(t, delta12, Body{"foo": "bar"}, Body{"foo": "baz"})
+	assert.Equal(t, int64(1), db.DbStats.DeltaSync().DeltaCacheMiss.Value())
+	assert.Equal(t, int64(0), db.DbStats.DeltaSync().DeltaCacheHit.Value())
+
+	_, doc3, err := collection.Put(ctx, docID, Body{"foo": "qux", BodyRev: rev2ID})
+	require.NoError(t, err)
+	rev3CV := doc3.HLV.GetCurrentVersionString()
+
+	// First request for rev2→rev3: delta must be computed (cache miss) and correct.
+	// rev3 is the current document version at this point, so toRev can be loaded directly.
+	delta23, _, err := collection.GetDelta(ctx, docID, rev2CV, rev3CV)
+	require.NoError(t, err)
+	assertDeltaTransforms(t, delta23, Body{"foo": "baz"}, Body{"foo": "qux"})
+	assert.Equal(t, int64(2), db.DbStats.DeltaSync().DeltaCacheMiss.Value())
+	assert.Equal(t, int64(0), db.DbStats.DeltaSync().DeltaCacheHit.Value())
+
+	// Second request for rev1→rev2: must be served from the cache and still correct.
+	delta12Cached, _, err := collection.GetDelta(ctx, docID, rev1CV, rev2CV)
+	require.NoError(t, err)
+	assertDeltaTransforms(t, delta12Cached, Body{"foo": "bar"}, Body{"foo": "baz"})
+	assert.Equal(t, int64(1), db.DbStats.DeltaSync().DeltaCacheHit.Value())
+
+	// Second request for rev2→rev3: must be served from the cache and still correct.
+	delta23Cached, _, err := collection.GetDelta(ctx, docID, rev2CV, rev3CV)
+	require.NoError(t, err)
+	assertDeltaTransforms(t, delta23Cached, Body{"foo": "baz"}, Body{"foo": "qux"})
+	assert.Equal(t, int64(2), db.DbStats.DeltaSync().DeltaCacheHit.Value())
+
+	// First request for rev1→rev3: a new pair, so the delta must be computed (cache miss) and correct.
+	// rev3 is still the current document version; rev1's body is retrieved from the delta backup store.
+	delta13, _, err := collection.GetDelta(ctx, docID, rev1CV, rev3CV)
+	require.NoError(t, err)
+	assertDeltaTransforms(t, delta13, Body{"foo": "bar"}, Body{"foo": "qux"})
+	assert.Equal(t, int64(3), db.DbStats.DeltaSync().DeltaCacheMiss.Value())
+	assert.Equal(t, int64(2), db.DbStats.DeltaSync().DeltaCacheHit.Value())
 }

--- a/db/delta_cache_test.go
+++ b/db/delta_cache_test.go
@@ -400,3 +400,52 @@ func TestGetDeltaThreeRevisions(t *testing.T) {
 	assert.Equal(t, int64(3), db.DbStats.DeltaSync().DeltaCacheMiss.Value())
 	assert.Equal(t, int64(2), db.DbStats.DeltaSync().DeltaCacheHit.Value())
 }
+
+func TestAccessCheckOnNonCurrentRevision(t *testing.T) {
+	if !base.IsEnterpriseEdition() {
+		t.Skip("delta sync requires enterprise edition")
+	}
+	if base.TestDisableRevCache() {
+		t.Skip("test requires delta cache to be in use")
+	}
+
+	dbcOptions := DatabaseContextOptions{
+		RevisionCacheOptions: &RevisionCacheOptions{
+			MaxItemCount: 100,
+		},
+		DeltaSyncOptions: DeltaSyncOptions{
+			Enabled:          true,
+			RevMaxAgeSeconds: DefaultDeltaSyncRevMaxAge,
+		},
+	}
+	db, ctx := SetupTestDBWithOptions(t, dbcOptions)
+	defer db.Close(ctx)
+
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+
+	docID := SafeDocumentName(t, t.Name())
+	rev1ID, doc1, err := collection.Put(ctx, docID, Body{"channels": "A"})
+	require.NoError(t, err)
+	rev1CV := doc1.HLV.GetCurrentVersionString()
+
+	rev2ID, doc2, err := collection.Put(ctx, docID, Body{"channels": "A", BodyRev: rev1ID})
+	require.NoError(t, err)
+	rev2CV := doc2.HLV.GetCurrentVersionString()
+
+	// request delta from rev1->rev2 to cache it
+	_, _, err = collection.GetDelta(ctx, docID, rev1CV, rev2CV)
+	require.NoError(t, err)
+
+	// create third revision to make rev2 non-current revision
+	_, _, err = collection.Put(ctx, docID, Body{"channels": "A", BodyRev: rev2ID})
+	require.NoError(t, err)
+
+	// flush main revision cache
+	db.FlushRevisionCacheForTest()
+
+	// Now request delta from rev1->rev2, delta cached but no rev2 in revision cache so fetch is done to see channel access,
+	// should return missing error given rev2 is no longer current revision
+	_, _, err = collection.GetDelta(ctx, docID, rev1CV, rev2CV)
+	require.ErrorContains(t, err, "404 missing")
+}

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -371,7 +371,6 @@ type RevisionDelta struct {
 	ToCV                  string                  // Target CV for the delta
 	DeltaBytes            []byte                  // The actual delta
 	AttachmentStorageMeta []AttachmentStorageMeta // Storage metadata of all attachments present on ToRevID
-	ToChannels            base.Set                // Full list of channels for the to revision
 	RevisionHistory       []string                // Revision history from parent of ToRevID to source revID, in descending order
 	HlvHistory            string                  // HLV History in CBL format
 	ToDeleted             bool                    // Flag if ToRevID is a tombstone
@@ -383,7 +382,6 @@ func newRevCacheDelta(deltaBytes []byte, fromRevID string, toRevision DocumentRe
 		ToRevID:               toRevision.RevID,
 		DeltaBytes:            deltaBytes,
 		AttachmentStorageMeta: toRevAttStorageMeta,
-		ToChannels:            toRevision.Channels,
 		RevisionHistory:       toRevision.History.parseAncestorRevisions(fromRevID),
 		HlvHistory:            toRevision.HlvHistory,
 		ToDeleted:             deleted,


### PR DESCRIPTION
CBG-5283

- Remove to channels off delta
- Fetch to revision from rev cache if available. If not we do slow path of KV fetch with unmarshal sync to gain channel access info. 
- We do not store channel info for HLV versions unless its current and we also do not store revID channel info unless its a leaf revision now. In any case its not available we deny access. 
- This situation will either fix itself almost immediately or a removal will be sent instead fo client asking for delta. But in any case it could be a good gap to fill up. 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
