### PR TITLE
CBG-4665: Only put an ActiveReplicator into an error state when the connect error is a fatal one

### DIFF
--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -337,13 +337,13 @@ func (arc *activeReplicatorCommon) synchronousReconnect() {
 	}
 
 	base.WarnfCtx(ctx, "aborting reconnect loop: %v", retryErr)
+	arc.replicationStats.NumReconnectsAborted.Add(1)
 	arc.lock.Lock()
+	defer arc.lock.Unlock()
 	// use setState to preserve last error from retry loop set by setLastError
 	arc.setState(ReplicationStateError)
 	arc._publishStatus()
 	arc._stop("stopping after failed reconnect attempts: " + retryErr.Error())
-	arc.lock.Unlock()
-	arc.replicationStats.NumReconnectsAborted.Add(1)
 }
 
 // disconnect will disconnect and stop the replicator, but not set the state - such that it will be reassigned and started again.

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -334,7 +334,15 @@ func (arc *activeReplicatorCommon) synchronousReconnect() {
 	}
 
 	base.WarnfCtx(ctx, "aborting reconnect loop: %v", retryErr)
+	arc.publishTerminalErrorAndStop(retryErr)
 	arc.replicationStats.NumReconnectsAborted.Add(1)
+}
+
+// publishTerminalErrorAndStop transitions the replicator to its terminal Error
+// state, publishes the status, and cancels the replicator context. Must be
+// called without holding arc.lock. Callers should increment NumReconnectsAborted
+// after this returns so observers of the stat can rely on state == Error.
+func (arc *activeReplicatorCommon) publishTerminalErrorAndStop(retryErr error) {
 	arc.lock.Lock()
 	defer arc.lock.Unlock()
 	// use setState to preserve last error from retry loop set by setLastError

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -158,12 +158,15 @@ func (arc *activeReplicatorCommon) Start(ctx context.Context) error {
 
 	err := arc.replicatorConnectFn()
 	if err != nil {
-		arc.setError(err)
 		base.WarnfCtx(arc.ctx, "Couldn't connect: %s", err)
 		if errors.Is(err, fatalReplicatorConnectError) {
+			arc.setError(err)
 			base.WarnfCtx(arc.ctx, "Stopping replication connection attempt")
 			defer arc.ctxCancel(errors.New("stopping after fatal replicator connection error"))
 		} else {
+			// record the error but keep state out of the terminal Error bucket -
+			// the reconnect loop below will transition to Reconnecting.
+			arc.setLastError(err)
 			base.InfofCtx(arc.ctx, base.KeyReplicate, "Attempting to reconnect in background: %v", err)
 			arc.reconnect()
 		}
@@ -334,21 +337,13 @@ func (arc *activeReplicatorCommon) synchronousReconnect() {
 	}
 
 	base.WarnfCtx(ctx, "aborting reconnect loop: %v", retryErr)
-	arc.publishTerminalErrorAndStop(retryErr)
-	arc.replicationStats.NumReconnectsAborted.Add(1)
-}
-
-// publishTerminalErrorAndStop transitions the replicator to its terminal Error
-// state, publishes the status, and cancels the replicator context. Must be
-// called without holding arc.lock. Callers should increment NumReconnectsAborted
-// after this returns so observers of the stat can rely on state == Error.
-func (arc *activeReplicatorCommon) publishTerminalErrorAndStop(retryErr error) {
 	arc.lock.Lock()
-	defer arc.lock.Unlock()
 	// use setState to preserve last error from retry loop set by setLastError
 	arc.setState(ReplicationStateError)
 	arc._publishStatus()
 	arc._stop("stopping after failed reconnect attempts: " + retryErr.Error())
+	arc.lock.Unlock()
+	arc.replicationStats.NumReconnectsAborted.Add(1)
 }
 
 // disconnect will disconnect and stop the replicator, but not set the state - such that it will be reassigned and started again.

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -158,7 +158,7 @@ func (arc *activeReplicatorCommon) Start(ctx context.Context) error {
 
 	err := arc.replicatorConnectFn()
 	if err != nil {
-		base.WarnfCtx(arc.ctx, "Couldn't connect: %s", err)
+		base.InfofCtx(arc.ctx, base.KeyReplicate, "Couldn't connect: %s", err)
 		if errors.Is(err, fatalReplicatorConnectError) {
 			arc.setError(err)
 			base.WarnfCtx(arc.ctx, "Stopping replication connection attempt")

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -2454,14 +2454,17 @@ func TestReplicatorReconnectTimeout(t *testing.T) {
 
 		expectedErrMsg := "unexpected status code 401 from target database"
 		require.ErrorContains(t, ar.Start(activeRT.Context()), expectedErrMsg)
+		// Wait for the reconnect loop to fully abort before asserting on state:
+		// during the retry loop, state transiently flips to Reconnecting and back
+		// to Error. NumReconnectsAborted is only incremented after the terminal
+		// Error state is published (see publishTerminalErrorAndStop).
+		base.RequireWaitForStat(t, ar.Push.GetStats().NumReconnectsAborted.Value, 1)
 		activeRT.WaitForReplicationStatus(id, db.ReplicationStateError)
 
 		status, err := activeRT.GetDatabase().SGReplicateMgr.GetReplicationStatus(activeRT.Context(), id, db.DefaultReplicationStatusOptions())
 		require.NoError(t, err)
 		require.Equal(t, db.ReplicationStateError, status.Status)
 		require.Equal(t, expectedErrMsg, status.ErrorMessage)
-		// state is updated by the reconnect loop slightly before NumReconnectsAborted is set
-		base.RequireWaitForStat(t, ar.Push.GetStats().NumReconnectsAborted.Value, 1)
 		firstNumConnectAttempts := ar.Push.GetStats().NumConnectAttempts.Value()
 		require.GreaterOrEqual(t, firstNumConnectAttempts, int64(1))
 

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -2454,17 +2454,14 @@ func TestReplicatorReconnectTimeout(t *testing.T) {
 
 		expectedErrMsg := "unexpected status code 401 from target database"
 		require.ErrorContains(t, ar.Start(activeRT.Context()), expectedErrMsg)
-		// Wait for the reconnect loop to fully abort before asserting on state:
-		// during the retry loop, state transiently flips to Reconnecting and back
-		// to Error. NumReconnectsAborted is only incremented after the terminal
-		// Error state is published (see publishTerminalErrorAndStop).
-		base.RequireWaitForStat(t, ar.Push.GetStats().NumReconnectsAborted.Value, 1)
 		activeRT.WaitForReplicationStatus(id, db.ReplicationStateError)
 
 		status, err := activeRT.GetDatabase().SGReplicateMgr.GetReplicationStatus(activeRT.Context(), id, db.DefaultReplicationStatusOptions())
 		require.NoError(t, err)
 		require.Equal(t, db.ReplicationStateError, status.Status)
 		require.Equal(t, expectedErrMsg, status.ErrorMessage)
+		// state is updated by the reconnect loop slightly before NumReconnectsAborted is set
+		base.RequireWaitForStat(t, ar.Push.GetStats().NumReconnectsAborted.Value, 1)
 		firstNumConnectAttempts := ar.Push.GetStats().NumConnectAttempts.Value()
 		require.GreaterOrEqual(t, firstNumConnectAttempts, int64(1))
 


### PR DESCRIPTION
CBG-4665

Fixes a prominent flake in `TestReplicatorReconnectTimeout` where the `NumReconnectsAborted` stat was incremented prior to the replicator state changing.

- Fix attempt 1: Reorder stat/error state change so error state is always before the stat change.
- Fix attempt 2: Instead of reordering the stat or state change, only put the replicator into an error state when it's a fatal error on startup. This avoids a transient 'error' state which the test was getting into before the aborted stat had a chance to be set and the 2nd error state set.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/498/