### PR TITLE
CBG-5321: TestDeltaGenerationWithBypassRevCache test flake

### DIFF
--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -1260,6 +1260,7 @@ func TestBlipDeltaComputationFromBackupRev(t *testing.T) {
 
 // TestDeltaGenerationWithBypassRevCache tests that delta generation works when the rev cache is bypassed.
 func TestDeltaGenerationWithBypassRevCache(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeySync)
 	if !base.IsEnterpriseEdition() {
 		t.Skip("Delta test requires EE")
 	}

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -1260,7 +1260,6 @@ func TestBlipDeltaComputationFromBackupRev(t *testing.T) {
 
 // TestDeltaGenerationWithBypassRevCache tests that delta generation works when the rev cache is bypassed.
 func TestDeltaGenerationWithBypassRevCache(t *testing.T) {
-	//base.SetUpTestLogging(t, base.LevelDebug, base.KeySync)
 	if !base.IsEnterpriseEdition() {
 		t.Skip("Delta test requires EE")
 	}

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -1260,7 +1260,7 @@ func TestBlipDeltaComputationFromBackupRev(t *testing.T) {
 
 // TestDeltaGenerationWithBypassRevCache tests that delta generation works when the rev cache is bypassed.
 func TestDeltaGenerationWithBypassRevCache(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeySync)
+	//base.SetUpTestLogging(t, base.LevelDebug, base.KeySync)
 	if !base.IsEnterpriseEdition() {
 		t.Skip("Delta test requires EE")
 	}
@@ -1305,7 +1305,9 @@ func TestDeltaGenerationWithBypassRevCache(t *testing.T) {
 		// code will go though bypass revision cache interface, delta will be generated from backup rev
 		btcRunner.WaitForVersion(client.id, docID, version2)
 		// assert rev sent as delta
-		assert.Equal(t, int64(1), rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value())
+		base.RequireWaitForStat(t, func() int64 {
+			return rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
+		}, 1)
 	})
 }
 


### PR DESCRIPTION
CBG-5321

Add wait for stat for send delta stat. We increment the stat after the delta is sent so small race condition where test client can get the delta revision before we increment stat. 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/541/ (ran 100 times)
