### PR TITLE
CBG-4985: Support LeakyBucket for CBS in RestTester

### DIFF
--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -160,6 +160,8 @@ type LeakyBucketConfig struct {
 	// AddCallback issues a callback during Add.
 	AddCallback func(key string) (bool, error)
 
+	CreateIndexIfNotExistsCallback func(indexName string)
+
 	// When IgnoreClose is set to true, bucket.Close() is a no-op.  Used when multiple references to a bucket are active.
 	IgnoreClose bool
 }

--- a/base/leaky_datastore.go
+++ b/base/leaky_datastore.go
@@ -415,6 +415,9 @@ func (lds *LeakyDataStore) CreateIndex(ctx context.Context, indexName string, ex
 }
 
 func (lds *LeakyDataStore) CreateIndexIfNotExists(ctx context.Context, indexName string, expression string, filterExpression string, options *N1qlIndexOptions) error {
+	if lds.config.CreateIndexIfNotExistsCallback != nil {
+		lds.config.CreateIndexIfNotExistsCallback(indexName)
+	}
 	n1qlStore, err := lds.getN1QLStore()
 	if err != nil {
 		return err

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -312,8 +312,8 @@ func (tbp *TestBucketPool) GetWalrusTestBucket(t testing.TB, url string) (b Buck
 		tbp.Fatalf(testCtx, "couldn't get %s bucket from <%s>: %v", typeName, url, err)
 	}
 
+	b = walrusBucket
 	// Wrap Walrus buckets with a leaky bucket to support vbucket IDs on feed.
-	b = &LeakyBucket{bucket: walrusBucket, config: &LeakyBucketConfig{}}
 
 	ctx := bucketCtx(testCtx, b)
 	tbp.Logf(ctx, "Creating new %s test bucket", typeName)
@@ -728,11 +728,11 @@ loop:
 
 				start := time.Now()
 				b, err := tbp.cluster.openTestBucket(ctx, testBucketName, waitForReadyBucketTimeout)
-				ctx = KeyspaceLogCtx(ctx, b.GetName(), "", "")
 				if err != nil {
 					tbp.Logf(ctx, "Couldn't open bucket to get ready, got error: %v", err)
 					return
 				}
+				ctx = KeyspaceLogCtx(ctx, b.GetName(), "", "")
 
 				err, _ = RetryLoop(ctx, b.GetName()+"bucketReadierRetry", func() (bool, error, any) {
 					tbp.Logf(ctx, "Running bucket through readier function")

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -2322,10 +2322,9 @@ func TestConfigRedaction(t *testing.T) {
 }
 
 func TestSoftDeleteCasMismatch(t *testing.T) {
-	if !base.UnitTestUrlIsWalrus() {
-		t.Skip("Skip LeakyBucket test when running in integration")
-	}
-	rt := rest.NewRestTester(t, nil)
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		LeakyBucketConfig: &base.LeakyBucketConfig{},
+	})
 	defer rt.Close()
 
 	// Create role

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -2722,9 +2722,6 @@ func TestSendRevAsReadOnlyGuest(t *testing.T) {
 func TestSendRevisionNoRevHandling(t *testing.T) {
 	base.LongRunningTest(t)
 
-	if !base.UnitTestUrlIsWalrus() {
-		t.Skip("Skip LeakyBucket test when running in integration")
-	}
 	testCases := []struct {
 		error       error
 		expectNoRev bool
@@ -2745,9 +2742,10 @@ func TestSendRevisionNoRevHandling(t *testing.T) {
 				docName := fmt.Sprintf("%s", test.error)
 				rt := NewRestTester(t,
 					&RestTesterConfig{
-						GuestEnabled:     true,
-						CustomTestBucket: base.GetTestBucket(t).LeakyBucketClone(base.LeakyBucketConfig{}),
-					})
+						GuestEnabled:      true,
+						LeakyBucketConfig: &base.LeakyBucketConfig{},
+					},
+				)
 				defer rt.Close()
 
 				leakyDataStore, ok := base.AsLeakyDataStore(rt.Bucket().DefaultDataStore())

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -30,12 +30,14 @@ import (
 
 // Reproduces issue #2383 by forcing a partial error from the view on the first changes request.
 func TestReproduce2383(t *testing.T) {
-
 	if !base.UnitTestUrlIsWalrus() {
-		t.Skip("Skip LeakyBucket test when running in integration")
+		t.Skip("Skip test when running in integration, only works in view mode")
 	}
 
-	rt := rest.NewRestTester(t, &rest.RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		SyncFn:            channels.DocChannelsSyncFunction,
+		LeakyBucketConfig: &base.LeakyBucketConfig{},
+	})
 	defer rt.Close()
 
 	ctx := rt.Context()
@@ -2597,13 +2599,12 @@ func TestChangesQueryStarChannelBackfillLimit(t *testing.T) {
 // prepended to the cache.  Reproduces #3475
 func TestChangesViewBackfillSlowQuery(t *testing.T) {
 
-	if !base.UnitTestUrlIsWalrus() {
-		t.Skip("Skip test with LeakyBucket dependency test when running in integration")
-	}
-
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)
 
-	rtConfig := rest.RestTesterConfig{SyncFn: `function(doc, oldDoc){channel(doc.channels);}`}
+	rtConfig := rest.RestTesterConfig{
+		SyncFn:            `function(doc, oldDoc){channel(doc.channels);}`,
+		LeakyBucketConfig: &base.LeakyBucketConfig{},
+	}
 	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
 

--- a/rest/database_init_manager.go
+++ b/rest/database_init_manager.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
@@ -193,6 +194,30 @@ func (m *DatabaseInitManager) Cancel(dbName string, reason string) {
 		return
 	}
 	worker.Stop(reason)
+}
+
+func (m *DatabaseInitManager) Close(ctx context.Context) error {
+	m.cancelWorkers()
+	err, _ := base.RetryLoop(ctx, "Wait for DatabaseInitManager to shutdown",
+		func() (shouldRetry bool, err error, _ any) {
+			m.workersLock.Lock()
+			defer m.workersLock.Unlock()
+			for dbName := range m.workers {
+				return true, fmt.Errorf("DatabaseInitManager still has active initialization for database %s", dbName), nil
+			}
+			return false, nil, nil
+		},
+		base.CreateLinearSleeperFunc(1*time.Minute, 50*time.Millisecond),
+	)
+	return err
+}
+
+func (m *DatabaseInitManager) cancelWorkers() {
+	m.workersLock.Lock()
+	defer m.workersLock.Unlock()
+	for _, worker := range m.workers {
+		worker.Stop("DatabaseInitManager is shutting down, cancelling database initialization.")
+	}
 }
 
 // buildCollectionIndexData determines the set of indexes required for each collection in the config, including

--- a/rest/indextest/resync_test.go
+++ b/rest/indextest/resync_test.go
@@ -19,8 +19,15 @@ import (
 )
 
 func TestResyncWithoutIndexes(t *testing.T) {
+	var createdIndexes []string
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
-		PersistentConfig: true})
+		PersistentConfig: true,
+		LeakyBucketConfig: &base.LeakyBucketConfig{
+			CreateIndexIfNotExistsCallback: func(indexName string) {
+				createdIndexes = append(createdIndexes, indexName)
+			},
+		},
+	})
 	defer rt.Close()
 
 	dbName := "db"
@@ -36,46 +43,21 @@ func TestResyncWithoutIndexes(t *testing.T) {
 	rt.TakeDbOffline()
 
 	if !base.TestsDisableGSI() {
-		for _, collection := range rt.GetDatabase().CollectionByID {
-			n1qlStore, ok := base.AsN1QLStore(collection.GetCollectionDatastore())
-			require.True(t, ok)
-			require.NoError(t, base.DropAllIndexes(rt.Context(), n1qlStore))
-		}
+		rest.DropAllTestIndexesIncludingPrimary(t, rt.TestBucket)
 	}
 
-	// gocb pipeline bootstrap errors can occur before this stage
-	warningsBeforeResync := base.SyncGatewayStats.GlobalStats.ResourceUtilization.WarnCount.Value()
 	rest.RequireStatus(t, rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_resync?action=start", ""), http.StatusOK)
+
 	resyncStatus := rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
+
 	require.Equal(t, int64(1), resyncStatus.DocsChanged)
-	require.Equal(t, int64(0), base.SyncGatewayStats.GlobalStats.ResourceUtilization.WarnCount.Value()-warningsBeforeResync)
-
-	if !base.TestsDisableGSI() {
-		defaultDataStore, ok := base.AsN1QLStore(rt.Bucket().DefaultDataStore())
-		require.True(t, ok)
-
-		numIndexes, err := defaultDataStore.GetIndexes()
-		require.NoError(t, err)
-		if rt.GetDatabase().UseLegacySyncDocsIndex() {
-			require.Len(t, numIndexes, 1) // sg_syncDocs
-		} else {
-			require.Len(t, numIndexes, 2) // sg_roles, sg_syncDocs
-		}
-
-		for _, collection := range rt.GetDatabase().CollectionByID {
-			n1qlStore, ok := base.AsN1QLStore(collection.GetCollectionDatastore())
-			require.True(t, ok)
-			numIndexes, err := n1qlStore.GetIndexes()
-			require.NoError(t, err)
-			if collection.IsDefaultCollection() {
-				if rt.GetDatabase().UseLegacySyncDocsIndex() {
-					require.Len(t, numIndexes, 1) // sg_syncDocs
-				} else {
-					require.Len(t, numIndexes, 2) // sg_roles, sg_syncDocs
-				}
-			} else {
-				require.Len(t, numIndexes, 0, "Expected 0 indexes for non-default collection")
-			}
-		}
+	if base.TestsDisableGSI() {
+		return
 	}
+	if rt.GetDatabase().UseLegacySyncDocsIndex() {
+		require.ElementsMatch(t, []string{"sg_syncDocs_x1"}, createdIndexes)
+	} else {
+		require.ElementsMatch(t, []string{"sg_users_x1", "sg_roles_x1"}, createdIndexes)
+	}
+
 }

--- a/rest/indextest/resync_test.go
+++ b/rest/indextest/resync_test.go
@@ -50,10 +50,10 @@ func TestResyncWithoutIndexes(t *testing.T) {
 	require.Equal(t, int64(1), resyncStatus.DocsChanged)
 	require.Equal(t, int64(0), base.SyncGatewayStats.GlobalStats.ResourceUtilization.WarnCount.Value()-warningsBeforeResync)
 
-	defaultDataStore, ok := base.AsN1QLStore(rt.Bucket().DefaultDataStore())
-	require.True(t, ok)
-
 	if !base.TestsDisableGSI() {
+		defaultDataStore, ok := base.AsN1QLStore(rt.Bucket().DefaultDataStore())
+		require.True(t, ok)
+
 		numIndexes, err := defaultDataStore.GetIndexes()
 		require.NoError(t, err)
 		if rt.GetDatabase().UseLegacySyncDocsIndex() {

--- a/rest/indextest/resync_test.go
+++ b/rest/indextest/resync_test.go
@@ -38,9 +38,9 @@ func TestResyncWithoutIndexes(t *testing.T) {
 	rt.CreateTestDoc("doc1")
 
 	rt.SyncFn = `function(doc, oldDoc) {channel("A")}`
-	rest.RequireStatus(t, rt.UpsertDbConfig(dbName, rt.NewDbConfig()), http.StatusCreated)
-
-	rt.TakeDbOffline()
+	config := rt.NewDbConfig()
+	config.StartOffline = base.Ptr(true)
+	rest.RequireStatus(t, rt.UpsertDbConfig(dbName, config), http.StatusCreated)
 
 	if !base.TestsDisableGSI() {
 		rest.DropAllTestIndexesIncludingPrimary(t, rt.TestBucket)

--- a/rest/replicatortest/replicator_test_helper.go
+++ b/rest/replicatortest/replicator_test_helper.go
@@ -16,7 +16,6 @@ import (
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbase/sync_gateway/rest"
-	"github.com/couchbaselabs/rosmar"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -46,21 +45,6 @@ func addActiveRT(t *testing.T, dbName string, testBucket *base.TestBucket) (acti
 				},
 			},
 		})
-
-	// If this is a walrus bucket, we need to jump through some hoops to ensure the shared in-memory walrus bucket isn't
-	// deleted when bucket.Close() is called during DatabaseContext.Close().
-	// Using IgnoreClose in leakyBucket to no-op the close operation.
-	// Because RestTester has Sync Gateway create the database context and bucket based on the bucketSpec, we can't
-	// set up the leakyBucket wrapper prior to bucket creation.
-	// Instead, we need to modify the leaky bucket config (created for vbno handling) after the fact.
-	leakyBucket, ok := base.AsLeakyBucket(activeRT.GetDatabase().Bucket)
-	if ok {
-		ub := leakyBucket.GetUnderlyingBucket()
-		_, isWalrusBucket := ub.(*rosmar.Bucket)
-		if isWalrusBucket {
-			leakyBucket.SetIgnoreClose(true)
-		}
-	}
 
 	// Trigger the lazy load of bucket for RestTester startup
 	_ = activeRT.Bucket()

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -1208,10 +1208,6 @@ func TestRevocationsWithQueryLimitChangesLimit(t *testing.T) {
 }
 
 func TestRevocationUserHasDocAccessDocNotFound(t *testing.T) {
-	if !base.UnitTestUrlIsWalrus() {
-		t.Skip("Skip test with LeakyBucket dependency when running in integration")
-	}
-
 	revocationTester, rt := InitScenario(t, &RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
 			QueryPaginationLimit: base.Ptr(2),
@@ -1224,6 +1220,7 @@ func TestRevocationUserHasDocAccessDocNotFound(t *testing.T) {
 				},
 			},
 		}},
+		LeakyBucketConfig: &base.LeakyBucketConfig{},
 	})
 	defer rt.Close()
 
@@ -1241,8 +1238,12 @@ func TestRevocationUserHasDocAccessDocNotFound(t *testing.T) {
 
 	leakyDataStore, ok := base.AsLeakyDataStore(rt.GetSingleDataStore())
 	require.True(t, ok)
+	shouldDeleteDoc := true
 	leakyDataStore.SetGetRawCallback(func(s string) error {
-		require.NoError(t, leakyDataStore.Delete("doc"))
+		if shouldDeleteDoc {
+			shouldDeleteDoc = false
+			require.NoError(t, leakyDataStore.Delete("doc"))
+		}
 		return nil
 	})
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -103,7 +103,8 @@ type ServerContext struct {
 	DatabaseInitManager           *DatabaseInitManager // Manages database initialization (index creation and readiness) independent of database stop/start/reload, when using persistent config
 	ActiveReplicationsCounter
 	invalidDatabaseConfigTracking invalidDatabaseConfigs
-	SGCollect                     *sgCollect // singleton instance for this server's sgcollect_info process
+	SGCollect                     *sgCollect      // singleton instance for this server's sgcollect_info process
+	connectToBucketFn             db.OpenBucketFn // supply a custom function for buckets, used for testing only
 }
 
 type ActiveReplicationsCounter struct {
@@ -125,12 +126,11 @@ type bootstrapContext struct {
 }
 
 type getOrAddDatabaseConfigOptions struct {
-	failFast          bool            // if set, a failure to connect to a bucket of collection will immediately fail
-	useExisting       bool            //  if true, return an existing DatabaseContext vs return an error
-	connectToBucketFn db.OpenBucketFn // supply a custom function for buckets, used for testing only
-	forceOnline       bool            // force the database to come online, even if startOffline is set
-	asyncOnline       bool            // Whether getOrAddDatabaseConfig should block until database is ready, when startOffline=false
-	loadFromBucket    bool            // If this is load config from bucket operation
+	failFast       bool // if set, a failure to connect to a bucket of collection will immediately fail
+	useExisting    bool //  if true, return an existing DatabaseContext vs return an error
+	forceOnline    bool // force the database to come online, even if startOffline is set
+	asyncOnline    bool // Whether getOrAddDatabaseConfig should block until database is ready, when startOffline=false
+	loadFromBucket bool // If this is load config from bucket operation
 }
 
 func (sc *ServerContext) CreateLocalDatabase(ctx context.Context, dbs DbConfigMap) error {
@@ -282,9 +282,14 @@ func (sc *ServerContext) Close(ctx context.Context) {
 	// stop HTTP servers - prevents any further requests from coming in before we continue with tearing down everything else
 	sc.stopHTTPServers(ctx)
 
+	err := sc.DatabaseInitManager.Close(ctx)
+	if err != nil {
+		base.AssertfCtx(ctx, "Error waiting for async database initialization to close server context: %v", err)
+	}
+
 	// stop the config polling
 	if err := base.TerminateAndWaitForClose(sc.BootstrapContext.terminator, sc.BootstrapContext.doneChan, serverContextStopMaxWait); err != nil {
-		base.InfofCtx(ctx, base.KeyAll, "Couldn't stop background config update worker: %v", err)
+		base.AssertfCtx(ctx, "Couldn't stop background config update worker: %v", err)
 	}
 
 	// close cached bootstrap bucket connections for config polling
@@ -299,7 +304,7 @@ func (sc *ServerContext) Close(ctx context.Context) {
 	}
 
 	if err := base.TerminateAndWaitForClose(sc.statsContext.terminator, sc.statsContext.doneChan, serverContextStopMaxWait); err != nil {
-		base.InfofCtx(ctx, base.KeyAll, "Couldn't stop stats logger: %v", err)
+		base.AssertfCtx(ctx, "Couldn't stop stats logger when closing ServerContext: %v", err)
 	}
 
 	// close all databases
@@ -750,9 +755,9 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		base.MD(dbName), base.MD(spec.BucketName), base.SD(base.DefaultPool), base.SD(spec.Server))
 
 	// the connectToBucketFn is used for testing seam
-	if options.connectToBucketFn != nil {
+	if sc.connectToBucketFn != nil {
 		// the connectToBucketFn is used for testing seam
-		bucket, err = options.connectToBucketFn(ctx, spec, options.failFast)
+		bucket, err = sc.connectToBucketFn(ctx, spec, options.failFast)
 	} else {
 		bucket, err = db.ConnectToBucket(ctx, spec, options.failFast)
 	}

--- a/rest/serverless_test.go
+++ b/rest/serverless_test.go
@@ -178,6 +178,7 @@ func TestServerlessGoCBConnectionString(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server due to testing gocb connection strings")
 	}
+
 	tests := []struct {
 		name                 string
 		expectedConnstrQuery string
@@ -212,6 +213,7 @@ func TestServerlessGoCBConnectionString(t *testing.T) {
 			defer rt.Close()
 			sc := rt.ServerContext()
 			require.True(t, sc.Config.IsServerless())
+			sc.connectToBucketFn = nil
 
 			resp := rt.SendAdminRequest(http.MethodPut, "/db/", fmt.Sprintf(`{"bucket": "%s", "use_views": %t, "num_index_replicas": 0}`,
 				tb.GetName(), base.TestsDisableGSI()))
@@ -254,8 +256,10 @@ func TestServerlessUnsupportedOptions(t *testing.T) {
 
 			rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb.NoCloseClone(), PersistentConfig: true, serverless: true})
 			defer rt.Close()
+
 			sc := rt.ServerContext()
 			require.True(t, sc.Config.IsServerless())
+			sc.connectToBucketFn = nil
 
 			if test.name == "unsupported options specified" {
 				resp := rt.SendAdminRequest(http.MethodPut, "/db/", fmt.Sprintf(`{"bucket": "%s", "use_views": %t, "num_index_replicas": 0, "unsupported": {"dcp_read_buffer": %d, "kv_buffer": %d}}`,

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -549,10 +549,6 @@ func TestUserAndRoleResponseContentType(t *testing.T) {
 }
 
 func TestObtainUserChannelsForDeletedRoleCasFail(t *testing.T) {
-	if !base.UnitTestUrlIsWalrus() {
-		t.Skip("Skip LeakyBucket test when running in integration")
-	}
-
 	testCases := []struct {
 		Name      string
 		RunBefore bool
@@ -581,6 +577,7 @@ func TestObtainUserChannelsForDeletedRoleCasFail(t *testing.T) {
 				}
 			}
 		`,
+					LeakyBucketConfig: &base.LeakyBucketConfig{},
 				})
 			defer rt.Close()
 			ds := rt.GetSingleDataStore()

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -306,6 +306,16 @@ func (rt *RestTester) Bucket() base.Bucket {
 	sc.Auth.BcryptCost = bcrypt.MinCost
 
 	rt.RestTesterServerContext = NewServerContext(base.TestCtx(rt.TB()), &sc, rt.RestTesterConfig.PersistentConfig)
+
+	_, isLeaky := base.AsLeakyBucket(rt.TestBucket)
+	if rt.LeakyBucketConfig != nil || isLeaky {
+		rt.RestTesterServerContext.connectToBucketFn = func(ctx context.Context, spec base.BucketSpec, failfast bool) (base.Bucket, error) {
+			if spec.BucketName == testBucket.GetName() {
+				return testBucket.NoCloseClone(), nil
+			}
+			return db.ConnectToBucket(ctx, spec, false)
+		}
+	}
 	rt.RestTesterServerContext.allowScopesInPersistentConfig = true
 	if rt.RestTesterConfig.syncGatewayVersion != nil {
 		rt.RestTesterServerContext.BootstrapContext.sgVersion = *rt.RestTesterConfig.syncGatewayVersion
@@ -406,13 +416,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 			_, err := rt.TestBucket.GetMetadataStore().Incr(syncSeqKey, 0, rt.InitSyncSeq, 0)
 			require.NoError(rt.TB(), err)
 		}
-		_, isLeaky := base.AsLeakyBucket(rt.TestBucket)
-		var err error
-		if rt.LeakyBucketConfig != nil || isLeaky {
-			_, err = rt.RestTesterServerContext.AddDatabaseFromConfigWithBucket(ctx, rt.TB(), *rt.DatabaseConfig, testBucket.Bucket)
-		} else {
-			_, err = rt.RestTesterServerContext.AddDatabaseFromConfig(ctx, *rt.DatabaseConfig)
-		}
+		_, err := rt.RestTesterServerContext.AddDatabaseFromConfig(ctx, *rt.DatabaseConfig)
 		require.NoError(rt.TB(), err)
 		ctx = rt.Context() // get new ctx with db info before passing it down
 
@@ -1296,19 +1300,6 @@ func (s *SlowResponseRecorder) Write(buf []byte) (int, error) {
 	s.responseFinished.Done()
 
 	return numBytesWritten, err
-}
-
-// AddDatabaseFromConfigWithBucket adds a database to the ServerContext and sets a specific bucket on the database context.
-// If an existing config is found for the name, returns an error.
-func (sc *ServerContext) AddDatabaseFromConfigWithBucket(ctx context.Context, tb testing.TB, config DatabaseConfig, bucket base.Bucket) (*db.DatabaseContext, error) {
-	options := getOrAddDatabaseConfigOptions{
-		useExisting: false,
-		failFast:    false,
-		connectToBucketFn: func(_ context.Context, spec base.BucketSpec, _ bool) (base.Bucket, error) {
-			return bucket, nil
-		},
-	}
-	return sc.getOrAddDatabaseFromConfig(ctx, config, options)
 }
 
 // The parameters used to create a BlipTester

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -422,7 +422,7 @@ func (rt *RestTester) WaitForResyncDCPStatus(status db.BackgroundProcessState) d
 	timeout := 10 * time.Second
 	pollInterval := 10 * time.Millisecond
 	if !base.UnitTestUrlIsWalrus() || base.IsRaceDetectorEnabled(rt.TB()) || os.Getenv("CI") != "" {
-		timeout = 30 * time.Second
+		timeout = 60 * time.Second
 		pollInterval = 500 * time.Millisecond
 	}
 	var resyncStatus db.ResyncManagerResponseDCP

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"slices"
 	"strings"
 	"sync/atomic"
@@ -418,6 +419,12 @@ func (rt *RestTester) RunResync() db.ResyncManagerResponseDCP {
 
 // WaitForResyncDCPStatus waits for the resync status to reach the expected status and returns the final status.
 func (rt *RestTester) WaitForResyncDCPStatus(status db.BackgroundProcessState) db.ResyncManagerResponseDCP {
+	timeout := 10 * time.Second
+	pollInterval := 10 * time.Millisecond
+	if !base.UnitTestUrlIsWalrus() || base.IsRaceDetectorEnabled(rt.TB()) || os.Getenv("CI") != "" {
+		timeout = 30 * time.Second
+		pollInterval = 500 * time.Millisecond
+	}
 	var resyncStatus db.ResyncManagerResponseDCP
 	require.EventuallyWithT(rt.TB(), func(c *assert.CollectT) {
 		response := rt.SendAdminRequest("GET", "/{{.db}}/_resync", "")
@@ -425,7 +432,7 @@ func (rt *RestTester) WaitForResyncDCPStatus(status db.BackgroundProcessState) d
 		require.NoError(rt.TB(), json.Unmarshal(response.BodyBytes(), &resyncStatus))
 
 		assert.Equal(c, status, resyncStatus.State)
-	}, time.Second*10, time.Millisecond*10)
+	}, timeout, pollInterval)
 	if !slices.Contains([]db.BackgroundProcessState{db.BackgroundProcessStateRunning, db.BackgroundProcessStateStopping}, status) {
 		db.WaitForBackgroundManagerHeartbeatDocRemoval(rt.TB(), rt.GetDatabase().ResyncManager)
 	}


### PR DESCRIPTION
This is prep for helping with some flaky tests in `TestResyncWithoutIndexes` that could use a LeakyBucket to make assertions about index creation rather than relying on some quirks of the N1QL service and reporting.

- No longer are all rosmar buckets leaky buckets
- Opt into using a LeakyBucket on RestTester with adding `LeakyBucketConfig` parameter. The leaky bucket config can't always be used to set callbacks, because sometimes the callbacks require either the rest tester or the datastore, which aren't available when call `NewRestTester`. Fixing that is out of scope for this PR.
- Enable tests that previously required CBS.
- `TestReproduce2383` still doesn't work outside of rosmar but it is a views only test and enabling the leakiness on CBS causes a deadlock. The callback is overly restrictive but this isn't worth fixing.
- Move `connectToBucketFn` to ServerContext to allow tests that use persistent config to use a leaky bucket. This means that a test that opens a database via PUT /db/ will be able to still use a leaky bucket.

Added the fix for CBG-4985, this test is basically sensitive to the fact that even after asking to delete indexes, sometimes they reappear briefly. This is challenging but not impossible to reproduce, but I don't think has any meaningful side effects. The disappeared indexes in fact don't exist.

Removed the code to check for the warning counts, because that's not the behavior we are trying to test for, just the index creation. Unfortunately, we can't easily check to see if the queries work because now server falls back to a range scan.

This PR with leaky bucket has more usages than just fixing this test but this seems like an elegant way to fix this test.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/480/
