### PR TITLE
CBG-5296 Wait for DCP client close

### DIFF
--- a/base/dcp_client_test.go
+++ b/base/dcp_client_test.go
@@ -827,10 +827,11 @@ func TestDCPFeedContentBodyOnlyDocs(t *testing.T) {
 					}
 					dcpClient, err := NewDCPClient(ctx, bucket, feedArgs)
 					require.NoError(t, err)
-					_, err = dcpClient.Start()
+					doneChan, err := dcpClient.Start()
 					require.NoError(t, err)
 					defer func() {
 						assert.NoError(t, dcpClient.Close())
+						<-doneChan
 					}()
 
 					if live {

--- a/base/dcp_client_test.go
+++ b/base/dcp_client_test.go
@@ -831,7 +831,7 @@ func TestDCPFeedContentBodyOnlyDocs(t *testing.T) {
 					require.NoError(t, err)
 					defer func() {
 						assert.NoError(t, dcpClient.Close())
-						<-doneChan
+						RequireChanRecv(t, doneChan)
 					}()
 
 					if live {

--- a/base/dcp_client_test.go
+++ b/base/dcp_client_test.go
@@ -65,6 +65,7 @@ func TestOneShotDCP(t *testing.T) {
 
 	defer func() {
 		_ = dcpClient.Close()
+		RequireChanClosed(t, doneChan)
 	}()
 
 	// Add additional documents in a separate goroutine, to verify one-shot behaviour
@@ -392,17 +393,18 @@ func TestContinuousDCPRollback(t *testing.T) {
 	// function to force the rollback of some vBuckets
 	dcpClient1.forceRollbackvBucket(vbUUID)
 
-	_, startErr = dcpClient1.Start()
+	doneChan, startErr := dcpClient1.Start()
 	require.NoError(t, startErr)
+
+	defer func() {
+		assert.NoError(t, dcpClient1.Close())
+		RequireChanClosed(t, doneChan)
+	}()
 
 	// Assert that the number of vBuckets active are the same as the total number of vBuckets on the client.
 	// In continuous rollback the streams should not close after they're finished.
 	numVBuckets := len(dcpClient1.activeVbuckets)
 	require.Equal(t, dcpClient1.numVbuckets, uint16(numVBuckets))
-
-	defer func() {
-		assert.NoError(t, dcpClient1.Close())
-	}()
 
 }
 
@@ -591,6 +593,7 @@ func TestDCPOutOfRangeSequence(t *testing.T) {
 	require.NoError(t, startErr)
 	defer func() {
 		assert.NoError(t, dcpClient.Close())
+		RequireChanClosed(t, doneChan)
 	}()
 
 	select {
@@ -683,6 +686,7 @@ func TestDCPFeedEventTypes(t *testing.T) {
 
 	defer func() {
 		_ = dcpClient.Close() // extra close in case of early exit
+		RequireChanClosed(t, doneChan)
 	}()
 	xattrName := "_xattr1"
 	xattrBody := []byte(`{"an": "xattr"}`)
@@ -706,7 +710,7 @@ func TestDCPFeedEventTypes(t *testing.T) {
 	case <-timeout:
 		t.Fatalf("timeout waiting for doc deletion")
 	}
-	require.NoError(t, <-doneChan)
+	RequireChanClosed(t, doneChan)
 
 	xattrs, _, err := collection.GetXattrs(ctx, docID, []string{"_xattr1"})
 	require.NoError(t, err)
@@ -831,7 +835,7 @@ func TestDCPFeedContentBodyOnlyDocs(t *testing.T) {
 					require.NoError(t, err)
 					defer func() {
 						assert.NoError(t, dcpClient.Close())
-						RequireChanRecv(t, doneChan)
+						RequireChanClosed(t, doneChan)
 					}()
 
 					if live {

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -1037,3 +1037,28 @@ func RequireChanRecvWithTimeout[T any](t testing.TB, ch <-chan T, timeout time.D
 		return *new(T) // unreachable
 	}
 }
+
+// RequireChanClosedWithTimeout waits for channel to be closed. Will drain the channel if required.
+// Fails the test if the channel is not closed in time.
+func RequireChanClosedWithTimeout[T any](t testing.TB, ch <-chan T, timeout time.Duration) {
+	t.Helper()
+	for {
+		select {
+		case _, ok := <-ch:
+			// drain the channel until it's closed, but fail if it isn't closed within the timeout
+			if ok {
+				continue
+			}
+			return
+		case <-time.After(timeout):
+			require.FailNow(t, fmt.Sprintf("timed out after %v waiting for channel send", timeout))
+		}
+	}
+}
+
+// RequireChanClosedWithTimeout waits for channel to be closed. Will drain the channel if required.
+// Fails the test if the channel is not closed in TestChanTimeout.
+func RequireChanClosed[T any](t testing.TB, ch <-chan T) {
+	t.Helper()
+	RequireChanClosedWithTimeout(t, ch, TestChanTimeout)
+}


### PR DESCRIPTION
CBG-5296 Wait for DCP client close

avoid panic of running a DCP feed past when a bucket is closed

This is the reason that I wanted to make Close either obviously synchronous or obviously asynchronous, requiring to close and then wait for doneChan is confusing. 

https://github.com/couchbase/sync_gateway/pull/7919

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/483/
