### PR TITLE
CBG-5261 lock on StartOnlineProcesses

### DIFF
--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -1066,7 +1066,7 @@ func RequireChanClosed[T any](t testing.TB, ch <-chan T) {
 
 // WaitWithTimeout calls for the WaitGroup.Wait() and fails the test if the Wait does not return within the timeout.
 func WaitWithTimeout(t testing.TB, wg *sync.WaitGroup, timeout time.Duration) {
-
+	t.Helper()
 	// Create a channel so that a goroutine waiting on the waitgroup can send it's result (if any)
 	wgFinished := make(chan bool)
 

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -1063,3 +1063,24 @@ func RequireChanClosed[T any](t testing.TB, ch <-chan T) {
 	t.Helper()
 	RequireChanClosedWithTimeout(t, ch, TestChanTimeout)
 }
+
+// WaitWithTimeout calls for the WaitGroup.Wait() and fails the test if the Wait does not return within the timeout.
+func WaitWithTimeout(t testing.TB, wg *sync.WaitGroup, timeout time.Duration) {
+
+	// Create a channel so that a goroutine waiting on the waitgroup can send it's result (if any)
+	wgFinished := make(chan bool)
+
+	go func() {
+		wg.Wait()
+		wgFinished <- true
+	}()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-wgFinished:
+		return
+	case <-timer.C:
+		require.FailNow(t, fmt.Sprintf("Timed out waiting after %.2f sec", timeout.Seconds()))
+	}
+}

--- a/db/database.go
+++ b/db/database.go
@@ -2313,10 +2313,10 @@ func (db *DatabaseContext) StartOnlineProcesses(ctx context.Context) (returnedEr
 		_ = db.sequences.waitForReleasedSequences(ctx, initialSequenceTime)
 	}
 
+	needChangeCacheUnlock = false
 	if err := db.changeCache.Start(initialSequence); err != nil {
 		return err
 	}
-	needChangeCacheUnlock = false
 
 	// If this is an xattr import node, start import feed.  Must be started after the caching DCP feed, as import cfg
 	// subscription relies on the caching feed.

--- a/db/database.go
+++ b/db/database.go
@@ -2199,7 +2199,7 @@ func (db *DatabaseContext) StartOnlineProcesses(ctx context.Context) (returnedEr
 	db.BucketLock.RLock()
 	defer db.BucketLock.RUnlock()
 
-	if db.IsClosed() {
+	if db.Bucket == nil {
 		return base.RedactErrorf("cannot start online processes for database %q because it is closed", base.MD(db.Name))
 	}
 

--- a/db/database.go
+++ b/db/database.go
@@ -2194,14 +2194,26 @@ func (dbc *DatabaseContext) GetRequestPlusSequence() (uint64, error) {
 }
 
 func (db *DatabaseContext) StartOnlineProcesses(ctx context.Context) (returnedError error) {
+	// It is possible to call StartOnlineProcesses while Close is called if Database is loaded with
+	// StartOffline: true
+	db.BucketLock.RLock()
+	defer db.BucketLock.RUnlock()
 
+	if db.IsClosed() {
+		return base.RedactErrorf("cannot start online processes for database %q because it is closed", base.MD(db.Name))
+	}
+
+	needChangeCacheUnlock := false
 	defer func() {
 		if returnedError != nil {
+			// changeCache.Init locks the change cache, so if we the error occurs between changeCache.Init and
+			// changeCache.Start the cache must be unlocked
+			if needChangeCacheUnlock {
+				db.changeCache.lock.Unlock()
+			}
 			// indicate something has gone wrong in the online processes
 			db.DatabaseStartupError = NewDatabaseError(DatabaseOnlineProcessError)
 			// grab bucket lock so stopOnlineProcesses is not called at the same time as db.Close()
-			db.BucketLock.RLock()
-			defer db.BucketLock.RUnlock()
 			db._stopOnlineProcesses(ctx)
 		}
 	}()
@@ -2241,6 +2253,7 @@ func (db *DatabaseContext) StartOnlineProcesses(ctx context.Context) (returnedEr
 		base.InfofCtx(ctx, base.KeyCache, "Error initializing the change cache: %s", err)
 		return err
 	}
+	needChangeCacheUnlock = true
 
 	db.mutationListener.OnChangeCallback = db.changeCache.DocChanged
 
@@ -2303,6 +2316,7 @@ func (db *DatabaseContext) StartOnlineProcesses(ctx context.Context) (returnedEr
 	if err := db.changeCache.Start(initialSequence); err != nil {
 		return err
 	}
+	needChangeCacheUnlock = false
 
 	// If this is an xattr import node, start import feed.  Must be started after the caching DCP feed, as import cfg
 	// subscription relies on the caching feed.

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -173,6 +173,38 @@ func assertHTTPError(t *testing.T, err error, status int) bool {
 		assert.Equal(t, status, httpErr.Status)
 }
 
+func TestDatabaseStartOnlineProcessesWhileClosing(t *testing.T) {
+	timeout := 30 * time.Second
+	go func() {
+		select {
+		case <-t.Context().Done():
+			return
+		case <-time.After(timeout):
+			require.FailNow(t, fmt.Sprintf("test has timed out after %s", timeout))
+		}
+	}()
+	ctx := base.TestCtx(t)
+	tBucket := base.GetTestBucket(t)
+	defer tBucket.Close(ctx)
+	dbcOptions := DatabaseContextOptions{
+		Scopes: GetScopesOptions(t, tBucket, 1),
+	}
+
+	dbCtx, err := NewDatabaseContext(ctx, "db", tBucket, true, dbcOptions)
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		_ = dbCtx.StartOnlineProcesses(ctx)
+	})
+
+	wg.Go(func() {
+		dbCtx.Close(ctx)
+	})
+
+	base.WaitWithTimeout(t, &wg, timeout)
+}
+
 func TestDatabase(t *testing.T) {
 
 	db, ctx := setupTestDB(t)

--- a/db/utils.go
+++ b/db/utils.go
@@ -47,6 +47,7 @@ func NewBackgroundTask(ctx context.Context, taskName string, task BackgroundTask
 					return
 				}
 			case <-c:
+				base.InfofCtx(ctx, base.KeyAll, "Terminating background task: %q", taskName)
 				base.DebugfCtx(ctx, base.KeyAll, "Terminating background task")
 				return
 			}

--- a/db/utils.go
+++ b/db/utils.go
@@ -47,7 +47,6 @@ func NewBackgroundTask(ctx context.Context, taskName string, task BackgroundTask
 					return
 				}
 			case <-c:
-				base.InfofCtx(ctx, base.KeyAll, "Terminating background task: %q", taskName)
 				base.DebugfCtx(ctx, base.KeyAll, "Terminating background task")
 				return
 			}

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -460,7 +460,7 @@ func TestDBOfflineConcurrent(t *testing.T) {
 		wg.Done()
 	}()
 
-	rest.WaitWithTimeout(t, &wg, time.Second*30)
+	base.WaitWithTimeout(t, &wg, time.Second*30)
 	rest.RequireStatus(t, goroutineresponse1, http.StatusOK)
 	rest.RequireStatus(t, goroutineresponse2, http.StatusOK)
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2053,7 +2053,7 @@ func TestWebhookProperties(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
-	WaitWithTimeout(t, &wg, 30*time.Second)
+	base.WaitWithTimeout(t, &wg, 30*time.Second)
 }
 
 func TestWebhookSpecialProperties(t *testing.T) {

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -153,7 +153,7 @@ func TestBlipPushRevisionInspectChanges(t *testing.T) {
 	assert.Equal(t, subChangesRequest.SerialNumber(), subChangesResponse.SerialNumber())
 
 	// Wait until we got the expected callback on the "changes" profile handler
-	WaitWithTimeout(t, &receivedChangesRequestWg, time.Second*5)
+	base.WaitWithTimeout(t, &receivedChangesRequestWg, time.Second*5)
 }
 
 // Start subChanges w/ continuous=true, batchsize=10
@@ -255,7 +255,7 @@ func TestContinuousChangesSubscription(t *testing.T) {
 	}
 
 	// Wait until all expected changes are received by change handler
-	WaitWithTimeout(t, &receivedChangesWg, time.Second*30)
+	base.WaitWithTimeout(t, &receivedChangesWg, time.Second*30)
 
 	// Since batch size was set to 10, and 15 docs were added, expect at _least_ 2 batches
 	numBatchesReceivedSnapshot := atomic.LoadInt32(&numbatchesReceived)
@@ -370,7 +370,7 @@ func TestBlipOneShotChangesSubscription(t *testing.T) {
 	assert.Equal(t, subChangesRequest.SerialNumber(), subChangesResponse.SerialNumber())
 
 	// Wait until all expected changes are received by change handler
-	WaitWithTimeout(t, &receivedChangesWg, time.Second*60)
+	base.WaitWithTimeout(t, &receivedChangesWg, time.Second*60)
 
 	// Since batch size was set to 10, and 15 docs were added, expect at _least_ 2 batches
 	numBatchesReceivedSnapshot := atomic.LoadInt32(&numbatchesReceived)
@@ -522,7 +522,7 @@ func TestBlipSubChangesDocIDFilter(t *testing.T) {
 	assert.Equal(t, subChangesRequest.SerialNumber(), subChangesResponse.SerialNumber())
 
 	// Wait until all expected changes are received by change handler
-	WaitWithTimeout(t, &receivedChangesWg, time.Second*15)
+	base.WaitWithTimeout(t, &receivedChangesWg, time.Second*15)
 
 	// Since batch size was set to 10, and 15 docs were added, expect at _least_ 2 batches
 	numBatchesReceivedSnapshot := atomic.LoadInt32(&numbatchesReceived)
@@ -939,8 +939,8 @@ function(doc, oldDoc) {
 	rt.WaitForPendingChanges()
 
 	// Wait until all expected changes are received by change handler
-	WaitWithTimeout(t, &receivedChangesWg, time.Second*5)
-	WaitWithTimeout(t, &revsFinishedWg, time.Second*5)
+	base.WaitWithTimeout(t, &receivedChangesWg, time.Second*5)
+	base.WaitWithTimeout(t, &revsFinishedWg, time.Second*5)
 
 	assert.False(t, nonIntegerSequenceReceived, "Unexpected non-integer sequence seen.")
 
@@ -1079,8 +1079,8 @@ function(doc, oldDoc) {
 
 	timeout := 30 * time.Second * db.GetCachingFeedDelayFactor(t)
 	// Wait until all expected changes are received by change handler
-	WaitWithTimeout(t, &receivedChangesWg, timeout)
-	WaitWithTimeout(t, &revsFinishedWg, timeout)
+	base.WaitWithTimeout(t, &receivedChangesWg, timeout)
+	base.WaitWithTimeout(t, &revsFinishedWg, timeout)
 
 	assert.False(t, nonIntegerSequenceReceived, "Unexpected non-integer sequence seen.")
 
@@ -1163,7 +1163,7 @@ func TestBlipSendConcurrentRevs(t *testing.T) {
 		}()
 	}
 
-	WaitWithTimeout(t, &wg, time.Second*30)
+	base.WaitWithTimeout(t, &wg, time.Second*30)
 
 	throttleCount := rt.GetDatabase().DbStats.CBLReplicationPush().WriteThrottledCount.Value()
 	throttleTime := rt.GetDatabase().DbStats.CBLReplicationPush().WriteThrottledTime.Value()

--- a/rest/blip_legacy_revid_test.go
+++ b/rest/blip_legacy_revid_test.go
@@ -649,8 +649,8 @@ func TestChangesResponseLegacyRev(t *testing.T) {
 	subChangesResponse := subChangesRequest.Response()
 	assert.Equal(t, subChangesRequest.SerialNumber(), subChangesResponse.SerialNumber())
 
-	WaitWithTimeout(t, &receivedChangesRequestWg, time.Second*10)
-	WaitWithTimeout(t, &revsFinishedWg, time.Second*10)
+	base.WaitWithTimeout(t, &receivedChangesRequestWg, time.Second*10)
+	base.WaitWithTimeout(t, &revsFinishedWg, time.Second*10)
 
 }
 
@@ -753,8 +753,8 @@ func TestChangesResponseWithHLVInHistory(t *testing.T) {
 	subChangesResponse := subChangesRequest.Response()
 	assert.Equal(t, subChangesRequest.SerialNumber(), subChangesResponse.SerialNumber())
 
-	WaitWithTimeout(t, &receivedChangesRequestWg, time.Second*10)
-	WaitWithTimeout(t, &revsFinishedWg, time.Second*10)
+	base.WaitWithTimeout(t, &receivedChangesRequestWg, time.Second*10)
+	base.WaitWithTimeout(t, &revsFinishedWg, time.Second*10)
 }
 
 // TestCBLHasPreUpgradeMutationThatHasNotBeenReplicated:

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -2151,7 +2151,7 @@ func TestImportFilterTimeout(t *testing.T) {
 		rest.AssertStatus(t, response, 404)
 		syncFnFinishedWG.Done()
 	}()
-	rest.WaitWithTimeout(t, &syncFnFinishedWG, time.Second*15)
+	base.WaitWithTimeout(t, &syncFnFinishedWG, time.Second*15)
 }
 
 func TestImportRollback(t *testing.T) {

--- a/rest/sync_fn_test.go
+++ b/rest/sync_fn_test.go
@@ -403,7 +403,7 @@ func TestSyncFnTimeout(t *testing.T) {
 		AssertHTTPErrorReason(t, response, 500, "JS sync function timed out")
 		syncFnFinishedWG.Done()
 	}()
-	WaitWithTimeout(t, &syncFnFinishedWG, time.Second*15)
+	base.WaitWithTimeout(t, &syncFnFinishedWG, time.Second*15)
 }
 
 func TestResyncErrorScenariosUsingDCPStream(t *testing.T) {

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1851,8 +1851,8 @@ func (bt *BlipTester) GetDocAtRev(requestedDocID, requestedDocRev string) (resul
 
 	bt.Send(subChangesRequest)
 
-	WaitWithTimeout(bt.TB(), &changesFinishedWg, time.Second*30)
-	WaitWithTimeout(bt.TB(), &revsFinishedWg, time.Second*30)
+	base.WaitWithTimeout(bt.TB(), &changesFinishedWg, time.Second*30)
+	base.WaitWithTimeout(bt.TB(), &revsFinishedWg, time.Second*30)
 	return resultDoc, resultErr
 }
 
@@ -2264,27 +2264,6 @@ func (d RestDocument) IsRemoved() bool {
 		return false
 	}
 	return removed.(bool)
-}
-
-// WaitWithTimeout calls for the WaitGroup.Wait() and fails the test if the Wait does not return within the timeout.
-func WaitWithTimeout(t testing.TB, wg *sync.WaitGroup, timeout time.Duration) {
-
-	// Create a channel so that a goroutine waiting on the waitgroup can send it's result (if any)
-	wgFinished := make(chan bool)
-
-	go func() {
-		wg.Wait()
-		wgFinished <- true
-	}()
-
-	timer := time.NewTimer(timeout)
-	defer timer.Stop()
-	select {
-	case <-wgFinished:
-		return
-	case <-timer.C:
-		require.FailNow(t, fmt.Sprintf("Timed out waiting after %.2f sec", timeout.Seconds()))
-	}
 }
 
 // NewHTTPTestServerOnListener returns a new httptest server, which is configured to listen on the given listener.

--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -1305,7 +1305,7 @@ func (btcc *BlipTesterCollectionClient) StartPushWithOpts(opts BlipTesterPushOpt
 	go func() {
 		defer func() {
 			waitTime := time.Second * 5
-			WaitWithTimeout(btcc.TB(), &btcc.pushGoroutineWg, waitTime)
+			base.WaitWithTimeout(btcc.TB(), &btcc.pushGoroutineWg, waitTime)
 			btcc.pushRunning.Set(false)
 		}()
 		defer btcc.pushGoroutineWg.Done()


### PR DESCRIPTION
CBG-5261 lock on StartOnlineProcesses

There are multiple places where calling `Close` with `StartOnlineProcesses` can fail. The way this happens is if the database is called with: `StartOffline: true` and then the configuration is updated again in rapid succession.

There are multiple types of panics that occur. I'm not sure how valuable the test provided is, it was mostly helpful to run thousands of times to make sure all races occur.

The behavior of `changeCache.Init` to lock the change cache but not unlock until `changeCache.Start` would result in a hanging `Close`. This was latent non test only bug.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/537/
