### PR TITLE
Avoid data race in counting goroutines in test

### DIFF
--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -427,11 +427,12 @@ func SetUpTestGoroutineDump(m *testing.M) (teardownFn func()) {
 	}
 
 	return func() {
-		if n := runtime.NumGoroutine(); n > numExpected {
-			if err := pprof.Lookup("goroutine").WriteTo(os.Stderr, 2); err != nil {
+		goroutines := pprof.Lookup("goroutine")
+		if n := goroutines.Count(); n > numExpected {
+			if err := goroutines.WriteTo(os.Stderr, 2); err != nil {
 				panic(err)
 			}
-			if err := pprof.Lookup("goroutine").WriteTo(file, 0); err != nil {
+			if err := goroutines.WriteTo(file, 0); err != nil {
 				panic(err)
 			}
 			log.Printf(color("\n"+


### PR DESCRIPTION
Collect the profile before running the count, to make sure that the number of goroutines match the output. Before this change, sometimes the goroutine count would flag but the goroutines would be gone before they could be written.