### PR TITLE
Fix flake: TestRequireResync

### DIFF
--- a/rest/adminapitest/collections_admin_api_test.go
+++ b/rest/adminapitest/collections_admin_api_test.go
@@ -11,8 +11,8 @@ package adminapitest
 import (
 	"fmt"
 	"net/http"
-	"slices"
 	"testing"
+	"time"
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
@@ -233,41 +233,46 @@ func TestRequireResync(t *testing.T) {
 	resp = rt.CreateDatabase(db2Name, db2Config)
 	rest.RequireStatus(t, resp, http.StatusCreated)
 
+	dbConfigCas1 := getDBConfigCas(rt, db2Name)
+
 	// Get status, verify offline
-	resp = rt.SendAdminRequest("GET", "/"+db2Name+"/", "")
-	rest.RequireStatus(t, resp, http.StatusOK)
-	dbRootResponse := rest.DatabaseRoot{}
-	require.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &dbRootResponse))
+	dbRootResponse := rt.GetDatabaseRoot(db2Name)
 	require.Equal(t, db.RunStateString[db.DBOffline], dbRootResponse.State)
 	require.Equal(t, []string{scopeAndCollection1Name.String()}, dbRootResponse.RequireResync)
 
 	// Call _online, verify it doesn't override offline when resync is still required.
-	// The online call is async, but subsequent get to status should remain offline
 	onlineResponse := rt.SendAdminRequest("POST", "/"+db2Name+"/_online", "")
 	rest.RequireStatus(t, onlineResponse, http.StatusOK)
-	rt.WaitForDatabaseState(db2Name, db.RunStateString[db.DBOffline])
 
+	// The status will transition from: offline -> starting -> offline, so wait for requireResync: true and offline state.
+	//
+	// - /db/_online transitions state to Starting
+	// - Database written to bucket with a new cas value
+	// - requiresResync is set to true
+	// - Database transitions back to Offline
 	needsResync := []string{scope + "." + collection1}
-	rest.WaitAndAssertCondition(t, func() bool {
-		resp = rt.SendAdminRequest("GET", "/"+db2Name+"/", "")
-		rest.RequireStatus(t, resp, http.StatusOK)
-		dbRootResponse = rest.DatabaseRoot{}
-		require.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &dbRootResponse))
-		return slices.Equal(needsResync, dbRootResponse.RequireResync)
-	}, "expected %+v but got %+v for requireResync", needsResync, dbRootResponse.RequireResync)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.NotEqual(c, dbConfigCas1, getDBConfigCas(rt, db2Name))
+		assert.False(c, rt.ServerContext().DatabaseInitManager.HasActiveInitialization(db2Name))
+		dbRootResponse := rt.GetDatabaseRoot(db2Name)
+		assert.Equal(c, needsResync, dbRootResponse.RequireResync)
+		assert.Equal(c, db.RunStateString[db.DBOffline], dbRootResponse.State)
+	}, 10*time.Second, 50*time.Millisecond)
 
-	resp = rt.SendAdminRequest("GET", "/_all_dbs?verbose=true", "")
-	rest.RequireStatus(t, resp, http.StatusOK)
-	var allDBsSummary []rest.DbSummary
-	require.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &allDBsSummary))
-	require.Len(t, allDBsSummary, 2)
-	// databases sorted alphabetically
-	require.Equal(t, db1Name, allDBsSummary[0].DBName)
-	require.Equal(t, db.RunStateString[db.DBOnline], allDBsSummary[0].State)
-	require.Equal(t, false, allDBsSummary[0].RequireResync)
-	require.Equal(t, db2Name, allDBsSummary[1].DBName)
-	require.Equal(t, db.RunStateString[db.DBOffline], allDBsSummary[1].State)
-	require.Equal(t, true, allDBsSummary[1].RequireResync)
+	allDBsSummary := rt.GetAllDBsVerbose()
+	require.Equal(t, []rest.DbSummary{
+		rest.DbSummary{
+			DBName: db1Name,
+			Bucket: rt.Bucket().GetName(),
+			State:  db.RunStateString[db.DBOnline],
+		},
+		rest.DbSummary{
+			DBName:        db2Name,
+			Bucket:        rt.Bucket().GetName(),
+			State:         db.RunStateString[db.DBOffline],
+			RequireResync: true,
+		},
+	}, allDBsSummary)
 
 	// Run resync for collection
 	resyncCollections := base.NewCollectionNames(scopeAndCollection1Name)
@@ -282,23 +287,23 @@ func TestRequireResync(t *testing.T) {
 	require.NoError(t, err)
 	db.RequireBackgroundManagerState(t, db2.ResyncManager, db.BackgroundProcessStateCompleted)
 
-	resp = rt.SendAdminRequest("GET", "/_all_dbs?verbose=true", "")
-	rest.RequireStatus(t, resp, http.StatusOK)
-	allDBsSummary = nil
-	require.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &allDBsSummary))
-	require.Len(t, allDBsSummary, 2)
-	// databases sorted alphabetically
-	require.Equal(t, db1Name, allDBsSummary[0].DBName)
-	require.Equal(t, db.RunStateString[db.DBOnline], allDBsSummary[0].State)
-	require.Equal(t, false, allDBsSummary[0].RequireResync)
-	require.Equal(t, db2Name, allDBsSummary[1].DBName)
-	require.Equal(t, db.RunStateString[db.DBOffline], allDBsSummary[1].State)
-	require.Equal(t, false, allDBsSummary[1].RequireResync)
+	allDBsSummary = rt.GetAllDBsVerbose()
+	require.Equal(t, []rest.DbSummary{
+		rest.DbSummary{
+			DBName:        db1Name,
+			Bucket:        rt.Bucket().GetName(),
+			State:         db.RunStateString[db.DBOnline],
+			RequireResync: false,
+		},
+		rest.DbSummary{
+			DBName:        db2Name,
+			Bucket:        rt.Bucket().GetName(),
+			State:         db.RunStateString[db.DBOffline],
+			RequireResync: false,
+		},
+	}, allDBsSummary)
 
-	resp = rt.SendAdminRequest("GET", "/"+db2Name+"/", "")
-	rest.RequireStatus(t, resp, http.StatusOK)
-	dbRootResponse = rest.DatabaseRoot{}
-	require.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &dbRootResponse))
+	dbRootResponse = rt.GetDatabaseRoot(db2Name)
 	assert.Nil(t, dbRootResponse.RequireResync)
 
 	// Attempt online again, should now succeed
@@ -306,13 +311,23 @@ func TestRequireResync(t *testing.T) {
 	rest.RequireStatus(t, onlineResponse, http.StatusOK)
 	rt.WaitForDatabaseState(db2Name, db.RunStateString[db.DBOnline])
 
-	resp = rt.SendAdminRequest("GET", "/"+db2Name+"/", "")
-	rest.RequireStatus(t, resp, http.StatusOK)
-	dbRootResponse = rest.DatabaseRoot{}
-	require.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &dbRootResponse))
-	assert.Nil(t, dbRootResponse.RequireResync)
+	dbRootResponse = rt.GetDatabaseRoot(db2Name)
 	assert.Nil(t, dbRootResponse.RequireResync)
 
 	resp = rt.SendAdminRequest("GET", "/"+ks_db2_c1+"/testDoc1", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
+}
+
+// getDBConfigCas looks at the db config in the bucket and returns the cas value for a database
+func getDBConfigCas(rt *rest.RestTester, dbName string) uint64 {
+	cas, err := rt.ServerContext().BootstrapContext.GetConfig(
+		rt.Context(),
+		rt.Bucket().GetName(),
+		rt.ServerContext().Config.Bootstrap.ConfigGroupID,
+		dbName,
+		nil,
+	)
+	require.NoError(rt.TB(), err)
+	require.NotZero(rt.TB(), cas)
+	return cas
 }

--- a/rest/adminapitest/collections_admin_api_test.go
+++ b/rest/adminapitest/collections_admin_api_test.go
@@ -320,12 +320,13 @@ func TestRequireResync(t *testing.T) {
 
 // getDBConfigCas looks at the db config in the bucket and returns the cas value for a database
 func getDBConfigCas(rt *rest.RestTester, dbName string) uint64 {
+	var config rest.DatabaseConfig
 	cas, err := rt.ServerContext().BootstrapContext.GetConfig(
 		rt.Context(),
 		rt.Bucket().GetName(),
 		rt.ServerContext().Config.Bootstrap.ConfigGroupID,
 		dbName,
-		nil,
+		&config,
 	)
 	require.NoError(rt.TB(), err)
 	require.NotZero(rt.TB(), cas)

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -207,6 +207,15 @@ func (rt *RestTester) GetDatabaseRoot(dbname string) DatabaseRoot {
 	return dbroot
 }
 
+// GetAllDBsVerbose returns output from /_all_dbs?verbose=true which is a summary of databases sorted by database names.
+func (rt *RestTester) GetAllDBsVerbose() []DbSummary {
+	resp := rt.SendAdminRequest(http.MethodGet, "/_all_dbs?verbose=true", "")
+	RequireStatus(rt.TB(), resp, http.StatusOK)
+	var dbs []DbSummary
+	require.NoError(rt.TB(), base.JSONUnmarshal(resp.BodyBytes(), &dbs))
+	return dbs
+}
+
 // WaitForVersion retries a GET for a given document version until it returns 200 or 201 for a given document and revision. If version is not found, the test will fail.
 func (rt *RestTester) WaitForVersion(docID string, version DocVersion) {
 	if version.RevTreeID == "" {


### PR DESCRIPTION
With /db/_online being async, taking a database online when RequireResync is true will result in the following state transition:

- Offline
- Starting
- Mark RequireResync
- Mark Offline

In order to make sure that the second offline is hit, check db config cas which is written after Starting occurs

Failure was:

```
=== RUN   TestRequireResync
2026-04-13T17:17:42.644Z [INF] t:TestRequireResync Logging stats with frequency: &{1m0s}
2026-04-13T17:17:42.644Z [INF] t:TestRequireResync Initializing server admin connection...
2026-04-13T17:17:42.656Z [INF] t:TestRequireResync Finished initializing server admin connection
2026-04-13T17:17:42.656Z [INF] t:TestRequireResync Initializing bootstrap connection..
2026-04-13T17:17:42.750Z [WRN] t:TestRequireResync Config: No database configs for group "09c06158-b7ee-4a29-a547-c8ce01fb948f". Continuing startup to allow REST API database creation -- rest.(*ServerContext).initializeBootstrapConnection() at server_context.go:2153
2026-04-13T17:17:42.750Z [INF] t:TestRequireResync Finished initializing bootstrap connection
2026-04-13T17:17:42.755Z [INF] HTTP: c:#8155 PUT http://127.0.0.1/db1/ (as ADMIN)
2026-04-13T17:17:42.755Z [INF] db:db1 delta_sync enabled=false with rev_max_age_seconds=86400 for database db1
2026-04-13T17:17:42.755Z [WRN] db:db1 Deprecation notice: setting database configuration option "disable_public_all_docs" to false is deprecated. In the future, public access to the all_docs API will be disabled by default. -- rest.dbcOptionsFromConfig() at server_context.go:1423
2026-04-13T17:17:42.755Z [INF] db:db1 Opening db /db1 as bucket "sg_int_3_1776100407560602330", pool "default", server <couchbase://127.0.0.1?idle_http_connection_timeout=90000&kv_pool_size=2&max_idle_http_connections=64000&max_perhost_idle_http_connections=256>
2026-04-13T17:17:42.755Z [INF] db:db1 Opening Couchbase database sg_int_3_1776100407560602330 on <couchbase://127.0.0.1?idle_http_connection_timeout=90000&kv_pool_size=2&max_idle_http_connections=64000&max_perhost_idle_http_connections=256> as user "<ud>Administrator</ud>"
2026-04-13T17:17:42.755Z [INF] db:db1 Setting query timeouts for bucket sg_int_3_1776100407560602330 to 1m15s
2026-04-13T17:17:42.762Z [INF] b:sg_int_2_1776100407560602330 Setting max_concurrent_query_ops to 256 based on query node count (1)
2026-04-13T17:17:42.781Z [INF] db:db1 Setting max_concurrent_query_ops to 256 based on query node count (1)
2026-04-13T17:17:42.823Z [INF] db:db1 Initializing database db1 ...
2026-04-13T17:17:42.823Z [INF] db:db1 Starting new initialization for database db1 ...
2026-04-13T17:17:42.851Z [INF] c:CleanAgedItems db:db1 Created background task: "CleanAgedItems" with interval 1m0s
2026-04-13T17:17:42.852Z [INF] db:db1 col:sg_test_0 Using default sync function "function(doc){channel(\"sg_test_0\");}" for database db1.sg_test_0.sg_test_0
2026-04-13T17:17:42.852Z [INF] db:db1 col:sg_test_1 Using default sync function "function(doc){channel(\"sg_test_1\");}" for database db1.sg_test_0.sg_test_1
2026-04-13T17:17:42.852Z [INF] db:db1 Waiting for database init to complete...
2026-04-13T17:17:42.870Z [INF] db:db1 col:sg_test_0 Indexes ready - already online when checked
2026-04-13T17:17:42.905Z [INF] db:db1 col:sg_test_1 Indexes ready - already online when checked
2026-04-13T17:17:42.946Z [INF] db:db1 col:_default Indexes ready - already online when checked
2026-04-13T17:17:42.946Z [INF] db:db1 Database init completed, starting online processes
2026-04-13T17:17:42.946Z [INF] c:InsertPendingEntries db:db1 Created background task: "InsertPendingEntries" with interval 2.5s
2026-04-13T17:17:42.946Z [INF] c:CleanSkippedSequenceQueue db:db1 Created background task: "CleanSkippedSequenceQueue" with interval 30m0s
2026-04-13T17:17:43.467Z [INF] db:db1 Using metadata purge interval of 3.00 days for tombstone compaction.
2026-04-13T17:17:43.467Z [INF] c:Compact db:db1 Created background task: "Compact" with interval 24h0m0s
2026-04-13T17:17:43.467Z [INF] c:TotalSyncTimeStat db:db1 Created background task: "TotalSyncTimeStat" with interval 1s
2026-04-13T17:17:43.467Z [INF] db:db1 Attachment Migration: Starting new migration run with migration ID: bd658432-ce89-4920-9278-7e81158bdd16
2026-04-13T17:17:43.473Z [INF] HTTP: c:#8156 db:db1 col:sg_test_0 PUT http://127.0.0.1/db1.sg_test_0.sg_test_0/<ud>testDoc1</ud> (as ADMIN)
2026-04-13T17:17:43.474Z [INF] HTTP: c:#8157 db:db1 col:sg_test_1 PUT http://127.0.0.1/db1.sg_test_0.sg_test_1/<ud>testDoc2</ud> (as ADMIN)
2026-04-13T17:17:43.475Z [INF] HTTP: c:#8158 db:db1 PUT http://127.0.0.1/db1/_config (as ADMIN)
2026-04-13T17:17:43.475Z [INF] Closing db /db1 (bucket "sg_int_3_1776100407560602330")
2026-04-13T17:17:43.738Z [INF] db:db1 [Migration: bd658432-ce89-4920-9278-7e81158bdd16] Attachment Migration was terminated. 0/2 docs changed
2026-04-13T17:17:43.813Z [INF] db:db1 delta_sync enabled=false with rev_max_age_seconds=86400 for database db1
2026-04-13T17:17:43.813Z [WRN] db:db1 Deprecation notice: setting database configuration option "disable_public_all_docs" to false is deprecated. In the future, public access to the all_docs API will be disabled by default. -- rest.dbcOptionsFromConfig() at server_context.go:1423
2026-04-13T17:17:43.813Z [INF] db:db1 Opening db /db1 as bucket "sg_int_3_1776100407560602330", pool "default", server <couchbase://127.0.0.1?idle_http_connection_timeout=90000&kv_pool_size=2&max_idle_http_connections=64000&max_perhost_idle_http_connections=256>
2026-04-13T17:17:43.813Z [INF] db:db1 Opening Couchbase database sg_int_3_1776100407560602330 on <couchbase://127.0.0.1?idle_http_connection_timeout=90000&kv_pool_size=2&max_idle_http_connections=64000&max_perhost_idle_http_connections=256> as user "<ud>Administrator</ud>"
2026-04-13T17:17:43.813Z [INF] db:db1 Setting query timeouts for bucket sg_int_3_1776100407560602330 to 1m15s
2026-04-13T17:17:43.835Z [INF] db:db1 Setting max_concurrent_query_ops to 256 based on query node count (1)
2026-04-13T17:17:43.874Z [INF] db:db1 Initializing database db1 ...
2026-04-13T17:17:43.874Z [INF] db:db1 Starting new initialization for database db1 ...
2026-04-13T17:17:43.899Z [INF] c:CleanAgedItems db:db1 Created background task: "CleanAgedItems" with interval 1m0s
2026-04-13T17:17:43.900Z [INF] db:db1 col:sg_test_1 Using default sync function "function(doc){channel(\"sg_test_1\");}" for database db1.sg_test_0.sg_test_1
2026-04-13T17:17:43.900Z [INF] db:db1 Waiting for database init to complete...
2026-04-13T17:17:43.916Z [INF] db:db1 col:sg_test_1 Indexes ready - already online when checked
2026-04-13T17:17:43.940Z [INF] db:db1 col:_default Indexes ready - already online when checked
2026-04-13T17:17:43.940Z [INF] db:db1 Database init completed, starting online processes
2026-04-13T17:17:43.940Z [INF] c:InsertPendingEntries db:db1 Created background task: "InsertPendingEntries" with interval 2.5s
2026-04-13T17:17:43.940Z [INF] c:CleanSkippedSequenceQueue db:db1 Created background task: "CleanSkippedSequenceQueue" with interval 30m0s
2026-04-13T17:17:44.244Z [INF] db:db1 Using metadata purge interval of 3.00 days for tombstone compaction.
2026-04-13T17:17:44.244Z [INF] c:Compact db:db1 Created background task: "Compact" with interval 24h0m0s
2026-04-13T17:17:44.244Z [INF] c:TotalSyncTimeStat db:db1 Created background task: "TotalSyncTimeStat" with interval 1s
2026-04-13T17:17:44.245Z [INF] db:db1 Attachment Migration: Resuming migration with migration ID: bd658432-ce89-4920-9278-7e81158bdd16, 2 already processed
2026-04-13T17:17:44.250Z [INF] HTTP: c:#8159 db:db1 col:sg_test_1 GET http://127.0.0.1/db1.sg_test_0.sg_test_1/<ud>testDoc2</ud> (as ADMIN)
2026-04-13T17:17:44.252Z [INF] HTTP: c:#8160 PUT http://127.0.0.1/db2/ (as ADMIN)
2026-04-13T17:17:44.253Z [INF] db:db2 delta_sync enabled=false with rev_max_age_seconds=86400 for database db2
2026-04-13T17:17:44.253Z [WRN] db:db2 Deprecation notice: setting database configuration option "disable_public_all_docs" to false is deprecated. In the future, public access to the all_docs API will be disabled by default. -- rest.dbcOptionsFromConfig() at server_context.go:1423
2026-04-13T17:17:44.253Z [INF] db:db2 Opening db /db2 as bucket "sg_int_3_1776100407560602330", pool "default", server <couchbase://127.0.0.1?idle_http_connection_timeout=90000&kv_pool_size=2&max_idle_http_connections=64000&max_perhost_idle_http_connections=256>
2026-04-13T17:17:44.253Z [INF] db:db2 Opening Couchbase database sg_int_3_1776100407560602330 on <couchbase://127.0.0.1?idle_http_connection_timeout=90000&kv_pool_size=2&max_idle_http_connections=64000&max_perhost_idle_http_connections=256> as user "<ud>Administrator</ud>"
2026-04-13T17:17:44.253Z [INF] db:db2 Setting query timeouts for bucket sg_int_3_1776100407560602330 to 1m15s
2026-04-13T17:17:44.279Z [INF] db:db2 Setting max_concurrent_query_ops to 256 based on query node count (1)
2026-04-13T17:17:44.324Z [INF] db:db2 Initializing database db2 ...
2026-04-13T17:17:44.324Z [INF] db:db2 Starting new initialization for database db2 ...
2026-04-13T17:17:44.354Z [INF] c:CleanAgedItems db:db2 Created background task: "CleanAgedItems" with interval 1m0s
2026-04-13T17:17:44.354Z [INF] db:db2 col:sg_test_0 Using default sync function "function(doc){channel(\"sg_test_0\");}" for database db2.sg_test_0.sg_test_0
2026-04-13T17:17:44.356Z [INF] HTTP: c:#8161 db:db2 GET http://127.0.0.1/db2/ (as ADMIN)
2026-04-13T17:17:44.356Z [INF] HTTP: c:#8162 db:db2 POST http://127.0.0.1/db2/_online (as ADMIN)
2026-04-13T17:17:44.356Z [INF] HTTP: c:#8163 db:db2 GET http://127.0.0.1/db2/ (as ADMIN)
    collections_admin_api_test.go:251: starting WaitAndAssertCondition
2026-04-13T17:17:44.356Z [INF] HTTP: c:#8164 db:db2 GET http://127.0.0.1/db2/ (as ADMIN)
2026-04-13T17:17:44.356Z [INF] HTTP: c:#8165 GET http://127.0.0.1/_all_dbs?verbose=true (as ADMIN)
    collections_admin_api_test.go:269: 
        	Error Trace:	/home/ubuntu/workspace/SyncGatewayIntegration/rest/adminapitest/collections_admin_api_test.go:269
        	Error:      	Not equal: 
        	            	expected: "Offline"
        	            	actual  : "Starting"
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1 +1 @@
        	            	-Offline
        	            	+Starting
        	Test:       	TestRequireResync
2026-04-13T17:17:44.357Z [WRN] gocb: Failed to close cluster connectionManager in cluster close: cluster closed -- v2.logExf() at logging.go:125
2026-04-13T17:17:44.357Z [WRN] t:TestRequireResync Failed to close cluster connection: cluster closed -- base.(*CouchbaseCluster).GetClusterConnectionForBucket.func1() at bootstrap.go:537
2026-04-13T17:17:44.379Z [INF] db:db2 col:_default Indexes ready - already online when checked
2026-04-13T17:17:44.416Z [INF] db:db2 col:sg_test_0 Indexes ready - already online when checked
2026-04-13T17:17:44.539Z [INF] db:db1 [Migration: bd658432-ce89-4920-9278-7e81158bdd16] Attachment Migration was terminated. 0/3 docs changed
2026-04-13T17:17:44.665Z [INF] db:db2 delta_sync enabled=false with rev_max_age_seconds=86400 for database db2
2026-04-13T17:17:44.665Z [WRN] db:db2 Deprecation notice: setting database configuration option "disable_public_all_docs" to false is deprecated. In the future, public access to the all_docs API will be disabled by default. -- rest.dbcOptionsFromConfig() at server_context.go:1423
2026-04-13T17:17:44.665Z [INF] db:db2 Opening db /db2 as bucket "sg_int_3_1776100407560602330", pool "default", server <couchbase://127.0.0.1?idle_http_connection_timeout=90000&kv_pool_size=2&max_idle_http_connections=64000&max_perhost_idle_http_connections=256>
2026-04-13T17:17:44.665Z [INF] db:db2 Opening Couchbase database sg_int_3_1776100407560602330 on <couchbase://127.0.0.1?idle_http_connection_timeout=90000&kv_pool_size=2&max_idle_http_connections=64000&max_perhost_idle_http_connections=256> as user "<ud>Administrator</ud>"
2026-04-13T17:17:44.665Z [INF] db:db2 Setting query timeouts for bucket sg_int_3_1776100407560602330 to 1m15s
--- FAIL: TestRequireResync (2.02s)
=== RUN   TestResyncRollback
2026-04-13T17:17:44.665Z [INF] t:TestResyncRollback Logging stats with frequency: &{1m0s}
2026-04-13T17:17:44.666Z [INF] t:TestResyncRollback Initializing server admin connection...
2026-04-13T17:17:44.678Z [INF] t:TestResyncRollback Finished initializing server admin connection
2026-04-13T17:17:44.679Z [INF] t:TestResyncRollback db:db delta_sync enabled=false with rev_max_age_seconds=86400 for database db
2026-04-13T17:17:44.679Z [WRN] t:TestResyncRollback db:db Deprecation notice: setting database configuration option "disable_public_all_docs" to false is deprecated. In the future, public access to the all_docs API will be disabled by default. -- rest.dbcOptionsFromConfig() at server_context.go:1423
2026-04-13T17:17:44.679Z [INF] t:TestResyncRollback db:db Opening db /db as bucket "sg_int_1_1776100407560602330", pool "default", server <couchbase://127.0.0.1?idle_http_connection_timeout=90000&kv_pool_size=2&max_idle_http_connections=64000&max_perhost_idle_http_connections=256>
2026-04-13T17:17:44.679Z [INF] t:TestResyncRollback db:db Opening Couchbase database sg_int_1_1776100407560602330 on <couchbase://127.0.0.1?idle_http_connection_timeout=90000&kv_pool_size=2&max_idle_http_connections=64000&max_perhost_idle_http_connections=256> as user "<ud>Administrator</ud>"
2026-04-13T17:17:44.679Z [INF] t:TestResyncRollback db:db Setting query timeouts for bucket sg_int_1_1776100407560602330 to 1m15s
2026-04-13T17:17:44.690Z [INF] db:db2 Setting max_concurrent_query_ops to 256 based on query node count (1)
2026-04-13T17:17:44.695Z [INF] t:TestResyncRollback db:db Setting max_concurrent_query_ops to 256 based on query node count (1)
2026-04-13T17:17:44.728Z [INF] db:db2 Initializing database db2 ...
2026-04-13T17:17:44.728Z [INF] db:db2 Starting new initialization for database db2 ...
2026-04-13T17:17:44.728Z [INF] t:TestResyncRollback db:db Initializing database db ...
2026-04-13T17:17:44.728Z [INF] t:TestResyncRollback db:db Starting new initialization for database db ...
2026-04-13T17:17:44.753Z [INF] c:CleanAgedItems db:db2 Created background task: "CleanAgedItems" with interval 1m0s
2026-04-13T17:17:44.753Z [INF] db:db2 col:sg_test_0 Using default sync function "function(doc){channel(\"sg_test_0\");}" for database db2.sg_test_0.sg_test_0
panic: assignment to entry in nil map

goroutine 322907 [running]:
github.com/couchbase/sync_gateway/rest.(*ServerContext)._getOrAddDatabaseFromConfig(_, {_, _}, {0x18a5fa24e2020000, {0xc013aa9950, 0x22}, {0xc000326028, 0x8}, {0xc015344e90, 0x3}, ...}, ...)
	/home/ubuntu/workspace/SyncGatewayIntegration/rest/server_context.go:1050 +0x2d4e
github.com/couchbase/sync_gateway/rest.(*ServerContext)._reloadDatabaseWithConfig(_, {_, _}, {0x18a5fa24e2020000, {0xc013aa9950, 0x22}, {0xc000326028, 0x8}, {0xc015344e90, 0x3}, ...}, ...)
	/home/ubuntu/workspace/SyncGatewayIntegration/rest/server_context.go:581 +0x12f
github.com/couchbase/sync_gateway/rest.(*handler).updateConfigAndReloadDatabase(0xc0135cde00, {{0x1c5b3f8?, 0xc01a2a21b0?}}, {0xc012e9c821, 0x3}, {0xc00659c780, 0x1c}, 0x24?, 0xc00af7b088)
	/home/ubuntu/workspace/SyncGatewayIntegration/rest/admin_api.go:781 +0x358
github.com/couchbase/sync_gateway/rest.(*handler).handleDbOnline.func1({{0x1c5b3f8?, 0xc01a2a21b0?}})
	/home/ubuntu/workspace/SyncGatewayIntegration/rest/admin_api.go:311 +0x3c5
created by github.com/couchbase/sync_gateway/rest.(*handler).handleDbOnline in goroutine 318825
	/home/ubuntu/workspace/SyncGatewayIntegration/rest/admin_api.go:259 +0x35d
```

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`