### PR TITLE
CBG-5322 flaky test wait for stats

### DIFF
--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -3602,12 +3602,12 @@ func TestTombstoneCount(t *testing.T) {
 
 		deleteVersion := btcRunner.DeleteDoc(client.id, docID1, &docVersion)
 		rt.WaitForTombstone(docID1, deleteVersion)
-		assert.Equal(t, int64(1), rt.GetDatabase().DbStats.DatabaseStats.TombstoneCount.Value())
+		base.RequireWaitForStat(t, rt.GetDatabase().DbStats.DatabaseStats.TombstoneCount.Value, 1)
 
 		const docID2 = "doc2"
 		version := rt.CreateTestDoc(docID2)
 		rt.DeleteDoc(docID2, version)
-		assert.Equal(t, int64(2), rt.GetDatabase().DbStats.DatabaseStats.TombstoneCount.Value())
+		base.RequireWaitForStat(t, rt.GetDatabase().DbStats.DatabaseStats.TombstoneCount.Value, 2)
 	})
 
 }


### PR DESCRIPTION
The TombstoneCount stat is updated only after the document is written to the bucket so there can be a short race condition when document exists in the bucket but before stat is incremented.
