### PR TITLE
CBG-5180 add a multi node mode to BackgroundManager

### DIFF
--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -437,7 +437,7 @@ func TestAttachmentCompactionRunTwice(t *testing.T) {
 		}
 		if triggerStopCallback {
 			triggerStopCallback = false
-			err = testDB2.AttachmentCompactionManager.Stop()
+			err = testDB2.AttachmentCompactionManager.Stop(ctx2)
 			assert.NoError(t, err)
 		}
 		return nil
@@ -583,7 +583,7 @@ func TestAttachmentCompactionStopImmediateStart(t *testing.T) {
 		}
 		if triggerStopCallback {
 			triggerStopCallback = false
-			err = testDB2.AttachmentCompactionManager.Stop()
+			err = testDB2.AttachmentCompactionManager.Stop(ctx2)
 			assert.NoError(t, err)
 		}
 		return nil

--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -41,7 +41,7 @@ const (
 
 // errBackgroundManagerAlreadyStopping is returned when a Start or Stop is called while the process is in the Stopping
 // state.
-var errBackgroundManagerAlreadyStopping = base.HTTPErrorf(http.StatusServiceUnavailable, "Process currently stopping. Wait until stopped to retry")
+var errBackgroundManagerStatusAlreadyStopping = base.HTTPErrorf(http.StatusServiceUnavailable, "Process currently stopping. Wait until stopped to retry")
 
 // errBackgroundManagerStatusNotRunning is returned when the bucket status is not running but the local status is.
 var errBackgroundManagerStatusNotRunning = errors.New("status in bucket is not running, but local status is, avoiding overwriting local status to bucket")
@@ -82,7 +82,7 @@ type ClusterAwareBackgroundManagerOptions struct {
 	metadataStore base.DataStore
 	metaKeys      *base.MetadataKeys
 	processSuffix string
-	MultiNode     bool // If true, the background manager is expected to run on all nodes of a Sync Gateway cluster.
+	multiNode     bool // If true, the background manager is expected to run on all nodes of a Sync Gateway cluster.
 
 	lastSuccessfulHeartbeatUnix base.AtomicInt
 }
@@ -269,7 +269,7 @@ func (b *BackgroundManager) markStart(ctx context.Context) error {
 
 	if b.mode() == backgroundManagerModeMultiNode {
 		if b.clusterStateIs(ctx, BackgroundProcessStateStopping) {
-			return errBackgroundManagerAlreadyStopping
+			return errBackgroundManagerStatusAlreadyStopping
 		}
 	}
 
@@ -278,7 +278,7 @@ func (b *BackgroundManager) markStart(ctx context.Context) error {
 	}
 
 	if b.GetRunState() == BackgroundProcessStateStopping {
-		return errBackgroundManagerAlreadyStopping
+		return errBackgroundManagerStatusAlreadyStopping
 	}
 
 	// Now we know that we're the only running process we should instantiate these values
@@ -378,6 +378,8 @@ func (b *BackgroundManager) getStatusFromCluster(ctx context.Context) ([]byte, e
 		return nil, err
 	}
 
+	// In multi node mode, there is no heartbeat document. Each time a node comes online, it is expected to resume the
+	// background process.
 	if b.mode() == backgroundManagerModeMultiNode {
 		return status, nil
 	}
@@ -444,21 +446,13 @@ func (b *BackgroundManager) clearLastErrorMessage() {
 //
 // This will return an error if the status is not in a running state, as already stopped or stopping.
 func (b *BackgroundManager) Stop(ctx context.Context) error {
-	if err := b.markStop(); err != nil {
-		if errors.Is(err, errBackgroundManagerProcessAlreadyStopped) || errors.Is(err, errBackgroundManagerAlreadyStopping) {
+	if err := b.markStop(ctx); err != nil {
+		if errors.Is(err, errBackgroundManagerProcessAlreadyStopped) || errors.Is(err, errBackgroundManagerStatusAlreadyStopping) {
 			return nil
 		}
 		return err
 	}
-
-	if b.mode() == backgroundManagerModeMultiNode {
-		err := b.UpdateStatusClusterAware(ctx)
-		if err != nil {
-			base.WarnfCtx(ctx, "Failed to update cluster status to stopping: %v", err)
-		}
-	}
-
-	b.Terminate()
+	b.stopProcess(ctx)
 	return nil
 }
 
@@ -469,10 +463,11 @@ func (b *BackgroundManager) Terminate() {
 	b.backgroundManagerStatusUpdateWaitGroup.Wait()
 }
 
-func (b *BackgroundManager) markStop() error {
+func (b *BackgroundManager) markStop(ctx context.Context) error {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
+	currentState := b.GetRunState()
 	if b.mode() == backgroundManagerModeSingleNode {
 		_, _, err := b.clusterAwareOptions.metadataStore.GetRaw(b.clusterAwareOptions.HeartbeatDocID())
 		if err != nil {
@@ -488,22 +483,21 @@ func (b *BackgroundManager) markStop() error {
 		}
 
 		// If this is the node running the service
-		if b.GetRunState() == BackgroundProcessStateRunning {
+		if currentState == BackgroundProcessStateRunning {
 			b.setRunState(BackgroundProcessStateStopping)
 		}
 
 		return nil
 	}
 
-	if b.GetRunState() == BackgroundProcessStateStopping {
-		return errBackgroundManagerAlreadyStopping
+	if currentState == BackgroundProcessStateStopping {
+		return errBackgroundManagerStatusAlreadyStopping
 	}
 
-	if b.GetRunState() == BackgroundProcessStateCompleted || b.GetRunState() == BackgroundProcessStateStopped || b.GetRunState() == BackgroundProcessStateError {
+	if slices.Contains([]BackgroundProcessState{BackgroundProcessStateCompleted, BackgroundProcessStateStopped, BackgroundProcessStateError}, currentState) {
 		return errBackgroundManagerProcessAlreadyStopped
 	}
 
-	b.setRunState(BackgroundProcessStateStopping)
 	return nil
 }
 
@@ -671,16 +665,14 @@ func (b *BackgroundManager) startPollingMultiNodeStatus(ctx context.Context, ter
 	for {
 		select {
 		case <-ticker.C:
-			triggerStop, err := b.watchStatusDocMultiNode(ctx)
+			err := b.updateMultiNodeClusterAwareStatus(ctx)
 			if err != nil {
-				base.WarnfCtx(ctx, "Failed to watch poll status doc: %v, will retry", err)
-			}
-			if triggerStop {
-				continue
-			}
-			err = b.updateMultiNodeClusterAwareStatus(ctx)
-			if err != nil && !errors.Is(err, errBackgroundManagerStatusNotRunning) {
-				base.DebugfCtx(ctx, base.KeyAll, "Failed to update multi node cluster aware status: %v, will retry", err)
+				if errors.Is(err, errBackgroundManagerStatusNotRunning) {
+					b.stopProcess(ctx)
+					return
+				} else {
+					base.DebugfCtx(ctx, base.KeyAll, "Failed to update multi node cluster aware status: %v, will retry", err)
+				}
 			}
 		case <-terminator.Done():
 			ticker.Stop()
@@ -689,24 +681,19 @@ func (b *BackgroundManager) startPollingMultiNodeStatus(ctx context.Context, ter
 	}
 }
 
-// watchMultiNodeStatus polls the status document in the bucket. If another instance has stopped the process,
-// or it encounter a fatal error, then this node should stop.
-func (b *BackgroundManager) watchStatusDocMultiNode(ctx context.Context) (bool, error) {
-	state, err := b.getClusterStatusState(ctx)
-	if err != nil {
-		if base.IsDocNotFoundError(err) {
-			return false, nil
+// stopProcess terminates the locally running process.
+func (b *BackgroundManager) stopProcess(ctx context.Context) {
+	b.setRunState(BackgroundProcessStateStopping)
+	b.terminator.Close()
+
+	// Update the status to stopping for a multi node system indicating to other nodes to stop
+	if b.mode() == backgroundManagerModeMultiNode {
+		err := b.UpdateStatusClusterAware(ctx)
+		if err != nil {
+			base.WarnfCtx(ctx, "Failed to update cluster status to stopping: %v", err)
 		}
-		return false, err
 	}
 
-	if slices.Contains([]BackgroundProcessState{BackgroundProcessStateStopping, BackgroundProcessStateStopped, BackgroundProcessStateCompleted, BackgroundProcessStateError}, state) && b.GetRunState() == BackgroundProcessStateRunning {
-		_ = b.markStop()
-		b.terminator.Close()
-		return true, nil
-	}
-
-	return false, nil
 }
 
 // backgroundManagerMode defines the types of BackgroundManager that can run.
@@ -726,7 +713,7 @@ func (b *BackgroundManager) mode() backgroundManagerMode {
 	if b.clusterAwareOptions == nil {
 		return backgroundManagerModeLocal
 	}
-	if b.clusterAwareOptions.MultiNode {
+	if b.clusterAwareOptions.multiNode {
 		return backgroundManagerModeMultiNode
 	}
 	return backgroundManagerModeSingleNode

--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -147,7 +147,7 @@ func (b *BackgroundManager) Start(ctx context.Context, options map[string]any) e
 
 		err := base.JSONUnmarshal(processClusterStatus, &clusterStatus)
 		if err != nil {
-			base.InfofCtx(ctx, base.KeyAll, "Could not get the cluster status before calling BackgroundManager.Run %v", err)
+			base.InfofCtx(ctx, base.KeyAll, "Could not unmarshal the cluster status before calling BackgroundManager.Run %v", err)
 		}
 		if clusterStatus.Status.State == BackgroundProcessStateRunning && !clusterStatus.Status.StartTime.IsZero() {
 			b.setStartTime(clusterStatus.Status.StartTime)

--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -45,6 +45,10 @@ var errBackgroundManagerAlreadyStopping = base.HTTPErrorf(http.StatusServiceUnav
 
 var errBackgroundManagerStatusNotRunning = errors.New("status in bucket is not running, but local status is, avoiding overwriting local status to bucket")
 
+var errBackgroundManagerProcessAlreadyRunning = base.HTTPErrorf(http.StatusServiceUnavailable, "Process already running")
+
+var errBackgroundManagerProcessAlreadyStopped = base.HTTPErrorf(http.StatusServiceUnavailable, "Process already stopped")
+
 type BackgroundProcessAction string
 
 const (
@@ -115,6 +119,9 @@ func (b *BackgroundManager) GetName() string {
 func (b *BackgroundManager) Start(ctx context.Context, options map[string]any) error {
 	err := b.markStart(ctx)
 	if err != nil {
+		if b.mode() == backgroundManagerModeMultiNode && errors.Is(err, errBackgroundManagerProcessAlreadyRunning) {
+			return nil
+		}
 		return err
 	}
 
@@ -218,8 +225,6 @@ func (b *BackgroundManager) markStart(ctx context.Context) error {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
-	processAlreadyRunningErr := base.HTTPErrorf(http.StatusServiceUnavailable, "Process already running")
-
 	// If we're running in cluster aware 'mode' base the check off of a heartbeat doc
 	if b.mode() == backgroundManagerModeSingleNode {
 		_, err := b.clusterAwareOptions.metadataStore.WriteCas(b.clusterAwareOptions.HeartbeatDocID(), BackgroundManagerHeartbeatExpirySecs, 0, []byte("{}"), sgbucket.Raw)
@@ -230,7 +235,7 @@ func (b *BackgroundManager) markStart(ctx context.Context) error {
 			if err == nil && status.ShouldStop {
 				return base.HTTPErrorf(http.StatusServiceUnavailable, "Process stop still in progress - please wait before restarting")
 			}
-			return processAlreadyRunningErr
+			return errBackgroundManagerProcessAlreadyRunning
 		}
 
 		// Now we know that we're the only running process we should instantiate these values
@@ -257,17 +262,15 @@ func (b *BackgroundManager) markStart(ctx context.Context) error {
 		b.setRunState(BackgroundProcessStateRunning)
 		return nil
 	}
-	if b.mode() == backgroundManagerModeLocal && b.GetRunState() == BackgroundProcessStateRunning {
-		return processAlreadyRunningErr
-	}
 
 	if b.mode() == backgroundManagerModeMultiNode {
 		if b.clusterStateIs(ctx, BackgroundProcessStateStopping) {
 			return errBackgroundManagerAlreadyStopping
 		}
-		if b.GetRunState() == BackgroundProcessStateRunning {
-			return nil
-		}
+	}
+
+	if b.GetRunState() == BackgroundProcessStateRunning {
+		return errBackgroundManagerProcessAlreadyRunning
 	}
 
 	if b.GetRunState() == BackgroundProcessStateStopping {
@@ -431,6 +434,9 @@ func (b *BackgroundManager) setLastErrorMessage(msg string) {
 
 func (b *BackgroundManager) Stop(ctx context.Context) error {
 	if err := b.markStop(); err != nil {
+		if errors.Is(err, errBackgroundManagerProcessAlreadyStopped) || errors.Is(err, errBackgroundManagerAlreadyStopping) {
+			return nil
+		}
 		return err
 	}
 
@@ -454,7 +460,6 @@ func (b *BackgroundManager) Terminate() {
 }
 
 func (b *BackgroundManager) markStop() error {
-	processAlreadyStoppedErr := base.HTTPErrorf(http.StatusServiceUnavailable, "Process already stopped")
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
@@ -462,7 +467,7 @@ func (b *BackgroundManager) markStop() error {
 		_, _, err := b.clusterAwareOptions.metadataStore.GetRaw(b.clusterAwareOptions.HeartbeatDocID())
 		if err != nil {
 			if base.IsDocNotFoundError(err) {
-				return processAlreadyStoppedErr
+				return errBackgroundManagerProcessAlreadyStopped
 			}
 			return base.HTTPErrorf(http.StatusInternalServerError, "Unable to verify whether a process is running: %v", err)
 		}
@@ -485,7 +490,7 @@ func (b *BackgroundManager) markStop() error {
 	}
 
 	if b.GetRunState() == BackgroundProcessStateCompleted || b.GetRunState() == BackgroundProcessStateStopped || b.GetRunState() == BackgroundProcessStateError {
-		return processAlreadyStoppedErr
+		return errBackgroundManagerProcessAlreadyStopped
 	}
 
 	b.setRunState(BackgroundProcessStateStopping)
@@ -583,7 +588,7 @@ func (b *BackgroundManager) updateMultiNodeClusterAwareStatus(ctx context.Contex
 				if err != nil {
 					return nil, nil, false, err
 				}
-				if slices.Contains([]BackgroundProcessState{BackgroundProcessStateCompleted, BackgroundProcessStateStopping, BackgroundProcessStateError}, bucketState) && b.GetRunState() == BackgroundProcessStateRunning {
+				if slices.Contains([]BackgroundProcessState{BackgroundProcessStateCompleted, BackgroundProcessStateStopping, BackgroundProcessStateStopped, BackgroundProcessStateError}, bucketState) && b.GetRunState() == BackgroundProcessStateRunning {
 					return nil, nil, false, errBackgroundManagerStatusNotRunning
 				}
 			}

--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -43,6 +43,8 @@ const (
 // state.
 var errBackgroundManagerAlreadyStopping = base.HTTPErrorf(http.StatusServiceUnavailable, "Process currently stopping. Wait until stopped to retry")
 
+var errBackgroundManagerStatusNotRunning = errors.New("status in bucket is not running, but local status is, avoiding overwriting local status to bucket")
+
 type BackgroundProcessAction string
 
 const (
@@ -427,16 +429,16 @@ func (b *BackgroundManager) setLastErrorMessage(msg string) {
 	b.status.LastErrorMessage = msg
 }
 
-func (b *BackgroundManager) Stop() error {
+func (b *BackgroundManager) Stop(ctx context.Context) error {
 	if err := b.markStop(); err != nil {
 		return err
 	}
 
 	if b.mode() == backgroundManagerModeMultiNode {
 		// Use a detached context for status update as the original context might be cancelled
-		err := b.UpdateStatusClusterAware(context.Background())
+		err := b.UpdateStatusClusterAware(ctx)
 		if err != nil {
-			base.WarnfCtx(context.Background(), "Failed to update cluster status to stopping: %v", err)
+			base.WarnfCtx(ctx, "Failed to update cluster status to stopping: %v", err)
 		}
 	}
 
@@ -565,7 +567,6 @@ func (b *BackgroundManager) UpdateSingleNodeClusterAwareStatus(ctx context.Conte
 
 // updateMultiNodeClusterAwareStatus updates the cluster status document with the current local status. If the bucket status is in a stopping / stopped / completed / error state but the local status is running, then this method will not update the bucket status and instead return. The caller is responsible for taking appropriate action.
 func (b *BackgroundManager) updateMultiNodeClusterAwareStatus(ctx context.Context) error {
-	errStatusNotRunning := errors.New("status in bucket is running, local status is not")
 	docID := b.clusterAwareOptions.StatusDocID()
 	_, err := b.clusterAwareOptions.metadataStore.Update(docID, 0, func(current []byte) ([]byte, *uint32, bool, error) {
 		status, metadata, err := b.getStatusLocal()
@@ -583,7 +584,7 @@ func (b *BackgroundManager) updateMultiNodeClusterAwareStatus(ctx context.Contex
 					return nil, nil, false, err
 				}
 				if slices.Contains([]BackgroundProcessState{BackgroundProcessStateCompleted, BackgroundProcessStateStopping, BackgroundProcessStateError}, bucketState) && b.GetRunState() == BackgroundProcessStateRunning {
-					return nil, nil, false, errStatusNotRunning
+					return nil, nil, false, errBackgroundManagerStatusNotRunning
 				}
 			}
 		}
@@ -631,7 +632,7 @@ func (b *BackgroundManager) UpdateHeartbeatDocClusterAware(ctx context.Context) 
 	}
 
 	if status.ShouldStop {
-		err = b.Stop()
+		err = b.Stop(ctx)
 		if err != nil {
 			base.WarnfCtx(ctx, "Failed to stop process %q: %v", b.clusterAwareOptions.processSuffix, err)
 		}
@@ -654,7 +655,7 @@ func (b *BackgroundManager) startPollingMultiNodeStatus(ctx context.Context, ter
 				continue
 			}
 			err = b.updateMultiNodeClusterAwareStatus(ctx)
-			if err != nil {
+			if err != nil && !errors.Is(err, errBackgroundManagerStatusNotRunning) {
 				base.DebugfCtx(ctx, base.KeyAll, "Failed to update multi node cluster aware status: %v, will retry", err)
 			}
 		case <-terminator.Done():

--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -483,9 +483,7 @@ func (b *BackgroundManager) markStop(ctx context.Context) error {
 		}
 
 		// If this is the node running the service
-		if currentState == BackgroundProcessStateRunning {
-			b.setRunState(BackgroundProcessStateStopping)
-		}
+		b.compareAndSwapRunState(BackgroundProcessStateRunning, BackgroundProcessStateStopping)
 
 		return nil
 	}
@@ -497,6 +495,7 @@ func (b *BackgroundManager) markStop(ctx context.Context) error {
 	if slices.Contains([]BackgroundProcessState{BackgroundProcessStateCompleted, BackgroundProcessStateStopped, BackgroundProcessStateError}, currentState) {
 		return errBackgroundManagerProcessAlreadyStopped
 	}
+	b.setRunState(BackgroundProcessStateStopping)
 
 	return nil
 }
@@ -683,10 +682,11 @@ func (b *BackgroundManager) startPollingMultiNodeStatus(ctx context.Context, ter
 
 // stopProcess terminates the locally running process.
 func (b *BackgroundManager) stopProcess(ctx context.Context) {
-	b.setRunState(BackgroundProcessStateStopping)
 	b.terminator.Close()
+	b.compareAndSwapRunState(BackgroundProcessStateRunning, BackgroundProcessStateStopping)
 
-	// Update the status to stopping for a multi node system indicating to other nodes to stop
+	// Update the status to stopping for a multi node system. This was already updated in markStop for a single node
+	// process.
 	if b.mode() == backgroundManagerModeMultiNode {
 		err := b.UpdateStatusClusterAware(ctx)
 		if err != nil {
@@ -694,6 +694,15 @@ func (b *BackgroundManager) stopProcess(ctx context.Context) {
 		}
 	}
 
+}
+
+// compareAndSwapRunState does a compare and swap on the run state. If the existing state does not match the old state then no update occurs.
+func (b *BackgroundManager) compareAndSwapRunState(oldState BackgroundProcessState, newState BackgroundProcessState) {
+	b.statusLock.Lock()
+	defer b.statusLock.Unlock()
+	if b.status.State == oldState {
+		b.status.State = newState
+	}
 }
 
 // backgroundManagerMode defines the types of BackgroundManager that can run.

--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -52,7 +52,8 @@ const (
 
 // BackgroundManager this is the over-arching type which is exposed in DatabaseContext
 type BackgroundManager struct {
-	BackgroundManagerStatus
+	status                                 BackgroundManagerStatus
+	statusLock                             sync.RWMutex
 	name                                   string
 	lastError                              error
 	terminator                             *base.SafeTerminator
@@ -124,7 +125,7 @@ func (b *BackgroundManager) Start(ctx context.Context, options map[string]any) e
 	}
 
 	b.resetStatus()
-	b.StartTime = time.Now().UTC()
+	b.setStartTime(time.Now().UTC())
 
 	// If we're resuming a cluster-aware process, try to reuse the previous start time
 	if processClusterStatus != nil {
@@ -135,7 +136,7 @@ func (b *BackgroundManager) Start(ctx context.Context, options map[string]any) e
 		}
 		if err := base.JSONUnmarshal(processClusterStatus, &clusterStatus); err == nil {
 			if !clusterStatus.Status.StartTime.IsZero() {
-				b.StartTime = clusterStatus.Status.StartTime
+				b.setStartTime(clusterStatus.Status.StartTime)
 			}
 		}
 	}
@@ -179,13 +180,13 @@ func (b *BackgroundManager) Start(ctx context.Context, options map[string]any) e
 
 		b.Terminate()
 
-		b.lock.Lock()
-		if b.State == BackgroundProcessStateStopping {
-			b.State = BackgroundProcessStateStopped
-		} else if b.State != BackgroundProcessStateError {
-			b.State = BackgroundProcessStateCompleted
+		b.statusLock.Lock()
+		if b.status.State == BackgroundProcessStateStopping {
+			b.status.State = BackgroundProcessStateStopped
+		} else if b.status.State != BackgroundProcessStateError {
+			b.status.State = BackgroundProcessStateCompleted
 		}
-		b.lock.Unlock()
+		b.statusLock.Unlock()
 
 		// Once our background process run has completed we should update the completed status and delete the heartbeat
 		// doc
@@ -251,10 +252,10 @@ func (b *BackgroundManager) markStart(ctx context.Context) error {
 			}
 		}(b.terminator)
 
-		b.State = BackgroundProcessStateRunning
+		b.setRunState(BackgroundProcessStateRunning)
 		return nil
 	}
-	if b.mode() == backgroundManagerModeLocal && b.State == BackgroundProcessStateRunning {
+	if b.mode() == backgroundManagerModeLocal && b.GetRunState() == BackgroundProcessStateRunning {
 		return processAlreadyRunningErr
 	}
 
@@ -262,19 +263,19 @@ func (b *BackgroundManager) markStart(ctx context.Context) error {
 		if b.clusterStateIs(ctx, BackgroundProcessStateStopping) {
 			return errBackgroundManagerAlreadyStopping
 		}
-		if b.State == BackgroundProcessStateRunning {
+		if b.GetRunState() == BackgroundProcessStateRunning {
 			return nil
 		}
 	}
 
-	if b.State == BackgroundProcessStateStopping {
+	if b.GetRunState() == BackgroundProcessStateStopping {
 		return errBackgroundManagerAlreadyStopping
 	}
 
 	// Now we know that we're the only running process we should instantiate these values
 	b.terminator = base.NewSafeTerminator()
 
-	b.State = BackgroundProcessStateRunning
+	b.setRunState(BackgroundProcessStateRunning)
 	return nil
 }
 
@@ -336,10 +337,10 @@ func (b *BackgroundManager) GetStatus(ctx context.Context) ([]byte, error) {
 }
 
 func (b *BackgroundManager) getStatusLocal() ([]byte, []byte, error) {
-	b.lock.Lock()
-	defer b.lock.Unlock()
+	b.statusLock.Lock()
+	defer b.statusLock.Unlock()
 
-	backgroundStatus := b.BackgroundManagerStatus
+	backgroundStatus := b.status
 	if string(backgroundStatus.State) == "" {
 		backgroundStatus.State = BackgroundProcessStateCompleted
 	}
@@ -416,8 +417,14 @@ func (b *BackgroundManager) resetStatus() {
 	defer b.lock.Unlock()
 
 	b.lastError = nil
-	b.LastErrorMessage = ""
+	b.setLastErrorMessage("")
 	b.Process.ResetStatus()
+}
+
+func (b *BackgroundManager) setLastErrorMessage(msg string) {
+	b.statusLock.Lock()
+	defer b.statusLock.Unlock()
+	b.status.LastErrorMessage = msg
 }
 
 func (b *BackgroundManager) Stop() error {
@@ -464,29 +471,47 @@ func (b *BackgroundManager) markStop() error {
 		}
 
 		// If this is the node running the service
-		if b.State == BackgroundProcessStateRunning {
-			b.State = BackgroundProcessStateStopping
+		if b.GetRunState() == BackgroundProcessStateRunning {
+			b.setRunState(BackgroundProcessStateStopping)
 		}
 
 		return nil
 	}
 
-	if b.State == BackgroundProcessStateStopping {
+	if b.GetRunState() == BackgroundProcessStateStopping {
 		return errBackgroundManagerAlreadyStopping
 	}
 
-	if b.State == BackgroundProcessStateCompleted || b.State == BackgroundProcessStateStopped || b.State == BackgroundProcessStateError {
+	if b.GetRunState() == BackgroundProcessStateCompleted || b.GetRunState() == BackgroundProcessStateStopped || b.GetRunState() == BackgroundProcessStateError {
 		return processAlreadyStoppedErr
 	}
 
-	b.State = BackgroundProcessStateStopping
+	b.setRunState(BackgroundProcessStateStopping)
 	return nil
 }
 
 func (b *BackgroundManager) GetRunState() BackgroundProcessState {
-	b.lock.Lock()
-	defer b.lock.Unlock()
-	return b.State
+	b.statusLock.Lock()
+	defer b.statusLock.Unlock()
+	return b.status.State
+}
+
+func (b *BackgroundManager) setRunState(state BackgroundProcessState) {
+	b.statusLock.Lock()
+	defer b.statusLock.Unlock()
+	b.status.State = state
+}
+
+func (b *BackgroundManager) getStartTime() time.Time {
+	b.statusLock.Lock()
+	defer b.statusLock.Unlock()
+	return b.status.StartTime
+}
+
+func (b *BackgroundManager) setStartTime(startTime time.Time) {
+	b.statusLock.Lock()
+	defer b.statusLock.Unlock()
+	b.status.StartTime = startTime
 }
 
 func (b *BackgroundManager) SetError(err error) {
@@ -494,7 +519,7 @@ func (b *BackgroundManager) SetError(err error) {
 	defer b.lock.Unlock()
 
 	b.lastError = err
-	b.State = BackgroundProcessStateError
+	b.setRunState(BackgroundProcessStateError)
 	b.Terminate()
 }
 
@@ -557,7 +582,7 @@ func (b *BackgroundManager) updateMultiNodeClusterAwareStatus(ctx context.Contex
 				if err != nil {
 					return nil, nil, false, err
 				}
-				if slices.Contains([]BackgroundProcessState{BackgroundProcessStateCompleted, BackgroundProcessStateStopping, BackgroundProcessStateError}, bucketState) && b.State == BackgroundProcessStateRunning {
+				if slices.Contains([]BackgroundProcessState{BackgroundProcessStateCompleted, BackgroundProcessStateStopping, BackgroundProcessStateError}, bucketState) && b.GetRunState() == BackgroundProcessStateRunning {
 					return nil, nil, false, errStatusNotRunning
 				}
 			}
@@ -650,7 +675,7 @@ func (b *BackgroundManager) watchStatusDocMultiNode(ctx context.Context) (bool, 
 		return false, err
 	}
 
-	if slices.Contains([]BackgroundProcessState{BackgroundProcessStateStopping, BackgroundProcessStateStopped, BackgroundProcessStateCompleted, BackgroundProcessStateError}, state) && b.State == BackgroundProcessStateRunning {
+	if slices.Contains([]BackgroundProcessState{BackgroundProcessStateStopping, BackgroundProcessStateStopped, BackgroundProcessStateCompleted, BackgroundProcessStateError}, state) && b.GetRunState() == BackgroundProcessStateRunning {
 		_ = b.markStop()
 		b.terminator.Close()
 		return true, nil

--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -142,14 +142,15 @@ func (b *BackgroundManager) Start(ctx context.Context, options map[string]any) e
 	// If we're resuming a cluster-aware process, try to reuse the previous start time
 	if processClusterStatus != nil {
 		var clusterStatus struct {
-			Status struct {
-				StartTime time.Time `json:"start_time"`
-			} `json:"status"`
+			Status BackgroundManagerStatus `json:"status"`
 		}
-		if err := base.JSONUnmarshal(processClusterStatus, &clusterStatus); err == nil {
-			if !clusterStatus.Status.StartTime.IsZero() {
-				b.setStartTime(clusterStatus.Status.StartTime)
-			}
+
+		err := base.JSONUnmarshal(processClusterStatus, &clusterStatus)
+		if err != nil {
+			base.InfofCtx(ctx, base.KeyAll, "Could not get the cluster status before calling BackgroundManager.Run %v", err)
+		}
+		if clusterStatus.Status.State == BackgroundProcessStateRunning && !clusterStatus.Status.StartTime.IsZero() {
+			b.setStartTime(clusterStatus.Status.StartTime)
 		}
 	}
 

--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -43,10 +43,13 @@ const (
 // state.
 var errBackgroundManagerAlreadyStopping = base.HTTPErrorf(http.StatusServiceUnavailable, "Process currently stopping. Wait until stopped to retry")
 
+// errBackgroundManagerStatusNotRunning is returned when the bucket status is not running but the local status is.
 var errBackgroundManagerStatusNotRunning = errors.New("status in bucket is not running, but local status is, avoiding overwriting local status to bucket")
 
+// errBackgroundManagerProcessAlreadyRunning is returned when an action to Start a process occurs but it is already running.
 var errBackgroundManagerProcessAlreadyRunning = base.HTTPErrorf(http.StatusServiceUnavailable, "Process already running")
 
+// errBackgroundManagerProcessAlreadyStopped is returned when an action to Stop a process occurs but it is already stopped.
 var errBackgroundManagerProcessAlreadyStopped = base.HTTPErrorf(http.StatusServiceUnavailable, "Process already stopped")
 
 type BackgroundProcessAction string
@@ -79,7 +82,7 @@ type ClusterAwareBackgroundManagerOptions struct {
 	metadataStore base.DataStore
 	metaKeys      *base.MetadataKeys
 	processSuffix string
-	MultiNode     bool
+	MultiNode     bool // If true, the background manager is expected to run on all nodes of a Sync Gateway cluster.
 
 	lastSuccessfulHeartbeatUnix base.AtomicInt
 }
@@ -310,6 +313,8 @@ func (b *BackgroundManager) getClusterStatusState(ctx context.Context) (Backgrou
 	return state, nil
 
 }
+
+// getBackgroundManagerState returns the getBackgroundManagerState from raw bytes of the status document.
 func getBackgroundManagerState(statusRaw []byte) (BackgroundProcessState, error) {
 	var clusterStatus struct {
 		Status BackgroundProcessState `json:"status"`
@@ -422,16 +427,21 @@ func (b *BackgroundManager) resetStatus() {
 	defer b.lock.Unlock()
 
 	b.lastError = nil
-	b.setLastErrorMessage("")
+	b.clearLastErrorMessage()
 	b.Process.ResetStatus()
 }
 
-func (b *BackgroundManager) setLastErrorMessage(msg string) {
+// setLastErrorMessage sets the last error message
+func (b *BackgroundManager) clearLastErrorMessage() {
 	b.statusLock.Lock()
 	defer b.statusLock.Unlock()
-	b.status.LastErrorMessage = msg
+	b.status.LastErrorMessage = ""
 }
 
+// Stop triggers a Stop of the background process. This will transition the state to BackgroundProcessStateStopping and
+// return from this function.
+//
+// This will return an error if the status is not in a running state, as already stopped or stopping.
 func (b *BackgroundManager) Stop(ctx context.Context) error {
 	if err := b.markStop(); err != nil {
 		if errors.Is(err, errBackgroundManagerProcessAlreadyStopped) || errors.Is(err, errBackgroundManagerAlreadyStopping) {
@@ -497,30 +507,35 @@ func (b *BackgroundManager) markStop() error {
 	return nil
 }
 
+// GetRunState returns the in memory state of the background process. This may different from the serialized bucket state.
 func (b *BackgroundManager) GetRunState() BackgroundProcessState {
 	b.statusLock.Lock()
 	defer b.statusLock.Unlock()
 	return b.status.State
 }
 
+// setRunState sets the in memory state of the background process. This does not updated the serialized bucket state.
 func (b *BackgroundManager) setRunState(state BackgroundProcessState) {
 	b.statusLock.Lock()
 	defer b.statusLock.Unlock()
 	b.status.State = state
 }
 
+// getStartTime returns the current start time of the background process from an in memory value. This may be different from the seraialized start time. If no start time is present, returns nil time.Time.
 func (b *BackgroundManager) getStartTime() time.Time {
 	b.statusLock.Lock()
 	defer b.statusLock.Unlock()
 	return b.status.StartTime
 }
 
+// setStartTime sets the start time of the background process to an in memory value. This does not update the serialized bucket state.
 func (b *BackgroundManager) setStartTime(startTime time.Time) {
 	b.statusLock.Lock()
 	defer b.statusLock.Unlock()
 	b.status.StartTime = startTime
 }
 
+// SetError sets the last known error, transitions the state to BackgroundManagerStateError and terminates the process.
 func (b *BackgroundManager) SetError(err error) {
 	b.lock.Lock()
 	defer b.lock.Unlock()
@@ -530,6 +545,7 @@ func (b *BackgroundManager) SetError(err error) {
 	b.Terminate()
 }
 
+// UpdateStatusClusterAware reads the local status and writes that value to the bucket. This will update the "status" and "meta" keys of the status document.
 func (b *BackgroundManager) UpdateStatusClusterAware(ctx context.Context) error {
 	switch b.mode() {
 	case backgroundManagerModeSingleNode:
@@ -647,6 +663,9 @@ func (b *BackgroundManager) UpdateHeartbeatDocClusterAware(ctx context.Context) 
 	return nil
 }
 
+// startPollingMultiNodeStatus starts a loop which polls the status document for changes. If the status document
+// indicates that the process should stop, then this will trigger a stop of the local process. This is used for
+// multi-node cluster aware background managers where we want all nodes to stop if any node triggers a stop.
 func (b *BackgroundManager) startPollingMultiNodeStatus(ctx context.Context, terminator *base.SafeTerminator) {
 	ticker := time.NewTicker(BackgroundManagerStatusUpdateIntervalSecs * time.Second)
 	for {
@@ -702,6 +721,7 @@ const (
 	backgroundManagerModeMultiNode
 )
 
+// mode returns the running mode a BackgroundManager.
 func (b *BackgroundManager) mode() backgroundManagerMode {
 	if b.clusterAwareOptions == nil {
 		return backgroundManagerModeLocal

--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -10,7 +10,11 @@ package db
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
+	"slices"
 	"sync"
 	"time"
 
@@ -34,6 +38,10 @@ const (
 	BackgroundProcessStateStopped   BackgroundProcessState = "stopped"
 	BackgroundProcessStateError     BackgroundProcessState = "error"
 )
+
+// errBackgroundManagerAlreadyStopping is returned when a Start or Stop is called while the process is in the Stopping
+// state.
+var errBackgroundManagerAlreadyStopping = base.HTTPErrorf(http.StatusServiceUnavailable, "Process currently stopping. Wait until stopped to retry")
 
 type BackgroundProcessAction string
 
@@ -64,6 +72,7 @@ type ClusterAwareBackgroundManagerOptions struct {
 	metadataStore base.DataStore
 	metaKeys      *base.MetadataKeys
 	processSuffix string
+	MultiNode     bool
 
 	lastSuccessfulHeartbeatUnix base.AtomicInt
 }
@@ -107,7 +116,7 @@ func (b *BackgroundManager) Start(ctx context.Context, options map[string]any) e
 	}
 
 	var processClusterStatus []byte
-	if b.isClusterAware() {
+	if b.mode() != backgroundManagerModeLocal {
 		processClusterStatus, _, err = b.clusterAwareOptions.metadataStore.GetRaw(b.clusterAwareOptions.StatusDocID())
 		if err != nil && !base.IsDocNotFoundError(err) {
 			return pkgerrors.Wrap(err, "Failed to get current process status")
@@ -117,12 +126,26 @@ func (b *BackgroundManager) Start(ctx context.Context, options map[string]any) e
 	b.resetStatus()
 	b.StartTime = time.Now().UTC()
 
+	// If we're resuming a cluster-aware process, try to reuse the previous start time
+	if processClusterStatus != nil {
+		var clusterStatus struct {
+			Status struct {
+				StartTime time.Time `json:"start_time"`
+			} `json:"status"`
+		}
+		if err := base.JSONUnmarshal(processClusterStatus, &clusterStatus); err == nil {
+			if !clusterStatus.Status.StartTime.IsZero() {
+				b.StartTime = clusterStatus.Status.StartTime
+			}
+		}
+	}
+
 	err = b.Process.Init(ctx, options, processClusterStatus)
 	if err != nil {
 		return err
 	}
 
-	if b.isClusterAware() {
+	if b.mode() == backgroundManagerModeSingleNode {
 		b.backgroundManagerStatusUpdateWaitGroup.Add(1)
 		go func(terminator *base.SafeTerminator) {
 			defer b.backgroundManagerStatusUpdateWaitGroup.Done()
@@ -130,7 +153,7 @@ func (b *BackgroundManager) Start(ctx context.Context, options map[string]any) e
 			for {
 				select {
 				case <-ticker.C:
-					err := b.UpdateStatusClusterAware(ctx)
+					err := b.UpdateSingleNodeClusterAwareStatus(ctx)
 					if err != nil {
 						base.WarnfCtx(ctx, "Failed to update background manager status: %v", err)
 					}
@@ -140,8 +163,13 @@ func (b *BackgroundManager) Start(ctx context.Context, options map[string]any) e
 				}
 			}
 		}(b.terminator)
-	}
 
+	}
+	if b.mode() == backgroundManagerModeMultiNode {
+		b.backgroundManagerStatusUpdateWaitGroup.Go(func() {
+			b.startPollingMultiNodeStatus(ctx, b.terminator)
+		})
+	}
 	go func() {
 		err := b.Process.Run(ctx, options, b.UpdateStatusClusterAware, b.terminator)
 		if err != nil {
@@ -161,7 +189,7 @@ func (b *BackgroundManager) Start(ctx context.Context, options map[string]any) e
 
 		// Once our background process run has completed we should update the completed status and delete the heartbeat
 		// doc
-		if b.isClusterAware() {
+		if b.mode() != backgroundManagerModeLocal {
 			err := b.UpdateStatusClusterAware(ctx)
 			if err != nil {
 				base.WarnfCtx(ctx, "Failed to update background manager status: %v", err)
@@ -173,7 +201,7 @@ func (b *BackgroundManager) Start(ctx context.Context, options map[string]any) e
 		}
 	}()
 
-	if b.isClusterAware() {
+	if b.mode() != backgroundManagerModeLocal {
 		err := b.UpdateStatusClusterAware(ctx)
 		if err != nil {
 			base.ErrorfCtx(ctx, "Failed to update background manager status: %v", err)
@@ -190,7 +218,7 @@ func (b *BackgroundManager) markStart(ctx context.Context) error {
 	processAlreadyRunningErr := base.HTTPErrorf(http.StatusServiceUnavailable, "Process already running")
 
 	// If we're running in cluster aware 'mode' base the check off of a heartbeat doc
-	if b.isClusterAware() {
+	if b.mode() == backgroundManagerModeSingleNode {
 		_, err := b.clusterAwareOptions.metadataStore.WriteCas(b.clusterAwareOptions.HeartbeatDocID(), BackgroundManagerHeartbeatExpirySecs, 0, []byte("{}"), sgbucket.Raw)
 		if base.IsCasMismatch(err) {
 			// Check if markStop has been called but not yet processed
@@ -226,14 +254,21 @@ func (b *BackgroundManager) markStart(ctx context.Context) error {
 		b.State = BackgroundProcessStateRunning
 		return nil
 	}
-
-	// If we're not in cluster aware 'mode' rely on local data
-	if b.State == BackgroundProcessStateRunning {
+	if b.mode() == backgroundManagerModeLocal && b.State == BackgroundProcessStateRunning {
 		return processAlreadyRunningErr
 	}
 
+	if b.mode() == backgroundManagerModeMultiNode {
+		if b.clusterStateIs(ctx, BackgroundProcessStateStopping) {
+			return errBackgroundManagerAlreadyStopping
+		}
+		if b.State == BackgroundProcessStateRunning {
+			return nil
+		}
+	}
+
 	if b.State == BackgroundProcessStateStopping {
-		return base.HTTPErrorf(http.StatusServiceUnavailable, "Process currently stopping. Wait until stopped to retry")
+		return errBackgroundManagerAlreadyStopping
 	}
 
 	// Now we know that we're the only running process we should instantiate these values
@@ -243,8 +278,44 @@ func (b *BackgroundManager) markStart(ctx context.Context) error {
 	return nil
 }
 
+// clusterStateIs returns if the state matches the serialized state in the bucket. If the document is not present, it will not match.
+func (b *BackgroundManager) clusterStateIs(ctx context.Context, state BackgroundProcessState) bool {
+	clusterState, err := b.getClusterStatusState(ctx)
+	if err != nil {
+		if !base.IsDocNotFoundError(err) {
+			base.TracefCtx(ctx, base.KeyAll, "Error getting cluster status: %v, assuming no status", err)
+		}
+		return false
+	}
+	return clusterState == state
+}
+
+// getClusterStatusState gets the current background process state of the cluster and its CAS.
+func (b *BackgroundManager) getClusterStatusState(ctx context.Context) (BackgroundProcessState, error) {
+	docID := b.clusterAwareOptions.StatusDocID()
+	statusRaw, _, err := b.clusterAwareOptions.metadataStore.GetSubDocRaw(ctx, docID, "status")
+	if err != nil {
+		return "", err
+	}
+	state, err := getBackgroundManagerState(statusRaw)
+	if err != nil {
+		return "", fmt.Errorf("could not get background manager state from cluster status doc %q: %w", docID, err)
+	}
+	return state, nil
+
+}
+func getBackgroundManagerState(statusRaw []byte) (BackgroundProcessState, error) {
+	var clusterStatus struct {
+		Status BackgroundProcessState `json:"status"`
+	}
+	if err := base.JSONUnmarshal(statusRaw, &clusterStatus); err != nil {
+		return "", err
+	}
+	return clusterStatus.Status, nil
+}
+
 func (b *BackgroundManager) GetStatus(ctx context.Context) ([]byte, error) {
-	if b.isClusterAware() {
+	if b.mode() != backgroundManagerModeLocal {
 		status, err := b.getStatusFromCluster(ctx)
 		if err != nil {
 			return nil, err
@@ -293,6 +364,10 @@ func (b *BackgroundManager) getStatusFromCluster(ctx context.Context) ([]byte, e
 	err = base.JSONUnmarshal(status, &clusterStatus)
 	if err != nil {
 		return nil, err
+	}
+
+	if b.mode() == backgroundManagerModeMultiNode {
+		return status, nil
 	}
 
 	// Work here is required because if the process crashes we'd end up in a state where a GET would return 'running'
@@ -350,6 +425,14 @@ func (b *BackgroundManager) Stop() error {
 		return err
 	}
 
+	if b.mode() == backgroundManagerModeMultiNode {
+		// Use a detached context for status update as the original context might be cancelled
+		err := b.UpdateStatusClusterAware(context.Background())
+		if err != nil {
+			base.WarnfCtx(context.Background(), "Failed to update cluster status to stopping: %v", err)
+		}
+	}
+
 	b.Terminate()
 	return nil
 }
@@ -366,7 +449,7 @@ func (b *BackgroundManager) markStop() error {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
-	if b.isClusterAware() {
+	if b.mode() == backgroundManagerModeSingleNode {
 		_, _, err := b.clusterAwareOptions.metadataStore.GetRaw(b.clusterAwareOptions.HeartbeatDocID())
 		if err != nil {
 			if base.IsDocNotFoundError(err) {
@@ -389,10 +472,10 @@ func (b *BackgroundManager) markStop() error {
 	}
 
 	if b.State == BackgroundProcessStateStopping {
-		return base.HTTPErrorf(http.StatusServiceUnavailable, "Process already stopping")
+		return errBackgroundManagerAlreadyStopping
 	}
 
-	if b.State == BackgroundProcessStateCompleted || b.State == BackgroundProcessStateStopped {
+	if b.State == BackgroundProcessStateCompleted || b.State == BackgroundProcessStateStopped || b.State == BackgroundProcessStateError {
 		return processAlreadyStoppedErr
 	}
 
@@ -415,9 +498,22 @@ func (b *BackgroundManager) SetError(err error) {
 	b.Terminate()
 }
 
-// UpdateStatusClusterAware gets the current local status from the running process and updates the status document in
-// the bucket. Implements a retry. Used for Cluster Aware operations
 func (b *BackgroundManager) UpdateStatusClusterAware(ctx context.Context) error {
+	switch b.mode() {
+	case backgroundManagerModeSingleNode:
+		return b.UpdateSingleNodeClusterAwareStatus(ctx)
+	case backgroundManagerModeMultiNode:
+		return b.updateMultiNodeClusterAwareStatus(ctx)
+	case backgroundManagerModeLocal:
+		return nil
+	default:
+		return fmt.Errorf("unknown background manager mode: %v", b.mode())
+	}
+}
+
+// UpdateSingleNodeClusterAwareStatus gets the current local status from the running process and updates the status document in
+// the bucket. Implements a retry. Used for Cluster Aware operations
+func (b *BackgroundManager) UpdateSingleNodeClusterAwareStatus(ctx context.Context) error {
 	if b.clusterAwareOptions == nil {
 		return nil
 	}
@@ -439,6 +535,42 @@ func (b *BackgroundManager) UpdateStatusClusterAware(ctx context.Context) error 
 
 		return false, nil, nil
 	}, base.CreateSleeperFunc(5, 100))
+	return err
+}
+
+// updateMultiNodeClusterAwareStatus updates the cluster status document with the current local status. If the bucket status is in a stopping / stopped / completed / error state but the local status is running, then this method will not update the bucket status and instead return. The caller is responsible for taking appropriate action.
+func (b *BackgroundManager) updateMultiNodeClusterAwareStatus(ctx context.Context) error {
+	errStatusNotRunning := errors.New("status in bucket is running, local status is not")
+	docID := b.clusterAwareOptions.StatusDocID()
+	_, err := b.clusterAwareOptions.metadataStore.Update(docID, 0, func(current []byte) ([]byte, *uint32, bool, error) {
+		status, metadata, err := b.getStatusLocal()
+		if err != nil {
+			return nil, nil, false, err
+		}
+		output := make(map[string]json.RawMessage, 2)
+		if current != nil {
+			if err := base.JSONUnmarshal(current, &output); err != nil {
+				return nil, nil, false, fmt.Errorf("Could not unmarshal doc(%q) within updateClusterAwareStatus: %w", docID, err)
+			}
+			if status, ok := output["status"]; ok {
+				bucketState, err := getBackgroundManagerState(status)
+				if err != nil {
+					return nil, nil, false, err
+				}
+				if slices.Contains([]BackgroundProcessState{BackgroundProcessStateCompleted, BackgroundProcessStateStopping, BackgroundProcessStateError}, bucketState) && b.State == BackgroundProcessStateRunning {
+					return nil, nil, false, errStatusNotRunning
+				}
+			}
+		}
+		output["status"] = json.RawMessage(status)
+		output["meta"] = json.RawMessage(metadata)
+
+		outputBytes, err := base.JSONMarshal(output)
+		if err != nil {
+			return nil, nil, false, fmt.Errorf("could not marshal updated status doc %q: %w", docID, err)
+		}
+		return outputBytes, nil, false, nil
+	})
 	return err
 }
 
@@ -484,6 +616,67 @@ func (b *BackgroundManager) UpdateHeartbeatDocClusterAware(ctx context.Context) 
 	return nil
 }
 
-func (b *BackgroundManager) isClusterAware() bool {
-	return b.clusterAwareOptions != nil
+func (b *BackgroundManager) startPollingMultiNodeStatus(ctx context.Context, terminator *base.SafeTerminator) {
+	ticker := time.NewTicker(BackgroundManagerStatusUpdateIntervalSecs * time.Second)
+	for {
+		select {
+		case <-ticker.C:
+			triggerStop, err := b.watchStatusDocMultiNode(ctx)
+			if err != nil {
+				base.WarnfCtx(ctx, "Failed to watch poll status doc: %v, will retry", err)
+			}
+			if triggerStop {
+				continue
+			}
+			err = b.updateMultiNodeClusterAwareStatus(ctx)
+			if err != nil {
+				base.DebugfCtx(ctx, base.KeyAll, "Failed to update multi node cluster aware status: %v, will retry", err)
+			}
+		case <-terminator.Done():
+			ticker.Stop()
+			return
+		}
+	}
+}
+
+// watchMultiNodeStatus polls the status document in the bucket. If another instance has stopped the process,
+// or it encounter a fatal error, then this node should stop.
+func (b *BackgroundManager) watchStatusDocMultiNode(ctx context.Context) (bool, error) {
+	state, err := b.getClusterStatusState(ctx)
+	if err != nil {
+		if base.IsDocNotFoundError(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	if slices.Contains([]BackgroundProcessState{BackgroundProcessStateStopping, BackgroundProcessStateStopped, BackgroundProcessStateCompleted, BackgroundProcessStateError}, state) && b.State == BackgroundProcessStateRunning {
+		_ = b.markStop()
+		b.terminator.Close()
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// backgroundManagerMode defines the types of BackgroundManager that can run.
+type backgroundManagerMode int
+
+const (
+	// backgroundManagerModeLocal means that the BackgroundManager runs in memory only
+	backgroundManagerModeLocal backgroundManagerMode = iota
+	// backgroundManagerModeSingleNode means that the BackgroundManager is expected to run on a single node in a Sync Gateway cluster, and other nodes will be able to monitor the status
+	backgroundManagerModeSingleNode
+	// backgroundManagerModeMultiNode means that the BackgroundManager should run on all nodes of a Sync Gateway cluster
+	backgroundManagerModeMultiNode
+)
+
+func (b *BackgroundManager) mode() backgroundManagerMode {
+	if b.clusterAwareOptions == nil {
+		return backgroundManagerModeLocal
+	}
+	if b.clusterAwareOptions.MultiNode {
+		return backgroundManagerModeMultiNode
+	}
+	return backgroundManagerModeSingleNode
 }

--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -299,7 +299,7 @@ func (b *BackgroundManager) clusterStateIs(ctx context.Context, state Background
 	return clusterState == state
 }
 
-// getClusterStatusState gets the current background process state of the cluster and its CAS.
+// getClusterStatusState gets the current background process state of the cluster.
 func (b *BackgroundManager) getClusterStatusState(ctx context.Context) (BackgroundProcessState, error) {
 	docID := b.clusterAwareOptions.StatusDocID()
 	statusRaw, _, err := b.clusterAwareOptions.metadataStore.GetSubDocRaw(ctx, docID, "status")
@@ -451,7 +451,6 @@ func (b *BackgroundManager) Stop(ctx context.Context) error {
 	}
 
 	if b.mode() == backgroundManagerModeMultiNode {
-		// Use a detached context for status update as the original context might be cancelled
 		err := b.UpdateStatusClusterAware(ctx)
 		if err != nil {
 			base.WarnfCtx(ctx, "Failed to update cluster status to stopping: %v", err)
@@ -509,8 +508,8 @@ func (b *BackgroundManager) markStop() error {
 
 // GetRunState returns the in memory state of the background process. This may different from the serialized bucket state.
 func (b *BackgroundManager) GetRunState() BackgroundProcessState {
-	b.statusLock.Lock()
-	defer b.statusLock.Unlock()
+	b.statusLock.RLock()
+	defer b.statusLock.RUnlock()
 	return b.status.State
 }
 
@@ -523,8 +522,8 @@ func (b *BackgroundManager) setRunState(state BackgroundProcessState) {
 
 // getStartTime returns the current start time of the background process from an in memory value. This may be different from the seraialized start time. If no start time is present, returns nil time.Time.
 func (b *BackgroundManager) getStartTime() time.Time {
-	b.statusLock.Lock()
-	defer b.statusLock.Unlock()
+	b.statusLock.RLock()
+	defer b.statusLock.RUnlock()
 	return b.status.StartTime
 }
 

--- a/db/background_mgr_attachment_migration_test.go
+++ b/db/background_mgr_attachment_migration_test.go
@@ -104,7 +104,7 @@ func TestAttachmentMigrationManagerResumeStoppedMigration(t *testing.T) {
 		for {
 			stats := getAttachmentMigrationStats(t, attachMigrationMgr.Process)
 			if stats.DocsProcessed >= 200 {
-				err = attachMigrationMgr.Stop()
+				err = attachMigrationMgr.Stop(ctx)
 				require.NoError(t, err)
 				break
 			}

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -120,7 +120,7 @@ func TestResyncDCPInit(t *testing.T) {
 			defer db.Close(ctx)
 
 			defer func() {
-				_ = db.ResyncManager.Stop()
+				_ = db.ResyncManager.Stop(ctx)
 				// this gets called by background manager in each Start call.
 				// We have to manually call this for tests only to reset docsChanged/docsProcessed counters
 				db.ResyncManager.resetStatus()
@@ -190,7 +190,7 @@ func TestResyncManagerDCPStopInMidWay(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		waitForResyncDocsProcessed(t, db, 300)
-		require.NoError(t, db.ResyncManager.Stop())
+		require.NoError(t, db.ResyncManager.Stop(ctx))
 	}()
 
 	stats := waitForResyncState(t, db, BackgroundProcessStateStopped)
@@ -272,7 +272,7 @@ func TestResyncManagerDCPStart(t *testing.T) {
 
 			if distributed {
 				waitForResyncDocsChanged(t, db, int64(docsToCreate))
-				err := db.ResyncManager.Stop()
+				err := db.ResyncManager.Stop(ctx)
 				require.NoError(t, err)
 			} else {
 				RequireBackgroundManagerState(t, db.ResyncManager, BackgroundProcessStateCompleted)
@@ -362,7 +362,7 @@ func TestResyncManagerDCPResumeStoppedProcess(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		waitForResyncDocsProcessed(t, db, 2000)
-		require.NoError(t, db.ResyncManager.Stop())
+		require.NoError(t, db.ResyncManager.Stop(ctx))
 	}()
 
 	stats := waitForResyncState(t, db, BackgroundProcessStateStopped)
@@ -443,7 +443,7 @@ func TestResyncManagerDCPResumeStoppedProcessChangeCollections(t *testing.T) {
 		for {
 			stats := getResyncStats(t, db)
 			if stats.DocsProcessed >= (docsPerCollection / 5) {
-				err = db.ResyncManager.Stop()
+				err = db.ResyncManager.Stop(ctx)
 				require.NoError(t, err)
 				break
 			}

--- a/db/background_mgr_test.go
+++ b/db/background_mgr_test.go
@@ -294,7 +294,7 @@ func TestBackgroundManagerStartTimePreservedOnResume(t *testing.T) {
 	err := mgr1.Start(ctx, nil)
 	require.NoError(t, err)
 
-	origStartTime := mgr1.StartTime
+	origStartTime := mgr1.getStartTime()
 	require.False(t, origStartTime.IsZero())
 
 	err = mgr1.UpdateStatusClusterAware(ctx)
@@ -319,5 +319,5 @@ func TestBackgroundManagerStartTimePreservedOnResume(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = mgr2.Stop() }()
 
-	require.Equal(t, origStartTime, mgr2.StartTime, "mgr2 should have reused the start time from the cluster status doc")
+	require.Equal(t, origStartTime, mgr2.getStartTime(), "mgr2 should have reused the start time from the cluster status doc")
 }

--- a/db/background_mgr_test.go
+++ b/db/background_mgr_test.go
@@ -319,5 +319,58 @@ func TestBackgroundManagerStartTimePreservedOnResume(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { assert.NoError(t, mgr2.Stop(ctx)) }()
 
-	require.Equal(t, origStartTime, mgr2.getStartTime(), "mgr2 should have reused the start time from the cluster status doc")
+	require.NotEqual(t, origStartTime, mgr2.getStartTime())
+}
+
+func TestBackgroundManagerMultiNodeStartTimePreserved(t *testing.T) {
+	testBucket := base.GetTestBucket(t)
+	ctx := context.Background()
+	defer testBucket.Close(ctx)
+	metadataStore := testBucket.DefaultDataStore()
+	metaKeys := base.NewMetadataKeys("test-multi-start-time")
+
+	options := &ClusterAwareBackgroundManagerOptions{
+		metadataStore: metadataStore,
+		metaKeys:      metaKeys,
+		processSuffix: "multi-start-time",
+		MultiNode:     true,
+	}
+
+	process1 := &MockProcess{}
+	mgr1 := &BackgroundManager{
+		name:                "mgr1",
+		clusterAwareOptions: options,
+		Process:             process1,
+	}
+
+	// 1. Start mgr1
+	err := mgr1.Start(ctx, nil)
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, mgr1.Stop(ctx)) }()
+
+	// Wait for mgr1 to be running and have a start time
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, BackgroundProcessStateRunning, mgr1.GetRunState())
+		assert.False(c, mgr1.getStartTime().IsZero())
+	}, 5*time.Second, 100*time.Millisecond)
+
+	origStartTime := mgr1.getStartTime()
+
+	// Ensure mgr1 has updated its status to the cluster
+	err = mgr1.UpdateStatusClusterAware(ctx)
+	require.NoError(t, err)
+
+	// 2. Start mgr2 (MultiNode)
+	process2 := &MockProcess{}
+	mgr2 := &BackgroundManager{
+		name:                "mgr2",
+		clusterAwareOptions: options,
+		Process:             process2,
+	}
+
+	err = mgr2.Start(ctx, nil)
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, mgr2.Stop(ctx)) }()
+
+	assert.Equal(t, origStartTime, mgr2.getStartTime(), "mgr2 should have inherited mgr1's start time")
 }

--- a/db/background_mgr_test.go
+++ b/db/background_mgr_test.go
@@ -105,7 +105,7 @@ func TestBackgroundManagerModes(t *testing.T) {
 				metadataStore: metadataStore,
 				metaKeys:      metaKeys,
 				processSuffix: "multi",
-				MultiNode:     true,
+				multiNode:     true,
 			},
 		},
 	}
@@ -151,7 +151,7 @@ func TestBackgroundManagerMultiNodeTransitions(t *testing.T) {
 		metadataStore: metadataStore,
 		metaKeys:      metaKeys,
 		processSuffix: "multi-trans",
-		MultiNode:     true,
+		multiNode:     true,
 	}
 
 	process1 := &MockProcess{}
@@ -217,7 +217,7 @@ func TestBackgroundManagerMultiNodeSimultaneousTransitions(t *testing.T) {
 		metadataStore: metadataStore,
 		metaKeys:      metaKeys,
 		processSuffix: "multi-simul",
-		MultiNode:     true,
+		multiNode:     true,
 	}
 
 	numNodes := 5
@@ -281,7 +281,7 @@ func TestBackgroundManagerStartTimePreservedOnResume(t *testing.T) {
 		metadataStore: metadataStore,
 		metaKeys:      metaKeys,
 		processSuffix: "start-time",
-		MultiNode:     false,
+		multiNode:     false,
 	}
 
 	process1 := &MockProcess{}
@@ -333,7 +333,7 @@ func TestBackgroundManagerMultiNodeStartTimePreserved(t *testing.T) {
 		metadataStore: metadataStore,
 		metaKeys:      metaKeys,
 		processSuffix: "multi-start-time",
-		MultiNode:     true,
+		multiNode:     true,
 	}
 
 	process1 := &MockProcess{}

--- a/db/background_mgr_test.go
+++ b/db/background_mgr_test.go
@@ -126,7 +126,7 @@ func TestBackgroundManagerModes(t *testing.T) {
 				assert.Equal(c, BackgroundProcessStateRunning, mgr.GetRunState())
 			}, 5*time.Second, 100*time.Millisecond)
 
-			err = mgr.Stop()
+			err = mgr.Stop(ctx)
 			require.NoError(t, err)
 
 			require.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -164,9 +164,9 @@ func TestBackgroundManagerMultiNodeTransitions(t *testing.T) {
 	// 1. Start mgr1
 	err := mgr1.Start(ctx, nil)
 	require.NoError(t, err)
-	defer func() { _ = mgr1.Stop() }()
+	defer func() { assert.NoError(t, mgr1.Stop(ctx)) }()
 
-	// 2. Try to start mgr1 again (should fail)
+	// 2. Try to start mgr1 again
 	err = mgr1.Start(ctx, nil)
 	require.NoError(t, err)
 
@@ -179,7 +179,7 @@ func TestBackgroundManagerMultiNodeTransitions(t *testing.T) {
 	}
 	err = mgr2.Start(ctx, nil)
 	require.NoError(t, err)
-	defer func() { _ = mgr2.Stop() }()
+	defer func() { assert.NoError(t, mgr2.Stop(ctx)) }()
 
 	// Both should be running
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -188,7 +188,7 @@ func TestBackgroundManagerMultiNodeTransitions(t *testing.T) {
 	}, 10*time.Second, 100*time.Millisecond)
 
 	// 4. Stop via mgr1
-	err = mgr1.Stop()
+	err = mgr1.Stop(ctx)
 	require.NoError(t, err)
 
 	// Both should stop because they watch the same status doc
@@ -235,13 +235,13 @@ func TestBackgroundManagerMultiNodeSimultaneousTransitions(t *testing.T) {
 
 	// Start all simultaneously
 	var wg sync.WaitGroup
-	for i := 0; i < numNodes; i++ {
+	for i := range numNodes {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			_ = managers[i].Start(ctx, nil)
+			assert.NoError(t, managers[i].Start(ctx, nil))
 		}(i)
-		defer func(i int) { _ = managers[i].Stop() }(i)
+		defer func(i int) { assert.NoError(t, managers[i].Stop(ctx)) }(i)
 	}
 	wg.Wait()
 
@@ -257,7 +257,7 @@ func TestBackgroundManagerMultiNodeSimultaneousTransitions(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			_ = managers[i].Stop()
+			assert.NoError(t, managers[i].Stop(ctx))
 		}(i)
 	}
 	wg.Wait()
@@ -300,7 +300,7 @@ func TestBackgroundManagerStartTimePreservedOnResume(t *testing.T) {
 	err = mgr1.UpdateStatusClusterAware(ctx)
 	require.NoError(t, err)
 
-	err = mgr1.Stop()
+	err = mgr1.Stop(ctx)
 	require.NoError(t, err)
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -317,7 +317,7 @@ func TestBackgroundManagerStartTimePreservedOnResume(t *testing.T) {
 	}
 	err = mgr2.Start(ctx, nil)
 	require.NoError(t, err)
-	defer func() { _ = mgr2.Stop() }()
+	defer func() { assert.NoError(t, mgr2.Stop(ctx)) }()
 
 	require.Equal(t, origStartTime, mgr2.getStartTime(), "mgr2 should have reused the start time from the cluster status doc")
 }

--- a/db/background_mgr_test.go
+++ b/db/background_mgr_test.go
@@ -1,0 +1,323 @@
+//  Copyright 2012-Present Couchbase, Inc.
+//
+//  Use of this software is governed by the Business Source License included
+//  in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+//  in that file, in accordance with the Business Source License, use of this
+//  software will be governed by the Apache License, Version 2.0, included in
+//  the file licenses/APL2.txt.
+
+package db
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type MockProcess struct {
+	InitCalled           bool
+	RunCalled            bool
+	StopRequested        bool
+	SleepDuration        time.Duration
+	updateStatusCallback updateStatusCallbackFunc
+	lock                 sync.Mutex
+}
+
+func (m *MockProcess) Init(ctx context.Context, options map[string]any, clusterStatus []byte) error {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	m.InitCalled = true
+	return nil
+}
+
+func (m *MockProcess) Run(ctx context.Context, options map[string]any, persistClusterStatusCallback updateStatusCallbackFunc, terminator *base.SafeTerminator) error {
+	m.lock.Lock()
+	m.RunCalled = true
+	m.updateStatusCallback = persistClusterStatusCallback
+	m.lock.Unlock()
+
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-terminator.Done():
+			m.lock.Lock()
+			m.StopRequested = true
+			m.lock.Unlock()
+			return nil
+		case <-ticker.C:
+			if m.SleepDuration > 0 {
+				time.Sleep(m.SleepDuration)
+			}
+			if persistClusterStatusCallback != nil {
+				_ = persistClusterStatusCallback(ctx)
+			}
+		}
+	}
+}
+
+func (m *MockProcess) GetProcessStatus(status BackgroundManagerStatus) (statusOut []byte, meta []byte, err error) {
+	statusOut, err = base.JSONMarshal(status)
+	return statusOut, nil, err
+}
+
+func (m *MockProcess) ResetStatus() {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	m.InitCalled = false
+	m.RunCalled = false
+	m.StopRequested = false
+}
+
+func TestBackgroundManagerModes(t *testing.T) {
+	testBucket := base.GetTestBucket(t)
+	ctx := context.Background()
+	defer testBucket.Close(ctx)
+	metadataStore := testBucket.DefaultDataStore()
+	metaKeys := base.NewMetadataKeys("test")
+
+	modes := []struct {
+		name                string
+		clusterAwareOptions *ClusterAwareBackgroundManagerOptions
+	}{
+		{
+			name:                "Local",
+			clusterAwareOptions: nil,
+		},
+		{
+			name: "ClusterAware",
+			clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
+				metadataStore: metadataStore,
+				metaKeys:      metaKeys,
+				processSuffix: "aware",
+			},
+		},
+		{
+			name: "MultiNode",
+			clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
+				metadataStore: metadataStore,
+				metaKeys:      metaKeys,
+				processSuffix: "multi",
+				MultiNode:     true,
+			},
+		},
+	}
+
+	for _, mode := range modes {
+		t.Run(mode.name, func(t *testing.T) {
+			process := &MockProcess{}
+			mgr := &BackgroundManager{
+				name:                "test-mgr-" + mode.name,
+				clusterAwareOptions: mode.clusterAwareOptions,
+				Process:             process,
+			}
+
+			err := mgr.Start(ctx, nil)
+			require.NoError(t, err)
+
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				assert.Equal(c, BackgroundProcessStateRunning, mgr.GetRunState())
+			}, 5*time.Second, 100*time.Millisecond)
+
+			err = mgr.Stop()
+			require.NoError(t, err)
+
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				state := mgr.GetRunState()
+				assert.Contains(c, []BackgroundProcessState{BackgroundProcessStateStopped, BackgroundProcessStateCompleted}, state)
+			}, 5*time.Second, 100*time.Millisecond)
+
+			assert.True(t, process.RunCalled)
+			assert.True(t, process.StopRequested)
+		})
+	}
+}
+
+func TestBackgroundManagerMultiNodeTransitions(t *testing.T) {
+	testBucket := base.GetTestBucket(t)
+	ctx := context.Background()
+	defer testBucket.Close(ctx)
+	metadataStore := testBucket.DefaultDataStore()
+	metaKeys := base.NewMetadataKeys("test-transitions")
+
+	options := &ClusterAwareBackgroundManagerOptions{
+		metadataStore: metadataStore,
+		metaKeys:      metaKeys,
+		processSuffix: "multi-trans",
+		MultiNode:     true,
+	}
+
+	process1 := &MockProcess{}
+	mgr1 := &BackgroundManager{
+		name:                "mgr1",
+		clusterAwareOptions: options,
+		Process:             process1,
+	}
+
+	// 1. Start mgr1
+	err := mgr1.Start(ctx, nil)
+	require.NoError(t, err)
+	defer func() { _ = mgr1.Stop() }()
+
+	// 2. Try to start mgr1 again (should fail)
+	err = mgr1.Start(ctx, nil)
+	require.NoError(t, err)
+
+	// 3. Start mgr2 (should succeed because it's MultiNode)
+	process2 := &MockProcess{}
+	mgr2 := &BackgroundManager{
+		name:                "mgr2",
+		clusterAwareOptions: options,
+		Process:             process2,
+	}
+	err = mgr2.Start(ctx, nil)
+	require.NoError(t, err)
+	defer func() { _ = mgr2.Stop() }()
+
+	// Both should be running
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, BackgroundProcessStateRunning, mgr1.GetRunState(), "expected mgr1 to be running")
+		assert.Equal(c, BackgroundProcessStateRunning, mgr2.GetRunState(), "expected mgr2 to be running")
+	}, 10*time.Second, 100*time.Millisecond)
+
+	// 4. Stop via mgr1
+	err = mgr1.Stop()
+	require.NoError(t, err)
+
+	// Both should stop because they watch the same status doc
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Contains(c, []BackgroundProcessState{BackgroundProcessStateStopped, BackgroundProcessStateCompleted}, mgr1.GetRunState(), "expected mgr1 to be stopped or completed")
+		assert.Contains(c, []BackgroundProcessState{BackgroundProcessStateStopped, BackgroundProcessStateCompleted}, mgr2.GetRunState(), "expected mgr2 to be stopped or completed")
+	}, 15*time.Second, 500*time.Millisecond)
+
+	require.True(t, process1.StopRequested, "mgr1 should have received stop request")
+	require.True(t, process2.StopRequested, "mgr2 should have received stop request")
+
+	// 5. Restart (from Stopped state)
+	err = mgr1.Start(ctx, nil)
+	require.NoError(t, err)
+	assert.Equal(t, BackgroundProcessStateRunning, mgr1.GetRunState())
+}
+
+func TestBackgroundManagerMultiNodeSimultaneousTransitions(t *testing.T) {
+	testBucket := base.GetTestBucket(t)
+	ctx := context.Background()
+	defer testBucket.Close(ctx)
+	metadataStore := testBucket.DefaultDataStore()
+	metaKeys := base.NewMetadataKeys("test-simultaneous")
+
+	options := &ClusterAwareBackgroundManagerOptions{
+		metadataStore: metadataStore,
+		metaKeys:      metaKeys,
+		processSuffix: "multi-simul",
+		MultiNode:     true,
+	}
+
+	numNodes := 5
+	managers := make([]*BackgroundManager, numNodes)
+	processes := make([]*MockProcess, numNodes)
+
+	for i := 0; i < numNodes; i++ {
+		processes[i] = &MockProcess{}
+		managers[i] = &BackgroundManager{
+			name:                fmt.Sprintf("mgr%d", i),
+			clusterAwareOptions: options,
+			Process:             processes[i],
+		}
+	}
+
+	// Start all simultaneously
+	var wg sync.WaitGroup
+	for i := 0; i < numNodes; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_ = managers[i].Start(ctx, nil)
+		}(i)
+		defer func(i int) { _ = managers[i].Stop() }(i)
+	}
+	wg.Wait()
+
+	// All should eventually be running
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		for i := 0; i < numNodes; i++ {
+			assert.Equal(c, BackgroundProcessStateRunning, managers[i].GetRunState())
+		}
+	}, 10*time.Second, 100*time.Millisecond)
+
+	// Stop all simultaneously
+	for i := 0; i < numNodes; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_ = managers[i].Stop()
+		}(i)
+	}
+	wg.Wait()
+
+	// All should eventually be stopped
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		for i := 0; i < numNodes; i++ {
+			assert.Contains(c, []BackgroundProcessState{BackgroundProcessStateStopped, BackgroundProcessStateCompleted}, managers[i].GetRunState())
+		}
+	}, 15*time.Second, 500*time.Millisecond)
+}
+
+func TestBackgroundManagerStartTimePreservedOnResume(t *testing.T) {
+	testBucket := base.GetTestBucket(t)
+	ctx := context.Background()
+	defer testBucket.Close(ctx)
+	metadataStore := testBucket.DefaultDataStore()
+	metaKeys := base.NewMetadataKeys("test-start-time")
+
+	options := &ClusterAwareBackgroundManagerOptions{
+		metadataStore: metadataStore,
+		metaKeys:      metaKeys,
+		processSuffix: "start-time",
+		MultiNode:     false,
+	}
+
+	process1 := &MockProcess{}
+	mgr1 := &BackgroundManager{
+		name:                "mgr1",
+		clusterAwareOptions: options,
+		Process:             process1,
+	}
+
+	err := mgr1.Start(ctx, nil)
+	require.NoError(t, err)
+
+	origStartTime := mgr1.StartTime
+	require.False(t, origStartTime.IsZero())
+
+	err = mgr1.UpdateStatusClusterAware(ctx)
+	require.NoError(t, err)
+
+	err = mgr1.Stop()
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Contains(c, []BackgroundProcessState{BackgroundProcessStateStopped, BackgroundProcessStateCompleted}, mgr1.GetRunState())
+	}, 5*time.Second, 100*time.Millisecond)
+
+	WaitForBackgroundManagerHeartbeatDocRemoval(t, mgr1)
+
+	process2 := &MockProcess{}
+	mgr2 := &BackgroundManager{
+		name:                "mgr2",
+		clusterAwareOptions: options,
+		Process:             process2,
+	}
+	err = mgr2.Start(ctx, nil)
+	require.NoError(t, err)
+	defer func() { _ = mgr2.Stop() }()
+
+	require.Equal(t, origStartTime, mgr2.StartTime, "mgr2 should have reused the start time from the cluster status doc")
+}

--- a/db/database.go
+++ b/db/database.go
@@ -660,7 +660,7 @@ func (context *DatabaseContext) Close(ctx context.Context) {
 	}
 
 	// Stop All background processors
-	bgManagers := context.stopBackgroundManagers()
+	bgManagers := context.stopBackgroundManagers(ctx)
 
 	// Wait for database background tasks to finish.
 	waitForBGTCompletion(ctx, BGTCompletionMaxWait, context.backgroundTasks, context.Name)
@@ -680,7 +680,7 @@ func (context *DatabaseContext) Close(ctx context.Context) {
 
 // stopBackgroundManagers stops any running BackgroundManager.
 // Returns a list of BackgroundManager it signalled to stop
-func (dbCtx *DatabaseContext) stopBackgroundManagers() (stopped []*BackgroundManager) {
+func (dbCtx *DatabaseContext) stopBackgroundManagers(ctx context.Context) (stopped []*BackgroundManager) {
 	for _, manager := range []*BackgroundManager{
 		dbCtx.ResyncManager,
 		dbCtx.AttachmentCompactionManager,
@@ -688,7 +688,7 @@ func (dbCtx *DatabaseContext) stopBackgroundManagers() (stopped []*BackgroundMan
 		dbCtx.AsyncIndexInitManager,
 		dbCtx.AttachmentMigrationManager,
 	} {
-		if manager != nil && !isBackgroundManagerStopped(manager.GetRunState()) && manager.Stop() == nil {
+		if manager != nil && !isBackgroundManagerStopped(manager.GetRunState()) && manager.Stop(ctx) == nil {
 			stopped = append(stopped, manager)
 		}
 	}

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -3826,7 +3826,7 @@ func TestTombstoneCompactionStopWithManager(t *testing.T) {
 	callbackFunc := func() {
 		queryCount++
 		if queryCount == 2 {
-			assert.NoError(t, db.TombstoneCompactionManager.Stop())
+			assert.NoError(t, db.TombstoneCompactionManager.Stop(ctx))
 		}
 	}
 
@@ -4412,7 +4412,7 @@ func Test_stopBackgroundManagers(t *testing.T) {
 				assert.NoError(t, err)
 			}
 
-			bgManagers := db.stopBackgroundManagers()
+			bgManagers := db.stopBackgroundManagers(ctx)
 			assert.Len(t, bgManagers, testCase.expected, "Unexpected Num of BackgroundManagers returned")
 		})
 	}
@@ -4459,7 +4459,7 @@ func Test_waitForBackgroundManagersToStop(t *testing.T) {
 		ctx := base.TestCtx(t)
 		err := bgMngr.Start(ctx, map[string]any{})
 		require.NoError(t, err)
-		err = bgMngr.Stop()
+		err = bgMngr.Stop(ctx)
 		require.NoError(t, err)
 
 		startTime := time.Now()
@@ -4477,7 +4477,7 @@ func Test_waitForBackgroundManagersToStop(t *testing.T) {
 		ctx := base.TestCtx(t)
 		err := bgMngr.Start(ctx, map[string]any{})
 		require.NoError(t, err)
-		err = bgMngr.Stop()
+		err = bgMngr.Stop(ctx)
 		require.NoError(t, err)
 
 		startTime := time.Now()
@@ -4495,7 +4495,7 @@ func Test_waitForBackgroundManagersToStop(t *testing.T) {
 		ctx := base.TestCtx(t)
 		err := stoppableBgMngr.Start(ctx, map[string]any{})
 		require.NoError(t, err)
-		err = stoppableBgMngr.Stop()
+		err = stoppableBgMngr.Stop(ctx)
 		require.NoError(t, err)
 
 		unstoppableBgMngr := &BackgroundManager{
@@ -4505,7 +4505,7 @@ func Test_waitForBackgroundManagersToStop(t *testing.T) {
 
 		err = unstoppableBgMngr.Start(ctx, map[string]any{})
 		require.NoError(t, err)
-		err = unstoppableBgMngr.Stop()
+		err = unstoppableBgMngr.Stop(ctx)
 		require.NoError(t, err)
 
 		startTime := time.Now()

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -925,7 +925,7 @@ func MoveAttachmentXattrFromGlobalToSync(t *testing.T, dataStore base.DataStore,
 // heartbeat document. When restarting a background manager, the state of the heartbeat document is checked, allowing
 // for a small race if you try to stop and immediately restart a background manager.
 func WaitForBackgroundManagerHeartbeatDocRemoval(t testing.TB, mgr *BackgroundManager) {
-	if !mgr.isClusterAware() {
+	if mgr.mode() != backgroundManagerModeSingleNode {
 		return
 	}
 

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -429,7 +429,7 @@ func (h *handler) handlePostIndexInit() error {
 
 	if action == "stop" {
 		h.server.DatabaseInitManager.Cancel(h.db.Name, fmt.Sprintf("Initialization stopped by %s", h.rq.URL))
-		if err := h.db.AsyncIndexInitManager.Stop(); err != nil {
+		if err := h.db.AsyncIndexInitManager.Stop(h.ctx()); err != nil {
 			return err
 		}
 		b, err := h.db.AsyncIndexInitManager.GetStatus(h.ctx())

--- a/rest/api.go
+++ b/rest/api.go
@@ -154,7 +154,7 @@ func (h *handler) handleAttachmentMigration() error {
 		}
 		h.writeRawJSON(status)
 	} else if action == string(db.BackgroundProcessActionStop) {
-		err := h.db.AttachmentMigrationManager.Stop()
+		err := h.db.AttachmentMigrationManager.Stop(h.ctx())
 		if err != nil {
 			return err
 		}
@@ -222,7 +222,7 @@ func (h *handler) handleCompact() error {
 				return base.HTTPErrorf(http.StatusBadRequest, "Database compact is not running")
 			}
 
-			err := h.db.TombstoneCompactionManager.Stop()
+			err := h.db.TombstoneCompactionManager.Stop(h.ctx())
 			if err != nil {
 				return err
 			}
@@ -255,7 +255,7 @@ func (h *handler) handleCompact() error {
 			auditFields[base.AuditFieldCompactionReset] = h.getBoolQuery("dry_run")
 			base.Audit(h.ctx(), base.AuditIDDatabaseCompactStart, auditFields)
 		} else if action == string(db.BackgroundProcessActionStop) {
-			err := h.db.AttachmentCompactionManager.Stop()
+			err := h.db.AttachmentCompactionManager.Stop(h.ctx())
 			if err != nil {
 				return err
 			}
@@ -408,7 +408,7 @@ func (h *handler) handlePostResync() error {
 			return base.HTTPErrorf(http.StatusBadRequest, "Database _resync is not running")
 		}
 
-		err := h.db.ResyncManager.Stop()
+		err := h.db.ResyncManager.Stop(h.ctx())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
CBG-5180 add a multi node mode to BackgroundManager

Add a multi node mode existing modes of background manager for purposes of supporting resync. This mode is intended to be cluster aware and support calling Start() on one node and have all other nodes pick up and call the `BackgroundManager.Run` function. If another node calls `Stop` then all noes should stop.

The intended use case is for distributed resync to be able to call `ResyncManager.Run` on all nodes simultaneously.

This should support in this new mode:

- If Start is called and the cluster status is marked as "Running", then allow running to occur
- Update the status document on all nodes, since any node could trigger stop. The status document has entirely identical information on each node (except for stats, to be continued in a future PR). If the current manager is running but another node has moved the state to a stopped state, trigger stop on the local node.
- In this mode, there is no need for a heartbeat document since the intended behavior is to always allow a non running node to pick up this task. The intention behind this is to allow a distributed resync process to resume even if the entire Sync Gateway cluster rolls over. If it was a background manager task that couldn't resume in that case, that logic should be handled otherwise.
- Don't overwrite start_time if another node has already started.

Changes that might seem unrelated:

- Created a new function for updating the status document for the multi node background manager. This is to avoid modifying the existing background manager code too much; support for stopping the update if we detect the cluster status == stopped but our status is running; and allow using `DataStore.Update` in a future PR to allow some fancy stats modification.
- Because `b.State` is read inside `updateMultiNodeClusterAwareStatus` document, I had to make this a lockable property. Since you can not recursively lock a mutex, I decided to create a statusLock to separate modifying the status parameters on BackgroundManager separately. This could be pulled into a separate PR and was only discovered due to some race conditions.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/551/
