### PR TITLE
CBG-5351: TestReplicationStatusActions: avoid flake and crash

### DIFF
--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -734,10 +734,10 @@ func TestReplicationStatusActions(t *testing.T) {
 		}()
 		statusWg.Add(1)
 		go func() {
+			defer statusWg.Done()
 			for {
 				select {
 				case <-doneChan:
-					statusWg.Done()
 					return
 				default:
 				}

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -732,18 +732,17 @@ func TestReplicationStatusActions(t *testing.T) {
 			close(doneChan)
 			statusWg.Wait()
 		}()
-		statusWg.Add(1)
-		go func() {
-			defer statusWg.Done()
+		statusWg.Go(func() {
 			for {
 				select {
 				case <-doneChan:
 					return
-				default:
+				// wait just long enough to release control back to go scheduler if GOMAXPROCS=1
+				case <-time.After(5 * time.Millisecond):
+					_ = rt1.GetReplicationStatus(replicationID)
 				}
-				_ = rt1.GetReplicationStatus(replicationID)
 			}
-		}()
+		})
 
 		// wait for document originally written to rt2 to arrive at rt1
 		changesResults := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -728,6 +728,10 @@ func TestReplicationStatusActions(t *testing.T) {
 		// Start goroutine to continuously poll for status of replication on rt1 to detect race conditions
 		doneChan := make(chan struct{})
 		var statusWg sync.WaitGroup
+		defer func() {
+			close(doneChan)
+			statusWg.Wait()
+		}()
 		statusWg.Add(1)
 		go func() {
 			for {
@@ -789,10 +793,6 @@ func TestReplicationStatusActions(t *testing.T) {
 			return status.DocsCheckedPull == 2 && status.DocsRead == 0
 		})
 		assert.NoError(t, statError)
-
-		// Terminate status goroutine
-		close(doneChan)
-		statusWg.Wait()
 	})
 }
 


### PR DESCRIPTION
CBG-5351: TestReplicationStatusActions: avoid flake or crash

- If GOMAXPROCS=1 running a continuous loop doesn't cede time back to the scheduler to run ISGR operations
- If a part of the test fails, make sure to clean up leaked goroutine