### PR TITLE
CBG-5224: cross collection query joins

### DIFF
--- a/base/cluster_n1ql.go
+++ b/base/cluster_n1ql.go
@@ -217,6 +217,12 @@ func (cl *ClusterOnlyN1QLStore) indexManager(scopeName, collectionName string) *
 }
 
 func (cl *ClusterOnlyN1QLStore) WaitForIndexesOnline(ctx context.Context, indexNames []string, option WaitForIndexesOnlineOption) error {
+	// CBS omits _system scope indexes from system:indexes (used by the gocb CollectionQueryIndexManager
+	// backing indexManager.GetAllIndexes), so for system-scope collections we must use
+	// WaitForSystemCollectionIndexesOnline which queries system:all_indexes instead.
+	if cl.scopeName == SystemScope {
+		return WaitForSystemCollectionIndexesOnline(ctx, cl, cl.scopeName, cl.collectionName, indexNames, option)
+	}
 	keyspace := strings.Join([]string{cl.bucketName, cl.scopeName, cl.collectionName}, ".")
 	return WaitForIndexesOnline(ctx, keyspace, cl.indexManager(cl.scopeName, cl.collectionName), indexNames, option)
 }

--- a/base/collection_common.go
+++ b/base/collection_common.go
@@ -28,6 +28,10 @@ func DefaultScopeAndCollectionName() ScopeAndCollectionName {
 	return ScopeAndCollectionName{Scope: DefaultScope, Collection: DefaultCollection}
 }
 
+func MobileSystemScopeAndCollectionName() ScopeAndCollectionName {
+	return ScopeAndCollectionName{Scope: SystemScope, Collection: SystemCollectionMobile}
+}
+
 func NewScopeAndCollectionName(scope, collection string) ScopeAndCollectionName {
 	return ScopeAndCollectionName{
 		Scope:      scope,

--- a/base/collection_n1ql.go
+++ b/base/collection_n1ql.go
@@ -143,6 +143,12 @@ func (c *Collection) CreatePrimaryIndex(ctx context.Context, indexName string, o
 
 // WaitForIndexesOnline takes set of indexes and watches them till they're online.
 func (c *Collection) WaitForIndexesOnline(ctx context.Context, indexNames []string, option WaitForIndexesOnlineOption) error {
+	// CBS omits _system scope indexes from system:indexes (used by the gocb CollectionQueryIndexManager
+	// backing indexManager.GetAllIndexes), so for system-scope collections we must use
+	// WaitForSystemCollectionIndexesOnline which queries system:all_indexes instead.
+	if c.ScopeName() == SystemScope {
+		return WaitForSystemCollectionIndexesOnline(ctx, c, c.ScopeName(), c.CollectionName(), indexNames, option)
+	}
 	keyspace := strings.Join([]string{c.BucketName(), c.ScopeName(), c.CollectionName()}, ".")
 	return WaitForIndexesOnline(ctx, keyspace, c.indexManager(), indexNames, option)
 }

--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -632,6 +632,101 @@ func WaitForIndexesOnline(ctx context.Context, keyspace string, mgr *indexManage
 	return err
 }
 
+// GetSystemCollectionIndexesMeta queries system:all_indexes (which, unlike system:indexes, includes
+// indexes on system-scope collections such as _system._mobile) and returns state metadata for the
+// named indexes.  bucketName, scopeName, and collectionName identify the target keyspace.
+func GetSystemCollectionIndexesMeta(ctx context.Context, store N1QLStore, scopeName, collectionName string, indexNames []string) (map[string]IndexMeta, error) {
+	if len(indexNames) == 0 {
+		return nil, fmt.Errorf("must specify at least one index name")
+	}
+
+	quotedNames := make([]string, 0, len(indexNames))
+	for _, name := range indexNames {
+		quotedNames = append(quotedNames, strconv.Quote(name))
+	}
+
+	statement := fmt.Sprintf(
+		"SELECT name, state FROM system:all_indexes WHERE bucket_id = '%s' AND scope_id = '%s' AND keyspace_id = '%s' AND name IN [%s]",
+		store.BucketName(),
+		scopeName,
+		collectionName,
+		strings.Join(quotedNames, ","),
+	)
+
+	results, err := store.executeQuery(statement)
+	if store.IsErrNoResults(err) {
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if closeErr := results.Close(); closeErr != nil {
+			WarnfCtx(ctx, "Error closing results from GetSystemCollectionIndexesMeta: %v", closeErr)
+		}
+	}()
+
+	indexes := make(map[string]IndexMeta)
+	var meta IndexMeta
+	for results.Next(ctx, &meta) {
+		indexes[meta.Name] = meta
+	}
+	return indexes, nil
+}
+
+// WaitForSystemCollectionIndexesOnline waits for the named indexes to come online on a
+// system-scope collection (e.g. _system._mobile).  CBS omits system-scope indexes from
+// system:indexes, so this function queries system:all_indexes instead.  store is used only
+// to run the query; scopeName and collectionName identify the target keyspace within the
+// store's bucket.
+func WaitForSystemCollectionIndexesOnline(ctx context.Context, store N1QLStore, scopeName, collectionName string, indexNames []string, waitOption WaitForIndexesOnlineOption) error {
+	var retrySleeper RetrySleeper
+	initialWaitTime := 100
+	maxSleepTime := 5000
+	switch waitOption {
+	case WaitForIndexesDefault:
+		retrySleeper = CreateMaxDoublingSleeperFunc(180, initialWaitTime, maxSleepTime)
+	case WaitForIndexesFailfast:
+		retrySleeper = CreateFastFailRetrySleeperFunc()
+	case WaitForIndexesInfinite:
+		retrySleeper = CreateIndefiniteMaxDoublingSleeperFunc(initialWaitTime, maxSleepTime)
+	default:
+		return fmt.Errorf("invalid WaitForIndexesOnlineOption: %d", waitOption)
+	}
+
+	onlineIndexes := make(map[string]bool)
+	keyspace := strings.Join([]string{store.BucketName(), scopeName, collectionName}, ".")
+
+	err, _ := RetryLoop(ctx, "WaitForSystemCollectionIndexesOnline", func() (shouldRetry bool, err error, _ any) {
+		watchedOnlineIndexCount := 0
+		currIndexes, err := GetSystemCollectionIndexesMeta(ctx, store, scopeName, collectionName, indexNames)
+		if err != nil {
+			return false, err, nil
+		}
+		for _, idx := range currIndexes {
+			if idx.State == IndexStateOnline && slices.Contains(indexNames, idx.Name) {
+				if !onlineIndexes[idx.Name] {
+					InfofCtx(ctx, KeyAll, "Index %s on %s is online", MD(idx.Name), MD(keyspace))
+					onlineIndexes[idx.Name] = true
+				}
+			}
+		}
+		var offlineIndexes []string
+		for _, name := range indexNames {
+			if onlineIndexes[name] {
+				watchedOnlineIndexCount++
+			} else {
+				offlineIndexes = append(offlineIndexes, name)
+			}
+		}
+		if watchedOnlineIndexCount == len(indexNames) {
+			return false, nil, nil
+		}
+		DebugfCtx(ctx, KeyAll, "Indexes %s on %s not ready - retrying...", strings.Join(offlineIndexes, ", "), MD(keyspace))
+		return true, nil, nil
+	}, retrySleeper)
+	return err
+}
+
 func GetAllIndexes(mgr *indexManager) (indexes []string, err error) {
 	indexes = []string{}
 	indexInfo, err := mgr.GetAllIndexes()

--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -645,6 +645,9 @@ func GetSystemCollectionIndexesMeta(ctx context.Context, store N1QLStore, scopeN
 		quotedNames = append(quotedNames, strconv.Quote(name))
 	}
 
+	// bucket_id, scope_id, and keyspace_id are trusted internal values originating from the
+	// CBS cluster topology (not user input), so direct interpolation is safe here.
+	// Index names are escaped via strconv.Quote above.
 	statement := fmt.Sprintf(
 		"SELECT name, state FROM system:all_indexes WHERE bucket_id = '%s' AND scope_id = '%s' AND keyspace_id = '%s' AND name IN [%s]",
 		store.BucketName(),

--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -703,7 +703,7 @@ func WaitForSystemCollectionIndexesOnline(ctx context.Context, store N1QLStore, 
 			return false, err, nil
 		}
 		for _, idx := range currIndexes {
-			if idx.State == IndexStateOnline && slices.Contains(indexNames, idx.Name) {
+			if idx.State == IndexStateOnline {
 				if !onlineIndexes[idx.Name] {
 					InfofCtx(ctx, KeyAll, "Index %s on %s is online", MD(idx.Name), MD(keyspace))
 					onlineIndexes[idx.Name] = true

--- a/db/database.go
+++ b/db/database.go
@@ -1179,7 +1179,7 @@ outerLoop:
 				//principalName = viewRow.Key
 				startKey = viewRow.Key
 			} else {
-				var queryRow principalRow
+				var queryRow PrincipalRow
 				found := results.Next(ctx, &queryRow)
 				if !found {
 					break
@@ -1366,7 +1366,7 @@ outerLoop:
 				skipAddition = true
 			}
 
-			var queryRow principalRow
+			var queryRow PrincipalRow
 			found := results.Next(ctx, &queryRow)
 			if !found {
 				break

--- a/db/design_doc.go
+++ b/db/design_doc.go
@@ -63,6 +63,10 @@ type principalsViewRow struct {
 	Value bool   // 'isUser' flag
 }
 
+func (r principalsViewRow) rowID() string {
+	return r.ID
+}
+
 func isInternalDDoc(ddocName string) bool {
 	return strings.HasPrefix(ddocName, "sync_")
 }

--- a/db/indexes.go
+++ b/db/indexes.go
@@ -482,7 +482,7 @@ func InitializeDualMetadataStoreIndexes(ctx context.Context, metadataStore *base
 	}
 	primaryCtx := base.CollectionLogCtx(ctx, metadataStore.Primary().ScopeName(), metadataStore.Primary().CollectionName())
 	primaryOptions.MetadataIndexes = IndexesMetadataOnly // primary store only needs metadata indexes (no other data can be stored here)
-	if err := InitializeIndexes(primaryCtx, primaryN1QL, options); err != nil {
+	if err := InitializeIndexes(primaryCtx, primaryN1QL, primaryOptions); err != nil {
 		return fmt.Errorf("initializing indexes on primary metadata store: %w", err)
 	}
 

--- a/db/indexes.go
+++ b/db/indexes.go
@@ -465,38 +465,6 @@ func InitializeIndexes(ctx context.Context, n1QLStore base.N1QLStore, options In
 	return nil
 }
 
-// InitializeDualMetadataStoreIndexes initializes the principal indexes (IndexSyncDocs,
-// IndexUser, IndexRole) on both the primary and fallback datastores of a *base.MetadataStore.
-// This is required during metadata migration when user and role documents may be present in
-// both datastores and both must be queryable via N1QL.
-//
-// options.MetadataIndexes is forced to IndexesMetadataOnly for each store so that only
-// metadata-specific principal indexes are created; non-principal indexes are the
-// responsibility of the caller for the appropriate data collections.
-func InitializeDualMetadataStoreIndexes(ctx context.Context, metadataStore *base.MetadataStore, options InitializeIndexOptions) error {
-	primaryOptions := options
-
-	primaryN1QL, ok := base.AsN1QLStore(metadataStore.Primary())
-	if !ok {
-		return fmt.Errorf("primary datastore (%T) is not an N1QL store; cannot initialize dual metadata store indexes", metadataStore.Primary())
-	}
-	primaryCtx := base.CollectionLogCtx(ctx, metadataStore.Primary().ScopeName(), metadataStore.Primary().CollectionName())
-	primaryOptions.MetadataIndexes = IndexesMetadataOnly // primary store only needs metadata indexes (no other data can be stored here)
-	if err := InitializeIndexes(primaryCtx, primaryN1QL, primaryOptions); err != nil {
-		return fmt.Errorf("initializing indexes on primary metadata store: %w", err)
-	}
-
-	fallbackN1QL, ok := base.AsN1QLStore(metadataStore.Fallback())
-	if !ok {
-		return fmt.Errorf("fallback datastore (%T) is not an N1QL store; cannot initialize dual metadata store indexes", metadataStore.Fallback())
-	}
-	fallbackCtx := base.CollectionLogCtx(ctx, metadataStore.Fallback().ScopeName(), metadataStore.Fallback().CollectionName())
-	if err := InitializeIndexes(fallbackCtx, fallbackN1QL, options); err != nil {
-		return fmt.Errorf("initializing indexes on fallback metadata store: %w", err)
-	}
-	return nil
-}
-
 // Return true if the string representation of the error contains
 // the substring "[5000]" and false otherwise.
 func isIndexerError(err error) bool {

--- a/db/indexes.go
+++ b/db/indexes.go
@@ -465,6 +465,38 @@ func InitializeIndexes(ctx context.Context, n1QLStore base.N1QLStore, options In
 	return nil
 }
 
+// InitializeDualMetadataStoreIndexes initializes the principal indexes (IndexSyncDocs,
+// IndexUser, IndexRole) on both the primary and fallback datastores of a *base.MetadataStore.
+// This is required during metadata migration when user and role documents may be present in
+// both datastores and both must be queryable via N1QL.
+//
+// options.MetadataIndexes is forced to IndexesMetadataOnly for each store so that only
+// metadata-specific principal indexes are created; non-principal indexes are the
+// responsibility of the caller for the appropriate data collections.
+func InitializeDualMetadataStoreIndexes(ctx context.Context, metadataStore *base.MetadataStore, options InitializeIndexOptions) error {
+	primaryOptions := options
+
+	primaryN1QL, ok := base.AsN1QLStore(metadataStore.Primary())
+	if !ok {
+		return fmt.Errorf("primary datastore (%T) is not an N1QL store; cannot initialize dual metadata store indexes", metadataStore.Primary())
+	}
+	primaryCtx := base.CollectionLogCtx(ctx, metadataStore.Primary().ScopeName(), metadataStore.Primary().CollectionName())
+	primaryOptions.MetadataIndexes = IndexesMetadataOnly // primary store only needs metadata indexes (no other data can be stored here)
+	if err := InitializeIndexes(primaryCtx, primaryN1QL, options); err != nil {
+		return fmt.Errorf("initializing indexes on primary metadata store: %w", err)
+	}
+
+	fallbackN1QL, ok := base.AsN1QLStore(metadataStore.Fallback())
+	if !ok {
+		return fmt.Errorf("fallback datastore (%T) is not an N1QL store; cannot initialize dual metadata store indexes", metadataStore.Fallback())
+	}
+	fallbackCtx := base.CollectionLogCtx(ctx, metadataStore.Fallback().ScopeName(), metadataStore.Fallback().CollectionName())
+	if err := InitializeIndexes(fallbackCtx, fallbackN1QL, options); err != nil {
+		return fmt.Errorf("initializing indexes on fallback metadata store: %w", err)
+	}
+	return nil
+}
+
 // Return true if the string representation of the error contains
 // the substring "[5000]" and false otherwise.
 func isIndexerError(err error) bool {

--- a/db/indextest/indextest_dual_metadata_test.go
+++ b/db/indextest/indextest_dual_metadata_test.go
@@ -160,29 +160,17 @@ func TestQueryPrincipalsDualMetadataStore(t *testing.T) {
 	writeUser(t, fallbackStore, bobKey, "bob-fallback") // bob also in fallback (duplicate)
 	writeUser(t, fallbackStore, carolKey, "carol")      // carol: fallback only
 
-	type principalQueryRow struct {
-		ID   string `json:"id"`
-		Name string `json:"name"`
-	}
-
-	// drainIter collects all rows from a query iterator into a map keyed by META().id.
-	drainIter := func(t *testing.T, iter sgbucket.QueryResultIterator) map[string]principalQueryRow {
-		t.Helper()
-		results := make(map[string]principalQueryRow)
-		var row principalQueryRow
-		for iter.Next(dbCtx, &row) {
-			results[row.ID] = row
-			row = principalQueryRow{} // reset
-		}
-		require.NoError(t, iter.Close())
-		return results
-	}
-
 	t.Run("QueryPrincipals", func(t *testing.T) {
 		iter, err := database.QueryPrincipals(dbCtx, "", 0)
 		require.NoError(t, err)
 
-		results := drainIter(t, iter)
+		results := make(map[string]db.PrincipalRow)
+		var row db.PrincipalRow
+		for iter.Next(dbCtx, &row) {
+			results[row.Id] = row
+			row = db.PrincipalRow{}
+		}
+		require.NoError(t, iter.Close())
 
 		require.Len(t, results, 3, "expected exactly 3 unique principals after deduplication")
 		require.Contains(t, results, aliceKey, "alice should be present")
@@ -198,7 +186,13 @@ func TestQueryPrincipalsDualMetadataStore(t *testing.T) {
 		iter, err := database.QueryUsers(dbCtx, "", 0)
 		require.NoError(t, err)
 
-		results := drainIter(t, iter)
+		results := make(map[string]db.QueryUsersRow)
+		var row db.QueryUsersRow
+		for iter.Next(dbCtx, &row) {
+			results[row.ID] = row
+			row = db.QueryUsersRow{}
+		}
+		require.NoError(t, iter.Close())
 
 		require.Len(t, results, 3, "expected exactly 3 unique users after deduplication")
 		require.Contains(t, results, aliceKey)
@@ -497,18 +491,14 @@ func TestQueryRolesDualMetadataStore(t *testing.T) {
 
 	metaKeys := base.DefaultMetadataKeys
 
-	type principalQueryRow struct {
-		ID   string `json:"id"`
-		Name string `json:"name"`
-	}
-
-	drainIter := func(t *testing.T, iter sgbucket.QueryResultIterator) map[string]principalQueryRow {
+	// drainIter collects all rows from a query iterator into a map keyed by META().id.
+	drainIter := func(t *testing.T, iter sgbucket.QueryResultIterator) map[string]db.PrincipalRow {
 		t.Helper()
-		results := make(map[string]principalQueryRow)
-		var row principalQueryRow
+		results := make(map[string]db.PrincipalRow)
+		var row db.PrincipalRow
 		for iter.Next(dbCtx, &row) {
-			results[row.ID] = row
-			row = principalQueryRow{}
+			results[row.Id] = row
+			row = db.PrincipalRow{}
 		}
 		require.NoError(t, iter.Close())
 		return results

--- a/db/indextest/indextest_dual_metadata_test.go
+++ b/db/indextest/indextest_dual_metadata_test.go
@@ -59,16 +59,24 @@ func TestDualMetadataStoreIndexes(t *testing.T) {
 
 	// Verify that each expected index is present and online on both stores.
 	for _, store := range []base.DataStore{primaryStore, fallbackStore} {
-		n1qlStore, err := base.NewClusterOnlyN1QLStore(
-			gocbBucket.GetCluster(),
-			gocbBucket.BucketName(),
-			store.ScopeName(),
-			store.CollectionName(),
-		)
-		require.NoError(t, err)
 
-		indexesMeta, err := base.GetSystemCollectionIndexesMeta(ctx, n1qlStore, base.SystemScope, base.SystemCollectionMobile, expectedIndexes)
-		require.NoError(t, err)
+		var indexesMeta map[string]base.IndexMeta
+		if store.GetName() == primaryStore.GetName() {
+			n1qlStore, err := base.NewClusterOnlyN1QLStore(
+				gocbBucket.GetCluster(),
+				gocbBucket.BucketName(),
+				store.ScopeName(),
+				store.CollectionName(),
+			)
+			require.NoError(t, err)
+			indexesMeta, err = base.GetSystemCollectionIndexesMeta(ctx, n1qlStore, base.SystemScope, base.SystemCollectionMobile, expectedIndexes)
+			require.NoError(t, err)
+		} else {
+			fallbackN1QLStore, ok := base.AsN1QLStore(fallbackStore)
+			require.True(t, ok)
+			indexesMeta, err = base.GetIndexesMeta(ctx, fallbackN1QLStore, expectedIndexes)
+			require.NoError(t, err)
+		}
 
 		for _, indexName := range expectedIndexes {
 			meta, found := indexesMeta[indexName]

--- a/db/indextest/indextest_dual_metadata_test.go
+++ b/db/indextest/indextest_dual_metadata_test.go
@@ -314,7 +314,6 @@ func TestQueryUsersRealDocsDualMetadataStore(t *testing.T) {
 //   - The primary-store version is preferred for duplicates.
 //   - The final result set contains exactly the expected number of unique users.
 func TestGetUsersPaginationDualMetadataStore(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	ctx := base.TestCtx(t)
 	bucket := base.GetTestBucket(t)
 	t.Cleanup(func() { bucket.Close(ctx) })
@@ -426,4 +425,116 @@ func TestGetUsersPaginationDualMetadataStore(t *testing.T) {
 		assert.Equal(t, name+"@primary.example", *usersByName[name].Email,
 			"duplicate user %q should use the primary-store version", name)
 	}
+}
+
+// TestQueryRolesDualMetadataStore verifies that QueryRoles and QueryAllRoles correctly
+// deduplicate role results when using a dual MetadataStore. Roles are written to both
+// the primary and fallback stores, and the primary version is preferred for duplicates.
+//
+// Test data:
+//   - "admin":     primary only
+//   - "editor":    both stores; primary has name="editor" (written first), fallback also has it
+//   - "viewer":    fallback only
+//
+// Expected: three unique roles with "editor" from primary store.
+func TestQueryRolesDualMetadataStore(t *testing.T) {
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	t.Cleanup(func() { bucket.Close(ctx) })
+
+	primaryStore := bucket.GetMobileSystemDataStore()
+	fallbackStore := bucket.DefaultDataStore()
+	ms := base.NewMetadataStore(primaryStore, fallbackStore)
+
+	setupIndexes(t, bucket, testIndexCreationOptions{
+		numPartitions:          db.DefaultNumIndexPartitions,
+		useLegacySyncDocsIndex: false,
+		useXattrs:              true,
+	})
+
+	indexOptions := db.InitializeIndexOptions{
+		NumReplicas:                0,
+		LegacySyncDocsIndex:        false,
+		UseXattrs:                  true,
+		NumPartitions:              db.DefaultNumIndexPartitions,
+		WaitForIndexesOnlineOption: base.WaitForIndexesDefault,
+	}
+	require.NoError(t, db.InitializeDualMetadataStoreIndexes(t, ctx, ms, indexOptions))
+
+	dbOptions := getDatabaseContextOptions(false)
+	dbOptions.Scopes = db.GetScopesOptions(t, bucket, 2)
+	dbOptions.EnableXattr = true
+	dbOptions.MetadataStore = ms
+
+	database, dbCtx := db.CreateTestDatabase(t, bucket, dbOptions)
+	t.Cleanup(func() { database.Close(dbCtx) })
+
+	authOpts := auth.AuthenticatorOptions{
+		LogCtx:   ctx,
+		MetaKeys: base.DefaultMetadataKeys,
+	}
+
+	createAndSaveRole := func(t *testing.T, store base.DataStore, roleName string) {
+		t.Helper()
+		authr := auth.NewAuthenticator(store, nil, authOpts)
+		role, err := authr.NewRole(roleName, nil)
+		require.NoError(t, err)
+		require.NoError(t, authr.Save(role))
+	}
+
+	createAndSaveRole(t, primaryStore, "admin")   // primary only
+	createAndSaveRole(t, primaryStore, "editor")  // both stores
+	createAndSaveRole(t, fallbackStore, "editor") // duplicate in fallback
+	createAndSaveRole(t, fallbackStore, "viewer") // fallback only
+
+	metaKeys := base.DefaultMetadataKeys
+
+	type principalQueryRow struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	}
+
+	drainIter := func(t *testing.T, iter sgbucket.QueryResultIterator) map[string]principalQueryRow {
+		t.Helper()
+		results := make(map[string]principalQueryRow)
+		var row principalQueryRow
+		for iter.Next(dbCtx, &row) {
+			results[row.ID] = row
+			row = principalQueryRow{}
+		}
+		require.NoError(t, iter.Close())
+		return results
+	}
+
+	t.Run("QueryRoles", func(t *testing.T) {
+		iter, err := database.QueryRoles(dbCtx, "", 0)
+		require.NoError(t, err)
+
+		results := drainIter(t, iter)
+
+		adminKey := metaKeys.RoleKey("admin")
+		editorKey := metaKeys.RoleKey("editor")
+		viewerKey := metaKeys.RoleKey("viewer")
+
+		require.Len(t, results, 3, "expected exactly 3 unique roles after deduplication")
+		assert.Contains(t, results, adminKey, "admin should be present")
+		assert.Contains(t, results, editorKey, "editor should be present")
+		assert.Contains(t, results, viewerKey, "viewer should be present")
+	})
+
+	t.Run("QueryAllRoles", func(t *testing.T) {
+		iter, err := database.QueryAllRoles(dbCtx, "", 0)
+		require.NoError(t, err)
+
+		results := drainIter(t, iter)
+
+		adminKey := metaKeys.RoleKey("admin")
+		editorKey := metaKeys.RoleKey("editor")
+		viewerKey := metaKeys.RoleKey("viewer")
+
+		require.Len(t, results, 3, "expected exactly 3 unique roles after deduplication")
+		assert.Contains(t, results, adminKey, "admin should be present")
+		assert.Contains(t, results, editorKey, "editor should be present")
+		assert.Contains(t, results, viewerKey, "viewer should be present")
+	})
 }

--- a/db/indextest/indextest_dual_metadata_test.go
+++ b/db/indextest/indextest_dual_metadata_test.go
@@ -13,10 +13,10 @@
 package indextest
 
 import (
-	"fmt"
 	"testing"
 
 	sgbucket "github.com/couchbase/sg-bucket"
+	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"
@@ -43,14 +43,14 @@ func TestDualMetadataStoreIndexes(t *testing.T) {
 		UseXattrs:                  base.TestUseXattrs(),
 		NumPartitions:              db.DefaultNumIndexPartitions,
 		WaitForIndexesOnlineOption: base.WaitForIndexesDefault,
+		MetadataIndexes:            db.IndexesAll,
 	}
 	require.NoError(t, db.InitializeDualMetadataStoreIndexes(ctx, ms, indexOptions))
 
-	// Determine the expected principal index names based on xattr mode.
-	suffix := "x1"
+	// Determine the expected principal index names
 	expectedIndexes := []string{
-		fmt.Sprintf("sg_users_%s", suffix),
-		fmt.Sprintf("sg_roles_%s", suffix),
+		"sg_users_x1",
+		"sg_roles_x1",
 	}
 
 	gocbBucket, err := base.AsGocbV2Bucket(bucket.Bucket)
@@ -199,4 +199,106 @@ func TestQueryPrincipalsDualMetadataStore(t *testing.T) {
 		assert.Equal(t, "bob-primary", results[bobKey].Name,
 			"primary datastore version of bob should be preferred")
 	})
+}
+
+// TestQueryUsersRealDocsDualMetadataStore is a higher-level integration test that creates real
+// user documents via auth.Authenticator on both the primary (_system._mobile) and fallback
+// (_default._default) stores, then calls QueryUsers directly (the same code path as the
+// /_user/ REST endpoint) and asserts that:
+//
+//   - All users from both stores appear in the results.
+//   - The same username present in both stores is deduplicated to a single entry.
+//   - The primary-store version is preferred when a duplicate exists.
+//
+// Test data:
+//   - "alice": primary store only  (email="alice@primary.example")
+//   - "bob":   both stores; primary has email="bob@primary.example", fallback has "bob@fallback.example"
+//   - "carol": fallback store only (email="carol@fallback.example")
+//
+// Expected: three unique results with bob's email originating from the primary store.
+func TestQueryUsersRealDocsDualMetadataStore(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	t.Cleanup(func() { bucket.Close(ctx) })
+
+	// GetMobileSystemDataStore skips if the backing store does not support system collections.
+	primaryStore := bucket.GetMobileSystemDataStore()
+	fallbackStore := bucket.DefaultDataStore()
+	ms := base.NewMetadataStore(primaryStore, fallbackStore)
+
+	// Initialise data indexes on the default collection (used as the CBL sync data scope).
+	setupIndexes(t, bucket, testIndexCreationOptions{
+		numPartitions:          db.DefaultNumIndexPartitions,
+		useLegacySyncDocsIndex: false,
+		useXattrs:              true,
+	})
+
+	// Initialise principal indexes on BOTH the primary and fallback metadata stores.
+	indexOptions := db.InitializeIndexOptions{
+		NumReplicas:                0,
+		LegacySyncDocsIndex:        false,
+		UseXattrs:                  true,
+		NumPartitions:              db.DefaultNumIndexPartitions,
+		WaitForIndexesOnlineOption: base.WaitForIndexesDefault,
+	}
+	require.NoError(t, db.InitializeDualMetadataStoreIndexes(ctx, ms, indexOptions))
+
+	// Build a DatabaseContext that uses the dual MetadataStore with the default collection for
+	// sync metadata.
+	dbOptions := getDatabaseContextOptions(false)
+	dbOptions.Scopes = db.GetScopesOptions(t, bucket, 2)
+	dbOptions.EnableXattr = true
+	dbOptions.MetadataStore = ms
+
+	database, dbCtx := db.CreateTestDatabase(t, bucket, dbOptions)
+	t.Cleanup(func() { database.Close(dbCtx) })
+
+	// authOpts mirrors the core options used by DatabaseContext.Authenticator() but targeting
+	// an individual store directly. channelComputer is nil because channel computation is not
+	// exercised in this test.
+	authOpts := auth.AuthenticatorOptions{
+		LogCtx:   ctx,
+		MetaKeys: base.DefaultMetadataKeys,
+	}
+
+	// createAndSaveUser writes a real user document to the given datastore via
+	// auth.Authenticator, producing the full document structure that QueryUsers expects.
+	// A store-specific email is used to distinguish which version is returned after
+	// deduplication.
+	createAndSaveUser := func(t *testing.T, store base.DataStore, username, email string) {
+		t.Helper()
+		authr := auth.NewAuthenticator(store, nil, authOpts)
+		user, err := authr.NewUser(username, "password", nil)
+		require.NoError(t, err)
+		require.NoError(t, user.SetEmail(email))
+		require.NoError(t, authr.Save(user))
+	}
+
+	createAndSaveUser(t, primaryStore, "alice", "alice@primary.example")   // alice: primary only
+	createAndSaveUser(t, primaryStore, "bob", "bob@primary.example")       // bob: written to primary
+	createAndSaveUser(t, fallbackStore, "bob", "bob@fallback.example")     // bob: also in fallback (duplicate)
+	createAndSaveUser(t, fallbackStore, "carol", "carol@fallback.example") // carol: fallback only
+
+	// QueryUsers is called by the /_user/ REST endpoint. Calling it directly here exercises
+	// the full dual-store query and deduplication path without the HTTP layer.
+	iter, err := database.QueryUsers(dbCtx, "", 0)
+	require.NoError(t, err)
+
+	results := make(map[string]db.QueryUsersRow)
+	var row db.QueryUsersRow
+	for iter.Next(dbCtx, &row) {
+		results[row.Name] = row
+		row = db.QueryUsersRow{} // reset for next iteration
+	}
+	require.NoError(t, iter.Close())
+
+	require.Len(t, results, 3, "expected exactly 3 unique users after deduplication across both datastores")
+	require.Contains(t, results, "alice", "alice (primary store only) should be present")
+	require.Contains(t, results, "bob", "bob should appear exactly once after deduplication")
+	require.Contains(t, results, "carol", "carol (fallback store only) should be present")
+
+	// The primary-store version of bob must take precedence over the fallback-store version.
+	assert.Equal(t, "bob@primary.example", results["bob"].Email,
+		"primary datastore version of bob should be preferred over fallback")
 }

--- a/db/indextest/indextest_dual_metadata_test.go
+++ b/db/indextest/indextest_dual_metadata_test.go
@@ -1,0 +1,202 @@
+// Copyright 2026-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+// Package indextest – Couchbase-Server-only tests for dual MetadataStore query
+// deduplication and index initialisation.  The package-level TestMain in main_test.go
+// already skips this entire package when not running against CBS with GSI.
+
+package indextest
+
+import (
+	"fmt"
+	"testing"
+
+	sgbucket "github.com/couchbase/sg-bucket"
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDualMetadataStoreIndexes verifies that InitializeDualMetadataStoreIndexes creates the
+// required principal indexes on both the primary (_system._mobile) and fallback
+// (_default._default) datastores.
+func TestDualMetadataStoreIndexes(t *testing.T) {
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	t.Cleanup(func() { bucket.Close(ctx) })
+
+	// GetMobileSystemDataStore skips if the backing store does not support system collections.
+	primaryStore := bucket.GetMobileSystemDataStore()
+	fallbackStore := bucket.DefaultDataStore()
+
+	ms := base.NewMetadataStore(primaryStore, fallbackStore)
+
+	indexOptions := db.InitializeIndexOptions{
+		NumReplicas:                0,
+		LegacySyncDocsIndex:        false,
+		UseXattrs:                  base.TestUseXattrs(),
+		NumPartitions:              db.DefaultNumIndexPartitions,
+		WaitForIndexesOnlineOption: base.WaitForIndexesDefault,
+	}
+	require.NoError(t, db.InitializeDualMetadataStoreIndexes(ctx, ms, indexOptions))
+
+	// Determine the expected principal index names based on xattr mode.
+	suffix := "x1"
+	expectedIndexes := []string{
+		fmt.Sprintf("sg_users_%s", suffix),
+		fmt.Sprintf("sg_roles_%s", suffix),
+	}
+
+	gocbBucket, err := base.AsGocbV2Bucket(bucket.Bucket)
+	require.NoError(t, err)
+
+	// Verify that each expected index is present and online on both stores.
+	for _, store := range []base.DataStore{primaryStore, fallbackStore} {
+		n1qlStore, err := base.NewClusterOnlyN1QLStore(
+			gocbBucket.GetCluster(),
+			gocbBucket.BucketName(),
+			store.ScopeName(),
+			store.CollectionName(),
+		)
+		require.NoError(t, err)
+
+		indexesMeta, err := base.GetSystemCollectionIndexesMeta(ctx, n1qlStore, base.SystemScope, base.SystemCollectionMobile, expectedIndexes)
+		require.NoError(t, err)
+
+		for _, indexName := range expectedIndexes {
+			meta, found := indexesMeta[indexName]
+			assert.True(t, found, "index %s missing on %s.%s", indexName, store.ScopeName(), store.CollectionName())
+			if found {
+				assert.Equal(t, base.IndexStateOnline, meta.State,
+					"index %s not online on %s.%s", indexName, store.ScopeName(), store.CollectionName())
+			}
+		}
+	}
+}
+
+// TestQueryPrincipalsDualMetadataStore verifies that QueryPrincipals and QueryUsers correctly
+// deduplicate results when the DatabaseContext uses a *base.MetadataStore (migration-in-progress
+// scenario), preferring the primary datastore version when the same document exists in both.
+//
+// Test data:
+//   - "alice": exists only in primary (name="alice")
+//   - "bob":   exists in both; primary has name="bob-primary", fallback has name="bob-fallback"
+//   - "carol": exists only in fallback (name="carol")
+//
+// Expected: three unique results, with "bob" returning the primary-store name value.
+func TestQueryPrincipalsDualMetadataStore(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	t.Cleanup(func() { bucket.Close(ctx) })
+
+	// GetMobileSystemDataStore skips if the backing store does not support system collections.
+	primaryStore := bucket.GetMobileSystemDataStore()
+	fallbackStore := bucket.DefaultDataStore()
+	ms := base.NewMetadataStore(primaryStore, fallbackStore)
+
+	// Initialise data indexes on the default collection (used as the CBL sync data scope).
+	setupIndexes(t, bucket, testIndexCreationOptions{
+		numPartitions:          db.DefaultNumIndexPartitions,
+		useLegacySyncDocsIndex: false,
+		useXattrs:              true,
+	})
+
+	// Initialise principal indexes on BOTH the primary and fallback metadata stores.
+	indexOptions := db.InitializeIndexOptions{
+		NumReplicas:                0,
+		LegacySyncDocsIndex:        false,
+		UseXattrs:                  true,
+		NumPartitions:              db.DefaultNumIndexPartitions,
+		WaitForIndexesOnlineOption: base.WaitForIndexesDefault,
+	}
+	require.NoError(t, db.InitializeDualMetadataStoreIndexes(ctx, ms, indexOptions))
+
+	// Build a DatabaseContext that uses the dual MetadataStore with the default collection for
+	// sync metadata
+	dbOptions := getDatabaseContextOptions(false)
+	dbOptions.Scopes = db.GetScopesOptions(t, bucket, 2)
+	dbOptions.EnableXattr = true
+	dbOptions.MetadataStore = ms
+
+	database, dbCtx := db.CreateTestDatabase(t, bucket, dbOptions)
+	t.Cleanup(func() { database.Close(dbCtx) })
+
+	metaKeys := base.DefaultMetadataKeys
+
+	// writeUser writes a minimal user doc directly to the specified store, bypassing the
+	// authenticator.  The "name" field deliberately differs between primary and fallback for
+	// "bob" so that the test can verify which version is returned by the query.
+	writeUser := func(t *testing.T, store base.DataStore, docKey, name string) {
+		t.Helper()
+		body, marshalErr := base.JSONMarshal(map[string]string{"name": name})
+		require.NoError(t, marshalErr)
+		added, setErr := store.AddRaw(docKey, 0, body)
+		require.NoError(t, setErr)
+		require.True(t, added, "expected document %s to be added (not already present)", docKey)
+	}
+
+	aliceKey := metaKeys.UserKey("alice")
+	bobKey := metaKeys.UserKey("bob")
+	carolKey := metaKeys.UserKey("carol")
+
+	writeUser(t, primaryStore, aliceKey, "alice")       // alice: primary only
+	writeUser(t, primaryStore, bobKey, "bob-primary")   // bob in primary
+	writeUser(t, fallbackStore, bobKey, "bob-fallback") // bob also in fallback (duplicate)
+	writeUser(t, fallbackStore, carolKey, "carol")      // carol: fallback only
+
+	type principalQueryRow struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	}
+
+	// drainIter collects all rows from a query iterator into a map keyed by META().id.
+	drainIter := func(t *testing.T, iter sgbucket.QueryResultIterator) map[string]principalQueryRow {
+		t.Helper()
+		results := make(map[string]principalQueryRow)
+		var row principalQueryRow
+		for iter.Next(dbCtx, &row) {
+			results[row.ID] = row
+			row = principalQueryRow{} // reset
+		}
+		require.NoError(t, iter.Close())
+		return results
+	}
+
+	t.Run("QueryPrincipals", func(t *testing.T) {
+		iter, err := database.QueryPrincipals(dbCtx, "", 0)
+		require.NoError(t, err)
+
+		results := drainIter(t, iter)
+
+		require.Len(t, results, 3, "expected exactly 3 unique principals after deduplication")
+		require.Contains(t, results, aliceKey, "alice should be present")
+		require.Contains(t, results, bobKey, "bob should be present")
+		require.Contains(t, results, carolKey, "carol should be present")
+
+		// Primary version of bob must be returned.
+		assert.Equal(t, "bob-primary", results[bobKey].Name,
+			"primary datastore version of bob should be preferred")
+	})
+
+	t.Run("QueryUsers", func(t *testing.T) {
+		iter, err := database.QueryUsers(dbCtx, "", 0)
+		require.NoError(t, err)
+
+		results := drainIter(t, iter)
+
+		require.Len(t, results, 3, "expected exactly 3 unique users after deduplication")
+		require.Contains(t, results, aliceKey)
+		require.Contains(t, results, bobKey)
+		require.Contains(t, results, carolKey)
+
+		assert.Equal(t, "bob-primary", results[bobKey].Name,
+			"primary datastore version of bob should be preferred")
+	})
+}

--- a/db/indextest/indextest_dual_metadata_test.go
+++ b/db/indextest/indextest_dual_metadata_test.go
@@ -13,6 +13,7 @@
 package indextest
 
 import (
+	"fmt"
 	"testing"
 
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -301,4 +302,128 @@ func TestQueryUsersRealDocsDualMetadataStore(t *testing.T) {
 	// The primary-store version of bob must take precedence over the fallback-store version.
 	assert.Equal(t, "bob@primary.example", results["bob"].Email,
 		"primary datastore version of bob should be preferred over fallback")
+}
+
+// TestGetUsersPaginationDualMetadataStore verifies that GetUsers correctly paginates through
+// all users when the internal QueryPaginationLimit is much smaller than the total number of
+// users.  Users are spread across the primary and fallback metadata stores with deliberate
+// duplicates to validate that:
+//
+//   - The pagination loop inside GetUsers fetches every page until exhausted.
+//   - Duplicate usernames present in both stores are deduplicated to a single entry.
+//   - The primary-store version is preferred for duplicates.
+//   - The final result set contains exactly the expected number of unique users.
+func TestGetUsersPaginationDualMetadataStore(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	t.Cleanup(func() { bucket.Close(ctx) })
+
+	primaryStore := bucket.GetMobileSystemDataStore()
+	fallbackStore := bucket.DefaultDataStore()
+	ms := base.NewMetadataStore(primaryStore, fallbackStore)
+
+	// Initialise data indexes on the default collection.
+	setupIndexes(t, bucket, testIndexCreationOptions{
+		numPartitions:          db.DefaultNumIndexPartitions,
+		useLegacySyncDocsIndex: false,
+		useXattrs:              true,
+	})
+
+	// Initialise principal indexes on both the primary and fallback metadata stores.
+	indexOptions := db.InitializeIndexOptions{
+		NumReplicas:                0,
+		LegacySyncDocsIndex:        false,
+		UseXattrs:                  true,
+		NumPartitions:              db.DefaultNumIndexPartitions,
+		WaitForIndexesOnlineOption: base.WaitForIndexesDefault,
+	}
+	require.NoError(t, db.InitializeDualMetadataStoreIndexes(t, ctx, ms, indexOptions))
+
+	// Use a very small pagination limit to force multiple pagination rounds inside GetUsers.
+	const paginationLimit = 3
+
+	dbOptions := getDatabaseContextOptions(false)
+	dbOptions.Scopes = db.GetScopesOptions(t, bucket, 2)
+	dbOptions.EnableXattr = true
+	dbOptions.MetadataStore = ms
+	dbOptions.QueryPaginationLimit = paginationLimit
+
+	database, dbCtx := db.CreateTestDatabase(t, bucket, dbOptions)
+	t.Cleanup(func() { database.Close(dbCtx) })
+
+	authOpts := auth.AuthenticatorOptions{
+		LogCtx:   ctx,
+		MetaKeys: base.DefaultMetadataKeys,
+	}
+
+	createAndSaveUser := func(t *testing.T, store base.DataStore, username, email string) {
+		t.Helper()
+		authr := auth.NewAuthenticator(store, nil, authOpts)
+		user, err := authr.NewUser(username, "password", nil)
+		require.NoError(t, err)
+		require.NoError(t, user.SetEmail(email))
+		require.NoError(t, authr.Save(user))
+	}
+
+	// ── Seed users ──
+	// Primary-only users (10 users).
+	for i := range 10 {
+		name := fmt.Sprintf("primary-only-%03d", i)
+		createAndSaveUser(t, primaryStore, name, name+"@primary.example")
+	}
+
+	// Fallback-only users (10 users).
+	for i := range 10 {
+		name := fmt.Sprintf("fallback-only-%03d", i)
+		createAndSaveUser(t, fallbackStore, name, name+"@fallback.example")
+	}
+
+	// Duplicate users present in both stores (5 users).
+	// Primary version has @primary.example, fallback has @fallback.example.
+	for i := range 5 {
+		name := fmt.Sprintf("dup-user-%03d", i)
+		createAndSaveUser(t, primaryStore, name, name+"@primary.example")
+		createAndSaveUser(t, fallbackStore, name, name+"@fallback.example")
+	}
+
+	// Total unique users: 10 (primary-only) + 10 (fallback-only) + 5 (duplicates) = 25.
+	const expectedUniqueUsers = 25
+
+	// Call GetUsers with limit=0 (no result cap) — pagination is driven by QueryPaginationLimit.
+	users, err := database.GetUsers(dbCtx, 0)
+	require.NoError(t, err)
+	require.Len(t, users, expectedUniqueUsers,
+		"GetUsers should return all %d unique users across paginated queries (pagination limit=%d)",
+		expectedUniqueUsers, paginationLimit)
+
+	// Build a lookup of returned users keyed by name for dedup and priority assertions.
+	usersByName := make(map[string]auth.PrincipalConfig, len(users))
+	for _, u := range users {
+		require.NotNil(t, u.Name)
+		_, exists := usersByName[*u.Name]
+		assert.False(t, exists, "duplicate user %q returned by GetUsers", *u.Name)
+		usersByName[*u.Name] = u
+	}
+
+	// Verify all primary-only users are present.
+	for i := range 10 {
+		name := fmt.Sprintf("primary-only-%03d", i)
+		assert.Contains(t, usersByName, name)
+	}
+
+	// Verify all fallback-only users are present.
+	for i := range 10 {
+		name := fmt.Sprintf("fallback-only-%03d", i)
+		assert.Contains(t, usersByName, name)
+	}
+
+	// Verify duplicate users are present with primary-store email (primary takes priority).
+	for i := range 5 {
+		name := fmt.Sprintf("dup-user-%03d", i)
+		require.Contains(t, usersByName, name)
+		require.NotNil(t, usersByName[name].Email)
+		assert.Equal(t, name+"@primary.example", *usersByName[name].Email,
+			"duplicate user %q should use the primary-store version", name)
+	}
 }

--- a/db/indextest/indextest_dual_metadata_test.go
+++ b/db/indextest/indextest_dual_metadata_test.go
@@ -45,7 +45,7 @@ func TestDualMetadataStoreIndexes(t *testing.T) {
 		WaitForIndexesOnlineOption: base.WaitForIndexesDefault,
 		MetadataIndexes:            db.IndexesAll,
 	}
-	require.NoError(t, db.InitializeDualMetadataStoreIndexes(ctx, ms, indexOptions))
+	require.NoError(t, db.InitializeDualMetadataStoreIndexes(t, ctx, ms, indexOptions))
 
 	// Determine the expected principal index names
 	expectedIndexes := []string{
@@ -116,7 +116,7 @@ func TestQueryPrincipalsDualMetadataStore(t *testing.T) {
 		NumPartitions:              db.DefaultNumIndexPartitions,
 		WaitForIndexesOnlineOption: base.WaitForIndexesDefault,
 	}
-	require.NoError(t, db.InitializeDualMetadataStoreIndexes(ctx, ms, indexOptions))
+	require.NoError(t, db.InitializeDualMetadataStoreIndexes(t, ctx, ms, indexOptions))
 
 	// Build a DatabaseContext that uses the dual MetadataStore with the default collection for
 	// sync metadata
@@ -242,7 +242,7 @@ func TestQueryUsersRealDocsDualMetadataStore(t *testing.T) {
 		NumPartitions:              db.DefaultNumIndexPartitions,
 		WaitForIndexesOnlineOption: base.WaitForIndexesDefault,
 	}
-	require.NoError(t, db.InitializeDualMetadataStoreIndexes(ctx, ms, indexOptions))
+	require.NoError(t, db.InitializeDualMetadataStoreIndexes(t, ctx, ms, indexOptions))
 
 	// Build a DatabaseContext that uses the dual MetadataStore with the default collection for
 	// sync metadata.

--- a/db/query.go
+++ b/db/query.go
@@ -577,7 +577,10 @@ func (context *DatabaseContext) QueryPrincipals(ctx context.Context, startKey st
 		queryStatement = fmt.Sprintf("%s LIMIT %d", queryStatement, limit)
 	}
 
-	// N1QL Query
+	// N1QL Query — when a dual MetadataStore is active query both keystores and merge.
+	if ms, ok := context.MetadataStore.(*base.MetadataStore); ok && !ms.MigrationComplete() {
+		return dualMetadataN1QLQuery(ctx, ms, QueryPrincipals.name, queryStatement, params, base.RequestPlus, QueryPrincipals.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold)
+	}
 	return N1QLQueryWithStats(ctx, context.MetadataStore, QueryPrincipals.name, queryStatement, params, base.RequestPlus, QueryPrincipals.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold)
 }
 
@@ -591,7 +594,10 @@ func (context *DatabaseContext) QueryUsers(ctx context.Context, startKey string,
 
 	queryStatement, params := context.BuildUsersQuery(startKey, limit)
 
-	// N1QL Query
+	// N1QL Query — when a dual MetadataStore is active query both keystores and merge.
+	if ms, ok := context.MetadataStore.(*base.MetadataStore); ok && !ms.MigrationComplete() {
+		return dualMetadataN1QLQuery(ctx, ms, QueryTypeUsers, queryStatement, params, base.RequestPlus, QueryUsers.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold)
+	}
 	return N1QLQueryWithStats(ctx, context.MetadataStore, QueryTypeUsers, queryStatement, params, base.RequestPlus, QueryUsers.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold)
 }
 
@@ -634,7 +640,10 @@ func (context *DatabaseContext) QueryRoles(ctx context.Context, startKey string,
 
 	queryStatement, params := context.BuildRolesQuery(startKey, limit)
 
-	// N1QL Query
+	// N1QL Query — when a dual MetadataStore is active query both keystores and merge.
+	if ms, ok := context.MetadataStore.(*base.MetadataStore); ok && !ms.MigrationComplete() {
+		return dualMetadataN1QLQuery(ctx, ms, QueryRolesExcludeDeleted.name, queryStatement, params, base.RequestPlus, QueryRolesExcludeDeleted.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold)
+	}
 	return N1QLQueryWithStats(ctx, context.MetadataStore, QueryRolesExcludeDeleted.name, queryStatement, params, base.RequestPlus, QueryRolesExcludeDeleted.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold)
 }
 
@@ -681,7 +690,10 @@ func (context *DatabaseContext) QueryAllRoles(ctx context.Context, startKey stri
 		queryStatement = fmt.Sprintf("%s LIMIT %d", queryStatement, limit)
 	}
 
-	// N1QL Query
+	// N1QL Query — when a dual MetadataStore is active query both keystores and merge.
+	if ms, ok := context.MetadataStore.(*base.MetadataStore); ok && !ms.MigrationComplete() {
+		return dualMetadataN1QLQuery(ctx, ms, QueryRolesExcludeDeleted.name, queryStatement, params, base.RequestPlus, QueryRolesExcludeDeleted.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold)
+	}
 	return N1QLQueryWithStats(ctx, context.MetadataStore, QueryRolesExcludeDeleted.name, queryStatement, params, base.RequestPlus, QueryRolesExcludeDeleted.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold)
 }
 

--- a/db/query.go
+++ b/db/query.go
@@ -573,13 +573,14 @@ func (context *DatabaseContext) QueryPrincipals(ctx context.Context, startKey st
 	params := make(map[string]any)
 	params[QueryParamStartKey] = startKey
 
-	if limit > 0 {
-		queryStatement = fmt.Sprintf("%s LIMIT %d", queryStatement, limit)
+	// N1QL Query — when a dual MetadataStore is active query both keystores and merge.
+	// LIMIT is handled internally by dualMetadataN1QLQuery; do not append it to the statement.
+	if ms, ok := context.MetadataStore.(*base.MetadataStore); ok && !ms.MigrationComplete() {
+		return dualMetadataN1QLQuery(ctx, ms, QueryPrincipals.name, queryStatement, params, base.RequestPlus, QueryPrincipals.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold, limit)
 	}
 
-	// N1QL Query — when a dual MetadataStore is active query both keystores and merge.
-	if ms, ok := context.MetadataStore.(*base.MetadataStore); ok && !ms.MigrationComplete() {
-		return dualMetadataN1QLQuery(ctx, ms, QueryPrincipals.name, queryStatement, params, base.RequestPlus, QueryPrincipals.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold)
+	if limit > 0 {
+		queryStatement = fmt.Sprintf("%s LIMIT %d", queryStatement, limit)
 	}
 	return N1QLQueryWithStats(ctx, context.MetadataStore, QueryPrincipals.name, queryStatement, params, base.RequestPlus, QueryPrincipals.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold)
 }
@@ -592,12 +593,13 @@ func (context *DatabaseContext) QueryUsers(ctx context.Context, startKey string,
 		return nil, errors.New("QueryUsers does not support views")
 	}
 
-	queryStatement, params := context.BuildUsersQuery(startKey, limit)
-
 	// N1QL Query — when a dual MetadataStore is active query both keystores and merge.
+	// LIMIT is handled internally by dualMetadataN1QLQuery; build the statement without it.
 	if ms, ok := context.MetadataStore.(*base.MetadataStore); ok && !ms.MigrationComplete() {
-		return dualMetadataN1QLQuery(ctx, ms, QueryTypeUsers, queryStatement, params, base.RequestPlus, QueryUsers.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold)
+		queryStatement, params := context.BuildUsersQuery(startKey, 0)
+		return dualMetadataN1QLQuery(ctx, ms, QueryTypeUsers, queryStatement, params, base.RequestPlus, QueryUsers.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold, limit)
 	}
+	queryStatement, params := context.BuildUsersQuery(startKey, limit)
 	return N1QLQueryWithStats(ctx, context.MetadataStore, QueryTypeUsers, queryStatement, params, base.RequestPlus, QueryUsers.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold)
 }
 
@@ -638,12 +640,13 @@ func (context *DatabaseContext) QueryRoles(ctx context.Context, startKey string,
 		return context.ViewQueryWithStats(ctx, context.MetadataStore, DesignDocSyncGateway(), ViewRolesExcludeDeleted, opts)
 	}
 
-	queryStatement, params := context.BuildRolesQuery(startKey, limit)
-
 	// N1QL Query — when a dual MetadataStore is active query both keystores and merge.
+	// LIMIT is handled internally by dualMetadataN1QLQuery; build the statement without it.
 	if ms, ok := context.MetadataStore.(*base.MetadataStore); ok && !ms.MigrationComplete() {
-		return dualMetadataN1QLQuery(ctx, ms, QueryRolesExcludeDeleted.name, queryStatement, params, base.RequestPlus, QueryRolesExcludeDeleted.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold)
+		queryStatement, params := context.BuildRolesQuery(startKey, 0)
+		return dualMetadataN1QLQuery(ctx, ms, QueryRolesExcludeDeleted.name, queryStatement, params, base.RequestPlus, QueryRolesExcludeDeleted.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold, limit)
 	}
+	queryStatement, params := context.BuildRolesQuery(startKey, limit)
 	return N1QLQueryWithStats(ctx, context.MetadataStore, QueryRolesExcludeDeleted.name, queryStatement, params, base.RequestPlus, QueryRolesExcludeDeleted.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold)
 }
 
@@ -686,13 +689,14 @@ func (context *DatabaseContext) QueryAllRoles(ctx context.Context, startKey stri
 	params := make(map[string]any)
 	params[QueryParamStartKey] = startKey
 
-	if limit > 0 {
-		queryStatement = fmt.Sprintf("%s LIMIT %d", queryStatement, limit)
+	// N1QL Query — when a dual MetadataStore is active query both keystores and merge.
+	// LIMIT is handled internally by dualMetadataN1QLQuery; do not append it to the statement.
+	if ms, ok := context.MetadataStore.(*base.MetadataStore); ok && !ms.MigrationComplete() {
+		return dualMetadataN1QLQuery(ctx, ms, QueryRolesExcludeDeleted.name, queryStatement, params, base.RequestPlus, QueryRolesExcludeDeleted.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold, limit)
 	}
 
-	// N1QL Query — when a dual MetadataStore is active query both keystores and merge.
-	if ms, ok := context.MetadataStore.(*base.MetadataStore); ok && !ms.MigrationComplete() {
-		return dualMetadataN1QLQuery(ctx, ms, QueryRolesExcludeDeleted.name, queryStatement, params, base.RequestPlus, QueryRolesExcludeDeleted.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold)
+	if limit > 0 {
+		queryStatement = fmt.Sprintf("%s LIMIT %d", queryStatement, limit)
 	}
 	return N1QLQueryWithStats(ctx, context.MetadataStore, QueryRolesExcludeDeleted.name, queryStatement, params, base.RequestPlus, QueryRolesExcludeDeleted.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold)
 }

--- a/db/query.go
+++ b/db/query.go
@@ -680,10 +680,13 @@ func (context *DatabaseContext) QueryAllRoles(ctx context.Context, startKey stri
 	}
 
 	var queryStatement string
+	var queryName string
 	if !context.UseLegacySyncDocsIndex() {
 		queryStatement = replaceIndexTokensQuery(QueryAllRolesUsingRoleIdx.statement, sgIndexes[IndexRole], context.UseXattrs(), context.numIndexPartitions())
+		queryName = QueryAllRolesUsingRoleIdx.name
 	} else {
 		queryStatement = replaceIndexTokensQuery(QueryAllRolesUsingSyncDocsIdx.statement, sgIndexes[IndexSyncDocs], context.UseXattrs(), context.numIndexPartitions())
+		queryName = QueryAllRolesUsingSyncDocsIdx.name
 	}
 
 	params := make(map[string]any)
@@ -692,13 +695,13 @@ func (context *DatabaseContext) QueryAllRoles(ctx context.Context, startKey stri
 	// N1QL Query — when a dual MetadataStore is active query both keystores and merge.
 	// LIMIT is handled internally by dualMetadataN1QLQuery; do not append it to the statement.
 	if ms, ok := context.MetadataStore.(*base.MetadataStore); ok && !ms.MigrationComplete() {
-		return dualMetadataN1QLQuery(ctx, ms, QueryRolesExcludeDeleted.name, queryStatement, params, base.RequestPlus, QueryRolesExcludeDeleted.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold, limit)
+		return dualMetadataN1QLQuery(ctx, ms, queryName, queryStatement, params, base.RequestPlus, QueryRolesExcludeDeleted.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold, limit)
 	}
 
 	if limit > 0 {
 		queryStatement = fmt.Sprintf("%s LIMIT %d", queryStatement, limit)
 	}
-	return N1QLQueryWithStats(ctx, context.MetadataStore, QueryRolesExcludeDeleted.name, queryStatement, params, base.RequestPlus, QueryRolesExcludeDeleted.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold)
+	return N1QLQueryWithStats(ctx, context.MetadataStore, queryName, queryStatement, params, base.RequestPlus, QueryRolesExcludeDeleted.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold)
 }
 
 type AllDocsViewQueryRow struct {

--- a/db/query.go
+++ b/db/query.go
@@ -29,9 +29,13 @@ type QueryIdRow struct {
 }
 
 // Used for queries that only return doc id
-type principalRow struct {
+type PrincipalRow struct {
 	Id   string
 	Name string
+}
+
+func (r PrincipalRow) rowID() string {
+	return r.Id
 }
 
 const (
@@ -264,6 +268,10 @@ type QueryUsersRow struct {
 	Name     string `json:"name"`
 	Email    string `json:"email,omitempty"`
 	Disabled bool   `json:"disabled,omitempty"`
+}
+
+func (r QueryUsersRow) rowID() string {
+	return r.ID
 }
 
 var QueryUsers = SGQuery{
@@ -576,7 +584,7 @@ func (context *DatabaseContext) QueryPrincipals(ctx context.Context, startKey st
 	// N1QL Query — when a dual MetadataStore is active query both keystores and merge.
 	// LIMIT is handled internally by dualMetadataN1QLQuery; do not append it to the statement.
 	if ms, ok := context.MetadataStore.(*base.MetadataStore); ok && !ms.MigrationComplete() {
-		return dualMetadataN1QLQuery(ctx, ms, QueryPrincipals.name, queryStatement, params, base.RequestPlus, QueryPrincipals.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold, limit)
+		return dualMetadataN1QLQuery[PrincipalRow](ctx, ms, QueryPrincipals.name, queryStatement, params, base.RequestPlus, QueryPrincipals.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold, limit)
 	}
 
 	if limit > 0 {
@@ -597,7 +605,7 @@ func (context *DatabaseContext) QueryUsers(ctx context.Context, startKey string,
 	// LIMIT is handled internally by dualMetadataN1QLQuery; build the statement without it.
 	if ms, ok := context.MetadataStore.(*base.MetadataStore); ok && !ms.MigrationComplete() {
 		queryStatement, params := context.BuildUsersQuery(startKey, 0)
-		return dualMetadataN1QLQuery(ctx, ms, QueryTypeUsers, queryStatement, params, base.RequestPlus, QueryUsers.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold, limit)
+		return dualMetadataN1QLQuery[QueryUsersRow](ctx, ms, QueryTypeUsers, queryStatement, params, base.RequestPlus, QueryUsers.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold, limit)
 	}
 	queryStatement, params := context.BuildUsersQuery(startKey, limit)
 	return N1QLQueryWithStats(ctx, context.MetadataStore, QueryTypeUsers, queryStatement, params, base.RequestPlus, QueryUsers.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold)
@@ -644,7 +652,7 @@ func (context *DatabaseContext) QueryRoles(ctx context.Context, startKey string,
 	// LIMIT is handled internally by dualMetadataN1QLQuery; build the statement without it.
 	if ms, ok := context.MetadataStore.(*base.MetadataStore); ok && !ms.MigrationComplete() {
 		queryStatement, params := context.BuildRolesQuery(startKey, 0)
-		return dualMetadataN1QLQuery(ctx, ms, QueryRolesExcludeDeleted.name, queryStatement, params, base.RequestPlus, QueryRolesExcludeDeleted.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold, limit)
+		return dualMetadataN1QLQuery[PrincipalRow](ctx, ms, QueryRolesExcludeDeleted.name, queryStatement, params, base.RequestPlus, QueryRolesExcludeDeleted.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold, limit)
 	}
 	queryStatement, params := context.BuildRolesQuery(startKey, limit)
 	return N1QLQueryWithStats(ctx, context.MetadataStore, QueryRolesExcludeDeleted.name, queryStatement, params, base.RequestPlus, QueryRolesExcludeDeleted.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold)
@@ -695,7 +703,7 @@ func (context *DatabaseContext) QueryAllRoles(ctx context.Context, startKey stri
 	// N1QL Query — when a dual MetadataStore is active query both keystores and merge.
 	// LIMIT is handled internally by dualMetadataN1QLQuery; do not append it to the statement.
 	if ms, ok := context.MetadataStore.(*base.MetadataStore); ok && !ms.MigrationComplete() {
-		return dualMetadataN1QLQuery(ctx, ms, queryName, queryStatement, params, base.RequestPlus, QueryRolesExcludeDeleted.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold, limit)
+		return dualMetadataN1QLQuery[PrincipalRow](ctx, ms, queryName, queryStatement, params, base.RequestPlus, QueryRolesExcludeDeleted.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold, limit)
 	}
 
 	if limit > 0 {

--- a/db/query_dual_metadata.go
+++ b/db/query_dual_metadata.go
@@ -9,6 +9,7 @@
 package db
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"time"
@@ -120,8 +121,9 @@ func (m *mergedDedupIterator) peekPrimary() bool {
 	raw := m.primary.NextBytes()
 	if raw == nil {
 		m.primaryDone = true
-		// If consumed exactly limit rows, primary may have been truncated.
-		if m.limit > 0 && m.primaryConsumed >= m.limit && !m.hasBoundary {
+		// Only an exhaustion after consuming exactly limit rows indicates the source may
+		// have been truncated by the per-store LIMIT and therefore needs a safe boundary.
+		if m.limit > 0 && m.primaryConsumed == m.limit && !m.hasBoundary {
 			m.boundary = m.lastPrimaryID
 			m.hasBoundary = true
 		}
@@ -144,8 +146,9 @@ func (m *mergedDedupIterator) peekFallback() bool {
 	raw := m.fallback.NextBytes()
 	if raw == nil {
 		m.fallbackDone = true
-		// If consumed exactly limit rows, fallback may have been truncated.
-		if m.limit > 0 && m.fallbackConsumed >= m.limit && !m.hasBoundary {
+		// Only an exhaustion after consuming exactly limit rows indicates the source may
+		// have been truncated by the per-store LIMIT and therefore needs a safe boundary.
+		if m.limit > 0 && m.fallbackConsumed == m.limit && !m.hasBoundary {
 			m.boundary = m.lastFallbackID
 			m.hasBoundary = true
 		}
@@ -243,18 +246,31 @@ func (m *mergedDedupIterator) Close() error {
 	return fallbackErr
 }
 
-// idOnlyRow is a minimal struct used to extract META().id from a raw N1QL result row.
-// All principal query SELECT clauses serialise META(<alias>).id as the top-level "id" field.
-type idOnlyRow struct {
-	ID string `json:"id"`
-}
+// idFieldKey is the byte pattern used to locate the "id" field in raw N1QL JSON result rows.
+var idFieldKey = []byte(`"id":"`)
 
-// extractRowID extracts the META().id value from a raw N1QL result row JSON byte slice.
-// Returns an empty string if the bytes cannot be parsed or the "id" field is absent.
+// extractRowID extracts the META().id value from a raw N1QL result row using a byte-level
+// scan rather than a full JSON unmarshal. This avoids double-parsing overhead since callers
+// of Next() will unmarshal the same raw bytes again into the destination struct.
+//
+// This is safe because N1QL results are machine-generated flat JSON objects with predictable
+// structure; the "id" field is always a top-level string key.
+//
+// Returns an empty string if the bytes cannot be scanned or the "id" field is absent.
 func extractRowID(raw []byte) string {
-	var row idOnlyRow
-	if err := base.JSONUnmarshal(raw, &row); err != nil {
+	idx := bytes.Index(raw, idFieldKey)
+	if idx < 0 {
 		return ""
 	}
-	return row.ID
+	start := idx + len(idFieldKey)
+	for i := start; i < len(raw); i++ {
+		if raw[i] == '\\' {
+			i++ // skip escaped character
+			continue
+		}
+		if raw[i] == '"' {
+			return string(raw[start:i])
+		}
+	}
+	return ""
 }

--- a/db/query_dual_metadata.go
+++ b/db/query_dual_metadata.go
@@ -20,14 +20,14 @@ import (
 
 // dualMetadataN1QLQuery executes the same N1QL statement independently against both the
 // primary and fallback datastores of a *base.MetadataStore, then returns a
-// mergedDedupIterator that merge-sorts the two result streams by document ID, deduplicating
+// dualMetadataStorePrincipalDedupIterator that merge-sorts the two result streams by document ID, deduplicating
 // and preferring the primary-store version when both contain the same document.
 //
 // The statement must still contain base.KeyspaceQueryToken; each store's Query method
 // replaces this token with its own escaped keyspace before execution.
 //
 // The statement should NOT include a LIMIT clause — callers pass the desired limit separately.
-// When limit > 0, each per-store query appends LIMIT <limit>. The mergedDedupIterator uses
+// When limit > 0, each per-store query appends LIMIT <limit>. The dualMetadataStorePrincipalDedupIterator uses
 // the limit to detect when a source hit its LIMIT (consumed exactly limit rows) vs. was truly
 // exhausted (consumed fewer). When a source hits its LIMIT, the iterator establishes a "safe
 // boundary" at that source's last emitted ID and stops returning rows from the other source
@@ -53,7 +53,7 @@ func dualMetadataN1QLQuery(ctx context.Context, ms *base.MetadataStore, queryNam
 		return nil, fmt.Errorf("dual metadata fallback N1QL query: %w", err)
 	}
 
-	return newMergedDedupIterator(primaryIter, fallbackIter, limit), nil
+	return newDualMetadataStorePrincipalDedupIterator(primaryIter, fallbackIter, limit), nil
 }
 
 // peekedRow holds a row that has been read from a source iterator but not yet emitted.
@@ -62,7 +62,7 @@ type peekedRow struct {
 	id  string
 }
 
-// mergedDedupIterator performs a sorted merge of two sgbucket.QueryResultIterators (primary and
+// dualMetadataStorePrincipalDedupIterator performs a sorted merge of two sgbucket.QueryResultIterators (primary and
 // fallback), emitting rows in ascending document-ID order. When both iterators contain a row
 // with the same ID, only the primary version is emitted.
 //
@@ -76,7 +76,7 @@ type peekedRow struct {
 // advancing past IDs the limited source might still have, ensuring subsequent pages do not
 // skip results. When a source returns fewer than limit rows, it is truly exhausted and no
 // boundary is imposed.
-type mergedDedupIterator struct {
+type dualMetadataStorePrincipalDedupIterator struct {
 	primary      sgbucket.QueryResultIterator
 	fallback     sgbucket.QueryResultIterator
 	primaryPeek  *peekedRow
@@ -98,11 +98,11 @@ type mergedDedupIterator struct {
 	fallbackDone bool
 }
 
-// Compile-time assertion that *mergedDedupIterator implements sgbucket.QueryResultIterator.
-var _ sgbucket.QueryResultIterator = (*mergedDedupIterator)(nil)
+// Compile-time assertion that *dualMetadataStorePrincipalDedupIterator implements sgbucket.QueryResultIterator.
+var _ sgbucket.QueryResultIterator = (*dualMetadataStorePrincipalDedupIterator)(nil)
 
-func newMergedDedupIterator(primary, fallback sgbucket.QueryResultIterator, limit int) *mergedDedupIterator {
-	return &mergedDedupIterator{
+func newDualMetadataStorePrincipalDedupIterator(primary, fallback sgbucket.QueryResultIterator, limit int) *dualMetadataStorePrincipalDedupIterator {
+	return &dualMetadataStorePrincipalDedupIterator{
 		primary:  primary,
 		fallback: fallback,
 		limit:    limit,
@@ -111,7 +111,7 @@ func newMergedDedupIterator(primary, fallback sgbucket.QueryResultIterator, limi
 
 // peekPrimary ensures primaryPeek is populated. Returns false if the primary iterator is
 // exhausted.
-func (m *mergedDedupIterator) peekPrimary() bool {
+func (m *dualMetadataStorePrincipalDedupIterator) peekPrimary() bool {
 	if m.primaryPeek != nil {
 		return true
 	}
@@ -136,7 +136,7 @@ func (m *mergedDedupIterator) peekPrimary() bool {
 
 // peekFallback ensures fallbackPeek is populated. Returns false if the fallback iterator is
 // exhausted.
-func (m *mergedDedupIterator) peekFallback() bool {
+func (m *dualMetadataStorePrincipalDedupIterator) peekFallback() bool {
 	if m.fallbackPeek != nil {
 		return true
 	}
@@ -161,7 +161,7 @@ func (m *mergedDedupIterator) peekFallback() bool {
 
 // NextBytes returns the raw JSON bytes of the next row from the sorted merge, or nil when
 // both iterators are exhausted or the safe boundary has been reached.
-func (m *mergedDedupIterator) NextBytes() []byte {
+func (m *dualMetadataStorePrincipalDedupIterator) NextBytes() []byte {
 	hasPrimary := m.peekPrimary()
 	hasFallback := m.peekFallback()
 
@@ -171,54 +171,52 @@ func (m *mergedDedupIterator) NextBytes() []byte {
 
 	// Determine which row to emit based on merge-sort comparison.
 	var row *peekedRow
-	var fromPrimary bool
 
 	switch {
 	case hasPrimary && !hasFallback:
 		row = m.primaryPeek
-		fromPrimary = true
+		m.lastPrimaryID = row.id
+		m.primaryPeek = nil // consume primary row
 	case !hasPrimary && hasFallback:
 		row = m.fallbackPeek
-		fromPrimary = false
+		m.lastFallbackID = row.id
+		m.fallbackPeek = nil // consume fallback row
 	case m.primaryPeek.id < m.fallbackPeek.id:
 		row = m.primaryPeek
-		fromPrimary = true
+		m.lastPrimaryID = row.id
+		m.primaryPeek = nil // consume primary row
 	case m.primaryPeek.id > m.fallbackPeek.id:
 		row = m.fallbackPeek
-		fromPrimary = false
+		m.lastFallbackID = row.id
+		m.fallbackPeek = nil // consume fallback row
 	default:
 		// Equal IDs — prefer primary, discard fallback.
 		row = m.primaryPeek
-		fromPrimary = true
+		m.lastPrimaryID = row.id
+		m.primaryPeek = nil // consume primary row
 		m.lastFallbackID = m.fallbackPeek.id
 		m.fallbackPeek = nil // discard duplicate
 	}
 
-	// Check safe boundary: do not emit rows beyond the boundary.
+	// Suppress rows from the other source that fall beyond the safe boundary. The boundary is
+	// the last ID emitted by the source that hit its LIMIT, so any row with id == boundary was
+	// already emitted (or deduped away via the default case above). Only rows strictly after
+	// the boundary are unsafe, hence > rather than >=.
 	if m.hasBoundary && row.id > m.boundary {
 		return nil
-	}
-
-	// Consume the selected row and track the last ID for boundary detection.
-	if fromPrimary {
-		m.lastPrimaryID = row.id
-		m.primaryPeek = nil
-	} else {
-		m.lastFallbackID = row.id
-		m.fallbackPeek = nil
 	}
 
 	return row.raw
 }
 
 // Next unmarshals the next merged row into valuePtr. Returns false when exhausted.
-func (m *mergedDedupIterator) Next(ctx context.Context, valuePtr any) bool {
+func (m *dualMetadataStorePrincipalDedupIterator) Next(ctx context.Context, valuePtr any) bool {
 	raw := m.NextBytes()
 	if raw == nil {
 		return false
 	}
 	if err := base.JSONUnmarshal(raw, valuePtr); err != nil {
-		base.WarnfCtx(ctx, "mergedDedupIterator: failed to unmarshal row: %v", err)
+		base.WarnfCtx(ctx, "dualMetadataStorePrincipalDedupIterator: failed to unmarshal row: %v", err)
 		return false
 	}
 	return true
@@ -226,7 +224,7 @@ func (m *mergedDedupIterator) Next(ctx context.Context, valuePtr any) bool {
 
 // One unmarshals the first merged row into valuePtr and closes both iterators.
 // Returns sgbucket.ErrNoRows when no rows are available.
-func (m *mergedDedupIterator) One(ctx context.Context, valuePtr any) error {
+func (m *dualMetadataStorePrincipalDedupIterator) One(ctx context.Context, valuePtr any) error {
 	defer func() {
 		_ = m.Close()
 	}()
@@ -237,7 +235,7 @@ func (m *mergedDedupIterator) One(ctx context.Context, valuePtr any) error {
 }
 
 // Close closes both the primary and fallback iterators.
-func (m *mergedDedupIterator) Close() error {
+func (m *dualMetadataStorePrincipalDedupIterator) Close() error {
 	primaryErr := m.primary.Close()
 	fallbackErr := m.fallback.Close()
 	if primaryErr != nil {

--- a/db/query_dual_metadata.go
+++ b/db/query_dual_metadata.go
@@ -11,137 +11,231 @@ package db
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 )
 
-// dualMetadataN1QLQuery runs the given N1QL statement against both the primary and fallback
-// datastores of a *base.MetadataStore and returns a mergeDedupIterator over the two result
-// streams. The primary datastore results are emitted first; fallback results are only emitted
-// for documents whose META().id was not already seen in the primary stream.
+// dualMetadataSortOrderKey is the N1QL column alias injected as a numeric literal into each
+// arm of the UNION ALL query to enforce primary-before-fallback ordering. Primary arms receive
+// value 0; fallback arms receive value 1. The outer ORDER BY uses this column as its first
+// sort key, ensuring all primary rows are returned before any fallback rows regardless of
+// N1QL's internal execution order.
+const dualMetadataSortOrderKey = "sort_order"
+
+// dualMetadataN1QLQuery executes a single UNION ALL N1QL statement across both the primary
+// and fallback datastores of a *base.MetadataStore and returns a unionDedupIterator over the
+// combined result stream.
 //
-// When a query limit is present in the statement it applies independently to each store, so
-// the merged stream may return up to 2× the requested limit of unique rows. Callers that
-// need strict limits should truncate after the desired number of rows.
+// The original statement (which may still contain base.KeyspaceQueryToken) is expanded by
+// buildDualMetadataUnionStatement into two fully-qualified sub-queries joined with UNION ALL.
+// A sort_order literal (0=primary, 1=fallback) is injected into each arm, and a single outer
+// ORDER BY sort_order[, <original order>] guarantees that all primary rows precede all
+// fallback rows in the result stream. unionDedupIterator relies on this ordering: "first seen
+// wins" always selects the primary-store version when the same META().id exists in both stores.
+//
+// The combined query is executed against the fallback (default) store. Because both keyspaces
+// are referenced with fully-qualified names, the fallback store's query_context does not
+// restrict access to the primary keyspace.
+//
+// When a query limit is present in the statement it applies independently to each sub-query,
+// so the merged stream may return up to 2x the requested limit of unique rows.
 func dualMetadataN1QLQuery(ctx context.Context, ms *base.MetadataStore, queryName string,
 	statement string, params map[string]any, consistency base.ConsistencyMode, adhoc bool,
 	dbStats *base.DbStats, slowQueryWarningThreshold time.Duration) (sgbucket.QueryResultIterator, error) {
 
-	primaryIter, err := N1QLQueryWithStats(ctx, ms.Primary(), queryName, statement, params, consistency, adhoc, dbStats, slowQueryWarningThreshold)
+	primaryN1QL, ok := base.AsN1QLStore(ms.Primary())
+	if !ok {
+		return nil, fmt.Errorf("primary datastore (%T) does not support N1QL", ms.Primary())
+	}
+	fallbackN1QL, ok := base.AsN1QLStore(ms.Fallback())
+	if !ok {
+		return nil, fmt.Errorf("fallback datastore (%T) does not support N1QL", ms.Fallback())
+	}
+
+	unionStatement := buildDualMetadataUnionStatement(
+		statement,
+		primaryN1QL.EscapedKeyspace(), ms.Primary().GetName(),
+		fallbackN1QL.EscapedKeyspace(), ms.Fallback().GetName(),
+	)
+
+	// Execute against the fallback (default) store. Both keyspaces are fully-qualified in the
+	// statement, so the fallback store's query_context does not restrict which keyspaces are
+	// accessible.
+	iter, err := N1QLQueryWithStats(ctx, ms.Fallback(), queryName, unionStatement, params, consistency, adhoc, dbStats, slowQueryWarningThreshold)
 	if err != nil {
-		return nil, fmt.Errorf("dual metadata N1QL query on primary store: %w", err)
+		return nil, fmt.Errorf("dual metadata UNION ALL N1QL query: %w", err)
 	}
-
-	fallbackIter, err := N1QLQueryWithStats(ctx, ms.Fallback(), queryName, statement, params, consistency, adhoc, dbStats, slowQueryWarningThreshold)
-	if err != nil {
-		_ = primaryIter.Close()
-		return nil, fmt.Errorf("dual metadata N1QL query on fallback store: %w", err)
-	}
-
-	return newMergeDedupIterator(primaryIter, fallbackIter), nil
+	return newUnionDedupIterator(iter), nil
 }
 
-// mergeDedupIterator wraps two sgbucket.QueryResultIterators and emits each unique META().id
-// exactly once. The primary iterator is exhausted first; results from the fallback iterator
-// are only emitted when their META().id was not already seen in the primary stream. This
-// ensures the primary datastore version is always preferred when the same document exists in
-// both stores.
-type mergeDedupIterator struct {
-	primary     sgbucket.QueryResultIterator
-	fallback    sgbucket.QueryResultIterator
-	seenIDs     map[string]struct{}
-	primaryDone bool
-}
+// buildDualMetadataUnionStatement expands a single-keyspace N1QL statement into a UNION ALL
+// across the primary and fallback keyspaces. A sort_order literal is injected into each arm's
+// SELECT list (0 for primary, 1 for fallback), and base.KeyspaceQueryToken is replaced with
+// the actual fully-qualified keyspace name.
+//
+// Any ORDER BY clause present in the original statement is stripped from the individual arms
+// and re-applied as a single outer ORDER BY on the full UNION ALL result, with sort_order
+// prepended so that primary rows always sort before fallback rows. Any LIMIT clause is
+// preserved in each arm so it continues to apply independently per sub-query.
+//
+// The outer ORDER BY translates META(<alias>).id references to just `id`, which is the
+// projected column name at the UNION ALL result scope.
+//
+// Example output (simplified, no inner ORDER BY, no LIMIT):
+//
+//	(SELECT name, META(alias).id, 0 AS sort_order
+//	   FROM `bucket`.`_system`.`_mobile` AS alias WHERE ...)
+//	UNION ALL
+//	(SELECT name, META(alias).id, 1 AS sort_order
+//	   FROM `bucket`.`_default`.`_default` AS alias WHERE ...)
+//	ORDER BY sort_order, id
+func buildDualMetadataUnionStatement(statement, primaryEscapedKeyspace, primaryFullPath, fallbackEscapedKeyspace, fallbackFullPath string) string {
+	// Strip the inner ORDER BY so the outer ORDER BY governs the full merged result.
+	// Any LIMIT clause is re-attached to each arm so it continues to bound each sub-query.
+	coreStmt, innerOrderBy, limitClause := splitStatement(statement)
 
-// Compile-time assertion that *mergeDedupIterator implements sgbucket.QueryResultIterator.
-var _ sgbucket.QueryResultIterator = (*mergeDedupIterator)(nil)
-
-func newMergeDedupIterator(primary, fallback sgbucket.QueryResultIterator) *mergeDedupIterator {
-	return &mergeDedupIterator{
-		primary:  primary,
-		fallback: fallback,
-		seenIDs:  make(map[string]struct{}),
+	// " FROM $_keyspace" appears exactly once in each principal query statement. We prepend the
+	// sort_order literal to the SELECT column list by inserting before the FROM token, then
+	// replace the token with the actual escaped keyspace name.
+	inject := func(escapedKeyspace string, sortOrder int) string {
+		fromToken := " FROM " + base.KeyspaceQueryToken
+		withMeta := strings.Replace(
+			coreStmt,
+			fromToken,
+			fmt.Sprintf(", %d AS %s%s", sortOrder, dualMetadataSortOrderKey, fromToken),
+			1,
+		)
+		arm := strings.ReplaceAll(withMeta, base.KeyspaceQueryToken, escapedKeyspace)
+		return arm + limitClause
 	}
+
+	union := "(" + inject(primaryEscapedKeyspace, 0) + ") UNION ALL (" + inject(fallbackEscapedKeyspace, 1) + ")"
+
+	// Build the outer ORDER BY: sort_order (0=primary, 1=fallback) takes precedence so all
+	// primary rows precede all fallback rows in the merged stream.  The original inner ORDER BY
+	// columns are appended so document ordering within each store is preserved.
+	// META(<alias>).id is translated to just `id` because at the outer UNION ALL scope the
+	// document key is projected by its field name.
+	outerOrderBy := dualMetadataSortOrderKey
+	if innerOrderBy != "" {
+		adapted := strings.ReplaceAll(innerOrderBy, fmt.Sprintf("META(%s).id", base.KeyspaceQueryAlias), "id")
+		outerOrderBy += ", " + adapted
+	}
+
+	return union + " ORDER BY " + outerOrderBy
 }
 
-// NextBytes returns the raw JSON bytes of the next non-duplicate result row, or nil when the
-// merged stream is exhausted. Primary rows are emitted first; fallback rows whose META().id
-// was already seen from primary are silently skipped.
-func (m *mergeDedupIterator) NextBytes() []byte {
-	// Drain the primary iterator first.
-	if !m.primaryDone {
-		if raw := m.primary.NextBytes(); raw != nil {
-			id := extractRowID(raw)
-			m.seenIDs[id] = struct{}{}
-			return raw
+// splitStatement splits a N1QL statement into three parts following the standard clause order:
+// core (everything before ORDER BY), orderByColumns (the ORDER BY expression list without the
+// "ORDER BY" keyword), and limitClause (the LIMIT clause including the "LIMIT" keyword).
+//
+// All keyword matching is case-insensitive. If ORDER BY or LIMIT are absent the corresponding
+// return values are empty strings.
+func splitStatement(stmt string) (core, orderByColumns, limitClause string) {
+	upper := strings.ToUpper(stmt)
+
+	orderByIdx := strings.LastIndex(upper, " ORDER BY ")
+	if orderByIdx < 0 {
+		// No ORDER BY; check for a bare LIMIT (unusual but possible).
+		limitIdx := strings.LastIndex(upper, " LIMIT ")
+		if limitIdx < 0 {
+			return stmt, "", ""
 		}
-		m.primaryDone = true
+		return stmt[:limitIdx], "", stmt[limitIdx:]
 	}
 
-	// Drain the fallback iterator, skipping any document already seen in primary.
+	core = stmt[:orderByIdx]
+	remainder := stmt[orderByIdx+len(" ORDER BY "):]
+
+	upperRemainder := strings.ToUpper(remainder)
+	limitIdx := strings.Index(upperRemainder, " LIMIT ")
+	if limitIdx < 0 {
+		return core, remainder, ""
+	}
+	return core, remainder[:limitIdx], remainder[limitIdx:]
+}
+
+// unionDedupIterator wraps a single sgbucket.QueryResultIterator (typically the result of a
+// UNION ALL query) and emits each unique META().id exactly once.
+//
+// Deduplication relies on the sort_order column injected by buildDualMetadataUnionStatement:
+// the outer ORDER BY sort_order guarantees that all primary-keyspace rows (sort_order=0)
+// are returned before any fallback-keyspace rows (sort_order=1). As a result, "first seen
+// wins" always selects the primary-store version when the same document exists in both
+// keystores. The sort_order column injected by buildDualMetadataUnionStatement
+// are present in each emitted row but are harmlessly ignored by callers that unmarshal into
+// typed structs.
+type unionDedupIterator struct {
+	iter    sgbucket.QueryResultIterator
+	seenIDs map[string]struct{}
+}
+
+// Compile-time assertion that *unionDedupIterator implements sgbucket.QueryResultIterator.
+var _ sgbucket.QueryResultIterator = (*unionDedupIterator)(nil)
+
+func newUnionDedupIterator(iter sgbucket.QueryResultIterator) *unionDedupIterator {
+	return &unionDedupIterator{
+		iter:    iter,
+		seenIDs: make(map[string]struct{}),
+	}
+}
+
+// NextBytes returns the raw JSON bytes of the next non-duplicate row, or nil when exhausted.
+// Rows whose META().id has already been emitted are silently skipped.
+func (u *unionDedupIterator) NextBytes() []byte {
 	for {
-		raw := m.fallback.NextBytes()
+		raw := u.iter.NextBytes()
 		if raw == nil {
 			return nil
 		}
 		id := extractRowID(raw)
-		if _, seen := m.seenIDs[id]; seen {
+		if _, seen := u.seenIDs[id]; seen {
 			continue
 		}
-		m.seenIDs[id] = struct{}{}
+		u.seenIDs[id] = struct{}{}
 		return raw
 	}
 }
 
-// Next unmarshals the next non-duplicate result row into valuePtr. Returns false when the
-// merged stream is exhausted.
-func (m *mergeDedupIterator) Next(_ context.Context, valuePtr any) bool {
-	raw := m.NextBytes()
+// Next unmarshals the next non-duplicate row into valuePtr. Returns false when exhausted.
+func (u *unionDedupIterator) Next(ctx context.Context, valuePtr any) bool {
+	raw := u.NextBytes()
 	if raw == nil {
 		return false
 	}
 	if err := base.JSONUnmarshal(raw, valuePtr); err != nil {
-		base.WarnfCtx(context.Background(), "mergeDedupIterator: failed to unmarshal row: %v", err)
+		base.WarnfCtx(ctx, "unionDedupIterator: failed to unmarshal row: %v", err)
 		return false
 	}
 	return true
 }
 
-// One unmarshals the first non-duplicate result row into valuePtr and closes the iterator.
-// Returns sgbucket.ErrNoRows when the merged stream is empty.
-func (m *mergeDedupIterator) One(ctx context.Context, valuePtr any) error {
-	defer func() {
-		_ = m.Close()
-	}()
-
-	if !m.Next(ctx, valuePtr) {
+// One unmarshals the first non-duplicate row into valuePtr and closes the iterator.
+// Returns sgbucket.ErrNoRows when the stream is empty.
+func (u *unionDedupIterator) One(ctx context.Context, valuePtr any) error {
+	defer func() { _ = u.Close() }()
+	if !u.Next(ctx, valuePtr) {
 		return sgbucket.ErrNoRows
 	}
 	return nil
 }
 
-// Close closes both underlying iterators. The first non-nil error encountered is returned.
-func (m *mergeDedupIterator) Close() error {
-	primaryErr := m.primary.Close()
-	fallbackErr := m.fallback.Close()
-	if primaryErr != nil {
-		return primaryErr
-	}
-	return fallbackErr
+// Close closes the underlying iterator.
+func (u *unionDedupIterator) Close() error {
+	return u.iter.Close()
 }
 
 // idOnlyRow is a minimal struct used to extract META().id from a raw N1QL result row.
-// All principal query SELECT clauses include META(<alias>).id which serialises as the
-// top-level "id" JSON field.
+// All principal query SELECT clauses serialise META(<alias>).id as the top-level "id" field.
 type idOnlyRow struct {
 	ID string `json:"id"`
 }
 
 // extractRowID extracts the META().id value from a raw N1QL result row JSON byte slice.
-// Returns an empty string if the bytes cannot be parsed or the field is absent.
-// SHOULD WE REMOVE THIS AND JUST USE NEXT TO ASSIGN ID TO MAP??
+// Returns an empty string if the bytes cannot be parsed or the "id" field is absent.
 func extractRowID(raw []byte) string {
 	var row idOnlyRow
 	if err := base.JSONUnmarshal(raw, &row); err != nil {

--- a/db/query_dual_metadata.go
+++ b/db/query_dual_metadata.go
@@ -1,0 +1,151 @@
+// Copyright 2026-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package db
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	sgbucket "github.com/couchbase/sg-bucket"
+	"github.com/couchbase/sync_gateway/base"
+)
+
+// dualMetadataN1QLQuery runs the given N1QL statement against both the primary and fallback
+// datastores of a *base.MetadataStore and returns a mergeDedupIterator over the two result
+// streams. The primary datastore results are emitted first; fallback results are only emitted
+// for documents whose META().id was not already seen in the primary stream.
+//
+// When a query limit is present in the statement it applies independently to each store, so
+// the merged stream may return up to 2× the requested limit of unique rows. Callers that
+// need strict limits should truncate after the desired number of rows.
+func dualMetadataN1QLQuery(ctx context.Context, ms *base.MetadataStore, queryName string,
+	statement string, params map[string]any, consistency base.ConsistencyMode, adhoc bool,
+	dbStats *base.DbStats, slowQueryWarningThreshold time.Duration) (sgbucket.QueryResultIterator, error) {
+
+	primaryIter, err := N1QLQueryWithStats(ctx, ms.Primary(), queryName, statement, params, consistency, adhoc, dbStats, slowQueryWarningThreshold)
+	if err != nil {
+		return nil, fmt.Errorf("dual metadata N1QL query on primary store: %w", err)
+	}
+
+	fallbackIter, err := N1QLQueryWithStats(ctx, ms.Fallback(), queryName, statement, params, consistency, adhoc, dbStats, slowQueryWarningThreshold)
+	if err != nil {
+		_ = primaryIter.Close()
+		return nil, fmt.Errorf("dual metadata N1QL query on fallback store: %w", err)
+	}
+
+	return newMergeDedupIterator(primaryIter, fallbackIter), nil
+}
+
+// mergeDedupIterator wraps two sgbucket.QueryResultIterators and emits each unique META().id
+// exactly once. The primary iterator is exhausted first; results from the fallback iterator
+// are only emitted when their META().id was not already seen in the primary stream. This
+// ensures the primary datastore version is always preferred when the same document exists in
+// both stores.
+type mergeDedupIterator struct {
+	primary     sgbucket.QueryResultIterator
+	fallback    sgbucket.QueryResultIterator
+	seenIDs     map[string]struct{}
+	primaryDone bool
+}
+
+// Compile-time assertion that *mergeDedupIterator implements sgbucket.QueryResultIterator.
+var _ sgbucket.QueryResultIterator = (*mergeDedupIterator)(nil)
+
+func newMergeDedupIterator(primary, fallback sgbucket.QueryResultIterator) *mergeDedupIterator {
+	return &mergeDedupIterator{
+		primary:  primary,
+		fallback: fallback,
+		seenIDs:  make(map[string]struct{}),
+	}
+}
+
+// NextBytes returns the raw JSON bytes of the next non-duplicate result row, or nil when the
+// merged stream is exhausted. Primary rows are emitted first; fallback rows whose META().id
+// was already seen from primary are silently skipped.
+func (m *mergeDedupIterator) NextBytes() []byte {
+	// Drain the primary iterator first.
+	if !m.primaryDone {
+		if raw := m.primary.NextBytes(); raw != nil {
+			id := extractRowID(raw)
+			m.seenIDs[id] = struct{}{}
+			return raw
+		}
+		m.primaryDone = true
+	}
+
+	// Drain the fallback iterator, skipping any document already seen in primary.
+	for {
+		raw := m.fallback.NextBytes()
+		if raw == nil {
+			return nil
+		}
+		id := extractRowID(raw)
+		if _, seen := m.seenIDs[id]; seen {
+			continue
+		}
+		m.seenIDs[id] = struct{}{}
+		return raw
+	}
+}
+
+// Next unmarshals the next non-duplicate result row into valuePtr. Returns false when the
+// merged stream is exhausted.
+func (m *mergeDedupIterator) Next(_ context.Context, valuePtr any) bool {
+	raw := m.NextBytes()
+	if raw == nil {
+		return false
+	}
+	if err := base.JSONUnmarshal(raw, valuePtr); err != nil {
+		base.WarnfCtx(context.Background(), "mergeDedupIterator: failed to unmarshal row: %v", err)
+		return false
+	}
+	return true
+}
+
+// One unmarshals the first non-duplicate result row into valuePtr and closes the iterator.
+// Returns sgbucket.ErrNoRows when the merged stream is empty.
+func (m *mergeDedupIterator) One(ctx context.Context, valuePtr any) error {
+	defer func() {
+		_ = m.Close()
+	}()
+
+	if !m.Next(ctx, valuePtr) {
+		return sgbucket.ErrNoRows
+	}
+	return nil
+}
+
+// Close closes both underlying iterators. The first non-nil error encountered is returned.
+func (m *mergeDedupIterator) Close() error {
+	primaryErr := m.primary.Close()
+	fallbackErr := m.fallback.Close()
+	if primaryErr != nil {
+		return primaryErr
+	}
+	return fallbackErr
+}
+
+// idOnlyRow is a minimal struct used to extract META().id from a raw N1QL result row.
+// All principal query SELECT clauses include META(<alias>).id which serialises as the
+// top-level "id" JSON field.
+type idOnlyRow struct {
+	ID string `json:"id"`
+}
+
+// extractRowID extracts the META().id value from a raw N1QL result row JSON byte slice.
+// Returns an empty string if the bytes cannot be parsed or the field is absent.
+// SHOULD WE REMOVE THIS AND JUST USE NEXT TO ASSIGN ID TO MAP??
+func extractRowID(raw []byte) string {
+	var row idOnlyRow
+	if err := base.JSONUnmarshal(raw, &row); err != nil {
+		return ""
+	}
+	return row.ID
+}

--- a/db/query_dual_metadata.go
+++ b/db/query_dual_metadata.go
@@ -11,6 +11,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -19,10 +20,10 @@ import (
 )
 
 // dualMetadataSortOrderKey is the N1QL column alias injected as a numeric literal into each
-// arm of the UNION ALL query to enforce primary-before-fallback ordering. Primary arms receive
-// value 0; fallback arms receive value 1. The outer ORDER BY uses this column as its first
-// sort key, ensuring all primary rows are returned before any fallback rows regardless of
-// N1QL's internal execution order.
+// arm of the UNION ALL query. Primary arms receive value 0; fallback arms receive value 1.
+// The outer ORDER BY places sort_order after id, so that for equal document IDs the
+// primary-store row (0) is returned before the fallback-store row (1). This guarantees the
+// unionDedupIterator's "first seen wins" strategy always selects the primary-store version.
 const dualMetadataSortOrderKey = "sort_order"
 
 // dualMetadataN1QLQuery executes a single UNION ALL N1QL statement across both the primary
@@ -32,16 +33,17 @@ const dualMetadataSortOrderKey = "sort_order"
 // The original statement (which may still contain base.KeyspaceQueryToken) is expanded by
 // buildDualMetadataUnionStatement into two fully-qualified sub-queries joined with UNION ALL.
 // A sort_order literal (0=primary, 1=fallback) is injected into each arm, and a single outer
-// ORDER BY sort_order[, <original order>] guarantees that all primary rows precede all
-// fallback rows in the result stream. unionDedupIterator relies on this ordering: "first seen
-// wins" always selects the primary-store version when the same META().id exists in both stores.
+// ORDER BY id[, <original order>], sort_order ensures document IDs are monotonically
+// non-decreasing (required for startKey-based pagination) while for equal IDs the primary-store
+// row sorts first (required for correct deduplication by unionDedupIterator).
 //
 // The combined query is executed against the fallback (default) store. Because both keyspaces
 // are referenced with fully-qualified names, the fallback store's query_context does not
 // restrict access to the primary keyspace.
 //
-// When a query limit is present in the statement it applies independently to each sub-query,
-// so the merged stream may return up to 2x the requested limit of unique rows.
+// Any LIMIT clause from the original statement is moved from the individual arms to the outer
+// UNION ALL and doubled to account for worst-case duplicate overlap. This prevents per-arm
+// limits from permanently hiding results when the two stores have interleaved ID ranges.
 func dualMetadataN1QLQuery(ctx context.Context, ms *base.MetadataStore, queryName string,
 	statement string, params map[string]any, consistency base.ConsistencyMode, adhoc bool,
 	dbStats *base.DbStats, slowQueryWarningThreshold time.Duration) (sgbucket.QueryResultIterator, error) {
@@ -73,25 +75,36 @@ func dualMetadataN1QLQuery(ctx context.Context, ms *base.MetadataStore, queryNam
 // the actual fully-qualified keyspace name.
 //
 // Any ORDER BY clause present in the original statement is stripped from the individual arms
-// and re-applied as a single outer ORDER BY on the full UNION ALL result, with sort_order
-// prepended so that primary rows always sort before fallback rows. Any LIMIT clause is
-// preserved in each arm so it continues to apply independently per sub-query.
+// and re-applied as a single outer ORDER BY on the full UNION ALL result. The outer ORDER BY
+// uses the document id as the primary sort key (for correct startKey-based pagination) and
+// appends sort_order so that for equal IDs the primary-store row (0) precedes the
+// fallback-store row (1), enabling unionDedupIterator's "first seen wins" deduplication.
+//
+// Any LIMIT clause is doubled on both the individual arms and the outer UNION ALL to account
+// for worst-case duplicate overlap between the two stores (each document can appear at most
+// twice — once per store). The per-arm doubled limit bounds how many rows each sub-query
+// reads, while the outer doubled limit caps the merged stream. With at most 2 copies per ID,
+// 2*N raw rows always yield at least N unique results after deduplication, ensuring the
+// pagination termination condition in GetUsers works correctly.
 //
 // The outer ORDER BY translates META(<alias>).id references to just `id`, which is the
 // projected column name at the UNION ALL result scope.
 //
-// Example output (simplified, no inner ORDER BY, no LIMIT):
+// Example output (simplified, original LIMIT 3):
 //
 //	(SELECT name, META(alias).id, 0 AS sort_order
-//	   FROM `bucket`.`_system`.`_mobile` AS alias WHERE ...)
+//	   FROM `bucket`.`_system`.`_mobile` AS alias WHERE ... LIMIT 6)
 //	UNION ALL
 //	(SELECT name, META(alias).id, 1 AS sort_order
-//	   FROM `bucket`.`_default`.`_default` AS alias WHERE ...)
-//	ORDER BY sort_order, id
+//	   FROM `bucket`.`_default`.`_default` AS alias WHERE ... LIMIT 6)
+//	ORDER BY id, sort_order LIMIT 6
 func buildDualMetadataUnionStatement(statement, primaryEscapedKeyspace, fallbackEscapedKeyspace string) string {
 	// Strip the inner ORDER BY so the outer ORDER BY governs the full merged result.
-	// Any LIMIT clause is re-attached to each arm so it continues to bound each sub-query.
+	// The LIMIT clause is extracted, doubled, and applied to both each arm (bounding per-store
+	// read cost) and the outer UNION ALL (capping the merged stream).
 	coreStmt, innerOrderBy, limitClause := splitStatement(statement)
+
+	doubledLimit := doubleLimitClause(limitClause)
 
 	// " FROM $_keyspace" appears exactly once in each principal query statement. We prepend the
 	// sort_order literal to the SELECT column list by inserting before the FROM token, then
@@ -105,23 +118,22 @@ func buildDualMetadataUnionStatement(statement, primaryEscapedKeyspace, fallback
 			1,
 		)
 		arm := strings.ReplaceAll(withMeta, base.KeyspaceQueryToken, escapedKeyspace)
-		return arm + limitClause
+		return arm + doubledLimit
 	}
 
 	union := "(" + inject(primaryEscapedKeyspace, 0) + ") UNION ALL (" + inject(fallbackEscapedKeyspace, 1) + ")"
 
-	// Build the outer ORDER BY: sort_order (0=primary, 1=fallback) takes precedence so all
-	// primary rows precede all fallback rows in the merged stream.  The original inner ORDER BY
-	// columns are appended so document ordering within each store is preserved.
-	// META(<alias>).id is translated to just `id` because at the outer UNION ALL scope the
-	// document key is projected by its field name.
-	outerOrderBy := dualMetadataSortOrderKey
+	// Build the outer ORDER BY: id first (for correct startKey-based pagination), then
+	// sort_order so that for equal document IDs the primary-store row (0) precedes the
+	// fallback-store row (1). Any original inner ORDER BY columns are used as the id portion;
+	// META(<alias>).id is translated to just `id` at the outer UNION ALL scope.
+	outerOrderBy := "id"
 	if innerOrderBy != "" {
-		adapted := strings.ReplaceAll(innerOrderBy, fmt.Sprintf("META(%s).id", base.KeyspaceQueryAlias), "id")
-		outerOrderBy += ", " + adapted
+		outerOrderBy = strings.ReplaceAll(innerOrderBy, fmt.Sprintf("META(%s).id", base.KeyspaceQueryAlias), "id")
 	}
+	outerOrderBy += ", " + dualMetadataSortOrderKey
 
-	return union + " ORDER BY " + outerOrderBy
+	return union + " ORDER BY " + outerOrderBy + doubledLimit
 }
 
 // splitStatement splits a N1QL statement into three parts following the standard clause order:
@@ -154,16 +166,35 @@ func splitStatement(stmt string) (core, orderByColumns, limitClause string) {
 	return core, remainder[:limitIdx], remainder[limitIdx:]
 }
 
+// doubleLimitClause parses a LIMIT clause string (e.g. " LIMIT 10") and returns a new clause
+// with the limit value doubled (e.g. " LIMIT 20"). If the clause is empty or cannot be parsed
+// the original clause is returned unchanged.
+func doubleLimitClause(limitClause string) string {
+	if limitClause == "" {
+		return ""
+	}
+	trimmed := strings.TrimSpace(limitClause)
+	upper := strings.ToUpper(trimmed)
+	if !strings.HasPrefix(upper, "LIMIT ") {
+		return limitClause
+	}
+	numStr := strings.TrimSpace(trimmed[len("LIMIT "):])
+	n, err := strconv.Atoi(numStr)
+	if err != nil {
+		return limitClause
+	}
+	return fmt.Sprintf(" LIMIT %d", n*2)
+}
+
 // unionDedupIterator wraps a single sgbucket.QueryResultIterator (typically the result of a
 // UNION ALL query) and emits each unique META().id exactly once.
 //
 // Deduplication relies on the sort_order column injected by buildDualMetadataUnionStatement:
-// the outer ORDER BY sort_order guarantees that all primary-keyspace rows (sort_order=0)
-// are returned before any fallback-keyspace rows (sort_order=1). As a result, "first seen
-// wins" always selects the primary-store version when the same document exists in both
-// keystores. The sort_order column injected by buildDualMetadataUnionStatement
-// is present in each emitted row but are harmlessly ignored by callers that unmarshal into
-// typed structs.
+// the outer ORDER BY id, sort_order guarantees that for equal document IDs the primary-keyspace
+// row (sort_order=0) is returned before the fallback-keyspace row (sort_order=1). As a result,
+// "first seen wins" always selects the primary-store version when the same document exists in
+// both keystores. The sort_order column is present in each emitted row but is harmlessly
+// ignored by callers that unmarshal into typed structs.
 type unionDedupIterator struct {
 	iter    sgbucket.QueryResultIterator
 	seenIDs map[string]struct{}

--- a/db/query_dual_metadata.go
+++ b/db/query_dual_metadata.go
@@ -9,7 +9,6 @@
 package db
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"time"
@@ -18,10 +17,20 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 )
 
+// identifiableRow is implemented by query row types that carry a document ID, enabling the
+// generic dualMetadataStorePrincipalDedupIterator to extract IDs for merge-sort comparison
+// without a separate parsing step.
+type identifiableRow interface {
+	rowID() string
+}
+
 // dualMetadataN1QLQuery executes the same N1QL statement independently against both the
 // primary and fallback datastores of a *base.MetadataStore, then returns a
 // dualMetadataStorePrincipalDedupIterator that merge-sorts the two result streams by document ID, deduplicating
 // and preferring the primary-store version when both contain the same document.
+//
+// The type parameter T determines the row struct used for unmarshaling; it must implement
+// identifiableRow so the iterator can extract document IDs for merge-sort comparison.
 //
 // The statement must still contain base.KeyspaceQueryToken; each store's Query method
 // replaces this token with its own escaped keyspace before execution.
@@ -33,7 +42,7 @@ import (
 // boundary" at that source's last emitted ID and stops returning rows from the other source
 // beyond that boundary. This prevents the pagination cursor from jumping over IDs that the
 // limited source may still have, without doubling the per-store LIMIT.
-func dualMetadataN1QLQuery(ctx context.Context, ms *base.MetadataStore, queryName string,
+func dualMetadataN1QLQuery[T identifiableRow](ctx context.Context, ms *base.MetadataStore, queryName string,
 	statement string, params map[string]any, consistency base.ConsistencyMode, adhoc bool,
 	dbStats *base.DbStats, slowQueryWarningThreshold time.Duration, limit int) (sgbucket.QueryResultIterator, error) {
 
@@ -53,18 +62,16 @@ func dualMetadataN1QLQuery(ctx context.Context, ms *base.MetadataStore, queryNam
 		return nil, fmt.Errorf("dual metadata fallback N1QL query: %w", err)
 	}
 
-	return newDualMetadataStorePrincipalDedupIterator(primaryIter, fallbackIter, limit), nil
-}
-
-// peekedRow holds a row that has been read from a source iterator but not yet emitted.
-type peekedRow struct {
-	raw []byte
-	id  string
+	return newDualMetadataStorePrincipalDedupIterator[T](primaryIter, fallbackIter, limit), nil
 }
 
 // dualMetadataStorePrincipalDedupIterator performs a sorted merge of two sgbucket.QueryResultIterators (primary and
 // fallback), emitting rows in ascending document-ID order. When both iterators contain a row
 // with the same ID, only the primary version is emitted.
+//
+// The type parameter T must implement identifiableRow so that the iterator can extract the
+// document ID from each row for merge-sort comparison. Each source row is unmarshaled exactly
+// once at peek time; the merged result is copied directly into the caller's pointer in Next.
 //
 // Both source iterators must return rows sorted by META().id ascending (the standard ordering
 // for principal queries). The merge maintains this ordering in the output.
@@ -76,11 +83,11 @@ type peekedRow struct {
 // advancing past IDs the limited source might still have, ensuring subsequent pages do not
 // skip results. When a source returns fewer than limit rows, it is truly exhausted and no
 // boundary is imposed.
-type dualMetadataStorePrincipalDedupIterator struct {
+type dualMetadataStorePrincipalDedupIterator[T identifiableRow] struct {
 	primary      sgbucket.QueryResultIterator
 	fallback     sgbucket.QueryResultIterator
-	primaryPeek  *peekedRow
-	fallbackPeek *peekedRow
+	primaryPeek  *T
+	fallbackPeek *T
 
 	// Per-source consumed counts and last IDs for safe-boundary detection.
 	primaryConsumed  int
@@ -98,28 +105,25 @@ type dualMetadataStorePrincipalDedupIterator struct {
 	fallbackDone bool
 }
 
-// Compile-time assertion that *dualMetadataStorePrincipalDedupIterator implements sgbucket.QueryResultIterator.
-var _ sgbucket.QueryResultIterator = (*dualMetadataStorePrincipalDedupIterator)(nil)
-
-func newDualMetadataStorePrincipalDedupIterator(primary, fallback sgbucket.QueryResultIterator, limit int) *dualMetadataStorePrincipalDedupIterator {
-	return &dualMetadataStorePrincipalDedupIterator{
+func newDualMetadataStorePrincipalDedupIterator[T identifiableRow](primary, fallback sgbucket.QueryResultIterator, limit int) *dualMetadataStorePrincipalDedupIterator[T] {
+	return &dualMetadataStorePrincipalDedupIterator[T]{
 		primary:  primary,
 		fallback: fallback,
 		limit:    limit,
 	}
 }
 
-// peekPrimary ensures primaryPeek is populated. Returns false if the primary iterator is
-// exhausted.
-func (m *dualMetadataStorePrincipalDedupIterator) peekPrimary() bool {
+// peekPrimary ensures primaryPeek is populated by reading and unmarshaling the next row from
+// the primary source iterator. Returns false if the primary iterator is exhausted.
+func (m *dualMetadataStorePrincipalDedupIterator[T]) peekPrimary(ctx context.Context) bool {
 	if m.primaryPeek != nil {
 		return true
 	}
 	if m.primaryDone {
 		return false
 	}
-	raw := m.primary.NextBytes()
-	if raw == nil {
+	var row T
+	if !m.primary.Next(ctx, &row) {
 		m.primaryDone = true
 		// Only an exhaustion after consuming exactly limit rows indicates the source may
 		// have been truncated by the per-store LIMIT and therefore needs a safe boundary.
@@ -130,21 +134,21 @@ func (m *dualMetadataStorePrincipalDedupIterator) peekPrimary() bool {
 		return false
 	}
 	m.primaryConsumed++
-	m.primaryPeek = &peekedRow{raw: raw, id: extractRowID(raw)}
+	m.primaryPeek = &row
 	return true
 }
 
-// peekFallback ensures fallbackPeek is populated. Returns false if the fallback iterator is
-// exhausted.
-func (m *dualMetadataStorePrincipalDedupIterator) peekFallback() bool {
+// peekFallback ensures fallbackPeek is populated by reading and unmarshaling the next row from
+// the fallback source iterator. Returns false if the fallback iterator is exhausted.
+func (m *dualMetadataStorePrincipalDedupIterator[T]) peekFallback(ctx context.Context) bool {
 	if m.fallbackPeek != nil {
 		return true
 	}
 	if m.fallbackDone {
 		return false
 	}
-	raw := m.fallback.NextBytes()
-	if raw == nil {
+	var row T
+	if !m.fallback.Next(ctx, &row) {
 		m.fallbackDone = true
 		// Only an exhaustion after consuming exactly limit rows indicates the source may
 		// have been truncated by the per-store LIMIT and therefore needs a safe boundary.
@@ -155,68 +159,83 @@ func (m *dualMetadataStorePrincipalDedupIterator) peekFallback() bool {
 		return false
 	}
 	m.fallbackConsumed++
-	m.fallbackPeek = &peekedRow{raw: raw, id: extractRowID(raw)}
+	m.fallbackPeek = &row
 	return true
 }
 
-// NextBytes returns the raw JSON bytes of the next row from the sorted merge, or nil when
-// both iterators are exhausted or the safe boundary has been reached.
-func (m *dualMetadataStorePrincipalDedupIterator) NextBytes() []byte {
-	hasPrimary := m.peekPrimary()
-	hasFallback := m.peekFallback()
+// NextBytes is a no-op stub that satisfies the sgbucket.QueryResultIterator interface. Callers
+// should use Next instead, which performs the merge-sort and returns typed rows.
+func (m *dualMetadataStorePrincipalDedupIterator[T]) NextBytes() []byte {
+	return nil
+}
+
+// Next populates valuePtr with the next merged row. Returns false when both iterators are
+// exhausted or the safe boundary has been reached. valuePtr must be a *T.
+func (m *dualMetadataStorePrincipalDedupIterator[T]) Next(ctx context.Context, valuePtr any) bool {
+	hasPrimary := m.peekPrimary(ctx)
+	hasFallback := m.peekFallback(ctx)
 
 	if !hasPrimary && !hasFallback {
-		return nil
+		return false
+	}
+
+	// Extract IDs from the peeked rows for merge-sort comparison.
+	var primaryID, fallbackID string
+	if hasPrimary {
+		primaryID = (*m.primaryPeek).rowID()
+	}
+	if hasFallback {
+		fallbackID = (*m.fallbackPeek).rowID()
 	}
 
 	// Determine which row to emit based on merge-sort comparison.
-	var row *peekedRow
+	var selected *T
 
 	switch {
 	case hasPrimary && !hasFallback:
-		row = m.primaryPeek
-		m.lastPrimaryID = row.id
-		m.primaryPeek = nil // consume primary row
+		selected = m.primaryPeek
+		m.lastPrimaryID = primaryID
+		m.primaryPeek = nil
 	case !hasPrimary && hasFallback:
-		row = m.fallbackPeek
-		m.lastFallbackID = row.id
-		m.fallbackPeek = nil // consume fallback row
-	case m.primaryPeek.id < m.fallbackPeek.id:
-		row = m.primaryPeek
-		m.lastPrimaryID = row.id
-		m.primaryPeek = nil // consume primary row
-	case m.primaryPeek.id > m.fallbackPeek.id:
-		row = m.fallbackPeek
-		m.lastFallbackID = row.id
-		m.fallbackPeek = nil // consume fallback row
+		selected = m.fallbackPeek
+		m.lastFallbackID = fallbackID
+		m.fallbackPeek = nil
+	case primaryID < fallbackID:
+		selected = m.primaryPeek
+		m.lastPrimaryID = primaryID
+		m.primaryPeek = nil
+	case primaryID > fallbackID:
+		selected = m.fallbackPeek
+		m.lastFallbackID = fallbackID
+		m.fallbackPeek = nil
 	default:
 		// Equal IDs — prefer primary, discard fallback.
-		row = m.primaryPeek
-		m.lastPrimaryID = row.id
-		m.primaryPeek = nil // consume primary row
-		m.lastFallbackID = m.fallbackPeek.id
-		m.fallbackPeek = nil // discard duplicate
+		selected = m.primaryPeek
+		m.lastPrimaryID = primaryID
+		m.primaryPeek = nil
+		m.lastFallbackID = fallbackID
+		m.fallbackPeek = nil
 	}
+
+	selectedID := (*selected).rowID()
 
 	// Suppress rows from the other source that fall beyond the safe boundary. The boundary is
 	// the last ID emitted by the source that hit its LIMIT, so any row with id == boundary was
 	// already emitted (or deduped away via the default case above). Only rows strictly after
 	// the boundary are unsafe, hence > rather than >=.
-	if m.hasBoundary && row.id > m.boundary {
-		return nil
-	}
-
-	return row.raw
-}
-
-// Next unmarshals the next merged row into valuePtr. Returns false when exhausted.
-func (m *dualMetadataStorePrincipalDedupIterator) Next(ctx context.Context, valuePtr any) bool {
-	raw := m.NextBytes()
-	if raw == nil {
+	if m.hasBoundary && selectedID > m.boundary {
 		return false
 	}
-	if err := base.JSONUnmarshal(raw, valuePtr); err != nil {
-		base.WarnfCtx(ctx, "dualMetadataStorePrincipalDedupIterator: failed to unmarshal row: %v", err)
+
+	// valuePtr arrives as any because Next must satisfy the sgbucket.QueryResultIterator
+	// interface. At runtime it must be a *T — the same concrete type the iterator was
+	// instantiated with. The assertion enforces this contract: a mismatch means the caller
+	// is passing a pointer to a different struct, which would silently produce zero values
+	// without this guard.
+	if ptr, ok := valuePtr.(*T); ok {
+		*ptr = *selected
+	} else {
+		base.WarnfCtx(ctx, "dualMetadataStorePrincipalDedupIterator: type mismatch: expected %T, got %T", (*T)(nil), valuePtr)
 		return false
 	}
 	return true
@@ -224,7 +243,7 @@ func (m *dualMetadataStorePrincipalDedupIterator) Next(ctx context.Context, valu
 
 // One unmarshals the first merged row into valuePtr and closes both iterators.
 // Returns sgbucket.ErrNoRows when no rows are available.
-func (m *dualMetadataStorePrincipalDedupIterator) One(ctx context.Context, valuePtr any) error {
+func (m *dualMetadataStorePrincipalDedupIterator[T]) One(ctx context.Context, valuePtr any) error {
 	defer func() {
 		_ = m.Close()
 	}()
@@ -235,40 +254,11 @@ func (m *dualMetadataStorePrincipalDedupIterator) One(ctx context.Context, value
 }
 
 // Close closes both the primary and fallback iterators.
-func (m *dualMetadataStorePrincipalDedupIterator) Close() error {
+func (m *dualMetadataStorePrincipalDedupIterator[T]) Close() error {
 	primaryErr := m.primary.Close()
 	fallbackErr := m.fallback.Close()
 	if primaryErr != nil {
 		return primaryErr
 	}
 	return fallbackErr
-}
-
-// idFieldKey is the byte pattern used to locate the "id" field in raw N1QL JSON result rows.
-var idFieldKey = []byte(`"id":"`)
-
-// extractRowID extracts the META().id value from a raw N1QL result row using a byte-level
-// scan rather than a full JSON unmarshal. This avoids double-parsing overhead since callers
-// of Next() will unmarshal the same raw bytes again into the destination struct.
-//
-// This is safe because N1QL results are machine-generated flat JSON objects with predictable
-// structure; the "id" field is always a top-level string key.
-//
-// Returns an empty string if the bytes cannot be scanned or the "id" field is absent.
-func extractRowID(raw []byte) string {
-	idx := bytes.Index(raw, idFieldKey)
-	if idx < 0 {
-		return ""
-	}
-	start := idx + len(idFieldKey)
-	for i := start; i < len(raw); i++ {
-		if raw[i] == '\\' {
-			i++ // skip escaped character
-			continue
-		}
-		if raw[i] == '"' {
-			return string(raw[start:i])
-		}
-	}
-	return ""
 }

--- a/db/query_dual_metadata.go
+++ b/db/query_dual_metadata.go
@@ -11,248 +11,236 @@ package db
 import (
 	"context"
 	"fmt"
-	"strconv"
-	"strings"
 	"time"
 
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 )
 
-// dualMetadataSortOrderKey is the N1QL column alias injected as a numeric literal into each
-// arm of the UNION ALL query. Primary arms receive value 0; fallback arms receive value 1.
-// The outer ORDER BY places sort_order after id, so that for equal document IDs the
-// primary-store row (0) is returned before the fallback-store row (1). This guarantees the
-// unionDedupIterator's "first seen wins" strategy always selects the primary-store version.
-const dualMetadataSortOrderKey = "sort_order"
-
-// dualMetadataN1QLQuery executes a single UNION ALL N1QL statement across both the primary
-// and fallback datastores of a *base.MetadataStore and returns a unionDedupIterator over the
-// combined result stream.
+// dualMetadataN1QLQuery executes the same N1QL statement independently against both the
+// primary and fallback datastores of a *base.MetadataStore, then returns a
+// mergedDedupIterator that merge-sorts the two result streams by document ID, deduplicating
+// and preferring the primary-store version when both contain the same document.
 //
-// The original statement (which may still contain base.KeyspaceQueryToken) is expanded by
-// buildDualMetadataUnionStatement into two fully-qualified sub-queries joined with UNION ALL.
-// A sort_order literal (0=primary, 1=fallback) is injected into each arm, and a single outer
-// ORDER BY id[, <original order>], sort_order ensures document IDs are monotonically
-// non-decreasing (required for startKey-based pagination) while for equal IDs the primary-store
-// row sorts first (required for correct deduplication by unionDedupIterator).
+// The statement must still contain base.KeyspaceQueryToken; each store's Query method
+// replaces this token with its own escaped keyspace before execution.
 //
-// The combined query is executed against the fallback (default) store. Because both keyspaces
-// are referenced with fully-qualified names, the fallback store's query_context does not
-// restrict access to the primary keyspace.
-//
-// Any LIMIT clause from the original statement is moved from the individual arms to the outer
-// UNION ALL and doubled to account for worst-case duplicate overlap. This prevents per-arm
-// limits from permanently hiding results when the two stores have interleaved ID ranges.
+// The statement should NOT include a LIMIT clause — callers pass the desired limit separately.
+// When limit > 0, each per-store query appends LIMIT <limit>. The mergedDedupIterator uses
+// the limit to detect when a source hit its LIMIT (consumed exactly limit rows) vs. was truly
+// exhausted (consumed fewer). When a source hits its LIMIT, the iterator establishes a "safe
+// boundary" at that source's last emitted ID and stops returning rows from the other source
+// beyond that boundary. This prevents the pagination cursor from jumping over IDs that the
+// limited source may still have, without doubling the per-store LIMIT.
 func dualMetadataN1QLQuery(ctx context.Context, ms *base.MetadataStore, queryName string,
 	statement string, params map[string]any, consistency base.ConsistencyMode, adhoc bool,
-	dbStats *base.DbStats, slowQueryWarningThreshold time.Duration) (sgbucket.QueryResultIterator, error) {
+	dbStats *base.DbStats, slowQueryWarningThreshold time.Duration, limit int) (sgbucket.QueryResultIterator, error) {
 
-	primaryN1QL, ok := base.AsN1QLStore(ms.Primary())
-	if !ok {
-		return nil, fmt.Errorf("primary datastore (%T) does not support N1QL", ms.Primary())
-	}
-	fallbackN1QL, ok := base.AsN1QLStore(ms.Fallback())
-	if !ok {
-		return nil, fmt.Errorf("fallback datastore (%T) does not support N1QL", ms.Fallback())
+	storeStatement := statement
+	if limit > 0 {
+		storeStatement = fmt.Sprintf("%s LIMIT %d", statement, limit)
 	}
 
-	unionStatement := buildDualMetadataUnionStatement(statement, primaryN1QL.EscapedKeyspace(), fallbackN1QL.EscapedKeyspace())
-
-	// Execute against the fallback (default) store. Both keyspaces are fully-qualified in the
-	// statement, so the fallback store's query_context does not restrict which keyspaces are
-	// accessible.
-	iter, err := N1QLQueryWithStats(ctx, ms.Fallback(), queryName, unionStatement, params, consistency, adhoc, dbStats, slowQueryWarningThreshold)
+	primaryIter, err := N1QLQueryWithStats(ctx, ms.Primary(), queryName, storeStatement, params, consistency, adhoc, dbStats, slowQueryWarningThreshold)
 	if err != nil {
-		return nil, fmt.Errorf("dual metadata UNION ALL N1QL query: %w", err)
-	}
-	return newUnionDedupIterator(iter), nil
-}
-
-// buildDualMetadataUnionStatement expands a single-keyspace N1QL statement into a UNION ALL
-// across the primary and fallback keyspaces. A sort_order literal is injected into each arm's
-// SELECT list (0 for primary, 1 for fallback), and base.KeyspaceQueryToken is replaced with
-// the actual fully-qualified keyspace name.
-//
-// Any ORDER BY clause present in the original statement is stripped from the individual arms
-// and re-applied as a single outer ORDER BY on the full UNION ALL result. The outer ORDER BY
-// uses the document id as the primary sort key (for correct startKey-based pagination) and
-// appends sort_order so that for equal IDs the primary-store row (0) precedes the
-// fallback-store row (1), enabling unionDedupIterator's "first seen wins" deduplication.
-//
-// Any LIMIT clause is doubled on both the individual arms and the outer UNION ALL to account
-// for worst-case duplicate overlap between the two stores (each document can appear at most
-// twice — once per store). The per-arm doubled limit bounds how many rows each sub-query
-// reads, while the outer doubled limit caps the merged stream. With at most 2 copies per ID,
-// 2*N raw rows always yield at least N unique results after deduplication, ensuring the
-// pagination termination condition in GetUsers works correctly.
-//
-// The outer ORDER BY translates META(<alias>).id references to just `id`, which is the
-// projected column name at the UNION ALL result scope.
-//
-// Example output (simplified, original LIMIT 3):
-//
-//	(SELECT name, META(alias).id, 0 AS sort_order
-//	   FROM `bucket`.`_system`.`_mobile` AS alias WHERE ... LIMIT 6)
-//	UNION ALL
-//	(SELECT name, META(alias).id, 1 AS sort_order
-//	   FROM `bucket`.`_default`.`_default` AS alias WHERE ... LIMIT 6)
-//	ORDER BY id, sort_order LIMIT 6
-func buildDualMetadataUnionStatement(statement, primaryEscapedKeyspace, fallbackEscapedKeyspace string) string {
-	// Strip the inner ORDER BY so the outer ORDER BY governs the full merged result.
-	// The LIMIT clause is extracted, doubled, and applied to both each arm (bounding per-store
-	// read cost) and the outer UNION ALL (capping the merged stream).
-	coreStmt, innerOrderBy, limitClause := splitStatement(statement)
-
-	doubledLimit := doubleLimitClause(limitClause)
-
-	// " FROM $_keyspace" appears exactly once in each principal query statement. We prepend the
-	// sort_order literal to the SELECT column list by inserting before the FROM token, then
-	// replace the token with the actual escaped keyspace name.
-	inject := func(escapedKeyspace string, sortOrder int) string {
-		fromToken := " FROM " + base.KeyspaceQueryToken
-		withMeta := strings.Replace(
-			coreStmt,
-			fromToken,
-			fmt.Sprintf(", %d AS %s%s", sortOrder, dualMetadataSortOrderKey, fromToken),
-			1,
-		)
-		arm := strings.ReplaceAll(withMeta, base.KeyspaceQueryToken, escapedKeyspace)
-		return arm + doubledLimit
+		return nil, fmt.Errorf("dual metadata primary N1QL query: %w", err)
 	}
 
-	union := "(" + inject(primaryEscapedKeyspace, 0) + ") UNION ALL (" + inject(fallbackEscapedKeyspace, 1) + ")"
-
-	// Build the outer ORDER BY: id first (for correct startKey-based pagination), then
-	// sort_order so that for equal document IDs the primary-store row (0) precedes the
-	// fallback-store row (1). Any original inner ORDER BY columns are used as the id portion;
-	// META(<alias>).id is translated to just `id` at the outer UNION ALL scope.
-	outerOrderBy := "id"
-	if innerOrderBy != "" {
-		outerOrderBy = strings.ReplaceAll(innerOrderBy, fmt.Sprintf("META(%s).id", base.KeyspaceQueryAlias), "id")
-	}
-	outerOrderBy += ", " + dualMetadataSortOrderKey
-
-	return union + " ORDER BY " + outerOrderBy + doubledLimit
-}
-
-// splitStatement splits a N1QL statement into three parts following the standard clause order:
-// core (everything before ORDER BY), orderByColumns (the ORDER BY expression list without the
-// "ORDER BY" keyword), and limitClause (the LIMIT clause including the "LIMIT" keyword).
-//
-// All keyword matching is case-insensitive. If ORDER BY or LIMIT are absent the corresponding
-// return values are empty strings.
-func splitStatement(stmt string) (core, orderByColumns, limitClause string) {
-	upper := strings.ToUpper(stmt)
-
-	orderByIdx := strings.LastIndex(upper, " ORDER BY ")
-	if orderByIdx < 0 {
-		// No ORDER BY; check for a bare LIMIT (unusual but possible).
-		limitIdx := strings.LastIndex(upper, " LIMIT ")
-		if limitIdx < 0 {
-			return stmt, "", ""
-		}
-		return stmt[:limitIdx], "", stmt[limitIdx:]
-	}
-
-	core = stmt[:orderByIdx]
-	remainder := stmt[orderByIdx+len(" ORDER BY "):]
-
-	upperRemainder := strings.ToUpper(remainder)
-	limitIdx := strings.Index(upperRemainder, " LIMIT ")
-	if limitIdx < 0 {
-		return core, remainder, ""
-	}
-	return core, remainder[:limitIdx], remainder[limitIdx:]
-}
-
-// doubleLimitClause parses a LIMIT clause string (e.g. " LIMIT 10") and returns a new clause
-// with the limit value doubled (e.g. " LIMIT 20"). If the clause is empty or cannot be parsed
-// the original clause is returned unchanged.
-func doubleLimitClause(limitClause string) string {
-	if limitClause == "" {
-		return ""
-	}
-	trimmed := strings.TrimSpace(limitClause)
-	upper := strings.ToUpper(trimmed)
-	if !strings.HasPrefix(upper, "LIMIT ") {
-		return limitClause
-	}
-	numStr := strings.TrimSpace(trimmed[len("LIMIT "):])
-	n, err := strconv.Atoi(numStr)
+	fallbackIter, err := N1QLQueryWithStats(ctx, ms.Fallback(), queryName, storeStatement, params, consistency, adhoc, dbStats, slowQueryWarningThreshold)
 	if err != nil {
-		return limitClause
+		_ = primaryIter.Close()
+		return nil, fmt.Errorf("dual metadata fallback N1QL query: %w", err)
 	}
-	return fmt.Sprintf(" LIMIT %d", n*2)
+
+	return newMergedDedupIterator(primaryIter, fallbackIter, limit), nil
 }
 
-// unionDedupIterator wraps a single sgbucket.QueryResultIterator (typically the result of a
-// UNION ALL query) and emits each unique META().id exactly once.
+// peekedRow holds a row that has been read from a source iterator but not yet emitted.
+type peekedRow struct {
+	raw []byte
+	id  string
+}
+
+// mergedDedupIterator performs a sorted merge of two sgbucket.QueryResultIterators (primary and
+// fallback), emitting rows in ascending document-ID order. When both iterators contain a row
+// with the same ID, only the primary version is emitted.
 //
-// Deduplication relies on the sort_order column injected by buildDualMetadataUnionStatement:
-// the outer ORDER BY id, sort_order guarantees that for equal document IDs the primary-keyspace
-// row (sort_order=0) is returned before the fallback-keyspace row (sort_order=1). As a result,
-// "first seen wins" always selects the primary-store version when the same document exists in
-// both keystores. The sort_order column is present in each emitted row but is harmlessly
-// ignored by callers that unmarshal into typed structs.
-type unionDedupIterator struct {
-	iter    sgbucket.QueryResultIterator
-	seenIDs map[string]struct{}
+// Both source iterators must return rows sorted by META().id ascending (the standard ordering
+// for principal queries). The merge maintains this ordering in the output.
+//
+// When limit > 0, the iterator tracks how many rows each source produced. If a source returns
+// exactly limit rows and then exhausts, it may have been truncated by the N1QL LIMIT. In that
+// case a "safe boundary" is set to that source's last ID, and no further rows from the other
+// source with IDs beyond the boundary are emitted. This prevents the pagination cursor from
+// advancing past IDs the limited source might still have, ensuring subsequent pages do not
+// skip results. When a source returns fewer than limit rows, it is truly exhausted and no
+// boundary is imposed.
+type mergedDedupIterator struct {
+	primary      sgbucket.QueryResultIterator
+	fallback     sgbucket.QueryResultIterator
+	primaryPeek  *peekedRow
+	fallbackPeek *peekedRow
+
+	// Per-source consumed counts and last IDs for safe-boundary detection.
+	primaryConsumed  int
+	fallbackConsumed int
+	lastPrimaryID    string
+	lastFallbackID   string
+	limit            int // per-store N1QL LIMIT; 0 = unlimited
+
+	// Safe boundary: when a source exhausts at exactly limit rows, boundary is set to its
+	// last consumed ID. Rows from the other source with ID > boundary are suppressed.
+	boundary    string
+	hasBoundary bool
+
+	primaryDone  bool
+	fallbackDone bool
 }
 
-// Compile-time assertion that *unionDedupIterator implements sgbucket.QueryResultIterator.
-var _ sgbucket.QueryResultIterator = (*unionDedupIterator)(nil)
+// Compile-time assertion that *mergedDedupIterator implements sgbucket.QueryResultIterator.
+var _ sgbucket.QueryResultIterator = (*mergedDedupIterator)(nil)
 
-func newUnionDedupIterator(iter sgbucket.QueryResultIterator) *unionDedupIterator {
-	return &unionDedupIterator{
-		iter:    iter,
-		seenIDs: make(map[string]struct{}),
+func newMergedDedupIterator(primary, fallback sgbucket.QueryResultIterator, limit int) *mergedDedupIterator {
+	return &mergedDedupIterator{
+		primary:  primary,
+		fallback: fallback,
+		limit:    limit,
 	}
 }
 
-// NextBytes returns the raw JSON bytes of the next non-duplicate row, or nil when exhausted.
-// Rows whose META().id has already been emitted are silently skipped.
-func (u *unionDedupIterator) NextBytes() []byte {
-	for {
-		raw := u.iter.NextBytes()
-		if raw == nil {
-			return nil
-		}
-		id := extractRowID(raw)
-		if _, exists := u.seenIDs[id]; exists {
-			continue
-		}
-		u.seenIDs[id] = struct{}{}
-		return raw
+// peekPrimary ensures primaryPeek is populated. Returns false if the primary iterator is
+// exhausted.
+func (m *mergedDedupIterator) peekPrimary() bool {
+	if m.primaryPeek != nil {
+		return true
 	}
+	if m.primaryDone {
+		return false
+	}
+	raw := m.primary.NextBytes()
+	if raw == nil {
+		m.primaryDone = true
+		// If consumed exactly limit rows, primary may have been truncated.
+		if m.limit > 0 && m.primaryConsumed >= m.limit && !m.hasBoundary {
+			m.boundary = m.lastPrimaryID
+			m.hasBoundary = true
+		}
+		return false
+	}
+	m.primaryConsumed++
+	m.primaryPeek = &peekedRow{raw: raw, id: extractRowID(raw)}
+	return true
 }
 
-// Next unmarshals the next non-duplicate row into valuePtr. Returns false when exhausted.
-func (u *unionDedupIterator) Next(ctx context.Context, valuePtr any) bool {
-	raw := u.NextBytes()
+// peekFallback ensures fallbackPeek is populated. Returns false if the fallback iterator is
+// exhausted.
+func (m *mergedDedupIterator) peekFallback() bool {
+	if m.fallbackPeek != nil {
+		return true
+	}
+	if m.fallbackDone {
+		return false
+	}
+	raw := m.fallback.NextBytes()
+	if raw == nil {
+		m.fallbackDone = true
+		// If consumed exactly limit rows, fallback may have been truncated.
+		if m.limit > 0 && m.fallbackConsumed >= m.limit && !m.hasBoundary {
+			m.boundary = m.lastFallbackID
+			m.hasBoundary = true
+		}
+		return false
+	}
+	m.fallbackConsumed++
+	m.fallbackPeek = &peekedRow{raw: raw, id: extractRowID(raw)}
+	return true
+}
+
+// NextBytes returns the raw JSON bytes of the next row from the sorted merge, or nil when
+// both iterators are exhausted or the safe boundary has been reached.
+func (m *mergedDedupIterator) NextBytes() []byte {
+	hasPrimary := m.peekPrimary()
+	hasFallback := m.peekFallback()
+
+	if !hasPrimary && !hasFallback {
+		return nil
+	}
+
+	// Determine which row to emit based on merge-sort comparison.
+	var row *peekedRow
+	var fromPrimary bool
+
+	switch {
+	case hasPrimary && !hasFallback:
+		row = m.primaryPeek
+		fromPrimary = true
+	case !hasPrimary && hasFallback:
+		row = m.fallbackPeek
+		fromPrimary = false
+	case m.primaryPeek.id < m.fallbackPeek.id:
+		row = m.primaryPeek
+		fromPrimary = true
+	case m.primaryPeek.id > m.fallbackPeek.id:
+		row = m.fallbackPeek
+		fromPrimary = false
+	default:
+		// Equal IDs — prefer primary, discard fallback.
+		row = m.primaryPeek
+		fromPrimary = true
+		m.lastFallbackID = m.fallbackPeek.id
+		m.fallbackPeek = nil // discard duplicate
+	}
+
+	// Check safe boundary: do not emit rows beyond the boundary.
+	if m.hasBoundary && row.id > m.boundary {
+		return nil
+	}
+
+	// Consume the selected row and track the last ID for boundary detection.
+	if fromPrimary {
+		m.lastPrimaryID = row.id
+		m.primaryPeek = nil
+	} else {
+		m.lastFallbackID = row.id
+		m.fallbackPeek = nil
+	}
+
+	return row.raw
+}
+
+// Next unmarshals the next merged row into valuePtr. Returns false when exhausted.
+func (m *mergedDedupIterator) Next(ctx context.Context, valuePtr any) bool {
+	raw := m.NextBytes()
 	if raw == nil {
 		return false
 	}
 	if err := base.JSONUnmarshal(raw, valuePtr); err != nil {
-		base.WarnfCtx(ctx, "unionDedupIterator: failed to unmarshal row: %v", err)
+		base.WarnfCtx(ctx, "mergedDedupIterator: failed to unmarshal row: %v", err)
 		return false
 	}
 	return true
 }
 
-// One unmarshals the first non-duplicate row into valuePtr and closes the iterator.
-// Returns sgbucket.ErrNoRows when the stream is empty.
-func (u *unionDedupIterator) One(ctx context.Context, valuePtr any) error {
-	defer func() { _ = u.Close() }()
-	if !u.Next(ctx, valuePtr) {
+// One unmarshals the first merged row into valuePtr and closes both iterators.
+// Returns sgbucket.ErrNoRows when no rows are available.
+func (m *mergedDedupIterator) One(ctx context.Context, valuePtr any) error {
+	defer func() {
+		_ = m.Close()
+	}()
+	if !m.Next(ctx, valuePtr) {
 		return sgbucket.ErrNoRows
 	}
 	return nil
 }
 
-// Close closes the underlying iterator.
-func (u *unionDedupIterator) Close() error {
-	return u.iter.Close()
+// Close closes both the primary and fallback iterators.
+func (m *mergedDedupIterator) Close() error {
+	primaryErr := m.primary.Close()
+	fallbackErr := m.fallback.Close()
+	if primaryErr != nil {
+		return primaryErr
+	}
+	return fallbackErr
 }
 
 // idOnlyRow is a minimal struct used to extract META().id from a raw N1QL result row.

--- a/db/query_dual_metadata.go
+++ b/db/query_dual_metadata.go
@@ -55,11 +55,7 @@ func dualMetadataN1QLQuery(ctx context.Context, ms *base.MetadataStore, queryNam
 		return nil, fmt.Errorf("fallback datastore (%T) does not support N1QL", ms.Fallback())
 	}
 
-	unionStatement := buildDualMetadataUnionStatement(
-		statement,
-		primaryN1QL.EscapedKeyspace(), ms.Primary().GetName(),
-		fallbackN1QL.EscapedKeyspace(), ms.Fallback().GetName(),
-	)
+	unionStatement := buildDualMetadataUnionStatement(statement, primaryN1QL.EscapedKeyspace(), fallbackN1QL.EscapedKeyspace())
 
 	// Execute against the fallback (default) store. Both keyspaces are fully-qualified in the
 	// statement, so the fallback store's query_context does not restrict which keyspaces are
@@ -92,7 +88,7 @@ func dualMetadataN1QLQuery(ctx context.Context, ms *base.MetadataStore, queryNam
 //	(SELECT name, META(alias).id, 1 AS sort_order
 //	   FROM `bucket`.`_default`.`_default` AS alias WHERE ...)
 //	ORDER BY sort_order, id
-func buildDualMetadataUnionStatement(statement, primaryEscapedKeyspace, primaryFullPath, fallbackEscapedKeyspace, fallbackFullPath string) string {
+func buildDualMetadataUnionStatement(statement, primaryEscapedKeyspace, fallbackEscapedKeyspace string) string {
 	// Strip the inner ORDER BY so the outer ORDER BY governs the full merged result.
 	// Any LIMIT clause is re-attached to each arm so it continues to bound each sub-query.
 	coreStmt, innerOrderBy, limitClause := splitStatement(statement)
@@ -166,7 +162,7 @@ func splitStatement(stmt string) (core, orderByColumns, limitClause string) {
 // are returned before any fallback-keyspace rows (sort_order=1). As a result, "first seen
 // wins" always selects the primary-store version when the same document exists in both
 // keystores. The sort_order column injected by buildDualMetadataUnionStatement
-// are present in each emitted row but are harmlessly ignored by callers that unmarshal into
+// is present in each emitted row but are harmlessly ignored by callers that unmarshal into
 // typed structs.
 type unionDedupIterator struct {
 	iter    sgbucket.QueryResultIterator
@@ -192,7 +188,7 @@ func (u *unionDedupIterator) NextBytes() []byte {
 			return nil
 		}
 		id := extractRowID(raw)
-		if _, seen := u.seenIDs[id]; seen {
+		if _, exists := u.seenIDs[id]; exists {
 			continue
 		}
 		u.seenIDs[id] = struct{}{}

--- a/db/query_dual_metadata_test.go
+++ b/db/query_dual_metadata_test.go
@@ -11,6 +11,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -19,7 +20,7 @@ import (
 )
 
 // mockQueryResultIterator is an in-memory QueryResultIterator backed by a slice of raw JSON
-// byte slices, used to test mergeDedupIterator without a real database.
+// byte slices, used to test unionDedupIterator without a real database.
 type mockQueryResultIterator struct {
 	rows     [][]byte
 	pos      int
@@ -60,7 +61,8 @@ func (m *mockQueryResultIterator) Close() error {
 	return m.closeErr
 }
 
-// marshalRow builds a minimal principal-row JSON byte slice from id and name fields.
+// marshalRow builds a minimal principal-row JSON byte slice with id and name fields,
+// mimicking a row from the UNION ALL query used by buildDualMetadataUnionStatement.
 func marshalRow(id, name string) []byte {
 	row, err := base.JSONMarshal(map[string]string{"id": id, "name": name})
 	if err != nil {
@@ -69,17 +71,17 @@ func marshalRow(id, name string) []byte {
 	return row
 }
 
-// TestMergeDedupIterator_PrimaryOnly verifies that all primary rows are emitted when the
-// fallback iterator is empty.
-func TestMergeDedupIteratorPrimaryOnly(t *testing.T) {
+// TestUnionDedupIteratorPrimaryOnly verifies that all primary rows are emitted when there are
+// no fallback rows in the UNION ALL stream.
+func TestUnionDedupIteratorPrimaryOnly(t *testing.T) {
 	ctx := base.TestCtx(t)
-	primary := newMockIterator([][]byte{
+	// Simulate UNION ALL output with only primary rows (no fallback rows).
+	stream := newMockIterator([][]byte{
 		marshalRow("_sync:user:alice", "alice"),
 		marshalRow("_sync:user:bob", "bob"),
 	})
-	fallback := newMockIterator(nil)
 
-	iter := newMergeDedupIterator(primary, fallback)
+	iter := newUnionDedupIterator(stream)
 	var rows []principalRow
 	for {
 		var row principalRow
@@ -94,17 +96,17 @@ func TestMergeDedupIteratorPrimaryOnly(t *testing.T) {
 	assert.Equal(t, "_sync:user:bob", rows[1].Id)
 }
 
-// TestMergeDedupIterator_FallbackOnly verifies that all fallback rows are emitted when the
-// primary iterator is empty.
-func TestMergeDedupIteratorFallbackOnly(t *testing.T) {
+// TestUnionDedupIteratorFallbackOnly verifies that all fallback rows are emitted when there
+// are no primary rows in the UNION ALL stream.
+func TestUnionDedupIteratorFallbackOnly(t *testing.T) {
 	ctx := base.TestCtx(t)
-	primary := newMockIterator(nil)
-	fallback := newMockIterator([][]byte{
+	// Simulate UNION ALL output with only fallback rows.
+	stream := newMockIterator([][]byte{
 		marshalRow("_sync:user:carol", "carol"),
 		marshalRow("_sync:role:editor", "editor"),
 	})
 
-	iter := newMergeDedupIterator(primary, fallback)
+	iter := newUnionDedupIterator(stream)
 	var rows []principalRow
 	for {
 		var row principalRow
@@ -119,31 +121,31 @@ func TestMergeDedupIteratorFallbackOnly(t *testing.T) {
 	assert.Equal(t, "_sync:role:editor", rows[1].Id)
 }
 
-// TestMergeDedupIterator_BothEmpty verifies that an empty merged stream is handled cleanly.
-func TestMergeDedupIteratorBothEmpty(t *testing.T) {
-	iter := newMergeDedupIterator(newMockIterator(nil), newMockIterator(nil))
+// TestUnionDedupIteratorEmpty verifies that an empty UNION ALL stream is handled cleanly.
+func TestUnionDedupIteratorEmpty(t *testing.T) {
+	iter := newUnionDedupIterator(newMockIterator(nil))
 	var row principalRow
 	assert.False(t, iter.Next(context.Background(), &row))
 	require.NoError(t, iter.Close())
 }
 
-// TestMergeDedupIterator_DeduplicatesPrimaryPreferred verifies that when the same META().id
-// appears in both primary and fallback, only the primary version is emitted.  The Name field
-// is deliberately different between stores to confirm which version was chosen.
-func TestMergeDedupIteratorDeduplicatesPrimaryPreferred(t *testing.T) {
+// TestUnionDedupIteratorDeduplicatesPrimaryPreferred verifies that when the same META().id
+// appears in both the primary and fallback sections of the UNION ALL stream, only the primary
+// version (which appears first) is emitted. The Name field is different per store so the test
+// can confirm which copy was chosen.
+func TestUnionDedupIteratorDeduplicatesPrimaryPreferred(t *testing.T) {
 	ctx := base.TestCtx(t)
-	primary := newMockIterator([][]byte{
+	// Primary rows appear first in the UNION ALL stream, fallback rows second.
+	stream := newMockIterator([][]byte{
 		marshalRow("_sync:user:alice", "alice-primary"),
 		marshalRow("_sync:user:bob", "bob-primary"),
-	})
-	// fallback has the same two IDs plus one new one
-	fallback := newMockIterator([][]byte{
+		// Fallback section: alice and bob are duplicates, carol is new.
 		marshalRow("_sync:user:alice", "alice-fallback"),
 		marshalRow("_sync:user:bob", "bob-fallback"),
 		marshalRow("_sync:user:carol", "carol-fallback"),
 	})
 
-	iter := newMergeDedupIterator(primary, fallback)
+	iter := newUnionDedupIterator(stream)
 	var rows []principalRow
 	for {
 		var row principalRow
@@ -163,15 +165,19 @@ func TestMergeDedupIteratorDeduplicatesPrimaryPreferred(t *testing.T) {
 	assert.Equal(t, "carol-fallback", rows[2].Name, "fallback-only doc should be emitted")
 }
 
-// TestMergeDedupIterator_AllDuplicates verifies that when every fallback doc is a duplicate
-// of a primary doc, only the primary docs are returned (no extras).
-func TestMergeDedupIteratorAllDuplicates(t *testing.T) {
+// TestUnionDedupIteratorAllDuplicates verifies that when every fallback doc is a duplicate of
+// a primary doc, only the primary docs are returned (no extras).
+func TestUnionDedupIteratorAllDuplicates(t *testing.T) {
 	ctx := base.TestCtx(t)
-	rows := [][]byte{
+	stream := newMockIterator([][]byte{
+		// Primary section.
+		marshalRow("_sync:user:alice", "alice-primary"),
+		marshalRow("_sync:user:bob", "bob-primary"),
+		// Fallback section — identical IDs.
 		marshalRow("_sync:user:alice", "alice"),
 		marshalRow("_sync:user:bob", "bob"),
-	}
-	iter := newMergeDedupIterator(newMockIterator(rows), newMockIterator(rows))
+	})
+	iter := newUnionDedupIterator(stream)
 	var result []principalRow
 	for {
 		var row principalRow
@@ -182,20 +188,24 @@ func TestMergeDedupIteratorAllDuplicates(t *testing.T) {
 	}
 	require.NoError(t, iter.Close())
 	require.Len(t, result, 2)
+	assert.Equal(t, "_sync:user:alice", result[0].Id)
+	assert.Equal(t, "_sync:user:bob", result[1].Id)
+	assert.Equal(t, "alice-primary", result[0].Name)
+	assert.Equal(t, "bob-primary", result[1].Name)
 }
 
-// TestMergeDedupIterator_NextBytes verifies that NextBytes returns raw JSON and that
+// TestUnionDedupIteratorNextBytes verifies that NextBytes returns raw JSON and that
 // deduplication still works through the raw-bytes path.
-func TestMergeDedupIteratorNextBytes(t *testing.T) {
-	primary := newMockIterator([][]byte{
+func TestUnionDedupIteratorNextBytes(t *testing.T) {
+	stream := newMockIterator([][]byte{
+		// Primary section.
 		marshalRow("_sync:user:alice", "alice"),
-	})
-	fallback := newMockIterator([][]byte{
+		// Fallback section: alice is a duplicate, bob is new.
 		marshalRow("_sync:user:alice", "alice-dup"),
 		marshalRow("_sync:user:bob", "bob"),
 	})
 
-	iter := newMergeDedupIterator(primary, fallback)
+	iter := newUnionDedupIterator(stream)
 	var rawRows [][]byte
 	for {
 		raw := iter.NextBytes()
@@ -210,41 +220,35 @@ func TestMergeDedupIteratorNextBytes(t *testing.T) {
 	assert.Contains(t, string(rawRows[1]), "bob")
 }
 
-// TestMergeDedupIterator_CloseBothIterators verifies that Close is called on both underlying
-// iterators, even after partial iteration.
-func TestMergeDedupIteratorCloseBothIterators(t *testing.T) {
+// TestUnionDedupIteratorClosesProperly verifies that Close propagates to the underlying
+// iterator, even after partial iteration.
+func TestUnionDedupIteratorClosesProperly(t *testing.T) {
 	ctx := base.TestCtx(t)
-	primary := newMockIterator([][]byte{
+	mock := newMockIterator([][]byte{
 		marshalRow("_sync:user:alice", "alice"),
-	})
-	fallback := newMockIterator([][]byte{
 		marshalRow("_sync:user:bob", "bob"),
 	})
 
-	iter := newMergeDedupIterator(primary, fallback)
-	// Read one row then close without exhausting the iterators.
+	iter := newUnionDedupIterator(mock)
 	var row principalRow
 	require.True(t, iter.Next(ctx, &row))
 	require.NoError(t, iter.Close())
-	assert.True(t, primary.closed, "primary iterator should be closed")
-	assert.True(t, fallback.closed, "fallback iterator should be closed")
+	assert.True(t, mock.closed, "underlying iterator should be closed")
 }
 
-// TestMergeDedupIterator_One verifies the One helper returns the first row and closes both
-// underlying iterators.
-func TestMergeDedupIteratorOne(t *testing.T) {
+// TestUnionDedupIteratorOne verifies the One helper returns the first row and closes the
+// underlying iterator.
+func TestUnionDedupIteratorOne(t *testing.T) {
 	ctx := base.TestCtx(t)
-	primary := newMockIterator([][]byte{
+	mock := newMockIterator([][]byte{
 		marshalRow("_sync:user:alice", "alice"),
 	})
-	fallback := newMockIterator(nil)
 
-	iter := newMergeDedupIterator(primary, fallback)
+	iter := newUnionDedupIterator(mock)
 	var row principalRow
 	require.NoError(t, iter.One(ctx, &row))
 	assert.Equal(t, "_sync:user:alice", row.Id)
-	assert.True(t, primary.closed)
-	assert.True(t, fallback.closed)
+	assert.True(t, mock.closed)
 }
 
 // TestExtractRowID verifies that extractRowID correctly extracts the META().id value from
@@ -285,6 +289,11 @@ func TestExtractRowID(t *testing.T) {
 			raw:      nil,
 			expected: "",
 		},
+		{
+			name:     "row with sort_order column",
+			raw:      []byte(`{"id":"_sync:user:alice","name":"alice","sort_order":0}`),
+			expected: "_sync:user:alice",
+		},
 	}
 
 	for _, tc := range tests {
@@ -294,3 +303,174 @@ func TestExtractRowID(t *testing.T) {
 		})
 	}
 }
+
+// TestBuildDualMetadataUnionStatement verifies that buildDualMetadataUnionStatement produces
+// well-formed UNION ALL N1QL statements with the correct keyspace substitutions, sort_order
+// literal injection, inner ORDER BY stripping, and outer ORDER BY construction.
+func TestBuildDualMetadataUnionStatement(t *testing.T) {
+	primaryKS := "`bucket`.`_system`.`_mobile`"
+	primaryPath := "bucket._system._mobile"
+	fallbackKS := "`bucket`.`_default`.`_default`"
+	fallbackPath := "bucket._default._default"
+	alias := base.KeyspaceQueryAlias
+
+	tests := []struct {
+		name              string
+		statement         string
+		wantPrimaryKSInQ  string
+		wantFallbackKSInQ string
+		wantOuterOrderBy  string // expected suffix after "ORDER BY"
+		wantLimitInArm    string // expected LIMIT token present in each arm (empty = no LIMIT)
+	}{
+		{
+			name: "basic query without ORDER BY",
+			statement: "SELECT META($_keyspace).id AS id, name " +
+				"FROM $_keyspace WHERE type = 'user'",
+			wantPrimaryKSInQ:  primaryKS,
+			wantFallbackKSInQ: fallbackKS,
+			wantOuterOrderBy:  dualMetadataSortOrderKey,
+		},
+		{
+			name: "query with alias, no ORDER BY",
+			statement: "SELECT META(sgQueryKeyspaceAlias).id AS id, name " +
+				"FROM $_keyspace AS sgQueryKeyspaceAlias WHERE type = 'role'",
+			wantPrimaryKSInQ:  primaryKS,
+			wantFallbackKSInQ: fallbackKS,
+			wantOuterOrderBy:  dualMetadataSortOrderKey,
+		},
+		{
+			name: "query with ORDER BY META(alias).id",
+			statement: fmt.Sprintf(
+				"SELECT META(%s).id, name FROM $_keyspace AS %s WHERE type = 'user' ORDER BY META(%s).id",
+				alias, alias, alias,
+			),
+			wantPrimaryKSInQ:  primaryKS,
+			wantFallbackKSInQ: fallbackKS,
+			wantOuterOrderBy:  dualMetadataSortOrderKey + ", id",
+		},
+		{
+			name: "query with ORDER BY META(alias).id and LIMIT",
+			statement: fmt.Sprintf(
+				"SELECT META(%s).id, name FROM $_keyspace AS %s WHERE type = 'user' ORDER BY META(%s).id LIMIT 10",
+				alias, alias, alias,
+			),
+			wantPrimaryKSInQ:  primaryKS,
+			wantFallbackKSInQ: fallbackKS,
+			wantOuterOrderBy:  dualMetadataSortOrderKey + ", id",
+			wantLimitInArm:    "LIMIT 10",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := buildDualMetadataUnionStatement(
+				tc.statement,
+				primaryKS, primaryPath,
+				fallbackKS, fallbackPath,
+			)
+
+			assert.True(t, strings.HasPrefix(result, "("), "should start with opening paren")
+			assert.Contains(t, result, ") UNION ALL (", "should contain UNION ALL joining the sub-queries")
+
+			// The result must end with the outer ORDER BY clause.
+			assert.True(t, strings.HasSuffix(result, " ORDER BY "+tc.wantOuterOrderBy),
+				"result should end with outer ORDER BY %q; got: %s", tc.wantOuterOrderBy, result)
+
+			// Both keyspaces should appear in the output.
+			assert.Contains(t, result, tc.wantPrimaryKSInQ, "primary keyspace should be in result")
+			assert.Contains(t, result, tc.wantFallbackKSInQ, "fallback keyspace should be in result")
+
+			// full_path must not appear in the output.
+			assert.NotContains(t, result, "AS full_path", "full_path column must not be injected")
+
+			// sort_order literals 0 (primary) and 1 (fallback) must both be injected.
+			assert.Contains(t, result, "0 AS "+dualMetadataSortOrderKey, "primary arm must have sort_order=0")
+			assert.Contains(t, result, "1 AS "+dualMetadataSortOrderKey, "fallback arm must have sort_order=1")
+
+			// KeyspaceQueryToken must not appear in the output.
+			assert.NotContains(t, result, base.KeyspaceQueryToken, "token must be fully replaced")
+
+			// Split on UNION ALL to inspect each arm individually.
+			// The second part will include the trailing outer ORDER BY; both arms must contain
+			// the correct FROM clause.
+			parts := strings.SplitN(result, " UNION ALL ", 2)
+			require.Len(t, parts, 2, "should have exactly two UNION ALL arms")
+			assert.Contains(t, parts[0], "FROM "+tc.wantPrimaryKSInQ)
+			assert.Contains(t, parts[1], "FROM "+tc.wantFallbackKSInQ)
+
+			// Inner ORDER BY must not appear inside either arm (it was lifted to outer scope).
+			assert.NotContains(t, parts[0], " ORDER BY ", "primary arm must not contain inner ORDER BY")
+			// parts[1] includes the outer ORDER BY suffix; strip it before checking.
+			armTwo := strings.TrimSuffix(parts[1], " ORDER BY "+tc.wantOuterOrderBy)
+			assert.NotContains(t, armTwo, " ORDER BY ", "fallback arm must not contain inner ORDER BY")
+
+			// If the original statement had a LIMIT it must be re-attached to each arm.
+			if tc.wantLimitInArm != "" {
+				assert.Contains(t, parts[0], tc.wantLimitInArm, "primary arm must contain LIMIT")
+				assert.Contains(t, armTwo, tc.wantLimitInArm, "fallback arm must contain LIMIT")
+			}
+		})
+	}
+}
+
+// TestSplitStatement verifies that splitStatement correctly separates the core query, ORDER BY
+// columns, and LIMIT clause for a variety of input shapes.
+func TestSplitStatement(t *testing.T) {
+	tests := []struct {
+		name            string
+		stmt            string
+		wantCore        string
+		wantOrderBy     string
+		wantLimitClause string
+	}{
+		{
+			name:        "no ORDER BY, no LIMIT",
+			stmt:        "SELECT name FROM ks WHERE type = 'user'",
+			wantCore:    "SELECT name FROM ks WHERE type = 'user'",
+			wantOrderBy: "",
+		},
+		{
+			name:        "ORDER BY only",
+			stmt:        "SELECT name FROM ks WHERE type = 'user' ORDER BY META(alias).id",
+			wantCore:    "SELECT name FROM ks WHERE type = 'user'",
+			wantOrderBy: "META(alias).id",
+		},
+		{
+			name:            "ORDER BY and LIMIT",
+			stmt:            "SELECT name FROM ks WHERE type = 'user' ORDER BY META(alias).id LIMIT 100",
+			wantCore:        "SELECT name FROM ks WHERE type = 'user'",
+			wantOrderBy:     "META(alias).id",
+			wantLimitClause: " LIMIT 100",
+		},
+		{
+			name:            "bare LIMIT, no ORDER BY",
+			stmt:            "SELECT name FROM ks LIMIT 50",
+			wantCore:        "SELECT name FROM ks",
+			wantOrderBy:     "",
+			wantLimitClause: " LIMIT 50",
+		},
+		{
+			name:            "ORDER BY with multiple columns and LIMIT",
+			stmt:            "SELECT a, b FROM ks ORDER BY a, b DESC LIMIT 10",
+			wantCore:        "SELECT a, b FROM ks",
+			wantOrderBy:     "a, b DESC",
+			wantLimitClause: " LIMIT 10",
+		},
+		{
+			name:        "case-insensitive ORDER BY",
+			stmt:        "SELECT name FROM ks order by name",
+			wantCore:    "SELECT name FROM ks",
+			wantOrderBy: "name",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			core, orderBy, limit := splitStatement(tc.stmt)
+			assert.Equal(t, tc.wantCore, core)
+			assert.Equal(t, tc.wantOrderBy, orderBy)
+			assert.Equal(t, tc.wantLimitClause, limit)
+		})
+	}
+}
+

--- a/db/query_dual_metadata_test.go
+++ b/db/query_dual_metadata_test.go
@@ -80,10 +80,10 @@ func TestMergedDedupIteratorPrimaryOnly(t *testing.T) {
 	})
 	fallback := newMockIterator(nil)
 
-	iter := newDualMetadataStorePrincipalDedupIterator(primary, fallback, 0)
-	var rows []principalRow
+	iter := newDualMetadataStorePrincipalDedupIterator[PrincipalRow](primary, fallback, 0)
+	var rows []PrincipalRow
 	for {
-		var row principalRow
+		var row PrincipalRow
 		if !iter.Next(ctx, &row) {
 			break
 		}
@@ -105,10 +105,10 @@ func TestMergedDedupIteratorFallbackOnly(t *testing.T) {
 		marshalRow("_sync:role:editor", "editor"),
 	})
 
-	iter := newDualMetadataStorePrincipalDedupIterator(primary, fallback, 0)
-	var rows []principalRow
+	iter := newDualMetadataStorePrincipalDedupIterator[PrincipalRow](primary, fallback, 0)
+	var rows []PrincipalRow
 	for {
-		var row principalRow
+		var row PrincipalRow
 		if !iter.Next(ctx, &row) {
 			break
 		}
@@ -122,8 +122,8 @@ func TestMergedDedupIteratorFallbackOnly(t *testing.T) {
 
 // TestMergedDedupIteratorEmpty verifies that empty iterators are handled cleanly.
 func TestMergedDedupIteratorEmpty(t *testing.T) {
-	iter := newDualMetadataStorePrincipalDedupIterator(newMockIterator(nil), newMockIterator(nil), 0)
-	var row principalRow
+	iter := newDualMetadataStorePrincipalDedupIterator[PrincipalRow](newMockIterator(nil), newMockIterator(nil), 0)
+	var row PrincipalRow
 	assert.False(t, iter.Next(context.Background(), &row))
 	require.NoError(t, iter.Close())
 }
@@ -144,10 +144,10 @@ func TestMergedDedupIteratorDeduplicatesPrimaryPreferred(t *testing.T) {
 		marshalRow("_sync:user:carol", "carol-fallback"),
 	})
 
-	iter := newDualMetadataStorePrincipalDedupIterator(primary, fallback, 0)
-	var rows []principalRow
+	iter := newDualMetadataStorePrincipalDedupIterator[PrincipalRow](primary, fallback, 0)
+	var rows []PrincipalRow
 	for {
-		var row principalRow
+		var row PrincipalRow
 		if !iter.Next(ctx, &row) {
 			break
 		}
@@ -176,10 +176,10 @@ func TestMergedDedupIteratorAllDuplicates(t *testing.T) {
 		marshalRow("_sync:user:alice", "alice"),
 		marshalRow("_sync:user:bob", "bob"),
 	})
-	iter := newDualMetadataStorePrincipalDedupIterator(primary, fallback, 0)
-	var result []principalRow
+	iter := newDualMetadataStorePrincipalDedupIterator[PrincipalRow](primary, fallback, 0)
+	var result []PrincipalRow
 	for {
-		var row principalRow
+		var row PrincipalRow
 		if !iter.Next(ctx, &row) {
 			break
 		}
@@ -208,10 +208,10 @@ func TestMergedDedupIteratorMergeSortOrder(t *testing.T) {
 		marshalRow("F", "f"),
 	})
 
-	iter := newDualMetadataStorePrincipalDedupIterator(primary, fallback, 0)
+	iter := newDualMetadataStorePrincipalDedupIterator[PrincipalRow](primary, fallback, 0)
 	var ids []string
 	for {
-		var row principalRow
+		var row PrincipalRow
 		if !iter.Next(ctx, &row) {
 			break
 		}
@@ -223,30 +223,6 @@ func TestMergedDedupIteratorMergeSortOrder(t *testing.T) {
 
 // TestMergedDedupIteratorNextBytes verifies that NextBytes returns raw JSON and that
 // deduplication still works through the raw-bytes path.
-func TestMergedDedupIteratorNextBytes(t *testing.T) {
-	primary := newMockIterator([][]byte{
-		marshalRow("_sync:user:alice", "alice"),
-	})
-	fallback := newMockIterator([][]byte{
-		marshalRow("_sync:user:alice", "alice-dup"),
-		marshalRow("_sync:user:bob", "bob"),
-	})
-
-	iter := newDualMetadataStorePrincipalDedupIterator(primary, fallback, 0)
-	var rawRows [][]byte
-	for {
-		raw := iter.NextBytes()
-		if raw == nil {
-			break
-		}
-		rawRows = append(rawRows, raw)
-	}
-	require.NoError(t, iter.Close())
-	require.Len(t, rawRows, 2, "duplicate alice row from fallback should be suppressed")
-	assert.Contains(t, string(rawRows[0]), "alice")
-	assert.Contains(t, string(rawRows[1]), "bob")
-}
-
 // TestMergedDedupIteratorClosesProperly verifies that Close propagates to both underlying
 // iterators, even after partial iteration.
 func TestMergedDedupIteratorClosesProperly(t *testing.T) {
@@ -258,8 +234,8 @@ func TestMergedDedupIteratorClosesProperly(t *testing.T) {
 		marshalRow("_sync:user:bob", "bob"),
 	})
 
-	iter := newDualMetadataStorePrincipalDedupIterator(mockPrimary, mockFallback, 0)
-	var row principalRow
+	iter := newDualMetadataStorePrincipalDedupIterator[PrincipalRow](mockPrimary, mockFallback, 0)
+	var row PrincipalRow
 	require.True(t, iter.Next(ctx, &row))
 	require.NoError(t, iter.Close())
 	assert.True(t, mockPrimary.closed, "primary iterator should be closed")
@@ -275,8 +251,8 @@ func TestMergedDedupIteratorOne(t *testing.T) {
 	})
 	mockFallback := newMockIterator(nil)
 
-	iter := newDualMetadataStorePrincipalDedupIterator(mockPrimary, mockFallback, 0)
-	var row principalRow
+	iter := newDualMetadataStorePrincipalDedupIterator[PrincipalRow](mockPrimary, mockFallback, 0)
+	var row PrincipalRow
 	require.NoError(t, iter.One(ctx, &row))
 	assert.Equal(t, "_sync:user:alice", row.Id)
 	assert.True(t, mockPrimary.closed)
@@ -301,10 +277,10 @@ func TestMergedDedupIteratorSafeBoundary(t *testing.T) {
 		marshalRow("C", "c"),
 	})
 
-	iter := newDualMetadataStorePrincipalDedupIterator(primary, fallback, 2)
+	iter := newDualMetadataStorePrincipalDedupIterator[PrincipalRow](primary, fallback, 2)
 	var ids []string
 	for {
-		var row principalRow
+		var row PrincipalRow
 		if !iter.Next(ctx, &row) {
 			break
 		}
@@ -328,10 +304,10 @@ func TestMergedDedupIteratorSafeBoundaryPrimaryExhausts(t *testing.T) {
 		marshalRow("D", "d"),
 	})
 
-	iter := newDualMetadataStorePrincipalDedupIterator(primary, fallback, 2)
+	iter := newDualMetadataStorePrincipalDedupIterator[PrincipalRow](primary, fallback, 2)
 	var ids []string
 	for {
-		var row principalRow
+		var row PrincipalRow
 		if !iter.Next(ctx, &row) {
 			break
 		}
@@ -358,10 +334,10 @@ func TestMergedDedupIteratorNoBoundaryWhenBelowLimit(t *testing.T) {
 		marshalRow("E", "e"),
 	})
 
-	iter := newDualMetadataStorePrincipalDedupIterator(primary, fallback, 5)
+	iter := newDualMetadataStorePrincipalDedupIterator[PrincipalRow](primary, fallback, 5)
 	var ids []string
 	for {
-		var row principalRow
+		var row PrincipalRow
 		if !iter.Next(ctx, &row) {
 			break
 		}
@@ -390,10 +366,10 @@ func TestMergedDedupIteratorBoundaryWithDuplicates(t *testing.T) {
 		marshalRow("E", "e-fallback"),
 	})
 
-	iter := newDualMetadataStorePrincipalDedupIterator(primary, fallback, 3)
-	var rows []principalRow
+	iter := newDualMetadataStorePrincipalDedupIterator[PrincipalRow](primary, fallback, 3)
+	var rows []PrincipalRow
 	for {
-		var row principalRow
+		var row PrincipalRow
 		if !iter.Next(ctx, &row) {
 			break
 		}
@@ -420,10 +396,10 @@ func TestMergedDedupIteratorUnlimited(t *testing.T) {
 		marshalRow("C", "c"),
 	})
 
-	iter := newDualMetadataStorePrincipalDedupIterator(primary, fallback, 0)
+	iter := newDualMetadataStorePrincipalDedupIterator[PrincipalRow](primary, fallback, 0)
 	var ids []string
 	for {
-		var row principalRow
+		var row PrincipalRow
 		if !iter.Next(ctx, &row) {
 			break
 		}
@@ -445,10 +421,10 @@ func TestMergedDeduplicateWithDuplicate(t *testing.T) {
 		marshalRow("D", "d"),
 	})
 
-	iter := newDualMetadataStorePrincipalDedupIterator(primary, fallback, 0)
+	iter := newDualMetadataStorePrincipalDedupIterator[PrincipalRow](primary, fallback, 0)
 	var ids []string
 	for {
-		var row principalRow
+		var row PrincipalRow
 		if !iter.Next(ctx, &row) {
 			break
 		}
@@ -497,12 +473,12 @@ func TestMergedDedupIteratorPaginationSimulation(t *testing.T) {
 		}
 		primary := newMockIterator(filterAndLimit(data.primary))
 		fallback := newMockIterator(filterAndLimit(data.fallback))
-		iter := newDualMetadataStorePrincipalDedupIterator(primary, fallback, limit)
+		iter := newDualMetadataStorePrincipalDedupIterator[PrincipalRow](primary, fallback, limit)
 
 		ctx := base.TestCtx(t)
 		resultCount := 0
 		for {
-			var row principalRow
+			var row PrincipalRow
 			if !iter.Next(ctx, &row) {
 				break
 			}
@@ -527,79 +503,6 @@ func TestMergedDedupIteratorPaginationSimulation(t *testing.T) {
 		"all IDs should be collected across paginated queries")
 }
 
-// TestExtractRowID verifies that extractRowID correctly extracts the META().id value from
-// various raw JSON byte slices.
-func TestExtractRowID(t *testing.T) {
-	tests := []struct {
-		name     string
-		raw      []byte
-		expected string
-	}{
-		{
-			name:     "well-formed row",
-			raw:      []byte(`{"id":"_sync:user:alice","name":"alice"}`),
-			expected: "_sync:user:alice",
-		},
-		{
-			name:     "id field only",
-			raw:      []byte(`{"id":"_sync:role:editor"}`),
-			expected: "_sync:role:editor",
-		},
-		{
-			name:     "empty id",
-			raw:      []byte(`{"id":""}`),
-			expected: "",
-		},
-		{
-			name:     "missing id field",
-			raw:      []byte(`{"name":"alice"}`),
-			expected: "",
-		},
-		{
-			name:     "malformed JSON",
-			raw:      []byte(`not-json`),
-			expected: "",
-		},
-		{
-			name:     "nil bytes",
-			raw:      nil,
-			expected: "",
-		},
-		{
-			name:     "escaped characters in id value",
-			raw:      []byte(`{"id":"_sync:user:alice\\bob","name":"alice"}`),
-			expected: `_sync:user:alice\\bob`,
-		},
-		{
-			name:     "id not first field",
-			raw:      []byte(`{"name":"alice","email":"a@b.com","id":"_sync:user:alice"}`),
-			expected: "_sync:user:alice",
-		},
-		{
-			name:     "empty JSON object",
-			raw:      []byte(`{}`),
-			expected: "",
-		},
-		{
-			name:     "id with numeric value not string",
-			raw:      []byte(`{"id":12345}`),
-			expected: "",
-		},
-		{
-			name:     "id pattern embedded in field value does not cause false match",
-			raw:      []byte(`{"desc":"contains \"id\":\"fake\"","id":"_sync:user:real"}`),
-			expected: "_sync:user:real",
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got := extractRowID(tc.raw)
-			assert.Equal(t, tc.expected, got)
-		})
-	}
-}
-
 // TestMergedDedupIteratorBothExhaustAtLimit verifies behaviour when both sources exhaust at
 // exactly limit rows simultaneously. The first source to exhaust during the merge sets the
 // boundary; the second source's remaining rows beyond the boundary are suppressed.
@@ -619,10 +522,10 @@ func TestMergedDedupIteratorBothExhaustAtLimit(t *testing.T) {
 		marshalRow("D", "d"),
 	})
 
-	iter := newDualMetadataStorePrincipalDedupIterator(primary, fallback, 2)
+	iter := newDualMetadataStorePrincipalDedupIterator[PrincipalRow](primary, fallback, 2)
 	var ids []string
 	for {
-		var row principalRow
+		var row PrincipalRow
 		if !iter.Next(ctx, &row) {
 			break
 		}
@@ -653,10 +556,10 @@ func TestMergedDedupIteratorBoundaryIsExclusive(t *testing.T) {
 		marshalRow("E", "e"),
 	})
 
-	iter := newDualMetadataStorePrincipalDedupIterator(primary, fallback, 2)
-	var rows []principalRow
+	iter := newDualMetadataStorePrincipalDedupIterator[PrincipalRow](primary, fallback, 2)
+	var rows []PrincipalRow
 	for {
-		var row principalRow
+		var row PrincipalRow
 		if !iter.Next(ctx, &row) {
 			break
 		}
@@ -709,12 +612,12 @@ func TestMergedDedupIteratorPaginationSimulationWithDuplicates(t *testing.T) {
 		}
 		primary := newMockIterator(filterAndLimit(data.primary))
 		fallback := newMockIterator(filterAndLimit(data.fallback))
-		iter := newDualMetadataStorePrincipalDedupIterator(primary, fallback, limit)
+		iter := newDualMetadataStorePrincipalDedupIterator[PrincipalRow](primary, fallback, limit)
 
 		ctx := base.TestCtx(t)
 		resultCount := 0
 		for {
-			var row principalRow
+			var row PrincipalRow
 			if !iter.Next(ctx, &row) {
 				break
 			}
@@ -776,12 +679,12 @@ func TestMergedDedupIteratorPaginationSimulationHeavySkew(t *testing.T) {
 		}
 		primary := newMockIterator(filterAndLimit(data.primary))
 		fallback := newMockIterator(filterAndLimit(data.fallback))
-		iter := newDualMetadataStorePrincipalDedupIterator(primary, fallback, limit)
+		iter := newDualMetadataStorePrincipalDedupIterator[PrincipalRow](primary, fallback, limit)
 
 		ctx := base.TestCtx(t)
 		resultCount := 0
 		for {
-			var row principalRow
+			var row PrincipalRow
 			if !iter.Next(ctx, &row) {
 				break
 			}
@@ -815,7 +718,7 @@ func TestMergedDedupIteratorCloseErrorPropagation(t *testing.T) {
 		mockFallback := newMockIterator(nil)
 		mockFallback.closeErr = fmt.Errorf("fallback close error")
 
-		iter := newDualMetadataStorePrincipalDedupIterator(mockPrimary, mockFallback, 0)
+		iter := newDualMetadataStorePrincipalDedupIterator[PrincipalRow](mockPrimary, mockFallback, 0)
 		err := iter.Close()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "primary close error",
@@ -829,7 +732,7 @@ func TestMergedDedupIteratorCloseErrorPropagation(t *testing.T) {
 		mockFallback := newMockIterator(nil)
 		mockFallback.closeErr = fmt.Errorf("fallback close error")
 
-		iter := newDualMetadataStorePrincipalDedupIterator(mockPrimary, mockFallback, 0)
+		iter := newDualMetadataStorePrincipalDedupIterator[PrincipalRow](mockPrimary, mockFallback, 0)
 		err := iter.Close()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "fallback close error")
@@ -839,7 +742,7 @@ func TestMergedDedupIteratorCloseErrorPropagation(t *testing.T) {
 		mockPrimary := newMockIterator(nil)
 		mockFallback := newMockIterator(nil)
 
-		iter := newDualMetadataStorePrincipalDedupIterator(mockPrimary, mockFallback, 0)
+		iter := newDualMetadataStorePrincipalDedupIterator[PrincipalRow](mockPrimary, mockFallback, 0)
 		require.NoError(t, iter.Close())
 	})
 }
@@ -851,8 +754,8 @@ func TestMergedDedupIteratorOneEmpty(t *testing.T) {
 	mockPrimary := newMockIterator(nil)
 	mockFallback := newMockIterator(nil)
 
-	iter := newDualMetadataStorePrincipalDedupIterator(mockPrimary, mockFallback, 0)
-	var row principalRow
+	iter := newDualMetadataStorePrincipalDedupIterator[PrincipalRow](mockPrimary, mockFallback, 0)
+	var row PrincipalRow
 	err := iter.One(ctx, &row)
 	require.ErrorIs(t, err, sgbucket.ErrNoRows)
 	assert.True(t, mockPrimary.closed, "primary should be closed after One")
@@ -868,8 +771,8 @@ func TestMergedDedupIteratorOneFallbackRow(t *testing.T) {
 		marshalRow("_sync:user:alice", "alice"),
 	})
 
-	iter := newDualMetadataStorePrincipalDedupIterator(mockPrimary, mockFallback, 0)
-	var row principalRow
+	iter := newDualMetadataStorePrincipalDedupIterator[PrincipalRow](mockPrimary, mockFallback, 0)
+	var row PrincipalRow
 	require.NoError(t, iter.One(ctx, &row))
 	assert.Equal(t, "_sync:user:alice", row.Id)
 	assert.True(t, mockPrimary.closed)
@@ -900,10 +803,10 @@ func TestMergedDedupIteratorBoundaryWithDiscardedDuplicates(t *testing.T) {
 		marshalRow("D", "d-fallback"),
 	})
 
-	iter := newDualMetadataStorePrincipalDedupIterator(primary, fallback, 3)
-	var rows []principalRow
+	iter := newDualMetadataStorePrincipalDedupIterator[PrincipalRow](primary, fallback, 3)
+	var rows []PrincipalRow
 	for {
-		var row principalRow
+		var row PrincipalRow
 		if !iter.Next(ctx, &row) {
 			break
 		}
@@ -924,6 +827,7 @@ func TestMergedDedupIteratorBoundaryWithDiscardedDuplicates(t *testing.T) {
 func TestMergedDedupIteratorNextBytesWithBoundary(t *testing.T) {
 	// LIMIT 2. primary: [A, E], fallback: [B, C].
 	// Boundary set by fallback at C. E > C → suppressed.
+	ctx := base.TestCtx(t)
 	primary := newMockIterator([][]byte{
 		marshalRow("A", "a"),
 		marshalRow("E", "e"),
@@ -933,20 +837,20 @@ func TestMergedDedupIteratorNextBytesWithBoundary(t *testing.T) {
 		marshalRow("C", "c"),
 	})
 
-	iter := newDualMetadataStorePrincipalDedupIterator(primary, fallback, 2)
-	var rawRows [][]byte
+	iter := newDualMetadataStorePrincipalDedupIterator[PrincipalRow](primary, fallback, 2)
+	var rows []PrincipalRow
 	for {
-		raw := iter.NextBytes()
-		if raw == nil {
+		var row PrincipalRow
+		if !iter.Next(ctx, &row) {
 			break
 		}
-		rawRows = append(rawRows, raw)
+		rows = append(rows, row)
 	}
 	require.NoError(t, iter.Close())
-	require.Len(t, rawRows, 3, "E should be suppressed by boundary at C")
-	assert.Contains(t, string(rawRows[0]), `"A"`)
-	assert.Contains(t, string(rawRows[1]), `"B"`)
-	assert.Contains(t, string(rawRows[2]), `"C"`)
+	require.Len(t, rows, 3, "E should be suppressed by boundary at C")
+	assert.Equal(t, "A", rows[0].Id)
+	assert.Equal(t, "B", rows[1].Id)
+	assert.Equal(t, "C", rows[2].Id)
 }
 
 func TestMergeDeudupIteratorBoundryIsDuplicate(t *testing.T) {
@@ -962,10 +866,10 @@ func TestMergeDeudupIteratorBoundryIsDuplicate(t *testing.T) {
 		marshalRow("C", "c-fallback"),
 	})
 
-	iter := newDualMetadataStorePrincipalDedupIterator(primary, fallback, 2)
-	var rows []principalRow
+	iter := newDualMetadataStorePrincipalDedupIterator[PrincipalRow](primary, fallback, 2)
+	var rows []PrincipalRow
 	for {
-		var row principalRow
+		var row PrincipalRow
 		if !iter.Next(ctx, &row) {
 			break
 		}

--- a/db/query_dual_metadata_test.go
+++ b/db/query_dual_metadata_test.go
@@ -1,0 +1,296 @@
+// Copyright 2026-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package db
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockQueryResultIterator is an in-memory QueryResultIterator backed by a slice of raw JSON
+// byte slices, used to test mergeDedupIterator without a real database.
+type mockQueryResultIterator struct {
+	rows     [][]byte
+	pos      int
+	closed   bool
+	closeErr error
+}
+
+func newMockIterator(rows [][]byte) *mockQueryResultIterator {
+	return &mockQueryResultIterator{rows: rows}
+}
+
+func (m *mockQueryResultIterator) NextBytes() []byte {
+	if m.pos >= len(m.rows) {
+		return nil
+	}
+	raw := m.rows[m.pos]
+	m.pos++
+	return raw
+}
+
+func (m *mockQueryResultIterator) Next(_ context.Context, valuePtr any) bool {
+	raw := m.NextBytes()
+	if raw == nil {
+		return false
+	}
+	return base.JSONUnmarshal(raw, valuePtr) == nil
+}
+
+func (m *mockQueryResultIterator) One(ctx context.Context, valuePtr any) error {
+	if !m.Next(ctx, valuePtr) {
+		return fmt.Errorf("no rows")
+	}
+	return m.Close()
+}
+
+func (m *mockQueryResultIterator) Close() error {
+	m.closed = true
+	return m.closeErr
+}
+
+// marshalRow builds a minimal principal-row JSON byte slice from id and name fields.
+func marshalRow(id, name string) []byte {
+	row, err := base.JSONMarshal(map[string]string{"id": id, "name": name})
+	if err != nil {
+		panic(fmt.Sprintf("marshalRow: %v", err))
+	}
+	return row
+}
+
+// TestMergeDedupIterator_PrimaryOnly verifies that all primary rows are emitted when the
+// fallback iterator is empty.
+func TestMergeDedupIteratorPrimaryOnly(t *testing.T) {
+	ctx := base.TestCtx(t)
+	primary := newMockIterator([][]byte{
+		marshalRow("_sync:user:alice", "alice"),
+		marshalRow("_sync:user:bob", "bob"),
+	})
+	fallback := newMockIterator(nil)
+
+	iter := newMergeDedupIterator(primary, fallback)
+	var rows []principalRow
+	for {
+		var row principalRow
+		if !iter.Next(ctx, &row) {
+			break
+		}
+		rows = append(rows, row)
+	}
+	require.NoError(t, iter.Close())
+	require.Len(t, rows, 2)
+	assert.Equal(t, "_sync:user:alice", rows[0].Id)
+	assert.Equal(t, "_sync:user:bob", rows[1].Id)
+}
+
+// TestMergeDedupIterator_FallbackOnly verifies that all fallback rows are emitted when the
+// primary iterator is empty.
+func TestMergeDedupIteratorFallbackOnly(t *testing.T) {
+	ctx := base.TestCtx(t)
+	primary := newMockIterator(nil)
+	fallback := newMockIterator([][]byte{
+		marshalRow("_sync:user:carol", "carol"),
+		marshalRow("_sync:role:editor", "editor"),
+	})
+
+	iter := newMergeDedupIterator(primary, fallback)
+	var rows []principalRow
+	for {
+		var row principalRow
+		if !iter.Next(ctx, &row) {
+			break
+		}
+		rows = append(rows, row)
+	}
+	require.NoError(t, iter.Close())
+	require.Len(t, rows, 2)
+	assert.Equal(t, "_sync:user:carol", rows[0].Id)
+	assert.Equal(t, "_sync:role:editor", rows[1].Id)
+}
+
+// TestMergeDedupIterator_BothEmpty verifies that an empty merged stream is handled cleanly.
+func TestMergeDedupIteratorBothEmpty(t *testing.T) {
+	iter := newMergeDedupIterator(newMockIterator(nil), newMockIterator(nil))
+	var row principalRow
+	assert.False(t, iter.Next(context.Background(), &row))
+	require.NoError(t, iter.Close())
+}
+
+// TestMergeDedupIterator_DeduplicatesPrimaryPreferred verifies that when the same META().id
+// appears in both primary and fallback, only the primary version is emitted.  The Name field
+// is deliberately different between stores to confirm which version was chosen.
+func TestMergeDedupIteratorDeduplicatesPrimaryPreferred(t *testing.T) {
+	ctx := base.TestCtx(t)
+	primary := newMockIterator([][]byte{
+		marshalRow("_sync:user:alice", "alice-primary"),
+		marshalRow("_sync:user:bob", "bob-primary"),
+	})
+	// fallback has the same two IDs plus one new one
+	fallback := newMockIterator([][]byte{
+		marshalRow("_sync:user:alice", "alice-fallback"),
+		marshalRow("_sync:user:bob", "bob-fallback"),
+		marshalRow("_sync:user:carol", "carol-fallback"),
+	})
+
+	iter := newMergeDedupIterator(primary, fallback)
+	var rows []principalRow
+	for {
+		var row principalRow
+		if !iter.Next(ctx, &row) {
+			break
+		}
+		rows = append(rows, row)
+	}
+	require.NoError(t, iter.Close())
+
+	require.Len(t, rows, 3)
+	assert.Equal(t, "_sync:user:alice", rows[0].Id)
+	assert.Equal(t, "alice-primary", rows[0].Name, "primary version should be preferred")
+	assert.Equal(t, "_sync:user:bob", rows[1].Id)
+	assert.Equal(t, "bob-primary", rows[1].Name, "primary version should be preferred")
+	assert.Equal(t, "_sync:user:carol", rows[2].Id)
+	assert.Equal(t, "carol-fallback", rows[2].Name, "fallback-only doc should be emitted")
+}
+
+// TestMergeDedupIterator_AllDuplicates verifies that when every fallback doc is a duplicate
+// of a primary doc, only the primary docs are returned (no extras).
+func TestMergeDedupIteratorAllDuplicates(t *testing.T) {
+	ctx := base.TestCtx(t)
+	rows := [][]byte{
+		marshalRow("_sync:user:alice", "alice"),
+		marshalRow("_sync:user:bob", "bob"),
+	}
+	iter := newMergeDedupIterator(newMockIterator(rows), newMockIterator(rows))
+	var result []principalRow
+	for {
+		var row principalRow
+		if !iter.Next(ctx, &row) {
+			break
+		}
+		result = append(result, row)
+	}
+	require.NoError(t, iter.Close())
+	require.Len(t, result, 2)
+}
+
+// TestMergeDedupIterator_NextBytes verifies that NextBytes returns raw JSON and that
+// deduplication still works through the raw-bytes path.
+func TestMergeDedupIteratorNextBytes(t *testing.T) {
+	primary := newMockIterator([][]byte{
+		marshalRow("_sync:user:alice", "alice"),
+	})
+	fallback := newMockIterator([][]byte{
+		marshalRow("_sync:user:alice", "alice-dup"),
+		marshalRow("_sync:user:bob", "bob"),
+	})
+
+	iter := newMergeDedupIterator(primary, fallback)
+	var rawRows [][]byte
+	for {
+		raw := iter.NextBytes()
+		if raw == nil {
+			break
+		}
+		rawRows = append(rawRows, raw)
+	}
+	require.NoError(t, iter.Close())
+	require.Len(t, rawRows, 2, "duplicate alice row from fallback should be suppressed")
+	assert.Contains(t, string(rawRows[0]), "alice")
+	assert.Contains(t, string(rawRows[1]), "bob")
+}
+
+// TestMergeDedupIterator_CloseBothIterators verifies that Close is called on both underlying
+// iterators, even after partial iteration.
+func TestMergeDedupIteratorCloseBothIterators(t *testing.T) {
+	ctx := base.TestCtx(t)
+	primary := newMockIterator([][]byte{
+		marshalRow("_sync:user:alice", "alice"),
+	})
+	fallback := newMockIterator([][]byte{
+		marshalRow("_sync:user:bob", "bob"),
+	})
+
+	iter := newMergeDedupIterator(primary, fallback)
+	// Read one row then close without exhausting the iterators.
+	var row principalRow
+	require.True(t, iter.Next(ctx, &row))
+	require.NoError(t, iter.Close())
+	assert.True(t, primary.closed, "primary iterator should be closed")
+	assert.True(t, fallback.closed, "fallback iterator should be closed")
+}
+
+// TestMergeDedupIterator_One verifies the One helper returns the first row and closes both
+// underlying iterators.
+func TestMergeDedupIteratorOne(t *testing.T) {
+	ctx := base.TestCtx(t)
+	primary := newMockIterator([][]byte{
+		marshalRow("_sync:user:alice", "alice"),
+	})
+	fallback := newMockIterator(nil)
+
+	iter := newMergeDedupIterator(primary, fallback)
+	var row principalRow
+	require.NoError(t, iter.One(ctx, &row))
+	assert.Equal(t, "_sync:user:alice", row.Id)
+	assert.True(t, primary.closed)
+	assert.True(t, fallback.closed)
+}
+
+// TestExtractRowID verifies that extractRowID correctly extracts the META().id value from
+// various raw JSON byte slices.
+func TestExtractRowID(t *testing.T) {
+	tests := []struct {
+		name     string
+		raw      []byte
+		expected string
+	}{
+		{
+			name:     "well-formed row",
+			raw:      []byte(`{"id":"_sync:user:alice","name":"alice"}`),
+			expected: "_sync:user:alice",
+		},
+		{
+			name:     "id field only",
+			raw:      []byte(`{"id":"_sync:role:editor"}`),
+			expected: "_sync:role:editor",
+		},
+		{
+			name:     "empty id",
+			raw:      []byte(`{"id":""}`),
+			expected: "",
+		},
+		{
+			name:     "missing id field",
+			raw:      []byte(`{"name":"alice"}`),
+			expected: "",
+		},
+		{
+			name:     "malformed JSON",
+			raw:      []byte(`not-json`),
+			expected: "",
+		},
+		{
+			name:     "nil bytes",
+			raw:      nil,
+			expected: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractRowID(tc.raw)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}

--- a/db/query_dual_metadata_test.go
+++ b/db/query_dual_metadata_test.go
@@ -11,16 +11,16 @@ package db
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 
+	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 // mockQueryResultIterator is an in-memory QueryResultIterator backed by a slice of raw JSON
-// byte slices, used to test unionDedupIterator without a real database.
+// byte slices, used to test mergedDedupIterator without a real database.
 type mockQueryResultIterator struct {
 	rows     [][]byte
 	pos      int
@@ -61,8 +61,7 @@ func (m *mockQueryResultIterator) Close() error {
 	return m.closeErr
 }
 
-// marshalRow builds a minimal principal-row JSON byte slice with id and name fields,
-// mimicking a row from the UNION ALL query used by buildDualMetadataUnionStatement.
+// marshalRow builds a minimal principal-row JSON byte slice with id and name fields.
 func marshalRow(id, name string) []byte {
 	row, err := base.JSONMarshal(map[string]string{"id": id, "name": name})
 	if err != nil {
@@ -71,17 +70,17 @@ func marshalRow(id, name string) []byte {
 	return row
 }
 
-// TestUnionDedupIteratorPrimaryOnly verifies that all primary rows are emitted when there are
-// no fallback rows in the UNION ALL stream.
-func TestUnionDedupIteratorPrimaryOnly(t *testing.T) {
+// TestMergedDedupIteratorPrimaryOnly verifies that all primary rows are emitted when there are
+// no fallback rows.
+func TestMergedDedupIteratorPrimaryOnly(t *testing.T) {
 	ctx := base.TestCtx(t)
-	// Simulate UNION ALL output with only primary rows (no fallback rows).
-	stream := newMockIterator([][]byte{
+	primary := newMockIterator([][]byte{
 		marshalRow("_sync:user:alice", "alice"),
 		marshalRow("_sync:user:bob", "bob"),
 	})
+	fallback := newMockIterator(nil)
 
-	iter := newUnionDedupIterator(stream)
+	iter := newMergedDedupIterator(primary, fallback, 0)
 	var rows []principalRow
 	for {
 		var row principalRow
@@ -96,17 +95,17 @@ func TestUnionDedupIteratorPrimaryOnly(t *testing.T) {
 	assert.Equal(t, "_sync:user:bob", rows[1].Id)
 }
 
-// TestUnionDedupIteratorFallbackOnly verifies that all fallback rows are emitted when there
-// are no primary rows in the UNION ALL stream.
-func TestUnionDedupIteratorFallbackOnly(t *testing.T) {
+// TestMergedDedupIteratorFallbackOnly verifies that all fallback rows are emitted when there
+// are no primary rows.
+func TestMergedDedupIteratorFallbackOnly(t *testing.T) {
 	ctx := base.TestCtx(t)
-	// Simulate UNION ALL output with only fallback rows.
-	stream := newMockIterator([][]byte{
+	primary := newMockIterator(nil)
+	fallback := newMockIterator([][]byte{
 		marshalRow("_sync:user:carol", "carol"),
 		marshalRow("_sync:role:editor", "editor"),
 	})
 
-	iter := newUnionDedupIterator(stream)
+	iter := newMergedDedupIterator(primary, fallback, 0)
 	var rows []principalRow
 	for {
 		var row principalRow
@@ -121,31 +120,31 @@ func TestUnionDedupIteratorFallbackOnly(t *testing.T) {
 	assert.Equal(t, "_sync:role:editor", rows[1].Id)
 }
 
-// TestUnionDedupIteratorEmpty verifies that an empty UNION ALL stream is handled cleanly.
-func TestUnionDedupIteratorEmpty(t *testing.T) {
-	iter := newUnionDedupIterator(newMockIterator(nil))
+// TestMergedDedupIteratorEmpty verifies that empty iterators are handled cleanly.
+func TestMergedDedupIteratorEmpty(t *testing.T) {
+	iter := newMergedDedupIterator(newMockIterator(nil), newMockIterator(nil), 0)
 	var row principalRow
 	assert.False(t, iter.Next(context.Background(), &row))
 	require.NoError(t, iter.Close())
 }
 
-// TestUnionDedupIteratorDeduplicatesPrimaryPreferred verifies that when the same META().id
-// appears in both the primary and fallback sections of the UNION ALL stream, only the primary
-// version (which appears first) is emitted. The Name field is different per store so the test
-// can confirm which copy was chosen.
-func TestUnionDedupIteratorDeduplicatesPrimaryPreferred(t *testing.T) {
+// TestMergedDedupIteratorDeduplicatesPrimaryPreferred verifies that when the same ID
+// appears in both primary and fallback, only the primary version is emitted. Results are
+// in sorted ID order.
+func TestMergedDedupIteratorDeduplicatesPrimaryPreferred(t *testing.T) {
 	ctx := base.TestCtx(t)
-	// Primary rows appear first in the UNION ALL stream, fallback rows second.
-	stream := newMockIterator([][]byte{
+	// Both iterators sorted by ID.
+	primary := newMockIterator([][]byte{
 		marshalRow("_sync:user:alice", "alice-primary"),
 		marshalRow("_sync:user:bob", "bob-primary"),
-		// Fallback section: alice and bob are duplicates, carol is new.
+	})
+	fallback := newMockIterator([][]byte{
 		marshalRow("_sync:user:alice", "alice-fallback"),
 		marshalRow("_sync:user:bob", "bob-fallback"),
 		marshalRow("_sync:user:carol", "carol-fallback"),
 	})
 
-	iter := newUnionDedupIterator(stream)
+	iter := newMergedDedupIterator(primary, fallback, 0)
 	var rows []principalRow
 	for {
 		var row principalRow
@@ -165,19 +164,19 @@ func TestUnionDedupIteratorDeduplicatesPrimaryPreferred(t *testing.T) {
 	assert.Equal(t, "carol-fallback", rows[2].Name, "fallback-only doc should be emitted")
 }
 
-// TestUnionDedupIteratorAllDuplicates verifies that when every fallback doc is a duplicate of
-// a primary doc, only the primary docs are returned (no extras).
-func TestUnionDedupIteratorAllDuplicates(t *testing.T) {
+// TestMergedDedupIteratorAllDuplicates verifies that when every fallback doc is a duplicate of
+// a primary doc, only the primary docs are returned.
+func TestMergedDedupIteratorAllDuplicates(t *testing.T) {
 	ctx := base.TestCtx(t)
-	stream := newMockIterator([][]byte{
-		// Primary section.
+	primary := newMockIterator([][]byte{
 		marshalRow("_sync:user:alice", "alice-primary"),
 		marshalRow("_sync:user:bob", "bob-primary"),
-		// Fallback section — identical IDs.
+	})
+	fallback := newMockIterator([][]byte{
 		marshalRow("_sync:user:alice", "alice"),
 		marshalRow("_sync:user:bob", "bob"),
 	})
-	iter := newUnionDedupIterator(stream)
+	iter := newMergedDedupIterator(primary, fallback, 0)
 	var result []principalRow
 	for {
 		var row principalRow
@@ -194,18 +193,46 @@ func TestUnionDedupIteratorAllDuplicates(t *testing.T) {
 	assert.Equal(t, "bob-primary", result[1].Name)
 }
 
-// TestUnionDedupIteratorNextBytes verifies that NextBytes returns raw JSON and that
+// TestMergedDedupIteratorMergeSortOrder verifies that interleaved IDs from both stores are
+// emitted in globally sorted order.
+func TestMergedDedupIteratorMergeSortOrder(t *testing.T) {
+	ctx := base.TestCtx(t)
+	primary := newMockIterator([][]byte{
+		marshalRow("A", "a"),
+		marshalRow("C", "c"),
+		marshalRow("E", "e"),
+	})
+	fallback := newMockIterator([][]byte{
+		marshalRow("B", "b"),
+		marshalRow("D", "d"),
+		marshalRow("F", "f"),
+	})
+
+	iter := newMergedDedupIterator(primary, fallback, 0)
+	var ids []string
+	for {
+		var row principalRow
+		if !iter.Next(ctx, &row) {
+			break
+		}
+		ids = append(ids, row.Id)
+	}
+	require.NoError(t, iter.Close())
+	assert.Equal(t, []string{"A", "B", "C", "D", "E", "F"}, ids)
+}
+
+// TestMergedDedupIteratorNextBytes verifies that NextBytes returns raw JSON and that
 // deduplication still works through the raw-bytes path.
-func TestUnionDedupIteratorNextBytes(t *testing.T) {
-	stream := newMockIterator([][]byte{
-		// Primary section.
+func TestMergedDedupIteratorNextBytes(t *testing.T) {
+	primary := newMockIterator([][]byte{
 		marshalRow("_sync:user:alice", "alice"),
-		// Fallback section: alice is a duplicate, bob is new.
+	})
+	fallback := newMockIterator([][]byte{
 		marshalRow("_sync:user:alice", "alice-dup"),
 		marshalRow("_sync:user:bob", "bob"),
 	})
 
-	iter := newUnionDedupIterator(stream)
+	iter := newMergedDedupIterator(primary, fallback, 0)
 	var rawRows [][]byte
 	for {
 		raw := iter.NextBytes()
@@ -220,35 +247,284 @@ func TestUnionDedupIteratorNextBytes(t *testing.T) {
 	assert.Contains(t, string(rawRows[1]), "bob")
 }
 
-// TestUnionDedupIteratorClosesProperly verifies that Close propagates to the underlying
-// iterator, even after partial iteration.
-func TestUnionDedupIteratorClosesProperly(t *testing.T) {
+// TestMergedDedupIteratorClosesProperly verifies that Close propagates to both underlying
+// iterators, even after partial iteration.
+func TestMergedDedupIteratorClosesProperly(t *testing.T) {
 	ctx := base.TestCtx(t)
-	mock := newMockIterator([][]byte{
+	mockPrimary := newMockIterator([][]byte{
 		marshalRow("_sync:user:alice", "alice"),
+	})
+	mockFallback := newMockIterator([][]byte{
 		marshalRow("_sync:user:bob", "bob"),
 	})
 
-	iter := newUnionDedupIterator(mock)
+	iter := newMergedDedupIterator(mockPrimary, mockFallback, 0)
 	var row principalRow
 	require.True(t, iter.Next(ctx, &row))
 	require.NoError(t, iter.Close())
-	assert.True(t, mock.closed, "underlying iterator should be closed")
+	assert.True(t, mockPrimary.closed, "primary iterator should be closed")
+	assert.True(t, mockFallback.closed, "fallback iterator should be closed")
 }
 
-// TestUnionDedupIteratorOne verifies the One helper returns the first row and closes the
-// underlying iterator.
-func TestUnionDedupIteratorOne(t *testing.T) {
+// TestMergedDedupIteratorOne verifies the One helper returns the first row and closes both
+// iterators.
+func TestMergedDedupIteratorOne(t *testing.T) {
 	ctx := base.TestCtx(t)
-	mock := newMockIterator([][]byte{
+	mockPrimary := newMockIterator([][]byte{
 		marshalRow("_sync:user:alice", "alice"),
 	})
+	mockFallback := newMockIterator(nil)
 
-	iter := newUnionDedupIterator(mock)
+	iter := newMergedDedupIterator(mockPrimary, mockFallback, 0)
 	var row principalRow
 	require.NoError(t, iter.One(ctx, &row))
 	assert.Equal(t, "_sync:user:alice", row.Id)
-	assert.True(t, mock.closed)
+	assert.True(t, mockPrimary.closed)
+	assert.True(t, mockFallback.closed)
+}
+
+// TestMergedDedupIteratorSafeBoundary verifies the safe-boundary mechanism: when a source
+// exhausts at exactly limit rows, the iterator stops emitting rows from the other source
+// whose IDs exceed the exhausted source's last ID. This prevents pagination cursor jumping.
+func TestMergedDedupIteratorSafeBoundary(t *testing.T) {
+	ctx := base.TestCtx(t)
+	// Simulate LIMIT 2: primary returns [A, E] (2 rows = limit), fallback returns [B, C] (2 rows = limit).
+	// Without boundary, merged output would be [A, B, C, E] and cursor would jump to E, skipping D.
+	// With boundary: fallback exhausts at 2==limit → boundary=C. E > C → stop.
+	// Output: [A, B, C]. Next page starts at C and picks up D.
+	primary := newMockIterator([][]byte{
+		marshalRow("A", "a"),
+		marshalRow("E", "e"),
+	})
+	fallback := newMockIterator([][]byte{
+		marshalRow("B", "b"),
+		marshalRow("C", "c"),
+	})
+
+	iter := newMergedDedupIterator(primary, fallback, 2)
+	var ids []string
+	for {
+		var row principalRow
+		if !iter.Next(ctx, &row) {
+			break
+		}
+		ids = append(ids, row.Id)
+	}
+	require.NoError(t, iter.Close())
+	assert.Equal(t, []string{"A", "B", "C"}, ids, "E should be suppressed by safe boundary at C")
+}
+
+// TestMergedDedupIteratorSafeBoundaryPrimaryExhausts verifies the boundary when primary
+// exhausts first.
+func TestMergedDedupIteratorSafeBoundaryPrimaryExhausts(t *testing.T) {
+	ctx := base.TestCtx(t)
+	// LIMIT 2: primary [A, B] hit limit → boundary = B. fallback [C, D] → C > B → stop
+	primary := newMockIterator([][]byte{
+		marshalRow("A", "a"),
+		marshalRow("B", "b"),
+	})
+	fallback := newMockIterator([][]byte{
+		marshalRow("C", "c"),
+		marshalRow("D", "d"),
+	})
+
+	iter := newMergedDedupIterator(primary, fallback, 2)
+	var ids []string
+	for {
+		var row principalRow
+		if !iter.Next(ctx, &row) {
+			break
+		}
+		ids = append(ids, row.Id)
+	}
+	require.NoError(t, iter.Close())
+	assert.Equal(t, []string{"A", "B"}, ids, "C and D should be suppressed by safe boundary at B")
+}
+
+// TestMergedDedupIteratorNoBoundaryWhenBelowLimit verifies that when a source returns fewer
+// than limit rows (truly exhausted), no boundary is set and all remaining rows from the other
+// source are emitted.
+func TestMergedDedupIteratorNoBoundaryWhenBelowLimit(t *testing.T) {
+	ctx := base.TestCtx(t)
+	// LIMIT 5, primary returns 2 rows (< 5, truly exhausted), fallback returns 3.
+	// No boundary should be set — all results should be emitted.
+	primary := newMockIterator([][]byte{
+		marshalRow("A", "a"),
+		marshalRow("C", "c"),
+	})
+	fallback := newMockIterator([][]byte{
+		marshalRow("B", "b"),
+		marshalRow("D", "d"),
+		marshalRow("E", "e"),
+	})
+
+	iter := newMergedDedupIterator(primary, fallback, 5)
+	var ids []string
+	for {
+		var row principalRow
+		if !iter.Next(ctx, &row) {
+			break
+		}
+		ids = append(ids, row.Id)
+	}
+	require.NoError(t, iter.Close())
+	assert.Equal(t, []string{"A", "B", "C", "D", "E"}, ids, "all rows should be emitted when below limit")
+}
+
+// TestMergedDedupIteratorBoundaryWithDuplicates verifies the safe boundary works correctly
+// when there are duplicate IDs across stores.
+func TestMergedDedupIteratorBoundaryWithDuplicates(t *testing.T) {
+	ctx := base.TestCtx(t)
+	// LIMIT 3: primary [A, B, C] (hit limit), fallback [A, D, E] (hit limit).
+	// Merge: A(primary, dup fallback discarded), B, C. Primary exhausts at 3==limit → boundary=C.
+	// Fallback next peek: D > C → stop.
+	// Output: [A, B, C].
+	primary := newMockIterator([][]byte{
+		marshalRow("A", "a-primary"),
+		marshalRow("B", "b-primary"),
+		marshalRow("C", "c-primary"),
+	})
+	fallback := newMockIterator([][]byte{
+		marshalRow("A", "a-fallback"),
+		marshalRow("D", "d-fallback"),
+		marshalRow("E", "e-fallback"),
+	})
+
+	iter := newMergedDedupIterator(primary, fallback, 3)
+	var rows []principalRow
+	for {
+		var row principalRow
+		if !iter.Next(ctx, &row) {
+			break
+		}
+		rows = append(rows, row)
+	}
+	require.NoError(t, iter.Close())
+	require.Len(t, rows, 3)
+	assert.Equal(t, "A", rows[0].Id)
+	assert.Equal(t, "a-primary", rows[0].Name, "primary preferred for duplicate")
+	assert.Equal(t, "B", rows[1].Id)
+	assert.Equal(t, "C", rows[2].Id)
+}
+
+// TestMergedDedupIteratorUnlimited verifies that with limit=0, all rows from both stores are
+// emitted without any boundary constraint.
+func TestMergedDedupIteratorUnlimited(t *testing.T) {
+	ctx := base.TestCtx(t)
+	primary := newMockIterator([][]byte{
+		marshalRow("A", "a"),
+		marshalRow("E", "e"),
+	})
+	fallback := newMockIterator([][]byte{
+		marshalRow("B", "b"),
+		marshalRow("C", "c"),
+	})
+
+	iter := newMergedDedupIterator(primary, fallback, 0)
+	var ids []string
+	for {
+		var row principalRow
+		if !iter.Next(ctx, &row) {
+			break
+		}
+		ids = append(ids, row.Id)
+	}
+	require.NoError(t, iter.Close())
+	assert.Equal(t, []string{"A", "B", "C", "E"}, ids, "all rows emitted when unlimited")
+}
+
+// TestMergedDeduplicateWithDuplicate verifies duplicates in differing orders from each store still produce the right result
+func TestMergedDeduplicateWithDuplicate(t *testing.T) {
+	ctx := base.TestCtx(t)
+	primary := newMockIterator([][]byte{
+		marshalRow("A", "a"),
+		marshalRow("C", "c"),
+	})
+	fallback := newMockIterator([][]byte{
+		marshalRow("C", "c"),
+		marshalRow("D", "d"),
+	})
+
+	iter := newMergedDedupIterator(primary, fallback, 0)
+	var ids []string
+	for {
+		var row principalRow
+		if !iter.Next(ctx, &row) {
+			break
+		}
+		ids = append(ids, row.Id)
+	}
+	require.NoError(t, iter.Close())
+	assert.Equal(t, []string{"A", "C", "D"}, ids)
+}
+
+// TestMergedDedupIteratorPaginationSimulation simulates the pagination loop used by GetUsers
+// to verify that no IDs are missed across multiple pages when the stores have interleaved IDs.
+func TestMergedDedupIteratorPaginationSimulation(t *testing.T) {
+	// Full dataset:
+	//   primary: [A, D, G, J]
+	//   fallback: [B, C, E, F, H, I]
+	// Expected global sorted unique: [A, B, C, D, E, F, G, H, I, J]
+	// Pagination limit: 2 per page
+
+	type storeData struct {
+		primary  []string
+		fallback []string
+	}
+	data := storeData{
+		primary:  []string{"A", "D", "G", "J"},
+		fallback: []string{"B", "C", "E", "F", "H", "I"},
+	}
+
+	const limit = 2
+	var allCollected []string
+	startKey := ""
+	maxPages := 20 // safety limit
+
+	for page := range maxPages {
+		// Simulate the per-store query: filter rows >= startKey, then take first `limit`.
+		filterAndLimit := func(ids []string) [][]byte {
+			var rows [][]byte
+			for _, id := range ids {
+				if id >= startKey {
+					rows = append(rows, marshalRow(id, id))
+					if len(rows) >= limit {
+						break
+					}
+				}
+			}
+			return rows
+		}
+		primary := newMockIterator(filterAndLimit(data.primary))
+		fallback := newMockIterator(filterAndLimit(data.fallback))
+		iter := newMergedDedupIterator(primary, fallback, limit)
+
+		ctx := base.TestCtx(t)
+		resultCount := 0
+		for {
+			var row principalRow
+			if !iter.Next(ctx, &row) {
+				break
+			}
+			// Skip the overlapping first row (same as GetUsers pagination logic).
+			if resultCount == 0 && startKey != "" && row.Id == startKey {
+				resultCount++
+				continue
+			}
+			startKey = row.Id
+			resultCount++
+			allCollected = append(allCollected, row.Id)
+		}
+		_ = iter.Close()
+
+		if resultCount < limit {
+			break
+		}
+		require.Less(t, page, maxPages-1, "pagination should terminate")
+	}
+
+	assert.Equal(t, []string{"A", "B", "C", "D", "E", "F", "G", "H", "I", "J"}, allCollected,
+		"all IDs should be collected across paginated queries")
 }
 
 // TestExtractRowID verifies that extractRowID correctly extracts the META().id value from
@@ -289,11 +565,6 @@ func TestExtractRowID(t *testing.T) {
 			raw:      nil,
 			expected: "",
 		},
-		{
-			name:     "row with sort_order column",
-			raw:      []byte(`{"id":"_sync:user:alice","name":"alice","sort_order":0}`),
-			expected: "_sync:user:alice",
-		},
 	}
 
 	for _, tc := range tests {
@@ -304,195 +575,351 @@ func TestExtractRowID(t *testing.T) {
 	}
 }
 
-// TestBuildDualMetadataUnionStatement verifies that buildDualMetadataUnionStatement produces
-// well-formed UNION ALL N1QL statements with the correct keyspace substitutions, sort_order
-// literal injection, inner ORDER BY stripping, outer ORDER BY construction, and limit doubling.
-func TestBuildDualMetadataUnionStatement(t *testing.T) {
-	primaryKS := "`bucket`.`_system`.`_mobile`"
-	fallbackKS := "`bucket`.`_default`.`_default`"
-	alias := base.KeyspaceQueryAlias
+// TestMergedDedupIteratorBothExhaustAtLimit verifies behaviour when both sources exhaust at
+// exactly limit rows simultaneously. The first source to exhaust during the merge sets the
+// boundary; the second source's remaining rows beyond the boundary are suppressed.
+func TestMergedDedupIteratorBothExhaustAtLimit(t *testing.T) {
+	ctx := base.TestCtx(t)
+	// LIMIT 2. primary: [A, C], fallback: [B, D].
+	// Merge: A(primary), B(fallback), C(primary). After C emitted, peekPrimary → nil.
+	// primaryConsumed=2==limit → boundary=C. peekFallback has D already peeked.
+	// D > C → stop.
+	// Output: [A, B, C].
+	primary := newMockIterator([][]byte{
+		marshalRow("A", "a"),
+		marshalRow("C", "c"),
+	})
+	fallback := newMockIterator([][]byte{
+		marshalRow("B", "b"),
+		marshalRow("D", "d"),
+	})
 
-	tests := []struct {
-		name              string
-		statement         string
-		wantPrimaryKSInQ  string
-		wantFallbackKSInQ string
-		wantOuterOrderBy  string // expected ORDER BY columns (without trailing LIMIT)
-		wantLimitInArm    string // expected doubled LIMIT in each arm (empty = no LIMIT)
-		wantOuterLimit    string // expected doubled LIMIT on the outer UNION ALL (empty = no LIMIT)
-	}{
-		{
-			name: "basic query without ORDER BY",
-			statement: "SELECT META($_keyspace).id AS id, name " +
-				"FROM $_keyspace WHERE type = 'user'",
-			wantPrimaryKSInQ:  primaryKS,
-			wantFallbackKSInQ: fallbackKS,
-			wantOuterOrderBy:  "id, " + dualMetadataSortOrderKey,
-		},
-		{
-			name: "query with alias, no ORDER BY",
-			statement: "SELECT META(sgQueryKeyspaceAlias).id AS id, name " +
-				"FROM $_keyspace AS sgQueryKeyspaceAlias WHERE type = 'role'",
-			wantPrimaryKSInQ:  primaryKS,
-			wantFallbackKSInQ: fallbackKS,
-			wantOuterOrderBy:  "id, " + dualMetadataSortOrderKey,
-		},
-		{
-			name: "query with ORDER BY META(alias).id",
-			statement: fmt.Sprintf(
-				"SELECT META(%s).id, name FROM $_keyspace AS %s WHERE type = 'user' ORDER BY META(%s).id",
-				alias, alias, alias,
-			),
-			wantPrimaryKSInQ:  primaryKS,
-			wantFallbackKSInQ: fallbackKS,
-			wantOuterOrderBy:  "id, " + dualMetadataSortOrderKey,
-		},
-		{
-			name: "query with ORDER BY META(alias).id and LIMIT",
-			statement: fmt.Sprintf(
-				"SELECT META(%s).id, name FROM $_keyspace AS %s WHERE type = 'user' ORDER BY META(%s).id LIMIT 10",
-				alias, alias, alias,
-			),
-			wantPrimaryKSInQ:  primaryKS,
-			wantFallbackKSInQ: fallbackKS,
-			wantOuterOrderBy:  "id, " + dualMetadataSortOrderKey,
-			wantLimitInArm:    "LIMIT 20",
-			wantOuterLimit:    "LIMIT 20",
-		},
+	iter := newMergedDedupIterator(primary, fallback, 2)
+	var ids []string
+	for {
+		var row principalRow
+		if !iter.Next(ctx, &row) {
+			break
+		}
+		ids = append(ids, row.Id)
 	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			result := buildDualMetadataUnionStatement(tc.statement, primaryKS, fallbackKS)
-
-			assert.True(t, strings.HasPrefix(result, "("), "should start with opening paren")
-			assert.Contains(t, result, ") UNION ALL (", "should contain UNION ALL joining the sub-queries")
-
-			// Both keyspaces should appear in the output.
-			assert.Contains(t, result, tc.wantPrimaryKSInQ, "primary keyspace should be in result")
-			assert.Contains(t, result, tc.wantFallbackKSInQ, "fallback keyspace should be in result")
-
-			// sort_order literals 0 (primary) and 1 (fallback) must both be injected.
-			assert.Contains(t, result, "0 AS "+dualMetadataSortOrderKey, "primary arm must have sort_order=0")
-			assert.Contains(t, result, "1 AS "+dualMetadataSortOrderKey, "fallback arm must have sort_order=1")
-
-			// KeyspaceQueryToken must not appear in the output.
-			assert.NotContains(t, result, base.KeyspaceQueryToken, "token must be fully replaced")
-
-			// The result must contain the outer ORDER BY clause.
-			assert.Contains(t, result, " ORDER BY "+tc.wantOuterOrderBy,
-				"result should contain outer ORDER BY %q; got: %s", tc.wantOuterOrderBy, result)
-
-			// If a LIMIT was expected, verify it appears at the end of the full statement.
-			if tc.wantOuterLimit != "" {
-				assert.True(t, strings.HasSuffix(result, tc.wantOuterLimit),
-					"result should end with outer %s; got: %s", tc.wantOuterLimit, result)
-			}
-
-			// Split on UNION ALL to inspect each arm individually.
-			// The second part will include the trailing outer ORDER BY; both arms must contain
-			// the correct FROM clause.
-			parts := strings.SplitN(result, " UNION ALL ", 2)
-			require.Len(t, parts, 2, "should have exactly two UNION ALL arms")
-			assert.Contains(t, parts[0], "FROM "+tc.wantPrimaryKSInQ)
-			assert.Contains(t, parts[1], "FROM "+tc.wantFallbackKSInQ)
-
-			// Inner ORDER BY must not appear inside either arm (it was lifted to outer scope).
-			assert.NotContains(t, parts[0], " ORDER BY ", "primary arm must not contain inner ORDER BY")
-			// parts[1] includes the outer ORDER BY suffix; strip it before checking.
-			outerSuffix := " ORDER BY " + tc.wantOuterOrderBy
-			if tc.wantOuterLimit != "" {
-				outerSuffix += " " + tc.wantOuterLimit
-			}
-			armTwo := strings.TrimSuffix(parts[1], outerSuffix)
-			assert.NotContains(t, armTwo, " ORDER BY ", "fallback arm must not contain inner ORDER BY")
-
-			// If the original statement had a LIMIT it must be doubled and present in each arm.
-			if tc.wantLimitInArm != "" {
-				assert.Contains(t, parts[0], tc.wantLimitInArm, "primary arm must contain doubled LIMIT")
-				assert.Contains(t, armTwo, tc.wantLimitInArm, "fallback arm must contain doubled LIMIT")
-			}
-		})
-	}
+	require.NoError(t, iter.Close())
+	assert.Equal(t, []string{"A", "B", "C"}, ids,
+		"first-to-exhaust sets boundary; D beyond boundary C should be suppressed")
 }
 
-// TestSplitStatement verifies that splitStatement correctly separates the core query, ORDER BY
-// columns, and LIMIT clause for a variety of input shapes.
-func TestSplitStatement(t *testing.T) {
-	tests := []struct {
-		name            string
-		stmt            string
-		wantCore        string
-		wantOrderBy     string
-		wantLimitClause string
-	}{
-		{
-			name:        "no ORDER BY, no LIMIT",
-			stmt:        "SELECT name FROM ks WHERE type = 'user'",
-			wantCore:    "SELECT name FROM ks WHERE type = 'user'",
-			wantOrderBy: "",
-		},
-		{
-			name:        "ORDER BY only",
-			stmt:        "SELECT name FROM ks WHERE type = 'user' ORDER BY META(alias).id",
-			wantCore:    "SELECT name FROM ks WHERE type = 'user'",
-			wantOrderBy: "META(alias).id",
-		},
-		{
-			name:            "ORDER BY and LIMIT",
-			stmt:            "SELECT name FROM ks WHERE type = 'user' ORDER BY META(alias).id LIMIT 100",
-			wantCore:        "SELECT name FROM ks WHERE type = 'user'",
-			wantOrderBy:     "META(alias).id",
-			wantLimitClause: " LIMIT 100",
-		},
-		{
-			name:            "bare LIMIT, no ORDER BY",
-			stmt:            "SELECT name FROM ks LIMIT 50",
-			wantCore:        "SELECT name FROM ks",
-			wantOrderBy:     "",
-			wantLimitClause: " LIMIT 50",
-		},
-		{
-			name:            "ORDER BY with multiple columns and LIMIT",
-			stmt:            "SELECT a, b FROM ks ORDER BY a, b DESC LIMIT 10",
-			wantCore:        "SELECT a, b FROM ks",
-			wantOrderBy:     "a, b DESC",
-			wantLimitClause: " LIMIT 10",
-		},
-		{
-			name:        "case-insensitive ORDER BY",
-			stmt:        "SELECT name FROM ks order by name",
-			wantCore:    "SELECT name FROM ks",
-			wantOrderBy: "name",
-		},
-	}
+// TestMergedDedupIteratorBoundaryIsExclusive verifies that a row whose ID equals the safe
+// boundary is still emitted (the check is row.id > boundary, not >=).
+func TestMergedDedupIteratorBoundaryIsExclusive(t *testing.T) {
+	ctx := base.TestCtx(t)
+	// LIMIT 2. primary: [B, D] (exhausts at limit → boundary=D).
+	// fallback: [A, D, E].
+	// Merge: A(fallback), B(primary), D==D → emit D(primary), discard D(fallback).
+	// Primary exhausts at 2==limit → boundary=D.
+	// Fallback peeks E. E > D → stop.
+	// Output: [A, B, D]. D itself is emitted even though it equals boundary.
+	primary := newMockIterator([][]byte{
+		marshalRow("B", "b"),
+		marshalRow("D", "d-primary"),
+	})
+	fallback := newMockIterator([][]byte{
+		marshalRow("A", "a"),
+		marshalRow("D", "d-fallback"),
+		marshalRow("E", "e"),
+	})
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			core, orderBy, limit := splitStatement(tc.stmt)
-			assert.Equal(t, tc.wantCore, core)
-			assert.Equal(t, tc.wantOrderBy, orderBy)
-			assert.Equal(t, tc.wantLimitClause, limit)
-		})
+	iter := newMergedDedupIterator(primary, fallback, 2)
+	var rows []principalRow
+	for {
+		var row principalRow
+		if !iter.Next(ctx, &row) {
+			break
+		}
+		rows = append(rows, row)
 	}
+	require.NoError(t, iter.Close())
+	require.Len(t, rows, 3)
+	assert.Equal(t, "A", rows[0].Id)
+	assert.Equal(t, "B", rows[1].Id)
+	assert.Equal(t, "D", rows[2].Id)
+	assert.Equal(t, "d-primary", rows[2].Name, "primary preferred for duplicate at boundary")
 }
 
-// TestDoubleLimitClause verifies that doubleLimitClause correctly doubles numeric LIMIT values.
-func TestDoubleLimitClause(t *testing.T) {
-	tests := []struct {
-		input string
-		want  string
-	}{
-		{"", ""},
-		{" LIMIT 3", " LIMIT 6"},
-		{" LIMIT 10", " LIMIT 20"},
-		{" LIMIT 100", " LIMIT 200"},
-		{" LIMIT 1", " LIMIT 2"},
-		{" LIMIT 0", " LIMIT 0"},
+// TestMergedDedupIteratorPaginationSimulationWithDuplicates simulates the GetUsers pagination
+// loop when both stores contain overlapping IDs. This verifies that duplicates are correctly
+// handled across page boundaries and no IDs are missed or emitted twice.
+func TestMergedDedupIteratorPaginationSimulationWithDuplicates(t *testing.T) {
+	// Full dataset:
+	//   primary:  [A, B, D, F, G]
+	//   fallback: [B, C, D, E, G, H]
+	// Global sorted unique: [A, B, C, D, E, F, G, H]
+	// Pagination limit: 3 per page
+
+	type storeData struct {
+		primary  []string
+		fallback []string
 	}
-	for _, tc := range tests {
-		t.Run(tc.input, func(t *testing.T) {
-			assert.Equal(t, tc.want, doubleLimitClause(tc.input))
-		})
+	data := storeData{
+		primary:  []string{"A", "B", "D", "F", "G"},
+		fallback: []string{"B", "C", "D", "E", "G", "H"},
 	}
+
+	const limit = 3
+	var allCollected []string
+	startKey := ""
+	maxPages := 20
+
+	for page := range maxPages {
+		filterAndLimit := func(ids []string) [][]byte {
+			var rows [][]byte
+			for _, id := range ids {
+				if id >= startKey {
+					rows = append(rows, marshalRow(id, id))
+					if len(rows) >= limit {
+						break
+					}
+				}
+			}
+			return rows
+		}
+		primary := newMockIterator(filterAndLimit(data.primary))
+		fallback := newMockIterator(filterAndLimit(data.fallback))
+		iter := newMergedDedupIterator(primary, fallback, limit)
+
+		ctx := base.TestCtx(t)
+		resultCount := 0
+		for {
+			var row principalRow
+			if !iter.Next(ctx, &row) {
+				break
+			}
+			if resultCount == 0 && startKey != "" && row.Id == startKey {
+				resultCount++
+				continue
+			}
+			startKey = row.Id
+			resultCount++
+			allCollected = append(allCollected, row.Id)
+		}
+		_ = iter.Close()
+
+		if resultCount < limit {
+			break
+		}
+		require.Less(t, page, maxPages-1, "pagination should terminate")
+	}
+
+	assert.Equal(t, []string{"A", "B", "C", "D", "E", "F", "G", "H"}, allCollected,
+		"all unique IDs should be collected across paginated queries with duplicates")
+}
+
+// TestMergedDedupIteratorPaginationSimulationHeavySkew simulates pagination when one store
+// has many more rows than the other, verifying that the boundary mechanism handles asymmetric
+// distributions without skipping IDs.
+func TestMergedDedupIteratorPaginationSimulationHeavySkew(t *testing.T) {
+	// primary: [A, Z]  (only 2 rows, big gap)
+	// fallback: [B, C, D, E, F, G, H, I, J]  (9 rows, dense)
+	// Global sorted unique: [A, B, C, D, E, F, G, H, I, J, Z]
+	// Pagination limit: 3
+
+	type storeData struct {
+		primary  []string
+		fallback []string
+	}
+	data := storeData{
+		primary:  []string{"A", "Z"},
+		fallback: []string{"B", "C", "D", "E", "F", "G", "H", "I", "J"},
+	}
+
+	const limit = 3
+	var allCollected []string
+	startKey := ""
+	maxPages := 20
+
+	for page := range maxPages {
+		filterAndLimit := func(ids []string) [][]byte {
+			var rows [][]byte
+			for _, id := range ids {
+				if id >= startKey {
+					rows = append(rows, marshalRow(id, id))
+					if len(rows) >= limit {
+						break
+					}
+				}
+			}
+			return rows
+		}
+		primary := newMockIterator(filterAndLimit(data.primary))
+		fallback := newMockIterator(filterAndLimit(data.fallback))
+		iter := newMergedDedupIterator(primary, fallback, limit)
+
+		ctx := base.TestCtx(t)
+		resultCount := 0
+		for {
+			var row principalRow
+			if !iter.Next(ctx, &row) {
+				break
+			}
+			if resultCount == 0 && startKey != "" && row.Id == startKey {
+				resultCount++
+				continue
+			}
+			startKey = row.Id
+			resultCount++
+			allCollected = append(allCollected, row.Id)
+		}
+		_ = iter.Close()
+
+		if resultCount < limit {
+			break
+		}
+		require.Less(t, page, maxPages-1, "pagination should terminate")
+	}
+
+	assert.Equal(t, []string{"A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "Z"}, allCollected,
+		"all IDs should be collected with heavily skewed store sizes")
+}
+
+// TestMergedDedupIteratorCloseErrorPropagation verifies that Close returns the primary
+// iterator's error when both iterators return errors, and the fallback iterator's error when
+// only the fallback fails.
+func TestMergedDedupIteratorCloseErrorPropagation(t *testing.T) {
+	t.Run("both_errors_returns_primary", func(t *testing.T) {
+		mockPrimary := newMockIterator(nil)
+		mockPrimary.closeErr = fmt.Errorf("primary close error")
+		mockFallback := newMockIterator(nil)
+		mockFallback.closeErr = fmt.Errorf("fallback close error")
+
+		iter := newMergedDedupIterator(mockPrimary, mockFallback, 0)
+		err := iter.Close()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "primary close error",
+			"primary error should take precedence")
+		assert.True(t, mockPrimary.closed)
+		assert.True(t, mockFallback.closed, "fallback should still be closed even when primary errors")
+	})
+
+	t.Run("only_fallback_error", func(t *testing.T) {
+		mockPrimary := newMockIterator(nil)
+		mockFallback := newMockIterator(nil)
+		mockFallback.closeErr = fmt.Errorf("fallback close error")
+
+		iter := newMergedDedupIterator(mockPrimary, mockFallback, 0)
+		err := iter.Close()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "fallback close error")
+	})
+
+	t.Run("no_errors", func(t *testing.T) {
+		mockPrimary := newMockIterator(nil)
+		mockFallback := newMockIterator(nil)
+
+		iter := newMergedDedupIterator(mockPrimary, mockFallback, 0)
+		require.NoError(t, iter.Close())
+	})
+}
+
+// TestMergedDedupIteratorOneEmpty verifies that One returns sgbucket.ErrNoRows when both
+// iterators are empty, and that both iterators are closed.
+func TestMergedDedupIteratorOneEmpty(t *testing.T) {
+	ctx := base.TestCtx(t)
+	mockPrimary := newMockIterator(nil)
+	mockFallback := newMockIterator(nil)
+
+	iter := newMergedDedupIterator(mockPrimary, mockFallback, 0)
+	var row principalRow
+	err := iter.One(ctx, &row)
+	require.ErrorIs(t, err, sgbucket.ErrNoRows)
+	assert.True(t, mockPrimary.closed, "primary should be closed after One")
+	assert.True(t, mockFallback.closed, "fallback should be closed after One")
+}
+
+// TestMergedDedupIteratorOneFallbackRow verifies that One returns the first row when it comes
+// from the fallback store (not just primary).
+func TestMergedDedupIteratorOneFallbackRow(t *testing.T) {
+	ctx := base.TestCtx(t)
+	mockPrimary := newMockIterator(nil)
+	mockFallback := newMockIterator([][]byte{
+		marshalRow("_sync:user:alice", "alice"),
+	})
+
+	iter := newMergedDedupIterator(mockPrimary, mockFallback, 0)
+	var row principalRow
+	require.NoError(t, iter.One(ctx, &row))
+	assert.Equal(t, "_sync:user:alice", row.Id)
+	assert.True(t, mockPrimary.closed)
+	assert.True(t, mockFallback.closed)
+}
+
+// TestMergedDedupIteratorBoundaryWithDiscardedDuplicates verifies that discarded fallback
+// duplicates still count toward fallbackConsumed, correctly triggering the safe boundary when
+// fallback has consumed exactly limit rows (including discards).
+func TestMergedDedupIteratorBoundaryWithDiscardedDuplicates(t *testing.T) {
+	ctx := base.TestCtx(t)
+	// LIMIT 3. primary: [A, B, C] (3 rows = limit). fallback: [A, B, D] (3 rows = limit).
+	// Merge: A(primary, discard A-fallback), B(primary, discard B-fallback), C(primary).
+	// Primary exhausts at 3==limit → boundary=C.
+	// Fallback peek: D (already consumed A,B as discards → fallbackConsumed=2).
+	// D > C → stop.
+	// Output: [A, B, C].
+	// Key: fallback consumed 2 rows that were discarded + has D peeked but never consumed.
+	// The boundary is set by primary exhausting, not by fallback's consumed count.
+	primary := newMockIterator([][]byte{
+		marshalRow("A", "a-primary"),
+		marshalRow("B", "b-primary"),
+		marshalRow("C", "c-primary"),
+	})
+	fallback := newMockIterator([][]byte{
+		marshalRow("A", "a-fallback"),
+		marshalRow("B", "b-fallback"),
+		marshalRow("D", "d-fallback"),
+	})
+
+	iter := newMergedDedupIterator(primary, fallback, 3)
+	var rows []principalRow
+	for {
+		var row principalRow
+		if !iter.Next(ctx, &row) {
+			break
+		}
+		rows = append(rows, row)
+	}
+	require.NoError(t, iter.Close())
+	require.Len(t, rows, 3)
+	assert.Equal(t, "A", rows[0].Id)
+	assert.Equal(t, "a-primary", rows[0].Name, "primary preferred")
+	assert.Equal(t, "B", rows[1].Id)
+	assert.Equal(t, "b-primary", rows[1].Name, "primary preferred")
+	assert.Equal(t, "C", rows[2].Id)
+	// D from fallback should be suppressed because D > boundary C.
+}
+
+// TestMergedDedupIteratorNextBytesWithBoundary verifies that the safe boundary works correctly
+// when consuming via the NextBytes path (raw JSON bytes).
+func TestMergedDedupIteratorNextBytesWithBoundary(t *testing.T) {
+	// LIMIT 2. primary: [A, E], fallback: [B, C].
+	// Boundary set by fallback at C. E > C → suppressed.
+	primary := newMockIterator([][]byte{
+		marshalRow("A", "a"),
+		marshalRow("E", "e"),
+	})
+	fallback := newMockIterator([][]byte{
+		marshalRow("B", "b"),
+		marshalRow("C", "c"),
+	})
+
+	iter := newMergedDedupIterator(primary, fallback, 2)
+	var rawRows [][]byte
+	for {
+		raw := iter.NextBytes()
+		if raw == nil {
+			break
+		}
+		rawRows = append(rawRows, raw)
+	}
+	require.NoError(t, iter.Close())
+	require.Len(t, rawRows, 3, "E should be suppressed by boundary at C")
+	assert.Contains(t, string(rawRows[0]), `"A"`)
+	assert.Contains(t, string(rawRows[1]), `"B"`)
+	assert.Contains(t, string(rawRows[2]), `"C"`)
 }

--- a/db/query_dual_metadata_test.go
+++ b/db/query_dual_metadata_test.go
@@ -306,7 +306,7 @@ func TestExtractRowID(t *testing.T) {
 
 // TestBuildDualMetadataUnionStatement verifies that buildDualMetadataUnionStatement produces
 // well-formed UNION ALL N1QL statements with the correct keyspace substitutions, sort_order
-// literal injection, inner ORDER BY stripping, and outer ORDER BY construction.
+// literal injection, inner ORDER BY stripping, outer ORDER BY construction, and limit doubling.
 func TestBuildDualMetadataUnionStatement(t *testing.T) {
 	primaryKS := "`bucket`.`_system`.`_mobile`"
 	fallbackKS := "`bucket`.`_default`.`_default`"
@@ -317,8 +317,9 @@ func TestBuildDualMetadataUnionStatement(t *testing.T) {
 		statement         string
 		wantPrimaryKSInQ  string
 		wantFallbackKSInQ string
-		wantOuterOrderBy  string // expected suffix after "ORDER BY"
-		wantLimitInArm    string // expected LIMIT token present in each arm (empty = no LIMIT)
+		wantOuterOrderBy  string // expected ORDER BY columns (without trailing LIMIT)
+		wantLimitInArm    string // expected doubled LIMIT in each arm (empty = no LIMIT)
+		wantOuterLimit    string // expected doubled LIMIT on the outer UNION ALL (empty = no LIMIT)
 	}{
 		{
 			name: "basic query without ORDER BY",
@@ -326,7 +327,7 @@ func TestBuildDualMetadataUnionStatement(t *testing.T) {
 				"FROM $_keyspace WHERE type = 'user'",
 			wantPrimaryKSInQ:  primaryKS,
 			wantFallbackKSInQ: fallbackKS,
-			wantOuterOrderBy:  dualMetadataSortOrderKey,
+			wantOuterOrderBy:  "id, " + dualMetadataSortOrderKey,
 		},
 		{
 			name: "query with alias, no ORDER BY",
@@ -334,7 +335,7 @@ func TestBuildDualMetadataUnionStatement(t *testing.T) {
 				"FROM $_keyspace AS sgQueryKeyspaceAlias WHERE type = 'role'",
 			wantPrimaryKSInQ:  primaryKS,
 			wantFallbackKSInQ: fallbackKS,
-			wantOuterOrderBy:  dualMetadataSortOrderKey,
+			wantOuterOrderBy:  "id, " + dualMetadataSortOrderKey,
 		},
 		{
 			name: "query with ORDER BY META(alias).id",
@@ -344,7 +345,7 @@ func TestBuildDualMetadataUnionStatement(t *testing.T) {
 			),
 			wantPrimaryKSInQ:  primaryKS,
 			wantFallbackKSInQ: fallbackKS,
-			wantOuterOrderBy:  dualMetadataSortOrderKey + ", id",
+			wantOuterOrderBy:  "id, " + dualMetadataSortOrderKey,
 		},
 		{
 			name: "query with ORDER BY META(alias).id and LIMIT",
@@ -354,8 +355,9 @@ func TestBuildDualMetadataUnionStatement(t *testing.T) {
 			),
 			wantPrimaryKSInQ:  primaryKS,
 			wantFallbackKSInQ: fallbackKS,
-			wantOuterOrderBy:  dualMetadataSortOrderKey + ", id",
-			wantLimitInArm:    "LIMIT 10",
+			wantOuterOrderBy:  "id, " + dualMetadataSortOrderKey,
+			wantLimitInArm:    "LIMIT 20",
+			wantOuterLimit:    "LIMIT 20",
 		},
 	}
 
@@ -365,10 +367,6 @@ func TestBuildDualMetadataUnionStatement(t *testing.T) {
 
 			assert.True(t, strings.HasPrefix(result, "("), "should start with opening paren")
 			assert.Contains(t, result, ") UNION ALL (", "should contain UNION ALL joining the sub-queries")
-
-			// The result must end with the outer ORDER BY clause.
-			assert.True(t, strings.HasSuffix(result, " ORDER BY "+tc.wantOuterOrderBy),
-				"result should end with outer ORDER BY %q; got: %s", tc.wantOuterOrderBy, result)
 
 			// Both keyspaces should appear in the output.
 			assert.Contains(t, result, tc.wantPrimaryKSInQ, "primary keyspace should be in result")
@@ -381,6 +379,16 @@ func TestBuildDualMetadataUnionStatement(t *testing.T) {
 			// KeyspaceQueryToken must not appear in the output.
 			assert.NotContains(t, result, base.KeyspaceQueryToken, "token must be fully replaced")
 
+			// The result must contain the outer ORDER BY clause.
+			assert.Contains(t, result, " ORDER BY "+tc.wantOuterOrderBy,
+				"result should contain outer ORDER BY %q; got: %s", tc.wantOuterOrderBy, result)
+
+			// If a LIMIT was expected, verify it appears at the end of the full statement.
+			if tc.wantOuterLimit != "" {
+				assert.True(t, strings.HasSuffix(result, tc.wantOuterLimit),
+					"result should end with outer %s; got: %s", tc.wantOuterLimit, result)
+			}
+
 			// Split on UNION ALL to inspect each arm individually.
 			// The second part will include the trailing outer ORDER BY; both arms must contain
 			// the correct FROM clause.
@@ -392,13 +400,17 @@ func TestBuildDualMetadataUnionStatement(t *testing.T) {
 			// Inner ORDER BY must not appear inside either arm (it was lifted to outer scope).
 			assert.NotContains(t, parts[0], " ORDER BY ", "primary arm must not contain inner ORDER BY")
 			// parts[1] includes the outer ORDER BY suffix; strip it before checking.
-			armTwo := strings.TrimSuffix(parts[1], " ORDER BY "+tc.wantOuterOrderBy)
+			outerSuffix := " ORDER BY " + tc.wantOuterOrderBy
+			if tc.wantOuterLimit != "" {
+				outerSuffix += " " + tc.wantOuterLimit
+			}
+			armTwo := strings.TrimSuffix(parts[1], outerSuffix)
 			assert.NotContains(t, armTwo, " ORDER BY ", "fallback arm must not contain inner ORDER BY")
 
-			// If the original statement had a LIMIT it must be re-attached to each arm.
+			// If the original statement had a LIMIT it must be doubled and present in each arm.
 			if tc.wantLimitInArm != "" {
-				assert.Contains(t, parts[0], tc.wantLimitInArm, "primary arm must contain LIMIT")
-				assert.Contains(t, armTwo, tc.wantLimitInArm, "fallback arm must contain LIMIT")
+				assert.Contains(t, parts[0], tc.wantLimitInArm, "primary arm must contain doubled LIMIT")
+				assert.Contains(t, armTwo, tc.wantLimitInArm, "fallback arm must contain doubled LIMIT")
 			}
 		})
 	}
@@ -461,6 +473,26 @@ func TestSplitStatement(t *testing.T) {
 			assert.Equal(t, tc.wantCore, core)
 			assert.Equal(t, tc.wantOrderBy, orderBy)
 			assert.Equal(t, tc.wantLimitClause, limit)
+		})
+	}
+}
+
+// TestDoubleLimitClause verifies that doubleLimitClause correctly doubles numeric LIMIT values.
+func TestDoubleLimitClause(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"", ""},
+		{" LIMIT 3", " LIMIT 6"},
+		{" LIMIT 10", " LIMIT 20"},
+		{" LIMIT 100", " LIMIT 200"},
+		{" LIMIT 1", " LIMIT 2"},
+		{" LIMIT 0", " LIMIT 0"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			assert.Equal(t, tc.want, doubleLimitClause(tc.input))
 		})
 	}
 }

--- a/db/query_dual_metadata_test.go
+++ b/db/query_dual_metadata_test.go
@@ -565,6 +565,31 @@ func TestExtractRowID(t *testing.T) {
 			raw:      nil,
 			expected: "",
 		},
+		{
+			name:     "escaped characters in id value",
+			raw:      []byte(`{"id":"_sync:user:alice\\bob","name":"alice"}`),
+			expected: `_sync:user:alice\\bob`,
+		},
+		{
+			name:     "id not first field",
+			raw:      []byte(`{"name":"alice","email":"a@b.com","id":"_sync:user:alice"}`),
+			expected: "_sync:user:alice",
+		},
+		{
+			name:     "empty JSON object",
+			raw:      []byte(`{}`),
+			expected: "",
+		},
+		{
+			name:     "id with numeric value not string",
+			raw:      []byte(`{"id":12345}`),
+			expected: "",
+		},
+		{
+			name:     "id pattern embedded in field value does not cause false match",
+			raw:      []byte(`{"desc":"contains \"id\":\"fake\"","id":"_sync:user:real"}`),
+			expected: "_sync:user:real",
+		},
 	}
 
 	for _, tc := range tests {

--- a/db/query_dual_metadata_test.go
+++ b/db/query_dual_metadata_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 // mockQueryResultIterator is an in-memory QueryResultIterator backed by a slice of raw JSON
-// byte slices, used to test mergedDedupIterator without a real database.
+// byte slices, used to test dualMetadataStorePrincipalDedupIterator without a real database.
 type mockQueryResultIterator struct {
 	rows     [][]byte
 	pos      int
@@ -80,7 +80,7 @@ func TestMergedDedupIteratorPrimaryOnly(t *testing.T) {
 	})
 	fallback := newMockIterator(nil)
 
-	iter := newMergedDedupIterator(primary, fallback, 0)
+	iter := newDualMetadataStorePrincipalDedupIterator(primary, fallback, 0)
 	var rows []principalRow
 	for {
 		var row principalRow
@@ -105,7 +105,7 @@ func TestMergedDedupIteratorFallbackOnly(t *testing.T) {
 		marshalRow("_sync:role:editor", "editor"),
 	})
 
-	iter := newMergedDedupIterator(primary, fallback, 0)
+	iter := newDualMetadataStorePrincipalDedupIterator(primary, fallback, 0)
 	var rows []principalRow
 	for {
 		var row principalRow
@@ -122,7 +122,7 @@ func TestMergedDedupIteratorFallbackOnly(t *testing.T) {
 
 // TestMergedDedupIteratorEmpty verifies that empty iterators are handled cleanly.
 func TestMergedDedupIteratorEmpty(t *testing.T) {
-	iter := newMergedDedupIterator(newMockIterator(nil), newMockIterator(nil), 0)
+	iter := newDualMetadataStorePrincipalDedupIterator(newMockIterator(nil), newMockIterator(nil), 0)
 	var row principalRow
 	assert.False(t, iter.Next(context.Background(), &row))
 	require.NoError(t, iter.Close())
@@ -144,7 +144,7 @@ func TestMergedDedupIteratorDeduplicatesPrimaryPreferred(t *testing.T) {
 		marshalRow("_sync:user:carol", "carol-fallback"),
 	})
 
-	iter := newMergedDedupIterator(primary, fallback, 0)
+	iter := newDualMetadataStorePrincipalDedupIterator(primary, fallback, 0)
 	var rows []principalRow
 	for {
 		var row principalRow
@@ -176,7 +176,7 @@ func TestMergedDedupIteratorAllDuplicates(t *testing.T) {
 		marshalRow("_sync:user:alice", "alice"),
 		marshalRow("_sync:user:bob", "bob"),
 	})
-	iter := newMergedDedupIterator(primary, fallback, 0)
+	iter := newDualMetadataStorePrincipalDedupIterator(primary, fallback, 0)
 	var result []principalRow
 	for {
 		var row principalRow
@@ -208,7 +208,7 @@ func TestMergedDedupIteratorMergeSortOrder(t *testing.T) {
 		marshalRow("F", "f"),
 	})
 
-	iter := newMergedDedupIterator(primary, fallback, 0)
+	iter := newDualMetadataStorePrincipalDedupIterator(primary, fallback, 0)
 	var ids []string
 	for {
 		var row principalRow
@@ -232,7 +232,7 @@ func TestMergedDedupIteratorNextBytes(t *testing.T) {
 		marshalRow("_sync:user:bob", "bob"),
 	})
 
-	iter := newMergedDedupIterator(primary, fallback, 0)
+	iter := newDualMetadataStorePrincipalDedupIterator(primary, fallback, 0)
 	var rawRows [][]byte
 	for {
 		raw := iter.NextBytes()
@@ -258,7 +258,7 @@ func TestMergedDedupIteratorClosesProperly(t *testing.T) {
 		marshalRow("_sync:user:bob", "bob"),
 	})
 
-	iter := newMergedDedupIterator(mockPrimary, mockFallback, 0)
+	iter := newDualMetadataStorePrincipalDedupIterator(mockPrimary, mockFallback, 0)
 	var row principalRow
 	require.True(t, iter.Next(ctx, &row))
 	require.NoError(t, iter.Close())
@@ -275,7 +275,7 @@ func TestMergedDedupIteratorOne(t *testing.T) {
 	})
 	mockFallback := newMockIterator(nil)
 
-	iter := newMergedDedupIterator(mockPrimary, mockFallback, 0)
+	iter := newDualMetadataStorePrincipalDedupIterator(mockPrimary, mockFallback, 0)
 	var row principalRow
 	require.NoError(t, iter.One(ctx, &row))
 	assert.Equal(t, "_sync:user:alice", row.Id)
@@ -301,7 +301,7 @@ func TestMergedDedupIteratorSafeBoundary(t *testing.T) {
 		marshalRow("C", "c"),
 	})
 
-	iter := newMergedDedupIterator(primary, fallback, 2)
+	iter := newDualMetadataStorePrincipalDedupIterator(primary, fallback, 2)
 	var ids []string
 	for {
 		var row principalRow
@@ -328,7 +328,7 @@ func TestMergedDedupIteratorSafeBoundaryPrimaryExhausts(t *testing.T) {
 		marshalRow("D", "d"),
 	})
 
-	iter := newMergedDedupIterator(primary, fallback, 2)
+	iter := newDualMetadataStorePrincipalDedupIterator(primary, fallback, 2)
 	var ids []string
 	for {
 		var row principalRow
@@ -358,7 +358,7 @@ func TestMergedDedupIteratorNoBoundaryWhenBelowLimit(t *testing.T) {
 		marshalRow("E", "e"),
 	})
 
-	iter := newMergedDedupIterator(primary, fallback, 5)
+	iter := newDualMetadataStorePrincipalDedupIterator(primary, fallback, 5)
 	var ids []string
 	for {
 		var row principalRow
@@ -390,7 +390,7 @@ func TestMergedDedupIteratorBoundaryWithDuplicates(t *testing.T) {
 		marshalRow("E", "e-fallback"),
 	})
 
-	iter := newMergedDedupIterator(primary, fallback, 3)
+	iter := newDualMetadataStorePrincipalDedupIterator(primary, fallback, 3)
 	var rows []principalRow
 	for {
 		var row principalRow
@@ -420,7 +420,7 @@ func TestMergedDedupIteratorUnlimited(t *testing.T) {
 		marshalRow("C", "c"),
 	})
 
-	iter := newMergedDedupIterator(primary, fallback, 0)
+	iter := newDualMetadataStorePrincipalDedupIterator(primary, fallback, 0)
 	var ids []string
 	for {
 		var row principalRow
@@ -445,7 +445,7 @@ func TestMergedDeduplicateWithDuplicate(t *testing.T) {
 		marshalRow("D", "d"),
 	})
 
-	iter := newMergedDedupIterator(primary, fallback, 0)
+	iter := newDualMetadataStorePrincipalDedupIterator(primary, fallback, 0)
 	var ids []string
 	for {
 		var row principalRow
@@ -497,7 +497,7 @@ func TestMergedDedupIteratorPaginationSimulation(t *testing.T) {
 		}
 		primary := newMockIterator(filterAndLimit(data.primary))
 		fallback := newMockIterator(filterAndLimit(data.fallback))
-		iter := newMergedDedupIterator(primary, fallback, limit)
+		iter := newDualMetadataStorePrincipalDedupIterator(primary, fallback, limit)
 
 		ctx := base.TestCtx(t)
 		resultCount := 0
@@ -619,7 +619,7 @@ func TestMergedDedupIteratorBothExhaustAtLimit(t *testing.T) {
 		marshalRow("D", "d"),
 	})
 
-	iter := newMergedDedupIterator(primary, fallback, 2)
+	iter := newDualMetadataStorePrincipalDedupIterator(primary, fallback, 2)
 	var ids []string
 	for {
 		var row principalRow
@@ -653,7 +653,7 @@ func TestMergedDedupIteratorBoundaryIsExclusive(t *testing.T) {
 		marshalRow("E", "e"),
 	})
 
-	iter := newMergedDedupIterator(primary, fallback, 2)
+	iter := newDualMetadataStorePrincipalDedupIterator(primary, fallback, 2)
 	var rows []principalRow
 	for {
 		var row principalRow
@@ -709,7 +709,7 @@ func TestMergedDedupIteratorPaginationSimulationWithDuplicates(t *testing.T) {
 		}
 		primary := newMockIterator(filterAndLimit(data.primary))
 		fallback := newMockIterator(filterAndLimit(data.fallback))
-		iter := newMergedDedupIterator(primary, fallback, limit)
+		iter := newDualMetadataStorePrincipalDedupIterator(primary, fallback, limit)
 
 		ctx := base.TestCtx(t)
 		resultCount := 0
@@ -776,7 +776,7 @@ func TestMergedDedupIteratorPaginationSimulationHeavySkew(t *testing.T) {
 		}
 		primary := newMockIterator(filterAndLimit(data.primary))
 		fallback := newMockIterator(filterAndLimit(data.fallback))
-		iter := newMergedDedupIterator(primary, fallback, limit)
+		iter := newDualMetadataStorePrincipalDedupIterator(primary, fallback, limit)
 
 		ctx := base.TestCtx(t)
 		resultCount := 0
@@ -815,7 +815,7 @@ func TestMergedDedupIteratorCloseErrorPropagation(t *testing.T) {
 		mockFallback := newMockIterator(nil)
 		mockFallback.closeErr = fmt.Errorf("fallback close error")
 
-		iter := newMergedDedupIterator(mockPrimary, mockFallback, 0)
+		iter := newDualMetadataStorePrincipalDedupIterator(mockPrimary, mockFallback, 0)
 		err := iter.Close()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "primary close error",
@@ -829,7 +829,7 @@ func TestMergedDedupIteratorCloseErrorPropagation(t *testing.T) {
 		mockFallback := newMockIterator(nil)
 		mockFallback.closeErr = fmt.Errorf("fallback close error")
 
-		iter := newMergedDedupIterator(mockPrimary, mockFallback, 0)
+		iter := newDualMetadataStorePrincipalDedupIterator(mockPrimary, mockFallback, 0)
 		err := iter.Close()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "fallback close error")
@@ -839,7 +839,7 @@ func TestMergedDedupIteratorCloseErrorPropagation(t *testing.T) {
 		mockPrimary := newMockIterator(nil)
 		mockFallback := newMockIterator(nil)
 
-		iter := newMergedDedupIterator(mockPrimary, mockFallback, 0)
+		iter := newDualMetadataStorePrincipalDedupIterator(mockPrimary, mockFallback, 0)
 		require.NoError(t, iter.Close())
 	})
 }
@@ -851,7 +851,7 @@ func TestMergedDedupIteratorOneEmpty(t *testing.T) {
 	mockPrimary := newMockIterator(nil)
 	mockFallback := newMockIterator(nil)
 
-	iter := newMergedDedupIterator(mockPrimary, mockFallback, 0)
+	iter := newDualMetadataStorePrincipalDedupIterator(mockPrimary, mockFallback, 0)
 	var row principalRow
 	err := iter.One(ctx, &row)
 	require.ErrorIs(t, err, sgbucket.ErrNoRows)
@@ -868,7 +868,7 @@ func TestMergedDedupIteratorOneFallbackRow(t *testing.T) {
 		marshalRow("_sync:user:alice", "alice"),
 	})
 
-	iter := newMergedDedupIterator(mockPrimary, mockFallback, 0)
+	iter := newDualMetadataStorePrincipalDedupIterator(mockPrimary, mockFallback, 0)
 	var row principalRow
 	require.NoError(t, iter.One(ctx, &row))
 	assert.Equal(t, "_sync:user:alice", row.Id)
@@ -900,7 +900,7 @@ func TestMergedDedupIteratorBoundaryWithDiscardedDuplicates(t *testing.T) {
 		marshalRow("D", "d-fallback"),
 	})
 
-	iter := newMergedDedupIterator(primary, fallback, 3)
+	iter := newDualMetadataStorePrincipalDedupIterator(primary, fallback, 3)
 	var rows []principalRow
 	for {
 		var row principalRow
@@ -933,7 +933,7 @@ func TestMergedDedupIteratorNextBytesWithBoundary(t *testing.T) {
 		marshalRow("C", "c"),
 	})
 
-	iter := newMergedDedupIterator(primary, fallback, 2)
+	iter := newDualMetadataStorePrincipalDedupIterator(primary, fallback, 2)
 	var rawRows [][]byte
 	for {
 		raw := iter.NextBytes()
@@ -947,4 +947,34 @@ func TestMergedDedupIteratorNextBytesWithBoundary(t *testing.T) {
 	assert.Contains(t, string(rawRows[0]), `"A"`)
 	assert.Contains(t, string(rawRows[1]), `"B"`)
 	assert.Contains(t, string(rawRows[2]), `"C"`)
+}
+
+func TestMergeDeudupIteratorBoundryIsDuplicate(t *testing.T) {
+	ctx := base.TestCtx(t)
+	// LIMIT 2. primary: [A, C], fallback: [B, C].
+	// Boundary set by primary at C. C from fallback is duplicate and should be discarded, not emitted.
+	primary := newMockIterator([][]byte{
+		marshalRow("A", "a"),
+		marshalRow("C", "c-primary"),
+	})
+	fallback := newMockIterator([][]byte{
+		marshalRow("B", "b"),
+		marshalRow("C", "c-fallback"),
+	})
+
+	iter := newDualMetadataStorePrincipalDedupIterator(primary, fallback, 2)
+	var rows []principalRow
+	for {
+		var row principalRow
+		if !iter.Next(ctx, &row) {
+			break
+		}
+		rows = append(rows, row)
+	}
+	require.NoError(t, iter.Close())
+	require.Len(t, rows, 3)
+	assert.Equal(t, "A", rows[0].Id)
+	assert.Equal(t, "B", rows[1].Id)
+	assert.Equal(t, "C", rows[2].Id)
+	assert.Equal(t, "c-primary", rows[2].Name, "primary version of C should be preferred and emitted at boundary; fallback C should be discarded")
 }

--- a/db/query_dual_metadata_test.go
+++ b/db/query_dual_metadata_test.go
@@ -309,9 +309,7 @@ func TestExtractRowID(t *testing.T) {
 // literal injection, inner ORDER BY stripping, and outer ORDER BY construction.
 func TestBuildDualMetadataUnionStatement(t *testing.T) {
 	primaryKS := "`bucket`.`_system`.`_mobile`"
-	primaryPath := "bucket._system._mobile"
 	fallbackKS := "`bucket`.`_default`.`_default`"
-	fallbackPath := "bucket._default._default"
 	alias := base.KeyspaceQueryAlias
 
 	tests := []struct {
@@ -363,11 +361,7 @@ func TestBuildDualMetadataUnionStatement(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result := buildDualMetadataUnionStatement(
-				tc.statement,
-				primaryKS, primaryPath,
-				fallbackKS, fallbackPath,
-			)
+			result := buildDualMetadataUnionStatement(tc.statement, primaryKS, fallbackKS)
 
 			assert.True(t, strings.HasPrefix(result, "("), "should start with opening paren")
 			assert.Contains(t, result, ") UNION ALL (", "should contain UNION ALL joining the sub-queries")
@@ -379,9 +373,6 @@ func TestBuildDualMetadataUnionStatement(t *testing.T) {
 			// Both keyspaces should appear in the output.
 			assert.Contains(t, result, tc.wantPrimaryKSInQ, "primary keyspace should be in result")
 			assert.Contains(t, result, tc.wantFallbackKSInQ, "fallback keyspace should be in result")
-
-			// full_path must not appear in the output.
-			assert.NotContains(t, result, "AS full_path", "full_path column must not be injected")
 
 			// sort_order literals 0 (primary) and 1 (fallback) must both be injected.
 			assert.Contains(t, result, "0 AS "+dualMetadataSortOrderKey, "primary arm must have sort_order=0")
@@ -473,4 +464,3 @@ func TestSplitStatement(t *testing.T) {
 		})
 	}
 }
-

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -356,6 +356,27 @@ var viewsAndGSIBucketInit base.TBPBucketInitFunc = func(ctx context.Context, b b
 
 	tbp.Logf(ctx, "Starting bucket init function")
 
+	mobileSystemDataStore, err := b.NamedDataStore(base.MobileSystemScopeAndCollectionName())
+	if err != nil {
+		return err
+	}
+	systemCollectionInitOptions := InitializeIndexOptions{
+		UseXattrs:                  true,
+		NumReplicas:                0,
+		WaitForIndexesOnlineOption: base.WaitForIndexesDefault,
+		LegacySyncDocsIndex:        false,
+		MetadataIndexes:            IndexesMetadataOnly,
+		NumPartitions:              DefaultNumIndexPartitions,
+	}
+	systemN1QLStore, ok := base.AsN1QLStore(mobileSystemDataStore)
+	if !ok {
+		return fmt.Errorf("bucket %T was not a N1QL store", b)
+	}
+
+	if err := InitializeIndexes(ctx, systemN1QLStore, systemCollectionInitOptions); err != nil {
+		return err
+	}
+
 	dataStores, err := b.ListDataStores()
 	if err != nil {
 		return err

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -356,25 +356,27 @@ var viewsAndGSIBucketInit base.TBPBucketInitFunc = func(ctx context.Context, b b
 
 	tbp.Logf(ctx, "Starting bucket init function")
 
-	mobileSystemDataStore, err := b.NamedDataStore(base.MobileSystemScopeAndCollectionName())
-	if err != nil {
-		return err
-	}
-	systemCollectionInitOptions := InitializeIndexOptions{
-		UseXattrs:                  true,
-		NumReplicas:                0,
-		WaitForIndexesOnlineOption: base.WaitForIndexesDefault,
-		LegacySyncDocsIndex:        false,
-		MetadataIndexes:            IndexesMetadataOnly,
-		NumPartitions:              DefaultNumIndexPartitions,
-	}
-	systemN1QLStore, ok := base.AsN1QLStore(mobileSystemDataStore)
-	if !ok {
-		return fmt.Errorf("bucket %T was not a N1QL store", b)
-	}
+	if !skipGSI {
+		mobileSystemDataStore, err := b.NamedDataStore(base.MobileSystemScopeAndCollectionName())
+		if err != nil {
+			return err
+		}
+		systemCollectionInitOptions := InitializeIndexOptions{
+			UseXattrs:                  true,
+			NumReplicas:                0,
+			WaitForIndexesOnlineOption: base.WaitForIndexesDefault,
+			LegacySyncDocsIndex:        false,
+			MetadataIndexes:            IndexesMetadataOnly,
+			NumPartitions:              DefaultNumIndexPartitions,
+		}
+		systemN1QLStore, ok := base.AsN1QLStore(mobileSystemDataStore)
+		if !ok {
+			return fmt.Errorf("bucket %T was not a N1QL store", b)
+		}
 
-	if err := InitializeIndexes(ctx, systemN1QLStore, systemCollectionInitOptions); err != nil {
-		return err
+		if err := InitializeIndexes(ctx, systemN1QLStore, systemCollectionInitOptions); err != nil {
+			return err
+		}
 	}
 
 	dataStores, err := b.ListDataStores()

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -1109,3 +1109,37 @@ func (c *collectionRevisionCache) PutRevEntry(t *testing.T, ctx context.Context,
 	value.store(docRev)
 	cache.revisionCache.revCacheMemoryBasedEviction(ctx)
 }
+
+// InitializeDualMetadataStoreIndexes initializes the principal indexes (IndexSyncDocs,
+// IndexUser, IndexRole) on both the primary and fallback datastores of a MetadataStore.
+// This is required during metadata migration when user and role documents may be present in
+// both datastores and both must be queryable via N1QL.
+//
+// options.MetadataIndexes is forced to IndexesMetadataOnly for primary store so that only
+// metadata-specific principal indexes are created given user non metadata docs cannot be stored here.
+// Fallback store initialises whatever is passed.
+// This is test only function, metadata store indexes for databases are created during Database Init
+func InitializeDualMetadataStoreIndexes(t *testing.T, ctx context.Context, metadataStore *base.MetadataStore, options InitializeIndexOptions) error {
+	t.Helper()
+	primaryOptions := options
+
+	primaryN1QL, ok := base.AsN1QLStore(metadataStore.Primary())
+	if !ok {
+		return fmt.Errorf("primary datastore (%T) is not an N1QL store; cannot initialize dual metadata store indexes", metadataStore.Primary())
+	}
+	primaryCtx := base.CollectionLogCtx(ctx, metadataStore.Primary().ScopeName(), metadataStore.Primary().CollectionName())
+	primaryOptions.MetadataIndexes = IndexesMetadataOnly // primary store only needs metadata indexes (no other data can be stored here)
+	if err := InitializeIndexes(primaryCtx, primaryN1QL, primaryOptions); err != nil {
+		return fmt.Errorf("initializing indexes on primary metadata store: %w", err)
+	}
+
+	fallbackN1QL, ok := base.AsN1QLStore(metadataStore.Fallback())
+	if !ok {
+		return fmt.Errorf("fallback datastore (%T) is not an N1QL store; cannot initialize dual metadata store indexes", metadataStore.Fallback())
+	}
+	fallbackCtx := base.CollectionLogCtx(ctx, metadataStore.Fallback().ScopeName(), metadataStore.Fallback().CollectionName())
+	if err := InitializeIndexes(fallbackCtx, fallbackN1QL, options); err != nil {
+		return fmt.Errorf("initializing indexes on fallback metadata store: %w", err)
+	}
+	return nil
+}

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -472,6 +472,9 @@ func (h *handler) handlePostIndexInit() error {
 	if _, ok := statusMap[base.DefaultScope]; !ok {
 		statusMap[base.DefaultScope] = make(map[string]db.CollectionIndexStatus, 1)
 	}
+	// init _mobile scope because we have metadata indexes initialized in _mobile collection
+	statusMap[base.SystemScope] = make(map[string]db.CollectionIndexStatus, 1)
+
 	var statusCallback CollectionCallbackFunc = func(dbName string, scName base.ScopeAndCollectionName, status db.CollectionIndexStatus) {
 		statusMap[scName.ScopeName()][scName.CollectionName()] = status
 		if err := h.db.AsyncIndexInitManager.UpdateStatusClusterAware(h.ctx()); err != nil {

--- a/rest/database_init_manager.go
+++ b/rest/database_init_manager.go
@@ -199,7 +199,8 @@ func (m *DatabaseInitManager) Cancel(dbName string, reason string) {
 // the metadata collection
 func buildCollectionIndexData(config *DatabaseConfig) CollectionInitData {
 	if len(config.Scopes) == 0 {
-		return CollectionInitData{base.DefaultScopeAndCollectionName(): db.IndexesAll}
+		// todo: only init these mobile collection indexes when required?
+		return CollectionInitData{base.DefaultScopeAndCollectionName(): db.IndexesAll, base.MobileSystemScopeAndCollectionName(): db.IndexesMetadataOnly}
 	}
 
 	defaultScopeAndCollectionMetadataIndexes := db.IndexesMetadataOnly
@@ -217,6 +218,8 @@ func buildCollectionIndexData(config *DatabaseConfig) CollectionInitData {
 	}
 
 	collectionInitData[base.DefaultScopeAndCollectionName()] = defaultScopeAndCollectionMetadataIndexes
+	// todo: only init these indexes when required?
+	collectionInitData[base.MobileSystemScopeAndCollectionName()] = db.IndexesMetadataOnly
 
 	return collectionInitData
 }

--- a/rest/database_init_manager_test.go
+++ b/rest/database_init_manager_test.go
@@ -309,9 +309,9 @@ func TestDatabaseInitConcurrentDatabasesSameBucket(t *testing.T) {
 	WaitForChannel(t, doneChan1, "modified init done chan")
 	WaitForChannel(t, doneChan2, "modified init done chan")
 
-	// Verify initialization was run for 5 collections (three for db1, two for db2)
-	// _mobile, _default, collection1, collection2, collection3 but _default
-	// and _mobile is checked for both
+	// Verify initialization/checks were run 7 times total: 3 for db1 and 4 for db2.
+	// The distinct collections are _mobile, _default, collection1, collection2, and
+	// collection3, but _default and _mobile are checked for both databases.
 	totalCount := atomic.LoadInt64(&collectionCount)
 	require.Equal(t, int64(7), totalCount)
 
@@ -408,7 +408,7 @@ func TestDatabaseInitConcurrentDatabasesDifferentBuckets(t *testing.T) {
 	WaitForChannel(t, databaseCompleteChannel, "database 1 init complete")
 	WaitForChannel(t, databaseCompleteChannel, "database 2 init complete")
 
-	// Verify initialization was run for 6 collections (four for db1, four for db2)
+	// Verify initialization was run for 8 collections (four for db1, four for db2)
 	// _mobile, _default, collection1, collection2
 	totalCount := atomic.LoadInt64(&collectionCount)
 	require.Equal(t, int64(8), totalCount)

--- a/rest/database_init_manager_test.go
+++ b/rest/database_init_manager_test.go
@@ -91,7 +91,7 @@ func TestDatabaseInitConfigChangeSameCollections(t *testing.T) {
 	// Use waitChannel to have collectionCallback block, to simulate long-running creation
 	testSignalChannel := make(chan error)
 	singleCollectionInitChannel := make(chan error)
-	expectedCollectionCount := int64(3) // default, collection1, collection2
+	expectedCollectionCount := int64(4) // _mobile, _default, collection1, collection2
 	// Create collection callback that blocks and waits for test notification the first time a collection is initialized, does not block afterward.
 	collectionCount := int64(0)
 	initMgr.testCollectionStatusUpdateCallback = func(dbName string, scName base.ScopeAndCollectionName, status db.CollectionIndexStatus) {
@@ -225,7 +225,8 @@ func TestDatabaseInitConfigChangeDifferentCollections(t *testing.T) {
 
 	// Verify initialization was run for four collections (one prior to cancellation, three for subsequent init)
 	totalCount := atomic.LoadInt64(&collectionCount)
-	require.Equal(t, int64(4), totalCount)
+	// _mobile, _default, collection1, collection2, collection3
+	require.Equal(t, int64(5), totalCount)
 
 }
 
@@ -309,8 +310,10 @@ func TestDatabaseInitConcurrentDatabasesSameBucket(t *testing.T) {
 	WaitForChannel(t, doneChan2, "modified init done chan")
 
 	// Verify initialization was run for 5 collections (three for db1, two for db2)
+	// _mobile, _default, collection1, collection2, collection3 but _default
+	// and _mobile is checked for both
 	totalCount := atomic.LoadInt64(&collectionCount)
-	require.Equal(t, int64(5), totalCount)
+	require.Equal(t, int64(7), totalCount)
 
 }
 
@@ -405,9 +408,10 @@ func TestDatabaseInitConcurrentDatabasesDifferentBuckets(t *testing.T) {
 	WaitForChannel(t, databaseCompleteChannel, "database 1 init complete")
 	WaitForChannel(t, databaseCompleteChannel, "database 2 init complete")
 
-	// Verify initialization was run for 6 collections (three for db1, three for db2)
+	// Verify initialization was run for 6 collections (four for db1, four for db2)
+	// _mobile, _default, collection1, collection2
 	totalCount := atomic.LoadInt64(&collectionCount)
-	require.Equal(t, int64(6), totalCount)
+	require.Equal(t, int64(8), totalCount)
 
 }
 
@@ -474,8 +478,9 @@ func TestDatabaseInitTeardownTiming(t *testing.T) {
 	WaitForChannel(t, doneChan1, "done chan 1")
 	wg.Wait()
 
-	// Verify initialization was run for 6 collections, since it runs on 3 collections twice
-	require.Equal(t, int64(6), collectionCount.Load())
+	// Verify initialization was run for 8 collections, since it runs on 4 collections twice
+	// _mobile, _default, collection1, collection2
+	require.Equal(t, int64(8), collectionCount.Load())
 
 	// Expect two database complete callbacks, since initialization is run twice
 	require.Equal(t, int64(2), databaseCompleteCount.Load())

--- a/rest/database_init_manager_test.go
+++ b/rest/database_init_manager_test.go
@@ -519,7 +519,8 @@ func TestBuildCollectionIndexData(t *testing.T) {
 				},
 			},
 			want: CollectionInitData{
-				base.DefaultScopeAndCollectionName(): db.IndexesAll,
+				base.DefaultScopeAndCollectionName():      db.IndexesAll,
+				base.MobileSystemScopeAndCollectionName(): db.IndexesMetadataOnly,
 			},
 		},
 		{
@@ -530,7 +531,8 @@ func TestBuildCollectionIndexData(t *testing.T) {
 				},
 			},
 			want: CollectionInitData{
-				base.DefaultScopeAndCollectionName(): db.IndexesAll,
+				base.DefaultScopeAndCollectionName():      db.IndexesAll,
+				base.MobileSystemScopeAndCollectionName(): db.IndexesMetadataOnly,
 			},
 		},
 		{
@@ -542,6 +544,7 @@ func TestBuildCollectionIndexData(t *testing.T) {
 			},
 			want: CollectionInitData{
 				base.DefaultScopeAndCollectionName():                    db.IndexesMetadataOnly,
+				base.MobileSystemScopeAndCollectionName():               db.IndexesMetadataOnly,
 				base.NewScopeAndCollectionName("scope1", "collection1"): db.IndexesWithoutMetadata,
 			},
 		},
@@ -554,6 +557,7 @@ func TestBuildCollectionIndexData(t *testing.T) {
 			},
 			want: CollectionInitData{
 				base.DefaultScopeAndCollectionName():                             db.IndexesAll,
+				base.MobileSystemScopeAndCollectionName():                        db.IndexesMetadataOnly,
 				base.NewScopeAndCollectionName(base.DefaultScope, "collection1"): db.IndexesWithoutMetadata,
 			},
 		},

--- a/rest/indextest/index_init_api_test.go
+++ b/rest/indextest/index_init_api_test.go
@@ -148,8 +148,9 @@ func TestChangeIndexPartitions(t *testing.T) {
 				require.NoError(c, err)
 				require.Empty(c, body.LastErrorMessage)
 				require.Equal(c, db.BackgroundProcessStateCompleted, body.State)
-				require.GreaterOrEqual(c, len(body.IndexStatus), 1, "expected at least one scope (maybe two if `_default` and a named scope)")
-				require.LessOrEqual(c, len(body.IndexStatus), 2, "expected at most two scopes (maybe one if `_default` only)")
+				// index status will include metadata indexes for _system._mobile
+				require.GreaterOrEqual(c, len(body.IndexStatus), 2, "expected at least two scopes (maybe three if `_default` and a named scope)")
+				require.LessOrEqual(c, len(body.IndexStatus), 3, "expected at most three scopes (maybe two if `_default` only, taking into account _mobile collection)")
 				for _, collections := range body.IndexStatus {
 					for _, status := range collections {
 						assert.Equal(c, db.CollectionIndexStatusReady, status)

--- a/rest/indextest/index_test.go
+++ b/rest/indextest/index_test.go
@@ -397,7 +397,7 @@ func TestAsyncOnlineOffline(t *testing.T) {
 	dbName := "db"
 
 	keyspace := dbName
-	expectedCollectionCount := 1 // metadata store
+	expectedCollectionCount := 2 // _default metadata store + _mobile metadata stores
 	if len(dbConfig.Scopes) > 0 {
 		keyspaces := getRESTKeyspaces(dbName, dbConfig.Scopes)
 		keyspace = keyspaces[0]
@@ -525,7 +525,7 @@ func TestAsyncCreateThenDelete(t *testing.T) {
 	dbConfigPayload, err := json.Marshal(dbConfig)
 	require.NoError(t, err)
 	dbName := "db"
-	expectedCollectionCount := 1 // metadata store
+	expectedCollectionCount := 2 // _default metadata store + _mobile metadata stores
 	if len(dbConfig.Scopes) > 0 {
 		keyspaces := getRESTKeyspaces(dbName, dbConfig.Scopes)
 		expectedCollectionCount += len(keyspaces)


### PR DESCRIPTION
CBG-5224

- Currently have metadata indexes being built always for the mobile datastore. This should probably be changed to only build when dual metadata store is active but I think maybe defer this in follow-up ticket. 
- Added `WaitForSystemCollectionIndexesOnline` which is needed for system collection indexes. The query is different for this, system collections only show in `system:all_indexes` over `system:indexes`
- Queries work as follows:
Step 1: run two independent queries in primary then fallback 
 Primary query  → [alice, bob, dave]
 Fallback query → [bob, carol, dave]

Both stores return results sorted by document ID.

Step 2: merge sort with deduplication (mergedDedupIterator)
- Iterator peeks each result set. 
- Compare each peek result, choosing the smaller ID, if both IDs equal then pick primary

Primary:  alice, bob, dave
Fallback: bob, carol, dave
 
Output:   alice, bob (from primary), carol, dave

No document is emitted twice. The primary store always wins on a tie.

Pagination problem: 
 Each per-store query has a LIMIT N (the pagination page size). Consider LIMIT 2:
   Primary  → [alice, eve]   (hit limit, may have more)
   Fallback → [bob,  carol]  (hit limit, may have more)

A normal merge would produce [alice, bob, carol, eve] and advance the cursor to eve. But primary might still have dave on its next page — and the cursor just jumped past it. Dave is lost forever.

Boundary fix in merge dedupe iterator:
When a source exhausts at exactly LIMIT rows, it's assumed to have been truncated (there may be more). The iterator sets a safe boundary at that source's last ID and stops emitting rows from the other source that go beyond it. Example: 
 
Primary  exhausts at limit → boundary = eve
Fallback has carol next    → carol < eve so return it

Concretely for this example:
Primary  → [alice, carol]   (hit limit, may have more)
  Fallback → [bob,  eve]  (hit limit, may have more)

Primary exhausts at limit=2, last ID = carol → boundary = carol
Fallback next item is eve which is > carol so we suppress this
 
Output this page: [alice, bob, carol]
Next page starts at: carol

If a datastore returns less than the limit we have exhausted this datastore so we do not set a safe boundary here. 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/500/
