### PR TITLE
RedactableError support for errors.Is/As/AsType

### DIFF
--- a/base/redactable_error.go
+++ b/base/redactable_error.go
@@ -57,7 +57,11 @@ func (re *RedactableError) Redact() string {
 	return fmt.Errorf(re.fmt, redactedArgs...).Error()
 }
 
+// Is returns true if any error in the chain matches the target error.
 func (re *RedactableError) Is(target error) bool {
+	if errors.Is(re, target) {
+		return true
+	}
 	for _, arg := range re.args {
 		err, ok := arg.(error)
 		if !ok {
@@ -70,7 +74,11 @@ func (re *RedactableError) Is(target error) bool {
 	return false
 }
 
+// As returns true if any error in the chain matches the target type and sets target as the value.
 func (re *RedactableError) As(target any) bool {
+	if errors.As(re, target) {
+		return true
+	}
 	for _, arg := range re.args {
 		err, ok := arg.(error)
 		if !ok {

--- a/base/redactable_error.go
+++ b/base/redactable_error.go
@@ -10,7 +10,10 @@ licenses/APL2.txt.
 
 package base
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 // RedactableError is an error that can be used as a drop-in replacement for an error,
 // which has the ability to redact any sensitive data by calling redact() on all of its args.
@@ -54,7 +57,28 @@ func (re *RedactableError) Redact() string {
 	return fmt.Errorf(re.fmt, redactedArgs...).Error()
 }
 
-// Unwrap returns the underlying error(s) created by fmt.Errorf. Allows use of errors.As, errors.AsType, errors.Is
-func (re *RedactableError) Unwrap() error {
-	return fmt.Errorf(re.fmt, re.args...)
+func (re *RedactableError) Is(target error) bool {
+	for _, arg := range re.args {
+		err, ok := arg.(error)
+		if !ok {
+			continue
+		}
+		if errors.Is(err, target) {
+			return true
+		}
+	}
+	return false
+}
+
+func (re *RedactableError) As(target any) bool {
+	for _, arg := range re.args {
+		err, ok := arg.(error)
+		if !ok {
+			continue
+		}
+		if errors.As(err, target) {
+			return true
+		}
+	}
+	return false
 }

--- a/base/redactable_error.go
+++ b/base/redactable_error.go
@@ -53,3 +53,8 @@ func (re *RedactableError) Redact() string {
 	// can't use Sprintf as it doesn't support `%w`
 	return fmt.Errorf(re.fmt, redactedArgs...).Error()
 }
+
+// Unwrap returns the underlying error(s) created by fmt.Errorf. Allows use of errors.As, errors.AsType, errors.Is
+func (re *RedactableError) Unwrap() error {
+	return fmt.Errorf(re.fmt, re.args...)
+}

--- a/base/redactable_error.go
+++ b/base/redactable_error.go
@@ -11,7 +11,6 @@ licenses/APL2.txt.
 package base
 
 import (
-	"errors"
 	"fmt"
 )
 
@@ -57,30 +56,14 @@ func (re *RedactableError) Redact() string {
 	return fmt.Errorf(re.fmt, redactedArgs...).Error()
 }
 
-// Is returns true if any error in the chain matches the target error.
-func (re *RedactableError) Is(target error) bool {
+// Unwrap returns the underlying error(s).
+func (re *RedactableError) Unwrap() []error {
+	var errs []error
 	for _, arg := range re.args {
 		err, ok := arg.(error)
-		if !ok {
-			continue
-		}
-		if errors.Is(err, target) {
-			return true
+		if ok {
+			errs = append(errs, err)
 		}
 	}
-	return false
-}
-
-// As returns true if any error in the chain matches the target type and sets target as the value.
-func (re *RedactableError) As(target any) bool {
-	for _, arg := range re.args {
-		err, ok := arg.(error)
-		if !ok {
-			continue
-		}
-		if errors.As(err, target) {
-			return true
-		}
-	}
-	return false
+	return errs
 }

--- a/base/redactable_error.go
+++ b/base/redactable_error.go
@@ -59,9 +59,6 @@ func (re *RedactableError) Redact() string {
 
 // Is returns true if any error in the chain matches the target error.
 func (re *RedactableError) Is(target error) bool {
-	if errors.Is(re, target) {
-		return true
-	}
 	for _, arg := range re.args {
 		err, ok := arg.(error)
 		if !ok {
@@ -76,9 +73,6 @@ func (re *RedactableError) Is(target error) bool {
 
 // As returns true if any error in the chain matches the target type and sets target as the value.
 func (re *RedactableError) As(target any) bool {
-	if errors.As(re, target) {
-		return true
-	}
 	for _, arg := range re.args {
 		err, ok := arg.(error)
 		if !ok {

--- a/base/redactable_error_test.go
+++ b/base/redactable_error_test.go
@@ -9,9 +9,11 @@
 package base
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRedactErrorf(t *testing.T) {
@@ -45,6 +47,77 @@ func TestRedactErrorf(t *testing.T) {
 		})
 	}
 }
+
+func TestRedactableError_IsAs(t *testing.T) {
+	innerErr := &customErr{msg: "inner error"}
+	re := RedactErrorf("wrapped: %w", innerErr)
+
+	t.Run("errors.Is", func(t *testing.T) {
+		require.ErrorIs(t, re, innerErr)
+	})
+
+	t.Run("errors.As", func(t *testing.T) {
+		var target *customErr
+		assert.True(t, errors.As(re, &target), "errors.As(re, &target) should be true")
+		assert.Equal(t, innerErr, target)
+
+		var redactedTarget *RedactableError
+		assert.True(t, errors.As(re, &redactedTarget), "errors.As(re, &redactedTarget) should be true")
+		assert.Equal(t, re, redactedTarget)
+	})
+
+	t.Run("errors.AsType", func(t *testing.T) {
+		err := &customErr{msg: "err"}
+		re := RedactErrorf("wrapped: %w", err)
+
+		target, ok := errors.AsType[*customErr](re)
+		assert.True(t, ok)
+		assert.Equal(t, err, target)
+
+		redactedTarget, ok := errors.AsType[*RedactableError](re)
+		assert.True(t, ok)
+		assert.Equal(t, re, redactedTarget)
+	})
+
+	t.Run("errors.As value type", func(t *testing.T) {
+		err := customValErr("val error")
+		re := RedactErrorf("wrapped: %w", err)
+
+		var target customValErr
+		assert.True(t, errors.As(re, &target))
+		assert.Equal(t, err, target)
+	})
+
+	t.Run("errors.AsType value type", func(t *testing.T) {
+		err := customValErr("val error")
+		re := RedactErrorf("wrapped: %w", err)
+
+		target, ok := errors.AsType[customValErr](re)
+		assert.True(t, ok)
+		assert.Equal(t, err, target)
+	})
+
+	t.Run("Multiple wraps", func(t *testing.T) {
+		err1 := &customErr{msg: "err1"}
+		err2 := &customErr{msg: "err2"}
+		re2 := RedactErrorf("err1: %w, err2: %w", err1, err2)
+
+		assert.True(t, errors.Is(re2, err1))
+		assert.True(t, errors.Is(re2, err2))
+
+		var target *customErr
+		assert.True(t, errors.As(re2, &target))
+		assert.Equal(t, err1, target) // errors.As returns the first one it finds
+	})
+}
+
+type customErr struct{ msg string }
+
+func (e *customErr) Error() string { return e.msg }
+
+type customValErr string
+
+func (e customValErr) Error() string { return string(e) }
 
 func BenchmarkRedactErrorf(b *testing.B) {
 	fmt := "Couldn't get user %q: "

--- a/base/redactable_error_test.go
+++ b/base/redactable_error_test.go
@@ -10,6 +10,7 @@ package base
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -109,6 +110,37 @@ func TestRedactableError_IsAs(t *testing.T) {
 		assert.True(t, errors.As(re2, &target))
 		assert.Equal(t, err1, target) // errors.As returns the first one it finds
 	})
+	t.Run("Redactor interface survives Unwrap, multiple redactable errors", func(t *testing.T) {
+		inner := RedactErrorf("user %s", UD("Bob"))
+		outer := RedactErrorf("wrapped: %w", inner)
+
+		// Outer redacts correctly
+		assert.Contains(t, outer.Redact(), "user <ud>Bob</ud>")
+
+		// errors.As does not unextract inner
+		var target *RedactableError
+		require.True(t, errors.As(outer, &target))
+
+		// Unwrapped inner still redacts
+		var r Redactor = target
+		assert.Contains(t, r.Redact(), "user <ud>Bob</ud>")
+		assert.NotContains(t, r.Redact(), "user Bob")
+	})
+	t.Run("Redactor interface survives Unwrap", func(t *testing.T) {
+		inner := RedactErrorf("user %s", UD("Bob"))
+		outer := fmt.Errorf("wrapped: %w", inner)
+
+		// errors.As extracts inner, still satisfies Redactor
+		var target *RedactableError
+		require.True(t, errors.As(outer, &target))
+		require.NotSame(t, outer, target)
+
+		// Unwrapped inner still redacts
+		var r Redactor = target
+		assert.Contains(t, r.Redact(), "user <ud>Bob</ud>")
+		assert.NotContains(t, r.Redact(), "user Bob")
+	})
+
 }
 
 type customErr struct{ msg string }


### PR DESCRIPTION
RedactableError support for errors.Is/As/AsType

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/493/
