### PR TITLE
CBG-5211 drop assertions about number of warnings

### DIFF
--- a/db/import_listener_test.go
+++ b/db/import_listener_test.go
@@ -24,7 +24,6 @@ func TestImportFeedEventRecover(t *testing.T) {
 			0: {}, // this is an invalid entry, because we expect this code to panic and recover
 		},
 	}
-	startWarnCount := base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().WarnCount.Value()
 
 	// assert false to indicate that this checkpoint will not be incremented
 	if base.IsDevMode() {
@@ -40,5 +39,4 @@ func TestImportFeedEventRecover(t *testing.T) {
 			Opcode: sgbucket.FeedOpMutation,
 		}))
 	}
-	require.Equal(t, startWarnCount+1, base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().WarnCount.Value())
 }


### PR DESCRIPTION
CBG-5211 drop assertions about number of warnings

If there is a gocb warning while this test is running, this test will flake. Running with and without cb_sg_devmode will detect if there is an issue without a recover.
