### PR TITLE
CBG-5313: Add documentation for _cluster_info

### DIFF
--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -73,6 +73,8 @@ paths:
     $ref: ./paths/admin/_stats.yaml
   /_config:
     $ref: ./paths/admin/_config.yaml
+  /_cluster_info:
+    $ref: ./paths/admin/_cluster_info.yaml
   /_status:
     $ref: ./paths/admin/_status.yaml
   /_sgcollect_info:

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -3234,3 +3234,101 @@ DiagnosticFunctionLogging:
       items:
         type: string
         example: This is an info message produced by console.log("test").
+
+ClusterInfo:
+  type: object
+  properties:
+    legacy_config:
+      description: Indicates if the server is using legacy (non persistent) configuration.
+      type: boolean
+    buckets:
+      description: Map of bucket names to bucket information.
+      type: object
+      additionalProperties:
+        x-additionalPropertiesName: bucketname
+        $ref: '#/BucketInfo'
+
+BucketInfo:
+  type: object
+  properties:
+    registry:
+      $ref: '#/GatewayRegistry'
+    enable_cross_cluster_versioning:
+      description: Indicates if cross-cluster versioning is enabled for this bucket.
+      type: boolean
+
+GatewayRegistry:
+  type: object
+  properties:
+    version:
+      type: string
+      description: Registry version. This is not the Sync Gateway version number.
+    config_groups:
+      type: object
+      description: Map of config groups, keyed by config group ID
+      additionalProperties:
+        x-additionalPropertiesName: configgroupid
+        $ref: '#/RegistryConfigGroup'
+    sg_version:
+      type: string
+      description: Latest patch version of Sync Gateway that touched the registry.
+    updated_at:
+      type: string
+      format: date-time
+      description: Time the registry was last updated
+    created_at:
+      type: string
+      format: date-time
+      description: Time the registry was created
+
+RegistryConfigGroup:
+  type: object
+  properties:
+    databases:
+      type: object
+      description: Map of databases in this config group.
+      additionalProperties:
+        x-additionalPropertiesName: dbname
+        $ref: '#/RegistryDatabase'
+
+RegistryDatabase:
+  type: object
+  properties:
+    scopes:
+      $ref: '#/RegistryScopes'
+    version:
+      type: string
+      description: Revision ID for a database configuration, used for ETag validation.
+    previous_version:
+      $ref: '#/RegistryDatabaseVersion'
+    metadata_id:
+      type: string
+      description: Metadata ID.
+    uuid:
+      type: string
+      description: Database UUID.
+
+RegistryDatabaseVersion:
+  type: object
+  properties:
+    scopes:
+      $ref: '#/RegistryScopes'
+    version:
+      type: string
+      description: Revision ID for a database configuration, used for ETag validation.
+
+RegistryScopes:
+  type: object
+  description: Map of scope names to registry scope information.
+  additionalProperties:
+    x-additionalPropertiesName: scopename
+    $ref: '#/RegistryScope'
+
+RegistryScope:
+  type: object
+  properties:
+    collections:
+      description: List of collections in this scope.
+      type: array
+      items:
+        type: string

--- a/docs/api/paths/admin/_cluster_info.yaml
+++ b/docs/api/paths/admin/_cluster_info.yaml
@@ -1,0 +1,27 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+get:
+  summary: Get the cluster information
+  description: |-
+    This will retrieve information about the Sync Gateway cluster's buckets.
+
+    Required Sync Gateway RBAC roles:
+
+    * Sync Gateway Dev Ops
+  responses:
+    '200':
+      description: Returned the cluster information successfully
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas.yaml#/ClusterInfo
+    '400':
+      $ref: ../../components/responses.yaml#/request-problem
+  tags:
+    - Server
+  operationId: get__cluster_info


### PR DESCRIPTION
CBG-5313: Add documentation for _cluster_info

This was introduced in Sync Gateway 3.1 but the documentation was never present. Give a careful look to the version flags, I tried to look at what these mean and I'm only somewhat sure I have the right information.