### PR TITLE
CBG-5259 wait for revision before adding a second document

### DIFF
--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -53,6 +53,7 @@ func TestBlipDeltaSyncPushAttachment(t *testing.T) {
 		// Push first rev
 		version := btcRunner.AddRev(btc.id, docID, EmptyDocVersion(), []byte(`{"key":"val"}`))
 
+		rt.WaitForVersion(docID, version)
 		// Push second rev with an attachment (no delta yet)
 		attData := base64.StdEncoding.EncodeToString([]byte("attach"))
 
@@ -60,17 +61,12 @@ func TestBlipDeltaSyncPushAttachment(t *testing.T) {
 
 		rt.WaitForVersion(docID, version)
 
-		// CBG-4766 this is not intentional, and maybe should be fixed. However, neither CBL nor SG since 3.0 use revpos, so a fix is low priority
-		revpos := 2
-		if btc.UseHLV() {
-			revpos = 1
-		}
 		syncData := db.GetRawSyncXattr(t, rt.GetSingleDataStore(), docID)
 		require.Empty(t, syncData.AttachmentsPre4dot0)
 		require.Equal(t, db.AttachmentMap{
 			"myAttachment": {
 				Digest:  "sha1-E84HH2iVirRjaYhTGJ1jYQANtcI=",
-				Revpos:  revpos,
+				Revpos:  2,
 				Length:  6,
 				Stub:    true,
 				Version: 2,
@@ -97,7 +93,7 @@ func TestBlipDeltaSyncPushAttachment(t *testing.T) {
 			"myAttachment": {
 				Digest:  "sha1-E84HH2iVirRjaYhTGJ1jYQANtcI=",
 				Length:  6,
-				Revpos:  revpos,
+				Revpos:  2,
 				Stub:    true,
 				Version: 2,
 			},


### PR DESCRIPTION
CBG-5259 wait for revision before adding a second document

fix test flake

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/495/
