### PR TITLE
[3.3.5 backport] CBG-5341: add no race to avoid race detection on replator tests

### DIFF
--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -141,6 +141,9 @@ func newActiveReplicatorCommon(ctx context.Context, config *ActiveReplicatorConf
 }
 
 // Start starts the replicator, setting the state to ReplicationStateStarting and starting the status reporter.
+// TODO: CBG-4882 - reconnect() and Start() race on reading/writing ctx
+//
+//go:norace
 func (arc *activeReplicatorCommon) Start(ctx context.Context) error {
 	arc.lock.Lock()
 	defer arc.lock.Unlock()
@@ -241,6 +244,9 @@ func (arc *activeReplicatorCommon) reset() error {
 }
 
 // reconnect asynchronously calls replicatorConnectFn until successful, or times out trying. Retry loop can be stopped by cancelling ctx
+// TODO: CBG-4882 - reconnect() and Start() race on reading/writing ctx
+//
+//go:norace
 func (arc *activeReplicatorCommon) reconnect() {
 	arc.reconnectActive.Set(true)
 	go func() {


### PR DESCRIPTION
CBG-5341

Add to race to Start and reconnect functions to avoid race detection on context read.

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
