### PR TITLE
CBG-5239 update go version 1.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ concurrency:
   cancel-in-progress: ${{ !contains(github.ref, 'release/') && !contains(github.ref, 'main') }}
 
 env:
-  GO_VERSION: &go_version 1.25.9
+  GO_VERSION: &go_version 1.26.2
   GOTESTSUM_VERSION: 1.13.0
   GO_TEST_ANNOTATIONS_VERSION: &go_test_annotations_version guyarb/golang-test-annotations@v0.8.0
 
@@ -40,8 +40,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: *go_version
       - name: go-build
@@ -51,8 +51,8 @@ jobs:
     name: addlicense
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: *go_version
       - run: go install github.com/google/addlicense@latest
@@ -62,14 +62,14 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: *go_version
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.7
+          version: v2.11.4
           args: --config=.golangci-strict.yml
 
   test:
@@ -89,8 +89,8 @@ jobs:
       MallocNanoZone: 0
     name: test (${{ matrix.name }})
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: *go_version
       - name: Install gotestsum
@@ -115,8 +115,8 @@ jobs:
     env:
       GOPRIVATE: github.com/couchbaselabs
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: *go_version
       - name: Install gotestsum
@@ -140,8 +140,8 @@ jobs:
       GOPRIVATE: github.com/couchbaselabs
       SG_TEST_USE_DEFAULT_COLLECTION: true
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: *go_version
       - name: Install gotestsum
@@ -163,8 +163,8 @@ jobs:
     env:
       GOPRIVATE: github.com/couchbaselabs
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: *go_version
       - name: Install gotestsum
@@ -189,8 +189,8 @@ jobs:
       GOPRIVATE: github.com/couchbaselabs
       SG_TEST_DISABLE_REV_CACHE: true
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: *go_version
       - name: Install gotestsum
@@ -211,14 +211,14 @@ jobs:
   python-format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: astral-sh/ruff-action@v3
         with:
           args: 'format --check'
   python-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: astral-sh/ruff-action@v3
   test-sgcollect:
     runs-on: ${{ matrix.os }}
@@ -227,7 +227,7 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v7
       - name: Run test
         run: |
@@ -243,8 +243,8 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: *go_version
       - name: Build
@@ -267,8 +267,8 @@ jobs:
     runs-on: ubuntu-latest
     name: build cache perf tool
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: *go_version
       - name: Build

--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -43,11 +43,11 @@ jobs:
     runs-on: ubuntu-latest
     name: Verify service script installation.
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       # build sync gateway since the executable is needed for service installation
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
-          go-version: 1.23.3
+          go-version: 1.26.2
       - name: "Build Sync Gateway"
         run: mkdir -p ./bin && go build -o ./bin ./...
       - name: "Run test scripts"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/couchbase/sync_gateway
 
-go 1.25.9
+go 1.26.2
 
 require (
 	dario.cat/mergo v1.0.0

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -888,7 +888,7 @@
         },
 
         "manifest/default.xml": {
-            "go_version": "1.25.9",
+            "go_version": "1.26.2",
             "interval": 30,
             "production": true,
             "release": "4.1.0",

--- a/topologytest/peer_test.go
+++ b/topologytest/peer_test.go
@@ -287,6 +287,17 @@ const (
 	PeerReplicationDirectionPull
 )
 
+func (r PeerReplicationDirection) String() string {
+	switch r {
+	case PeerReplicationDirectionPush:
+		return "push"
+	case PeerReplicationDirectionPull:
+		return "pull"
+	default:
+		return fmt.Sprintf("unknown replication direction %d", r)
+	}
+}
+
 // PeerReplicationConfig represents the configuration for a given replication.
 type PeerReplicationConfig struct {
 	direction PeerReplicationDirection


### PR DESCRIPTION
CBG-5239 update go version 1.26

- update actions versions
- fix a go vet issue in 1.26

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/5239/
