### PR TITLE
Remove dead code for rosmar

### DIFF
--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
-	"github.com/couchbaselabs/rosmar"
 	"github.com/robertkrimen/otto/underscore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1443,9 +1442,6 @@ func TestAddingLargeDoc(t *testing.T) {
 
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
-	defer func() { rosmar.MaxDocSize = 0 }()
-
-	rosmar.MaxDocSize = 20 * 1024 * 1024
 
 	docBody := `{"value":"` + base64.StdEncoding.EncodeToString(make([]byte, 22000000)) + `"}`
 

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
-	"github.com/couchbaselabs/rosmar"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -458,9 +457,6 @@ func TestAttachmentsNoCrossTalk(t *testing.T) {
 func TestAddingAttachment(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
-	defer func() { rosmar.MaxDocSize = 0 }()
-
-	rosmar.MaxDocSize = 20 * 1024 * 1024
 
 	testCases := []struct {
 		name        string


### PR DESCRIPTION
Removes the data race around `rosmar.MaxDocSize`. This test actually removed the MaxDocSize for other tests, because the default is  `20 * 1024 * 1024`. 

I would probably still make this code work the same way but if we do need to modify this we should make `MaxDocSize` an atomic.

```
WARNING: DATA RACE
10:07:40 Read at 0x000141f17a08 by goroutine 40939:
10:07:40   github.com/couchbaselabs/rosmar.checkDocSize()
10:07:40       C:/Jenkins/workspace/sgw-windows-wix/godeps/pkg/mod/github.com/couchbaselabs/rosmar@v0.0.0-20260413100711-3dc08faf7e1f/utils.go:75 +0x76
10:07:40   github.com/couchbaselabs/rosmar.(*Collection).set()
10:07:40       C:/Jenkins/workspace/sgw-windows-wix/godeps/pkg/mod/github.com/couchbaselabs/rosmar@v0.0.0-20260413100711-3dc08faf7e1f/collection.go:191 +0xb7
10:07:40   github.com/couchbaselabs/rosmar.(*Collection).Set()
10:07:40       C:/Jenkins/workspace/sgw-windows-wix/godeps/pkg/mod/github.com/couchbaselabs/rosmar@v0.0.0-20260413100711-3dc08faf7e1f/collection.go:294 +0x184
10:07:40   github.com/couchbaselabs/rosmar.(*dcpFeed).writeCheckpoint()
10:07:40       C:/Jenkins/workspace/sgw-windows-wix/godeps/pkg/mod/github.com/couchbaselabs/rosmar@v0.0.0-20260413100711-3dc08faf7e1f/feeds.go:241 +0x192
10:07:40   github.com/couchbaselabs/rosmar.(*dcpFeed).run()
10:07:40       C:/Jenkins/workspace/sgw-windows-wix/godeps/pkg/mod/github.com/couchbaselabs/rosmar@v0.0.0-20260413100711-3dc08faf7e1f/feeds.go:289 +0x72a
10:07:40   github.com/couchbaselabs/rosmar.(*Collection).StartDCPFeed.gowrap1()
10:07:40       C:/Jenkins/workspace/sgw-windows-wix/godeps/pkg/mod/github.com/couchbaselabs/rosmar@v0.0.0-20260413100711-3dc08faf7e1f/feeds.go:130 +0x2e
10:07:40 
10:07:40 Previous write at 0x000141f17a08 by goroutine 40862:
10:07:40   github.com/couchbase/sync_gateway/rest.TestAddingAttachment.func1()
10:07:40       C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/rest/attachment_test.go:461 +0x24
10:07:40   runtime.deferreturn()
10:07:40       C:/Users/Administrator/cbdeps/go1.26.2/src/runtime/panic.go:668 +0x5d
10:07:40   testing.tRunner()
10:07:40       C:/Users/Administrator/cbdeps/go1.26.2/src/testing/testing.go:2036 +0x1ca
10:07:40   testing.(*T).Run.gowrap1()
10:07:40       C:/Users/Administrator/cbdeps/go1.26.2/src/testing/testing.go:2101 +0x38
10:07:40 
10:07:40 Goroutine 40939 (running) created at:
10:07:40   github.com/couchbaselabs/rosmar.(*Collection).StartDCPFeed()
10:07:40       C:/Jenkins/workspace/sgw-windows-wix/godeps/pkg/mod/github.com/couchbaselabs/rosmar@v0.0.0-20260413100711-3dc08faf7e1f/feeds.go:130 +0xa90
10:07:40   github.com/couchbaselabs/rosmar.(*Bucket).StartDCPFeed()
10:07:40       C:/Jenkins/workspace/sgw-windows-wix/godeps/pkg/mod/github.com/couchbaselabs/rosmar@v0.0.0-20260413100711-3dc08faf7e1f/feeds.go:67 +0x684
10:07:40   github.com/couchbase/sync_gateway/base.(*LeakyBucket).StartDCPFeed()
10:07:40       C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/base/leaky_bucket.go:177 +0x301
10:07:40   github.com/couchbase/sync_gateway/base.(*RosmarDCPClient).Start()
10:07:40       C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/base/rosmar_dcp_client.go:59 +0x418
10:07:40   github.com/couchbase/sync_gateway/db.(*AttachmentMigrationManager).Run()
10:07:40       C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/db/background_mgr_attachment_migration.go:182 +0x774
10:07:40   github.com/couchbase/sync_gateway/db.(*BackgroundManager).Start.func2()
10:07:40       C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/db/background_mgr.go:146 +0x14a
10:07:40 
10:07:40 Goroutine 40862 (running) created at:
10:07:40   testing.(*T).Run()
10:07:40       C:/Users/Administrator/cbdeps/go1.26.2/src/testing/testing.go:2101 +0xb2a
10:07:40   testing.runTests.func1()
10:07:40       C:/Users/Administrator/cbdeps/go1.26.2/src/testing/testing.go:2585 +0x85
10:07:40   testing.tRunner()
10:07:40       C:/Users/Administrator/cbdeps/go1.26.2/src/testing/testing.go:2036 +0x1ca
10:07:40   testing.runTests()
10:07:40       C:/Users/Administrator/cbdeps/go1.26.2/src/testing/testing.go:2583 +0x9f7
10:07:40   testing.(*M).Run()
10:07:40       C:/Users/Administrator/cbdeps/go1.26.2/src/testing/testing.go:2443 +0xf4b
10:07:40   github.com/couchbase/sync_gateway/base.TestBucketPoolMain()
10:07:40       C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/base/main_test_bucket_pool.go:837 +0x6f8
10:07:40   github.com/couchbase/sync_gateway/db.TestBucketPoolWithIndexes()
10:07:40       C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/db/util_testing.go:516 +0x1de
10:07:40   github.com/couchbase/sync_gateway/rest.TestBucketPoolRestWithIndexes()
10:07:40       C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/rest/utilities_testing.go:2772 +0x125
10:07:40   github.com/couchbase/sync_gateway/rest.TestMain()
10:07:40       C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/rest/main_test.go:25 +0x1aa
10:07:40   main.main()
10:07:40       _testmain.go:1440 +0x16d
```