### PR TITLE
topologytest: use waitForConvergingTombstones in multi-actor delete/resurrect

### DIFF
--- a/topologytest/multi_actor_no_conflict_test.go
+++ b/topologytest/multi_actor_no_conflict_test.go
@@ -68,8 +68,8 @@ func TestMultiActorDelete(t *testing.T) {
 						createVersion := createPeer.CreateDocument(collectionName, docID, body1)
 						waitForVersionAndBody(t, collectionName, docID, createVersion, topology)
 
-						deleteVersion := deletePeer.DeleteDocument(collectionName, docID)
-						waitForTombstoneVersion(t, collectionName, docID, BodyAndVersion{docMeta: deleteVersion, updatePeer: deletePeerName}, topology)
+						deletePeer.DeleteDocument(collectionName, docID)
+						waitForConvergingTombstones(t, collectionName, docID, topology)
 					})
 				}
 			}
@@ -101,8 +101,8 @@ func TestMultiActorResurrect(t *testing.T) {
 							createVersion := createPeer.CreateDocument(collectionName, docID, body1)
 							waitForVersionAndBody(t, collectionName, docID, createVersion, topology)
 
-							deleteVersion := deletePeer.DeleteDocument(collectionName, docID)
-							waitForTombstoneVersion(t, collectionName, docID, BodyAndVersion{docMeta: deleteVersion, updatePeer: deletePeerName}, topology)
+							deletePeer.DeleteDocument(collectionName, docID)
+							waitForConvergingTombstones(t, collectionName, docID, topology)
 
 							resBody := fmt.Appendf(nil, `{"activePeer": "%s", "createPeer": "%s", "deletePeer": "%s", "resurrectPeer": "%s", "topology": "%s", "action": "resurrect"}`, resurrectPeerName, createPeerName, deletePeer, resurrectPeer, topology.specDescription)
 							resurrectVersion := resurrectPeer.WriteDocument(collectionName, docID, resBody)


### PR DESCRIPTION
## Summary

Fix the flake of `TestMultiActorResurrect/CBS+SG<->CBS+SG/create=sg1,delete=cbs1,resurrect=sg1` (seen in https://jenkins.sgwdev.com/job/Pipeline/job/main/364), and the same race surface in `TestMultiActorDelete`.

When a CBS peer raw-deletes a doc, two DCP events fire on the source bucket back-to-back: the raw delete (no `_mou`) and the local SG's import metadata-only update (with `_mou`). Rosmar XDCR replicates them sequentially, and between events the target bucket holds a tombstone with no `_mou`. A reader hitting that window — for example, a parallel SG import on the other bucket — concludes the doc has not been imported and adds a new HLV entry stamped with its own `sourceID`, re-anchoring the doc on the target bucket. The strict per-peer expected HLV used by `waitForTombstoneVersion` then doesn't match on the cross-bucket peer (`cbs2`).

This isn't an atomicity bug: rosmar's `writeWithMeta` writes body+xattrs+cas in one SQLite transaction. It's a logical race between two distinct, independently-replicated source mutations — the kind of non-determinism already documented at `topologytest/hlv_test.go:115-156`, which is exactly why `waitForConvergingTombstones` exists. The conflict tests already use it (`multi_actor_conflict_test.go:92,131`).

This change switches the two non-conflict multi-actor tests to `waitForConvergingTombstones`, which only requires non-CBL peers to converge to the same tombstone HLV (whatever that HLV ends up being). Resurrect doesn't need a precise pre-resurrect HLV — only that everyone has tombstoned.

## Test plan (local)

- [x] `go test -run 'TestMultiActorResurrect' -count=5 -shuffle=on ./topologytest/` — 0 failures across 5 shuffled iterations (was flaky before)
- [x] `go test -run '^TestMultiActor' -count=2 ./topologytest/` — green
- [x] `go test -run '^TestSingleActorDelete$|^TestSingleActorResurrect$' -count=2 ./topologytest/` — sanity, green (single-actor tests still use `waitForTombstoneVersion`; intentionally narrow scope, follow up if they flake)