### PR TITLE
CBG-5289: nil check on map niled by closure of server context

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -265,6 +265,16 @@ func (h *handler) handleDbOnline() error {
 			}
 		}()
 		time.Sleep(time.Duration(input.Delay) * time.Second)
+		// If the server was closed during the delay, skip the reload entirely.
+		// The nil-guard in _getOrAddDatabaseFromConfig is the definitive safety net,
+		// but this early check avoids acquiring locks and doing expensive work
+		// (bucket connection, index setup) against a torn-down ServerContext.
+		select {
+		case <-h.server.serverCtx.Done():
+			base.InfofCtx(ctx.Ctx, base.KeyCRUD, "Database %v online cancelled: server context closed", base.MD(h.db.Name))
+			return
+		default:
+		}
 		h.db.AccessLock.Lock()
 		defer h.db.AccessLock.Unlock()
 		if !atomic.CompareAndSwapUint32(&h.db.State, db.DBOffline, db.DBStarting) {

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -264,7 +264,6 @@ func (h *handler) handleDbOnline() error {
 				atomic.StoreUint32(&h.db.State, db.DBOffline)
 			}
 		}()
-		time.Sleep(time.Duration(input.Delay) * time.Second)
 		// If the server was closed during the delay, skip the reload entirely.
 		// The nil-guard in _getOrAddDatabaseFromConfig is the definitive safety net,
 		// but this early check avoids acquiring locks and doing expensive work
@@ -273,7 +272,8 @@ func (h *handler) handleDbOnline() error {
 		case <-h.server.serverCtx.Done():
 			base.InfofCtx(ctx.Ctx, base.KeyCRUD, "Database %v online cancelled: server context closed", base.MD(h.db.Name))
 			return
-		default:
+		case <-time.After(time.Duration(input.Delay) * time.Second):
+			// continue
 		}
 		h.db.AccessLock.Lock()
 		defer h.db.AccessLock.Unlock()

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -1525,6 +1525,38 @@ func TestDBOnlineConcurrent(t *testing.T) {
 	rt.WaitForDBOnline()
 }
 
+// TestHandleDbOnlineRaceWithClose is a regression test for a panic caused by a race between
+// the background goroutine spawned by handleDbOnline and sc.Close() nilling sc._databases.
+//
+// handleDbOnline returns 200 immediately but spawns a goroutine that sleeps for the requested
+// delay before acquiring _databasesLock to reload the database. If rt.Close() runs during
+// that sleep window it acquires _databasesLock, sets sc._databases = nil, and releases the lock.
+// The goroutine then acquires the lock and panics with "assignment to entry in nil map" at
+// server_context.go:1050 (sc._databases[dbcontext.Name] = dbcontext).
+func TestHandleDbOnlineRaceWithClose(t *testing.T) {
+	base.LongRunningTest(t)
+
+	rt := rest.NewRestTester(t, nil)
+	// Intentionally not using defer — we call rt.Close() explicitly to control timing.
+
+	// Start with an online DB; take it offline so _online will trigger a reload.
+	rest.RequireStatus(t, rt.SendAdminRequest(http.MethodPost, "/db/_offline", ""), http.StatusOK)
+
+	// POST _online with a 1-second delay. The handler returns 200 immediately and
+	// spawns a background goroutine that will sleep 1s before attempting to reload.
+	rest.RequireStatus(t, rt.SendAdminRequest(http.MethodPost, "/db/_online", `{"delay":1}`), http.StatusOK)
+
+	// Close the server context before the goroutine's 1-second sleep elapses.
+	// sc.Close() acquires _databasesLock, closes all databases, sets sc._databases = nil,
+	// then releases the lock. After the 1s delay the goroutine acquires the lock and
+	// tries to write to the now-nil map, producing the panic.
+	rt.Close()
+
+	// Keep the test goroutine alive long enough for the background goroutine to wake
+	// and attempt the reload against the closed server context.
+	time.Sleep(2 * time.Second)
+}
+
 // Test bring DB online with delay of 1 second
 func TestSingleDBOnlineWithDelay(t *testing.T) {
 

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -1527,12 +1527,6 @@ func TestDBOnlineConcurrent(t *testing.T) {
 
 // TestHandleDbOnlineRaceWithClose is a regression test for a panic caused by a race between
 // the background goroutine spawned by handleDbOnline and sc.Close() nilling sc._databases.
-//
-// handleDbOnline returns 200 immediately but spawns a goroutine that sleeps for the requested
-// delay before acquiring _databasesLock to reload the database. If rt.Close() runs during
-// that sleep window it acquires _databasesLock, sets sc._databases = nil, and releases the lock.
-// The goroutine then acquires the lock and panics with "assignment to entry in nil map" at
-// server_context.go:1050 (sc._databases[dbcontext.Name] = dbcontext).
 func TestHandleDbOnlineRaceWithClose(t *testing.T) {
 	base.LongRunningTest(t)
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -697,6 +697,14 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		return nil, err
 	}
 
+	// Guard against a race where sc.Close() has already nilled _databases (e.g. a background
+	// goroutine spawned by handleDbOnline outlives the server context). We hold _databasesLock
+	// here, so this check is definitive: if Close() ran first the map is nil; if we got here
+	// first the map is valid and Close() will wait for us to release the lock before proceeding.
+	if sc._databases == nil {
+		return nil, base.HTTPErrorf(http.StatusServiceUnavailable, "server context is closed")
+	}
+
 	previousDatabase := sc._databases[dbName]
 	if previousDatabase != nil {
 		if options.useExisting {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -80,6 +80,11 @@ type ServerContext struct {
 	_databases          map[string]*db.DatabaseContext    // _databases is a map of dbname to db.DatabaseContext
 	_databasesLock      sync.RWMutex                      // Lock for _databases and other db-specific maps above
 
+	// serverCtx is cancelled by Close() to broadcast server shutdown to all background
+	// goroutines that hold a reference to this ServerContext (e.g. handleDbOnline).
+	serverCtx       context.Context
+	serverCtxCancel context.CancelCauseFunc
+
 	statsContext      *statsContext
 	BootstrapContext  *bootstrapContext
 	HTTPClient        *http.Client
@@ -162,7 +167,7 @@ func (sc *ServerContext) CloseCpuPprofFile(ctx context.Context) (filename string
 }
 
 func NewServerContext(ctx context.Context, config *StartupConfig, persistentConfig bool) *ServerContext {
-
+	serverCtx, serverCtxCancel := context.WithCancelCause(context.Background())
 	sc := &ServerContext{
 		Config:              config,
 		persistentConfig:    persistentConfig,
@@ -177,6 +182,8 @@ func NewServerContext(ctx context.Context, config *StartupConfig, persistentConf
 		hasStarted:          make(chan struct{}),
 		_httpServers:        map[serverType]*serverInfo{},
 		SGCollect:           newSGCollect(ctx),
+		serverCtx:           serverCtx,
+		serverCtxCancel:     serverCtxCancel,
 	}
 	sc.invalidDatabaseConfigTracking = invalidDatabaseConfigs{
 		dbNames: map[string]*invalidConfigInfo{},
@@ -267,6 +274,11 @@ func (sc *ServerContext) PostStartup() {
 const serverContextStopMaxWait = 30 * time.Second
 
 func (sc *ServerContext) Close(ctx context.Context) {
+	// Cancel the server's lifetime context first so that any background goroutines
+	// watching serverCtx.Done() (e.g. handleDbOnline) can exit promptly rather than
+	// continuing work against a server that is tearing down.
+	sc.serverCtxCancel(errors.New("server context is closing"))
+
 	// stop HTTP servers - prevents any further requests from coming in before we continue with tearing down everything else
 	sc.stopHTTPServers(ctx)
 


### PR DESCRIPTION
CBG-5289

- Protect against panic for online endpoint when server context is closed underneath it. 
- This is a test only issue. 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/472/
