### PR TITLE
CBG-5295: Distributed resync to work only on subset of collections

### DIFF
--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -222,7 +222,7 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 			scopeName = sn
 		}
 
-		collectionNamesByScope := db.collectionNames()
+		collectionNamesByScope :=r.ResyncedCollections
 
 		sort.Strings(collectionNamesByScope[scopeName])
 		resyncDestKey = base.DestKey(db.Name, scopeName, collectionNamesByScope[scopeName], base.ShardedDCPFeedTypeResync)

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -222,7 +222,7 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 			scopeName = sn
 		}
 
-		collectionNamesByScope :=r.ResyncedCollections
+		collectionNamesByScope := r.ResyncedCollections
 
 		sort.Strings(collectionNamesByScope[scopeName])
 		resyncDestKey = base.DestKey(db.Name, scopeName, collectionNamesByScope[scopeName], base.ShardedDCPFeedTypeResync)


### PR DESCRIPTION
CBG-5295

Describe your PR here...
- Change the distributed resync behaviour to work only on the subset of collections passed by the user in the resync endpoint instead of all the collections in the database.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/496/
