### PR TITLE
CBG-5336: fix flaky TestSoftDeleteCasMismatch

### DIFF
--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -2337,13 +2338,19 @@ func TestSoftDeleteCasMismatch(t *testing.T) {
 
 	// Set callback to trigger a DELETE AFTER an update. This will trigger a CAS mismatch.
 	// Update is done on a GetRole operation so this delete is done between a GET and save operation.
-	triggerCallback := true
+	// Filter by the role doc key so unrelated bucket Updates can't consume the one-shot trigger,
+	// and clear the trigger before sending DELETE so the recursive Update inside DELETE no-ops.
+	roleDocID := rt.GetDatabase().Authenticator(base.TestCtx(t)).DocIDForRole("role")
+	var fired atomic.Bool
 	leakyDataStore.SetPostUpdateCallback(func(key string) {
-		if triggerCallback {
-			triggerCallback = false
-			resp = rt.SendAdminRequest("DELETE", "/db/_role/role", ``)
-			rest.RequireStatus(t, resp, http.StatusOK)
+		if key != roleDocID {
+			return
 		}
+		if !fired.CompareAndSwap(false, true) {
+			return
+		}
+		resp := rt.SendAdminRequest("DELETE", "/db/_role/role", ``)
+		rest.RequireStatus(t, resp, http.StatusOK)
 	})
 
 	resp = rt.SendAdminRequest("PUT", "/db/_role/role", `{"admin_channels":["chan"]}`)


### PR DESCRIPTION
## Summary
- The leaky-bucket `PostUpdateCallback` fires after **every** `Update` on the bucket regardless of doc key. The previous one-shot `triggerCallback` was a plain bool with no key filter, so any concurrent Update from a background process (attachment migration, sequence allocator, background tasks) could consume the trigger before the second PUT ran — sending the DELETE on the wrong goroutine and leaving the second PUT to complete with `replaced=true` → 200 instead of the intended 201-via-CAS-retry.
- Filter the callback by the role doc key (via `Authenticator.DocIDForRole`) so only Updates of the role doc count, and use `atomic.Bool.CompareAndSwap` to claim the trigger before sending DELETE.
- Note: `sync.Once` is **not** safe here — the DELETE handler's `casUpdatePrincipal` recursively triggers the callback while we're still inside `Once.Do`, and `Once.Do` holds a mutex during `f`, so the recursion deadlocks. `CompareAndSwap` is the correct primitive: it returns the consumption decision without holding any lock past the test-and-set.

## Test plan (local)
- [x] `go test -count=200 -run '^TestSoftDeleteCasMismatch$' ./rest/adminapitest/` — clean
- [x] `go test -race -count=20 -run '^TestSoftDeleteCasMismatch$' ./rest/adminapitest/` — no DATA RACE
- [x] `go test -count=1 ./rest/adminapitest/` — clean (full package)

Failing CI run that motivated the fix: https://github.com/couchbase/sync_gateway/actions/runs/24898637101/attempts/1 