### PR TITLE
CBG-5285: flake fix for TestActiveReplicatorPushAndPullConflict

### DIFF
--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -4261,20 +4261,6 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 				require.NoError(t, ar.Start(ctx1))
 				t.Logf("Replicator started")
 
-				// wait for both push and pull to complete:
-				// - the document originally written to rt2 to arrive at rt1
-				// - the document originally written to rt1 to get a conflict on push
-				// - if applicable: the resolved rev to be pushed up to rt2
-				require.EventuallyWithTf(t, func(c *assert.CollectT) {
-					status := ar.GetStatus(ctx1)
-					assert.Equal(c, 1, int(status.PullReplicationStatus.DocsRead))
-					assert.Equal(c, 1, int(status.PushReplicationStatus.DocWriteConflict))
-					if test.expectedPushResolved {
-						assert.Equal(c, 1, int(status.PushReplicationStatus.DocsWritten))
-					}
-				}, 10*time.Second, 100*time.Millisecond, "Expected both push and pull to be completed: %+v", ar.GetStatus(ctx1))
-				t.Logf("========================Replication should be done, checking with changes")
-
 				// Validate results on the local (rt1)
 				changesResults := rt1.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d", localDoc.Sequence), "", true)
 				assert.Equal(t, docID, changesResults.Results[0].ID)


### PR DESCRIPTION
CBG-5285

Remove assertions on stats to assert that both push and pull are complete. The issue is there is no gurentee on these stats. For example, 
- Setup push and pull replicator
-  pull starts up before push does and pulls remotes version
-  Solves for remote and writes remotes version as its current version. 
- Then push starts up after this has happened
- Sends its newly resolved confoict version lcoally 
- Remote rejects chnage as it alrwady has it 

So in this case `DocWriteConflict` doesn't get incremented as the push replication doesn't push the conflict before it gets resolved on active. Its a race condition and these assertions aren't always going to be true for it, i've removed them as really assertions below this assert the conflict is correctly resolved. I don't think these assertions are needed. 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/469/
