### PR TITLE
CBG-5333: setup builds for 3.2.8/3.3.5/4.0.5

### DIFF
--- a/manifest/3.2.xml
+++ b/manifest/3.2.xml
@@ -18,13 +18,13 @@ licenses/APL2.txt.
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="b1dc2359603ab411ce0788854ea879ce804c9055">
-        <annotation name="VERSION" value="3.2.7" keep="true"/>
+        <annotation name="VERSION" value="3.2.8" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>
 
 
     <!-- Sync Gateway -->
-    <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="release/3.2.7"/>
+    <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="release/3.2.8"/>
 
 </manifest>

--- a/manifest/3.2/3.2.7.xml
+++ b/manifest/3.2/3.2.7.xml
@@ -18,13 +18,13 @@ licenses/APL2.txt.
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="0ae8f452cece1e1f48f99e370a103b55bfea2dbe">
-        <annotation name="VERSION" value="3.3.5" keep="true"/>
+        <annotation name="VERSION" value="3.2.7" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>
 
 
     <!-- Sync Gateway -->
-    <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="release/3.3.5"/>
+    <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="0e5e0b317e5a8018a7f8e7d29e94770fbc192d9f"/>
 
 </manifest>

--- a/manifest/3.3/3.3.4.xml
+++ b/manifest/3.3/3.3.4.xml
@@ -18,13 +18,13 @@ licenses/APL2.txt.
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="0ae8f452cece1e1f48f99e370a103b55bfea2dbe">
-        <annotation name="VERSION" value="3.3.5" keep="true"/>
+        <annotation name="VERSION" value="3.3.4" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>
 
 
     <!-- Sync Gateway -->
-    <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="release/3.3.5"/>
+    <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="50b2d543e30a22211840008a66c376b044cc74be"/>
 
 </manifest>

--- a/manifest/4.0.xml
+++ b/manifest/4.0.xml
@@ -18,13 +18,13 @@ licenses/APL2.txt.
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="0ae8f452cece1e1f48f99e370a103b55bfea2dbe">
-        <annotation name="VERSION" value="4.0.4" keep="true"/>
+        <annotation name="VERSION" value="4.0.5" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>
 
 
     <!-- Sync Gateway -->
-    <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="release/4.0.4"/>
+    <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="release/4.0.5"/>
 
 </manifest>

--- a/manifest/4.0/4.0.4.xml
+++ b/manifest/4.0/4.0.4.xml
@@ -18,13 +18,13 @@ licenses/APL2.txt.
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="0ae8f452cece1e1f48f99e370a103b55bfea2dbe">
-        <annotation name="VERSION" value="3.3.5" keep="true"/>
+        <annotation name="VERSION" value="4.0.4" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>
 
 
     <!-- Sync Gateway -->
-    <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="release/3.3.5"/>
+    <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="ee73d54bc071963078d804388b1e5c8891da639c"/>
 
 </manifest>

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -611,11 +611,11 @@
             "trigger_blackduck": true
         },
         "manifest/3.2.xml": {
-            "go_version": "1.24.12",
+            "go_version": "1.25.9",
             "interval": 120,
             "production": true,
-            "release": "3.2.7",
-            "release_name": "Couchbase Sync Gateway 3.2.7",
+            "release": "3.2.8",
+            "release_name": "Couchbase Sync Gateway 3.2.8",
             "start_build": 1,
             "trigger_blackduck": true
         },
@@ -718,12 +718,22 @@
             "start_build": 2,
             "trigger_blackduck": true
         },
+        "manifest/3.2.7.xml": {
+            "do-build": false,
+            "go_version": "1.24.12",
+            "interval": 1440,
+            "production": true,
+            "release": "3.2.7",
+            "release_name": "Couchbase Sync Gateway 3.2.7",
+            "start_build": 3,
+            "trigger_blackduck": true
+        },
         "manifest/3.3.xml": {
-            "go_version": "1.24.13",
+            "go_version": "1.25.9",
             "interval": 120,
             "production": true,
-            "release": "3.3.4",
-            "release_name": "Couchbase Sync Gateway 3.3.4",
+            "release": "3.3.5",
+            "release_name": "Couchbase Sync Gateway 3.3.5",
             "start_build": 1,
             "trigger_blackduck": true
         },
@@ -807,12 +817,22 @@
             "start_build": 13,
             "trigger_blackduck": true
         },
-        "manifest/4.0.xml": {
+        "manifest/3.3/3.3.4.xml": {
+            "do-build": false,
             "go_version": "1.24.13",
+            "interval": 1440,
+            "production": true,
+            "release": "3.3.4",
+            "release_name": "Couchbase Sync Gateway 3.3.4",
+            "start_build": 6,
+            "trigger_blackduck": true
+        },
+        "manifest/4.0.xml": {
+            "go_version": "1.25.9",
             "interval": 120,
             "production": true,
-            "release": "4.0.4",
-            "release_name": "Couchbase Sync Gateway 4.0.4",
+            "release": "4.0.5",
+            "release_name": "Couchbase Sync Gateway 4.0.5",
             "start_build": 1,
             "trigger_blackduck": true
         },
@@ -884,6 +904,16 @@
             "release": "4.0.3",
             "release_name": "Couchbase Sync Gateway 4.0.3",
             "start_build": 22,
+            "trigger_blackduck": true
+        },
+        "manifest/4.0/4.0.4.xml": {
+            "do-build": false,
+            "go_version": "1.24.13",
+            "interval": 1440,
+            "production": true,
+            "release": "4.0.4",
+            "release_name": "Couchbase Sync Gateway 4.0.4",
+            "start_build": 9,
             "trigger_blackduck": true
         },
 

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -718,7 +718,7 @@
             "start_build": 2,
             "trigger_blackduck": true
         },
-        "manifest/3.2.7.xml": {
+        "manifest/3.2/3.2.7.xml": {
             "do-build": false,
             "go_version": "1.24.12",
             "interval": 1440,


### PR DESCRIPTION
CBG-5333

Build setup for 3.2.8/3.3.5/4.0.5 
Upgraded go to 1.25.9 on each release

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
