### PR TITLE
CBG-5302: error for starting replication with non existant run_as

### DIFF
--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -569,7 +569,7 @@ func (m *sgReplicateManager) NewActiveReplicatorConfig(config *ReplicationCfg) (
 			return nil, err
 		}
 		if user == nil {
-			return nil, base.HTTPErrorf(http.StatusUnauthorized, "run_as user %s not found", base.UD(config.RunAs))
+			return nil, base.HTTPErrorf(http.StatusBadRequest, "run_as user %s not found", base.UD(config.RunAs))
 		}
 		activeDB.SetUser(user)
 	}

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -569,7 +569,7 @@ func (m *sgReplicateManager) NewActiveReplicatorConfig(config *ReplicationCfg) (
 			return nil, err
 		}
 		if user == nil {
-			return nil, base.HTTPErrorf(http.StatusBadRequest, "run_as user %s not found", base.UD(config.RunAs))
+			return nil, base.RedactErrorf("run_as user %s not found", base.UD(config.RunAs))
 		}
 		activeDB.SetUser(user)
 	}

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -539,6 +539,7 @@ func (m *sgReplicateManager) StartReplications(ctx context.Context) error {
 			activeReplicator, err := m.InitializeReplication(replicationCfg)
 			if err != nil {
 				base.WarnfCtx(m.loggingCtx, "Error initializing replication %s: %v", replicationID, err)
+				m.saveInitializationError(replicationCfg, err)
 				continue
 			}
 			m.activeReplicatorsLock.Lock()
@@ -566,6 +567,9 @@ func (m *sgReplicateManager) NewActiveReplicatorConfig(config *ReplicationCfg) (
 		user, err := m.dbContext.Authenticator(m.loggingCtx).GetUser(config.RunAs)
 		if err != nil {
 			return nil, err
+		}
+		if user == nil {
+			return nil, base.HTTPErrorf(http.StatusUnauthorized, "run_as user %s not found", base.UD(config.RunAs))
 		}
 		activeDB.SetUser(user)
 	}
@@ -732,6 +736,29 @@ func (m *sgReplicateManager) replicationComplete(replicationID string) {
 	}
 }
 
+// saveInitializationError persists an error status for a replication that failed to initialise,
+// so that GetReplicationStatus returns ReplicationStateError instead of the target state.
+func (m *sgReplicateManager) saveInitializationError(config *ReplicationCfg, initErr error) {
+	status := &ReplicationStatus{
+		ID:           config.ID,
+		Status:       ReplicationStateError,
+		ErrorMessage: initErr.Error(),
+	}
+	expirySecs := int(m.dbContext.Options.LocalDocExpirySecs)
+	if config.Direction == ActiveReplicatorTypePush || config.Direction == ActiveReplicatorTypePushAndPull {
+		pushKey := m.dbContext.MetadataKeys.ReplicationStatusKey(PushCheckpointID(config.ID))
+		if err := setLocalStatus(m.loggingCtx, m.dbContext.MetadataStore, pushKey, status, expirySecs); err != nil {
+			base.WarnfCtx(m.loggingCtx, "Unable to persist error status for replication %s: %v", base.UD(config.ID), err)
+		}
+	}
+	if config.Direction == ActiveReplicatorTypePull || config.Direction == ActiveReplicatorTypePushAndPull {
+		pullKey := m.dbContext.MetadataKeys.ReplicationStatusKey(PullCheckpointID(config.ID))
+		if err := setLocalStatus(m.loggingCtx, m.dbContext.MetadataStore, pullKey, status, expirySecs); err != nil {
+			base.WarnfCtx(m.loggingCtx, "Unable to persist error status for replication %s: %v", base.UD(config.ID), err)
+		}
+	}
+}
+
 func (m *sgReplicateManager) Stop() {
 
 	// Close subscribe terminator first to stop subscribing/responding to cluster config changes prior to
@@ -801,6 +828,7 @@ func (m *sgReplicateManager) RefreshReplicationCfg(ctx context.Context) error {
 				replicator, initError := m.InitializeReplication(replicationCfg)
 				if initError != nil {
 					base.WarnfCtx(m.loggingCtx, "Error initializing upserted replication %s: %v", replicationID, initError)
+					m.saveInitializationError(replicationCfg, initError)
 				} else {
 					m.activeReplicators[replicationID] = replicator
 					activeReplicator = replicator
@@ -830,6 +858,7 @@ func (m *sgReplicateManager) RefreshReplicationCfg(ctx context.Context) error {
 				replicator, initError := m.InitializeReplication(replicationCfg)
 				if initError != nil {
 					base.WarnfCtx(m.loggingCtx, "Error initializing replication %s: %v", replicationID, initError)
+					m.saveInitializationError(replicationCfg, initError)
 					continue
 				}
 				m.activeReplicators[replicationID] = replicator

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -8138,7 +8138,7 @@ func TestISGRRunAsNonExistentUserPushesAsAdmin(t *testing.T) {
 		"/{{.db}}/_replication/"+repl1Name, replConf)
 	rest.RequireStatus(t, configResp, http.StatusCreated)
 
-	// StartReplications will error initialising the replicator but will no return error
+	// StartReplications will error initialising the replicator but will not return an error
 	require.NoError(t, activeRT.GetDatabase().SGReplicateMgr.StartReplications(activeRT.Context()))
 
 	activeRT.WaitForReplicationStatus(repl1Name, db.ReplicationStateError)
@@ -8162,7 +8162,6 @@ func TestISGRRunAsNonExistentUserPushesAsAdmin(t *testing.T) {
 		"/{{.db}}/_replication/"+repl2Name, replConfNoRunAs)
 	rest.RequireStatus(t, configResp, http.StatusCreated)
 
-	activeRT.WaitForReplicationStatus(repl2Name, db.ReplicationStateRunning)
 	// doc should be pushed successfully with the second replication that doesn't have run_as set
 	passiveRT.WaitForVersion(docID, version)
 	activeRT.WaitForReplicationStatus(repl2Name, db.ReplicationStateStopped)
@@ -8170,7 +8169,7 @@ func TestISGRRunAsNonExistentUserPushesAsAdmin(t *testing.T) {
 	// purge doc on passive
 	passiveRT.PurgeDoc(docID)
 
-	// now create a replication with the bad run_as user again, but this time don't specific initial state so the replication starts straight away
+	// now create a replication with the bad run_as user again, but this time don't specify initial state so the replication starts straight away
 	replConf = fmt.Sprintf(`{
         "replication_id": "%s",
         "remote": "%s/%s",
@@ -8199,7 +8198,7 @@ func TestISGRRunAsNonExistentUserPushesAsAdmin(t *testing.T) {
 // run_as user defined inline in the database config (legacy file-based config style, via
 // RestTesterConfig.DatabaseConfig.Replications) enters the error state and does not push
 // any documents.
-func TestISGRRunAsNonExistentUserLegacyConfig(t *testing.T) {
+func TestISGRRunAsNonExistentUserReplicationConfigInDbConfig(t *testing.T) {
 	base.LongRunningTest(t)
 	base.RequireNumTestBuckets(t, 2)
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyReplicate, base.KeyHTTP, base.KeyAccess, base.KeyChanges)

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -1533,6 +1533,8 @@ func TestRequireReplicatorStoppedBeforeUpsert(t *testing.T) {
 	const username = "alice"
 	rt.CreateUser("alice", []string{})
 
+	collectionsEnabled := strconv.FormatBool(!rt.GetDatabase().OnlyDefaultCollection())
+
 	DBURL := userDBURL(rt, username)
 
 	replicationConfig := fmt.Sprintf(`{
@@ -1541,8 +1543,9 @@ func TestRequireReplicatorStoppedBeforeUpsert(t *testing.T) {
 		"direction": "pushAndPull",
 		"conflict_resolution_type":"default",
 		"max_backoff":100,
+		"collections_enabled": %s,
         "continuous":true
-	}`, DBURL.String())
+	}`, DBURL.String(), collectionsEnabled)
 
 	response := rt.SendAdminRequest("PUT", "/{{.db}}/_replication/replication1", replicationConfig)
 	rest.RequireStatus(t, response, http.StatusCreated)
@@ -1550,11 +1553,7 @@ func TestRequireReplicatorStoppedBeforeUpsert(t *testing.T) {
 	response = rt.SendAdminRequest("GET", "/{{.db}}/_replicationStatus/", "")
 	rest.RequireStatus(t, response, http.StatusOK)
 
-	var body []map[string]any
-	err := base.JSONUnmarshal(response.BodyBytes(), &body)
-	fmt.Println(string(response.BodyBytes()))
-	assert.NoError(t, err)
-	assert.Equal(t, "running", body[0]["status"])
+	rt.WaitForReplicationStatus("replication1", db.ReplicationStateRunning)
 
 	replicationConfigUpdate := fmt.Sprintf(`{
 		"replication_id": "replication1",
@@ -8142,12 +8141,7 @@ func TestISGRRunAsNonExistentUserPushesAsAdmin(t *testing.T) {
 	// StartReplications will error initialising the replicator but will no return error
 	require.NoError(t, activeRT.GetDatabase().SGReplicateMgr.StartReplications(activeRT.Context()))
 
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		status := activeRT.GetReplicationStatus(repl1Name).Status
-		assert.Contains(c, []string{db.ReplicationStateError},
-			status,
-			"replication never reached stopped/error: currently %s", status)
-	}, 20*time.Second, 100*time.Millisecond)
+	activeRT.WaitForReplicationStatus(repl1Name, db.ReplicationStateError)
 
 	resp := passiveRT.SendAdminRequest(http.MethodGet,
 		"/{{.keyspace}}/"+docID, "")
@@ -8194,14 +8188,84 @@ func TestISGRRunAsNonExistentUserPushesAsAdmin(t *testing.T) {
 	rest.RequireStatus(t, configResp, http.StatusCreated)
 
 	// assert that the replication doesn't start
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		status := activeRT.GetReplicationStatus(repl3Name).Status
-		assert.Contains(c, []string{db.ReplicationStateError},
-			status,
-			"replication never reached stopped/error: currently %s", status)
-	}, 20*time.Second, 100*time.Millisecond)
+	activeRT.WaitForReplicationStatus(repl3Name, db.ReplicationStateError)
 
 	resp = passiveRT.SendAdminRequest(http.MethodGet,
 		"/{{.keyspace}}/"+docID, "")
 	require.Equal(t, http.StatusNotFound, resp.Code, "expected secret doc to not be pushed")
+}
+
+// TestISGRRunAsNonExistentUserLegacyConfig verifies that a replication with a non-existent
+// run_as user defined inline in the database config (legacy file-based config style, via
+// RestTesterConfig.DatabaseConfig.Replications) enters the error state and does not push
+// any documents.
+func TestISGRRunAsNonExistentUserLegacyConfig(t *testing.T) {
+	base.LongRunningTest(t)
+	base.RequireNumTestBuckets(t, 2)
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyReplicate, base.KeyHTTP, base.KeyAccess, base.KeyChanges)
+
+	const (
+		replName       = "repl-legacy"
+		runAsMissing   = "missinguser"
+		privateChannel = "secret"
+		aliceUser      = "alice"
+	)
+
+	syncFn := `function(doc) { channel(doc.channels); }`
+
+	// Passive peer — receives docs; provides alice for remote auth.
+	passiveRT := rest.NewRestTester(t, &rest.RestTesterConfig{
+		SyncFn: syncFn,
+	})
+	defer passiveRT.Close()
+
+	publicSrv := httptest.NewServer(passiveRT.TestPublicHandler())
+	defer publicSrv.Close()
+
+	passiveRT.CreateUser(aliceUser, []string{"*"})
+
+	// collectionsEnabled mirrors !OnlyDefaultCollection() for the passive RT.
+	// Both RTs share the same test environment so the topology is identical.
+	collectionsEnabled := !passiveRT.GetDatabase().OnlyDefaultCollection()
+
+	// Define the replication inline in the DatabaseConfig
+	// rather than creating it through the admin REST API.
+	// initial_state "stopped" prevents it from running before we call
+	// StartReplications, while still exercising the initialisation path that
+	// validates run_as.
+	activeRT := rest.NewRestTester(t, &rest.RestTesterConfig{
+		SyncFn:             syncFn,
+		SgReplicateEnabled: true,
+		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+			Replications: map[string]*db.ReplicationConfig{
+				replName: {
+					ID:                 replName,
+					Remote:             fmt.Sprintf("%s/%s", publicSrv.URL, passiveRT.GetDatabase().Name),
+					Direction:          db.ActiveReplicatorTypePush,
+					Continuous:         false,
+					RunAs:              runAsMissing,
+					RemoteUsername:     aliceUser,
+					RemotePassword:     rest.RestTesterDefaultUserPassword,
+					InitialState:       db.ReplicationStateStopped,
+					CollectionsEnabled: collectionsEnabled,
+				},
+			},
+		}},
+	})
+	defer activeRT.Close()
+
+	// Admin-authored private document; a non-existent run_as user can never
+	// be granted access to this channel.
+	docID := "private_doc_" + rest.SafeDocumentName(t, t.Name())
+	activeRT.PutDoc(docID, `{"channels":["`+privateChannel+`"],"content":"secret"}`)
+	activeRT.WaitForPendingChanges()
+
+	// StartReplications initialises the replicator; it errors on the missing
+	// run_as user but does not surface an error to the caller.
+	require.NoError(t, activeRT.GetDatabase().SGReplicateMgr.StartReplications(activeRT.Context()))
+
+	activeRT.WaitForReplicationStatus(replName, db.ReplicationStateError)
+
+	resp := passiveRT.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/"+docID, "")
+	require.Equal(t, http.StatusNotFound, resp.Code, "expected secret doc to not be pushed with invalid run_as user")
 }

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -8074,3 +8074,134 @@ func TestReplicationConfigUpdatedAt(t *testing.T) {
 		assert.Equal(t, configResponse.CreatedAt.UnixNano(), createdAtTime.UnixNano())
 	})
 }
+
+func TestISGRRunAsNonExistentUserPushesAsAdmin(t *testing.T) {
+	base.LongRunningTest(t)
+	base.RequireNumTestBuckets(t, 2)
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyReplicate, base.KeyHTTP, base.KeyAccess, base.KeyChanges)
+
+	const (
+		repl1Name      = "repl"
+		repl2Name      = "repl2"
+		repl3Name      = "repl3"
+		runAsMissing   = "missinguser"
+		privateChannel = "secret"
+	)
+
+	// Both peers use the default channels-from-doc sync function.
+	rtConfig := &rest.RestTesterConfig{
+		SyncFn: `function(doc) { channel(doc.channels); }`,
+	}
+
+	// Passive peer — receives docs. Needs an alice for remote auth.
+	passiveRT := rest.NewRestTester(t, rtConfig)
+	defer passiveRT.Close()
+
+	publicSrv := httptest.NewServer(passiveRT.TestPublicHandler())
+	defer publicSrv.Close()
+
+	// Active peer
+	activeRTConfig := &rest.RestTesterConfig{
+		SyncFn:             rtConfig.SyncFn,
+		SgReplicateEnabled: true,
+	}
+	activeRT := rest.NewRestTester(t, activeRTConfig)
+	defer activeRT.Close()
+
+	passiveRT.CreateUser("alice", []string{"*"})
+
+	// Admin-authored private document on active, in a channel that would
+	// never match a scoped run_as user's access (because no such user
+	// exists to grant access to).
+	docID := "private_doc_" + rest.SafeDocumentName(t, t.Name())
+	version := activeRT.PutDoc(docID, `{"channels":["`+privateChannel+`"],"content":"secret"}`)
+	activeRT.WaitForPendingChanges()
+
+	// One-shot (non-continuous) push with run_as: <non-existent user>.
+	// One-shot is used instead of continuous so the replicator reaches a
+	// terminal state on its own — a continuous replication holds the cbgt
+	// cluster-config subscription open and can deadlock on test teardown.
+	collectionsEnabled := strconv.FormatBool(!activeRT.GetDatabase().OnlyDefaultCollection())
+	replConf := fmt.Sprintf(`{
+        "replication_id": "%s",
+        "remote": "%s/%s",
+        "direction": "push",
+        "continuous": false,
+        "run_as": "%s",
+        "remote_username": "alice",
+        "remote_password": "%s",
+		"initial_state": "stopped",
+        "collections_enabled": %s
+    }`, repl1Name, publicSrv.URL, passiveRT.GetDatabase().Name,
+		runAsMissing, rest.RestTesterDefaultUserPassword, collectionsEnabled)
+
+	configResp := activeRT.SendAdminRequest(http.MethodPut,
+		"/{{.db}}/_replication/"+repl1Name, replConf)
+	rest.RequireStatus(t, configResp, http.StatusCreated)
+
+	// StartReplications will error initialising the replicator but will no return error
+	require.NoError(t, activeRT.GetDatabase().SGReplicateMgr.StartReplications(activeRT.Context()))
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		status := activeRT.GetReplicationStatus(repl1Name).Status
+		assert.Contains(c, []string{db.ReplicationStateError},
+			status,
+			"replication never reached stopped/error: currently %s", status)
+	}, 20*time.Second, 100*time.Millisecond)
+
+	resp := passiveRT.SendAdminRequest(http.MethodGet,
+		"/{{.keyspace}}/"+docID, "")
+	require.Equal(t, http.StatusNotFound, resp.Code, "expected secret doc to not be pushed")
+
+	// create a replication with the same config but without the run_as field, this should push the doc successfully as admin
+	replConfNoRunAs := fmt.Sprintf(`{
+		 "replication_id": "%s",
+        "remote": "%s/%s",
+        "direction": "push",
+        "continuous": false,
+        "remote_username": "alice",
+        "remote_password": "%s",
+        "collections_enabled": %s
+		}`, repl2Name, publicSrv.URL, passiveRT.GetDatabase().Name, rest.RestTesterDefaultUserPassword, collectionsEnabled)
+
+	configResp = activeRT.SendAdminRequest(http.MethodPut,
+		"/{{.db}}/_replication/"+repl2Name, replConfNoRunAs)
+	rest.RequireStatus(t, configResp, http.StatusCreated)
+
+	activeRT.WaitForReplicationStatus(repl2Name, db.ReplicationStateRunning)
+	// doc should be pushed successfully with the second replication that doesn't have run_as set
+	passiveRT.WaitForVersion(docID, version)
+	activeRT.WaitForReplicationStatus(repl2Name, db.ReplicationStateStopped)
+
+	// purge doc on passive
+	passiveRT.PurgeDoc(docID)
+
+	// now create a replication with the bad run_as user again, but this time don't specific initial state so the replication starts straight away
+	replConf = fmt.Sprintf(`{
+        "replication_id": "%s",
+        "remote": "%s/%s",
+        "direction": "push",
+        "continuous": false,
+        "run_as": "%s",
+        "remote_username": "alice",
+        "remote_password": "%s",
+        "collections_enabled": %s
+    }`, repl3Name, publicSrv.URL, passiveRT.GetDatabase().Name,
+		runAsMissing, rest.RestTesterDefaultUserPassword, collectionsEnabled)
+
+	configResp = activeRT.SendAdminRequest(http.MethodPut,
+		"/{{.db}}/_replication/"+repl3Name, replConf)
+	rest.RequireStatus(t, configResp, http.StatusCreated)
+
+	// assert that the replication doesn't start
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		status := activeRT.GetReplicationStatus(repl3Name).Status
+		assert.Contains(c, []string{db.ReplicationStateError},
+			status,
+			"replication never reached stopped/error: currently %s", status)
+	}, 20*time.Second, 100*time.Millisecond)
+
+	resp = passiveRT.SendAdminRequest(http.MethodGet,
+		"/{{.keyspace}}/"+docID, "")
+	require.Equal(t, http.StatusNotFound, resp.Code, "expected secret doc to not be pushed")
+}


### PR DESCRIPTION
CBG-5302

- Put replicator in error state when defining run as user that doesn't exists. 
- Will error start time not creation time

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/539/ (test flake)
