### PR TITLE
CBG-5337 remove pointless lock for DatabaseContext.Authenticator

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -753,12 +753,6 @@ func waitForBGTCompletion(ctx context.Context, waitTimeMax time.Duration, tasks 
 	}
 }
 
-func (context *DatabaseContext) IsClosed() bool {
-	context.BucketLock.RLock()
-	defer context.BucketLock.RUnlock()
-	return context.Bucket == nil
-}
-
 // For testing only!
 func (context *DatabaseContext) RestartListener(ctx context.Context) error {
 	context.mutationListener.Stop(ctx)
@@ -851,10 +845,9 @@ func (context *DatabaseContext) NotifyTerminatedChanges(ctx context.Context, use
 	context.mutationListener.NotifyCheckForTermination(ctx, base.SetOf(base.UserPrefixRoot+username))
 }
 
+// Authenticator returns an authenticator for this database context. The authenticator is stateless, so it's safe to
+// return a new instance on each call.
 func (context *DatabaseContext) Authenticator(ctx context.Context) *auth.Authenticator {
-	context.BucketLock.RLock()
-	defer context.BucketLock.RUnlock()
-
 	sessionCookieName := auth.DefaultCookieName
 	if context.Options.SessionCookieName != "" {
 		sessionCookieName = context.Options.SessionCookieName


### PR DESCRIPTION
CBG-5337 remove pointless lock for DatabaseContext.Authenticator

Used https://github.com/sasha-s/go-deadlock and replaced all `sync.RWMutex` with `deadlock.RWMutex`

The `DatabaseContext.Authenticator` / `NewAuthenticator` doesn't read the bucket object so locking for the bucket object is somewhat pointless.

Here's one deadlock already extant in CBG-5337:

```
POTENTIAL DEADLOCK: Inconsistent locking. saw this ordering in one goroutine:
happened before
../../db/sg_replicate_cfg.go:773 db.(*sgReplicateManager).RefreshReplicationCfg { m.activeReplicatorsLock.Lock() } <<<<<
../../db/sg_replicate_cfg.go:772 db.(*sgReplicateManager).RefreshReplicationCfg {  }
../../db/sg_replicate_cfg.go:872 db.(*sgReplicateManager).SubscribeCfgChanges.func1 { err := m.RefreshReplicationCfg(ctx) }

happened after
../../db/database.go:856 db.(*DatabaseContext).Authenticator { context.BucketLock.RLock() } <<<<<
../../db/database.go:855 db.(*DatabaseContext).Authenticator { func (context *DatabaseContext) Authenticator(ctx context.Context) *auth.Authenticator { }
../../db/sg_replicate_cfg.go:566 db.(*sgReplicateManager).NewActiveReplicatorConfig { if config.RunAs != "" { }
../../db/sg_replicate_cfg.go:681 db.(*sgReplicateManager).isCfgChanged { newConfig, err := m.NewActiveReplicatorConfig(newCfg) }
../../db/sg_replicate_cfg.go:796 db.(*sgReplicateManager).RefreshReplicationCfg { // If the config has changed, re-initialize the replication }
../../db/sg_replicate_cfg.go:872 db.(*sgReplicateManager).SubscribeCfgChanges.func1 { err := m.RefreshReplicationCfg(ctx) }

in another goroutine: happened before
../../db/database.go:654 db.(*DatabaseContext).Close { context.BucketLock.Lock() } <<<<<
../../db/database.go:653 db.(*DatabaseContext).Close { func (context *DatabaseContext) Close(ctx context.Context) { }
../server_context.go:315 rest.(*ServerContext).Close { db.Close(ctx) }
../utilities_testing.go:667 rest.(*RestTester).Close { } }
replicator_test.go:7595 replicatortest.TestSpecifyUserDocsToReplicate.func1 { require.NoError(t, err) }

happened after
../../db/sg_replicate_cfg.go:744 db.(*sgReplicateManager).Stop {  } <<<<<
../../db/sg_replicate_cfg.go:742 db.(*sgReplicateManager).Stop { // Stop active replications }
../../db/database.go:648 db.(*DatabaseContext)._stopOnlineProcesses { db.SGReplicateMgr.Stop() }
../../db/database.go:670 db.(*DatabaseContext).Close { // Stop the channel cache and its background tasks. }
../server_context.go:315 rest.(*ServerContext).Close { db.Close(ctx) }
../utilities_testing.go:667 rest.(*RestTester).Close { } }
replicator_test.go:7595 replicatortest.TestSpecifyUserDocsToReplicate.func1 { require.NoError(t, err) }

Other goroutines holding locks:
goroutine 114 lock 0xc0008998f8
../server_context.go:312 rest.(*ServerContext).Close { sc._databasesLock.Lock() } <<<<<
../server_context.go:311 rest.(*ServerContext).Close { // close all databases }
../utilities_testing.go:667 rest.(*RestTester).Close { } }
replicator_test.go:7595 replicatortest.TestSpecifyUserDocsToReplicate.func1 { require.NoError(t, err) }

goroutine 114 lock 0xc0006ce5f8
../../db/database.go:654 db.(*DatabaseContext).Close { context.BucketLock.Lock() } <<<<<
../../db/database.go:653 db.(*DatabaseContext).Close { func (context *DatabaseContext) Close(ctx context.Context) { }
../server_context.go:315 rest.(*ServerContext).Close { db.Close(ctx) }
../utilities_testing.go:667 rest.(*RestTester).Close { } }
replicator_test.go:7595 replicatortest.TestSpecifyUserDocsToReplicate.func1 { require.NoError(t, err) }
```

I created another in 
I created a recursive lock in https://github.com/couchbase/sync_gateway/pull/8203. 

```
POTENTIAL DEADLOCK: Recursive locking:
current goroutine 104 lock 0xc000344c78
../db/database.go:856 db.(*DatabaseContext).Authenticator { context.BucketLock.RLock() } <<<<<
../db/database.go:855 db.(*DatabaseContext).Authenticator { func (context *DatabaseContext) Authenticator(ctx context.Context) *auth.Authenticator { }
../db/users.go:45 db.(*DatabaseContext).UpdatePrincipal { func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.PrincipalConfig, isUser bool, allowReplace bool) (replaced bool, princ auth.Principal, err error) { }
../db/database.go:2461 db.(*DatabaseContext).InstallPrincipals.func1 { _, _, err = dbc.UpdatePrincipal(ctx, princ, (what == "user"), isGuest) }
../base/util.go:455 base.RetryLoop[...] { for { }
../db/database.go:2485 db.(*DatabaseContext).InstallPrincipals { err, _ := base.RetryLoop(ctx, "installPrincipals", worker, base.CreateDoublingSleeperFunc(16, 10)) }
../db/database.go:2233 db.(*DatabaseContext).StartOnlineProcesses { guest := map[string]*auth.PrincipalConfig{base.GuestUsername: db.Options.ConfigPrincipals.Guest} }
server_context.go:1102 rest.(*ServerContext)._getOrAddDatabaseFromConfig { base.InfofCtx(ctx, base.KeyAll, "Database init completed, starting online processes") }
server_context.go:614 rest.(*ServerContext).getOrAddDatabaseFromConfig { defer sc._databasesLock.Unlock() }
server_context.go:1620 rest.(*ServerContext).AddDatabaseFromConfig { failFast := false }
utilities_testing.go:418 rest.(*RestTester).Bucket { } }
utilities_testing.go:515 rest.(*RestTester).ServerContext { rt.Bucket() }
utilities_testing.go:548 rest.(*RestTester).GetDatabase { func (rt *RestTester) GetDatabase() *db.DatabaseContext { }
utilities_testing.go:588 rest.(*RestTester).GetSingleTestDatabaseCollection { func (rt *RestTester) GetSingleTestDatabaseCollection() (*db.DatabaseCollection, context.Context) { }
utilities_testing.go:601 rest.(*RestTester).GetSingleDataStore { func (rt *RestTester) GetSingleDataStore() base.DataStore { }
access_test.go:38 rest.TestPublicChanGuestAccess { defer rt.Close() }

Previous place where the lock was grabbed (same goroutine)
../db/database.go:2200 db.(*DatabaseContext).StartOnlineProcesses { db.BucketLock.RLock() } <<<<<
../db/database.go:2199 db.(*DatabaseContext).StartOnlineProcesses { // StartOffline: true }
server_context.go:1102 rest.(*ServerContext)._getOrAddDatabaseFromConfig { base.InfofCtx(ctx, base.KeyAll, "Database init completed, starting online processes") }
server_context.go:614 rest.(*ServerContext).getOrAddDatabaseFromConfig { defer sc._databasesLock.Unlock() }
server_context.go:1620 rest.(*ServerContext).AddDatabaseFromConfig { failFast := false }
utilities_testing.go:418 rest.(*RestTester).Bucket { } }
utilities_testing.go:515 rest.(*RestTester).ServerContext { rt.Bucket() }
utilities_testing.go:548 rest.(*RestTester).GetDatabase { func (rt *RestTester) GetDatabase() *db.DatabaseContext { }
utilities_testing.go:588 rest.(*RestTester).GetSingleTestDatabaseCollection { func (rt *RestTester) GetSingleTestDatabaseCollection() (*db.DatabaseCollection, context.Context) { }
utilities_testing.go:601 rest.(*RestTester).GetSingleDataStore { func (rt *RestTester) GetSingleDataStore() base.DataStore { }
access_test.go:38 rest.TestPublicChanGuestAccess { defer rt.Close() }

Other goroutines holding locks:
goroutine 104 lock 0xc000032718
server_context.go:613 rest.(*ServerContext).getOrAddDatabaseFromConfig { sc._databasesLock.Lock() } <<<<<
server_context.go:612 rest.(*ServerContext).getOrAddDatabaseFromConfig { // Obtain write lock during add database, to avoid race condition when creating based on ConfigServer }
server_context.go:1620 rest.(*ServerContext).AddDatabaseFromConfig { failFast := false }
utilities_testing.go:418 rest.(*RestTester).Bucket { } }
utilities_testing.go:515 rest.(*RestTester).ServerContext { rt.Bucket() }
utilities_testing.go:548 rest.(*RestTester).GetDatabase { func (rt *RestTester) GetDatabase() *db.DatabaseContext { }
utilities_testing.go:588 rest.(*RestTester).GetSingleTestDatabaseCollection { func (rt *RestTester) GetSingleTestDatabaseCollection() (*db.DatabaseCollection, context.Context) { }
utilities_testing.go:601 rest.(*RestTester).GetSingleDataStore { func (rt *RestTester) GetSingleDataStore() base.DataStore { }
access_test.go:38 rest.TestPublicChanGuestAccess { defer rt.Close() }
```


## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/538/
