### PR TITLE
CBG-4985 test-only: fix TestResyncWithoutIndexes

### DIFF
--- a/rest/indextest/resync_test.go
+++ b/rest/indextest/resync_test.go
@@ -31,9 +31,10 @@ func TestResyncWithoutIndexes(t *testing.T) {
 	rt.CreateTestDoc("doc1")
 
 	rt.SyncFn = `function(doc, oldDoc) {channel("A")}`
-	rest.RequireStatus(t, rt.UpsertDbConfig(dbName, rt.NewDbConfig()), http.StatusCreated)
-
-	rt.TakeDbOffline()
+	dbConfig := rt.NewDbConfig()
+	dbConfig.StartOffline = base.Ptr(true)
+	rest.RequireStatus(t, rt.UpsertDbConfig(dbName, dbConfig), http.StatusCreated)
+	rt.WaitForDBInitializationCompleted(dbName)
 
 	if !base.TestsDisableGSI() {
 		for _, collection := range rt.GetDatabase().CollectionByID {
@@ -43,12 +44,9 @@ func TestResyncWithoutIndexes(t *testing.T) {
 		}
 	}
 
-	// gocb pipeline bootstrap errors can occur before this stage
-	warningsBeforeResync := base.SyncGatewayStats.GlobalStats.ResourceUtilization.WarnCount.Value()
 	rest.RequireStatus(t, rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_resync?action=start", ""), http.StatusOK)
 	resyncStatus := rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
 	require.Equal(t, int64(1), resyncStatus.DocsChanged)
-	require.Equal(t, int64(0), base.SyncGatewayStats.GlobalStats.ResourceUtilization.WarnCount.Value()-warningsBeforeResync)
 
 	defaultDataStore, ok := base.AsN1QLStore(rt.Bucket().DefaultDataStore())
 	require.True(t, ok)
@@ -74,7 +72,7 @@ func TestResyncWithoutIndexes(t *testing.T) {
 					require.Len(t, numIndexes, 2) // sg_roles, sg_syncDocs
 				}
 			} else {
-				require.Len(t, numIndexes, 0, "Expected 0 indexes for non-default collection")
+				require.Len(t, numIndexes, 0, "Expected 0 indexes for non-default collection %s.%s", collection.ScopeName, collection.Name)
 			}
 		}
 	}

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"slices"
 	"strings"
 	"sync/atomic"
@@ -418,6 +419,12 @@ func (rt *RestTester) RunResync() db.ResyncManagerResponseDCP {
 
 // WaitForResyncDCPStatus waits for the resync status to reach the expected status and returns the final status.
 func (rt *RestTester) WaitForResyncDCPStatus(status db.BackgroundProcessState) db.ResyncManagerResponseDCP {
+	timeout := 10 * time.Second
+	pollInterval := 10 * time.Millisecond
+	if os.Getenv("CI") != "" {
+		timeout = 60 * time.Second
+		pollInterval = 100 * time.Millisecond
+	}
 	var resyncStatus db.ResyncManagerResponseDCP
 	require.EventuallyWithT(rt.TB(), func(c *assert.CollectT) {
 		response := rt.SendAdminRequest("GET", "/{{.db}}/_resync", "")
@@ -425,7 +432,7 @@ func (rt *RestTester) WaitForResyncDCPStatus(status db.BackgroundProcessState) d
 		require.NoError(rt.TB(), json.Unmarshal(response.BodyBytes(), &resyncStatus))
 
 		assert.Equal(c, status, resyncStatus.State)
-	}, time.Second*10, time.Millisecond*10)
+	}, timeout, pollInterval)
 	if !slices.Contains([]db.BackgroundProcessState{db.BackgroundProcessStateRunning, db.BackgroundProcessStateStopping}, status) {
 		db.WaitForBackgroundManagerHeartbeatDocRemoval(rt.TB(), rt.GetDatabase().ResyncManager)
 	}
@@ -515,6 +522,13 @@ func (rt *RestTester) PutDocWithAttachment(docID string, body string, attachment
 // test harness if the sequence remains in the skipped list after timeout.
 func (rt *RestTester) WaitForSequenceNotSkipped(sequence uint64) {
 	require.NoError(rt.TB(), rt.GetDatabase().WaitForSequenceNotSkipped(rt.Context(), sequence))
+}
+
+// WaitForDBInitializationCompleted polls the ServerContext until there is no active database initialization (index creation). Fails the test if initialization does not complete within the timeout.
+func (rt *RestTester) WaitForDBInitializationCompleted(dbName string) {
+	require.EventuallyWithT(rt.TB(), func(c *assert.CollectT) {
+		assert.False(c, rt.ServerContext().DatabaseInitManager.HasActiveInitialization(dbName))
+	}, 30*time.Second, 100*time.Millisecond, "Database initialization did not complete within expected time")
 }
 
 type RawDocResponse struct {


### PR DESCRIPTION
CBG-4985 test-only: wait for database initialization for indexes to be built

This seems to fix TestResyncWithoutIndexes running tests in jenkins many hundreds of times. I think that waiting for index initialization is probably a good idea in a variety of cases when closing `RestTester` but there might be a test where we explicitly test for this behavior and I didn't want to slow down this PR by investigating that. I might push a followup PR where I do that.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/533/
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/525/