### PR TITLE
CBG-5326: Function to handle document channel history compaction

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -245,6 +245,19 @@ func (c *DatabaseCollection) CompactDocChannelHistory(ctx context.Context, docid
 		c.dbStats().Database().Crc32MatchCount.Add(1)
 	}
 
+	if !isSgWrite {
+		var importErr error
+
+		doc, importErr = c.OnDemandImportForGet(ctx, docid, doc, rawDoc, xattrs, cas)
+		if importErr != nil {
+			return nil, importErr
+		}
+		if doc == nil {
+			return nil, fmt.Errorf("skipping compaction of document %s, %v ", base.UD(docid), base.ErrNotFound)
+		}
+		cas = doc.Cas
+	}
+
 	compactedChannels := make([]string, 0)
 
 	doc.SyncData.ChannelSetHistory = slices.DeleteFunc(doc.SyncData.ChannelSetHistory, func(channel ChannelSetEntry) bool {
@@ -296,11 +309,9 @@ func (c *DatabaseCollection) CompactDocChannelHistory(ctx context.Context, docid
 	// build macro expansion for sync data. This will avoid the update to xattrs causing an extra import event (i.e. sync cas will be == to doc cas)
 	opts := &sgbucket.MutateInOptions{}
 	// Only update _sync.cas and _mou.cas if the pre-compaction doc had already been imported by SGW
-	if isSgWrite {
-		opts.MacroExpansion = []sgbucket.MacroExpansionSpec{
-			sgbucket.NewMacroExpansionSpec(XattrMouCasPath(), sgbucket.MacroCas),
-			sgbucket.NewMacroExpansionSpec(xattrCasPath(base.SyncXattrName), sgbucket.MacroCas),
-		}
+	opts.MacroExpansion = []sgbucket.MacroExpansionSpec{
+		sgbucket.NewMacroExpansionSpec(XattrMouCasPath(), sgbucket.MacroCas),
+		sgbucket.NewMacroExpansionSpec(xattrCasPath(base.SyncXattrName), sgbucket.MacroCas),
 	}
 	opts.PreserveExpiry = true // if doc has expiry, we should preserve this
 

--- a/db/crud.go
+++ b/db/crud.go
@@ -231,7 +231,7 @@ func (c *DatabaseCollection) CompactDocChannelHistory(ctx context.Context, docid
 	}
 
 	xattrKeys := []string{base.SyncXattrName, base.VirtualXattrRevSeqNo, base.MouXattrName}
-	_, xattrs, cas, err := c.dataStore.GetWithXattrs(ctx, key, xattrKeys)
+	rawDoc, xattrs, cas, err := c.dataStore.GetWithXattrs(ctx, key, xattrKeys)
 	if err != nil {
 		return err
 	}
@@ -239,6 +239,20 @@ func (c *DatabaseCollection) CompactDocChannelHistory(ctx context.Context, docid
 	doc, err := c.unmarshalDocumentWithXattrs(ctx, key, nil, xattrs, cas, DocUnmarshalSync)
 	if err != nil {
 		return err
+	}
+
+	isSgWrite, crc32Match, _ := doc.IsSGWrite(ctx, rawDoc)
+	if crc32Match {
+		c.dbStats().Database().Crc32MatchCount.Add(1)
+	}
+
+	if !isSgWrite {
+		var importErr error
+
+		doc, importErr = c.OnDemandImportForGet(ctx, docid, doc, rawDoc, xattrs, cas)
+		if importErr != nil {
+			return importErr
+		}
 	}
 
 	// Store lengths before compaction to detect if any changes occur
@@ -274,7 +288,8 @@ func (c *DatabaseCollection) CompactDocChannelHistory(ctx context.Context, docid
 
 	revSeqNo, err := unmarshalRevSeqNo(xattrs[base.VirtualXattrRevSeqNo])
 	if err != nil {
-		base.InfofCtx(ctx, base.KeyCRUD, `Could not determine the revSeqNo when attempting to compact channel history for doc: %s. Error: %v`, base.UD(docid), err)
+		base.WarnfCtx(ctx, `Could not determine the revSeqNo when attempting to compact channel history for doc %s - history will not be compacted: %v`, base.UD(docid), err)
+		return base.RedactErrorf(`Could not determine the revSeqNo when attempting to compact channel history for doc %s - history will not be compacted: %v`, base.UD(docid), err)
 	}
 
 	metadataOnlyUpdate := computeMetadataOnlyUpdate(doc.Cas, revSeqNo, doc.MetadataOnlyUpdate)

--- a/db/crud.go
+++ b/db/crud.go
@@ -223,7 +223,7 @@ func (c *DatabaseCollection) GetDocSyncData(ctx context.Context, docid string) (
 }
 
 // CompactDocChannelHistory removes channel history entries that ended at or before the given sequence number.
-// This is used to truncate stale channel assignment history to reduce storage overhead.
+// This is used to prune stale channel assignment history to reduce storage overhead.
 func (c *DatabaseCollection) CompactDocChannelHistory(ctx context.Context, docid string, seq uint64) ([]string, error) {
 	key := realDocID(docid)
 	if key == "" {
@@ -243,19 +243,6 @@ func (c *DatabaseCollection) CompactDocChannelHistory(ctx context.Context, docid
 	isSgWrite, crc32Match, _ := doc.IsSGWrite(ctx, rawDoc)
 	if crc32Match {
 		c.dbStats().Database().Crc32MatchCount.Add(1)
-	}
-
-	if !isSgWrite {
-		var importErr error
-
-		doc, importErr = c.OnDemandImportForGet(ctx, docid, doc, rawDoc, xattrs, cas)
-		if importErr != nil {
-			return nil, importErr
-		}
-		if doc == nil {
-			return nil, base.ErrNotFound
-		}
-		cas = doc.Cas
 	}
 
 	compactedChannels := make([]string, 0)
@@ -309,8 +296,10 @@ func (c *DatabaseCollection) CompactDocChannelHistory(ctx context.Context, docid
 	// build macro expansion for sync data. This will avoid the update to xattrs causing an extra import event (i.e. sync cas will be == to doc cas)
 	opts := &sgbucket.MutateInOptions{}
 	spec := []sgbucket.MacroExpansionSpec{
-		sgbucket.NewMacroExpansionSpec(xattrCasPath(base.SyncXattrName), sgbucket.MacroCas),
 		sgbucket.NewMacroExpansionSpec(XattrMouCasPath(), sgbucket.MacroCas),
+	}
+	if isSgWrite {
+		spec = append(spec, sgbucket.NewMacroExpansionSpec(xattrCasPath(base.SyncXattrName), sgbucket.MacroCas))
 	}
 	opts.MacroExpansion = spec
 	opts.PreserveExpiry = true // if doc has expiry, we should preserve this

--- a/db/crud.go
+++ b/db/crud.go
@@ -224,21 +224,21 @@ func (c *DatabaseCollection) GetDocSyncData(ctx context.Context, docid string) (
 
 // CompactDocChannelHistory removes channel history entries that ended at or before the given sequence number.
 // This is used to truncate stale channel assignment history to reduce storage overhead.
-func (c *DatabaseCollection) CompactDocChannelHistory(ctx context.Context, docid string, seq uint64) error {
+func (c *DatabaseCollection) CompactDocChannelHistory(ctx context.Context, docid string, seq uint64) ([]string, error) {
 	key := realDocID(docid)
 	if key == "" {
-		return base.HTTPErrorf(400, "Invalid doc ID")
+		return nil, base.HTTPErrorf(400, "Invalid doc ID")
 	}
 
 	xattrKeys := []string{base.SyncXattrName, base.VirtualXattrRevSeqNo, base.MouXattrName}
 	rawDoc, xattrs, cas, err := c.dataStore.GetWithXattrs(ctx, key, xattrKeys)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	doc, err := c.unmarshalDocumentWithXattrs(ctx, key, nil, xattrs, cas, DocUnmarshalSync)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	isSgWrite, crc32Match, _ := doc.IsSGWrite(ctx, rawDoc)
@@ -251,56 +251,60 @@ func (c *DatabaseCollection) CompactDocChannelHistory(ctx context.Context, docid
 
 		doc, importErr = c.OnDemandImportForGet(ctx, docid, doc, rawDoc, xattrs, cas)
 		if importErr != nil {
-			return importErr
+			return nil, importErr
 		}
 		if doc == nil {
-			return fmt.Errorf("skipping compaction of document %s, %v ", base.UD(docid), base.ErrNotFound)
+			return nil, fmt.Errorf("skipping compaction of document %s, %v ", base.UD(docid), base.ErrNotFound)
 		}
 		cas = doc.Cas
 	}
 
-	// Store lengths before compaction to detect if any changes occur
-	historyLenBefore := len(doc.SyncData.ChannelSetHistory)
-	channelSetLenBefore := len(doc.SyncData.ChannelSet)
-	channelsLenBefore := len(doc.SyncData.Channels)
+	compactedChannels := make([]string, 0)
 
 	doc.SyncData.ChannelSetHistory = slices.DeleteFunc(doc.SyncData.ChannelSetHistory, func(channel ChannelSetEntry) bool {
-		return channel.End <= seq
+		del := channel.End <= seq
+		if del {
+			compactedChannels = append(compactedChannels, channel.Name)
+		}
+		return del
 	})
 
 	doc.SyncData.ChannelSet = slices.DeleteFunc(doc.SyncData.ChannelSet, func(channel ChannelSetEntry) bool {
-		return channel.End != 0 && channel.End <= seq
+		del := channel.End != 0 && channel.End <= seq
+		if del {
+			compactedChannels = append(compactedChannels, channel.Name)
+		}
+		return del
 	})
 
 	for chanName, chanEntry := range doc.SyncData.Channels {
 		if chanEntry != nil && chanEntry.Seq <= seq {
+			compactedChannels = append(compactedChannels, chanName)
 			delete(doc.SyncData.Channels, chanName)
 		}
 	}
 
 	// Exit early if no compaction occurred
-	if len(doc.SyncData.ChannelSetHistory) == historyLenBefore &&
-		len(doc.SyncData.ChannelSet) == channelSetLenBefore &&
-		len(doc.SyncData.Channels) == channelsLenBefore {
-		return nil
+	if len(compactedChannels) == 0 {
+		return []string{}, nil
 	}
 
 	rawSyncXattr, err := base.JSONMarshal(doc.SyncData)
 	if err != nil {
-		return base.RedactErrorf("failed to marshal sync data when trying to compact channel history for doc:%s. Error: %v", base.UD(docid), err)
+		return nil, base.RedactErrorf("failed to marshal sync data when trying to compact channel history for doc:%s. Error: %v", base.UD(docid), err)
 	}
 
 	revSeqNo, err := unmarshalRevSeqNo(xattrs[base.VirtualXattrRevSeqNo])
 	if err != nil {
 		base.WarnfCtx(ctx, `Could not determine the revSeqNo when attempting to compact channel history for doc %s - history will not be compacted: %v`, base.UD(docid), err)
-		return base.RedactErrorf(`Could not determine the revSeqNo when attempting to compact channel history for doc %s - history will not be compacted: %v`, base.UD(docid), err)
+		return nil, base.RedactErrorf(`Could not determine the revSeqNo when attempting to compact channel history for doc %s - history will not be compacted: %v`, base.UD(docid), err)
 	}
 
 	metadataOnlyUpdate := computeMetadataOnlyUpdate(doc.Cas, revSeqNo, doc.MetadataOnlyUpdate)
 
 	rawMouXattr, err := base.JSONMarshal(metadataOnlyUpdate)
 	if err != nil {
-		return base.RedactErrorf("failed to marshal _mou when attempting to compact channel history for doc: %s. Error: %v", base.UD(docid), err)
+		return nil, base.RedactErrorf("failed to marshal _mou when attempting to compact channel history for doc: %s. Error: %v", base.UD(docid), err)
 	}
 
 	// build macro expansion for sync data. This will avoid the update to xattrs causing an extra import event (i.e. sync cas will be == to doc cas)
@@ -317,7 +321,7 @@ func (c *DatabaseCollection) CompactDocChannelHistory(ctx context.Context, docid
 		base.MouXattrName:  rawMouXattr,
 	}
 	_, err = c.dataStore.UpdateXattrs(ctx, key, 0, cas, updatedXattr, opts)
-	return err
+	return compactedChannels, err
 }
 
 // unmarshalDocumentWithXattrs populates individual xattrs on unmarshalDocumentWithXattrs from a provided xattrs map

--- a/db/crud.go
+++ b/db/crud.go
@@ -295,10 +295,10 @@ func (c *DatabaseCollection) CompactDocChannelHistory(ctx context.Context, docid
 
 	// build macro expansion for sync data. This will avoid the update to xattrs causing an extra import event (i.e. sync cas will be == to doc cas)
 	opts := &sgbucket.MutateInOptions{}
-	spec := []sgbucket.MacroExpansionSpec{
-		sgbucket.NewMacroExpansionSpec(XattrMouCasPath(), sgbucket.MacroCas),
-	}
+	spec := []sgbucket.MacroExpansionSpec{}
+	// Only update _sync.cas if the pre-compaction doc had already been imported by SGW
 	if isSgWrite {
+		spec = append(spec, sgbucket.NewMacroExpansionSpec(XattrMouCasPath(), sgbucket.MacroCas))
 		spec = append(spec, sgbucket.NewMacroExpansionSpec(xattrCasPath(base.SyncXattrName), sgbucket.MacroCas))
 	}
 	opts.MacroExpansion = spec

--- a/db/crud.go
+++ b/db/crud.go
@@ -265,7 +265,7 @@ func (c *DatabaseCollection) CompactDocChannelHistory(ctx context.Context, docid
 	}
 	rawMouXattr, err := base.JSONMarshal(metadataOnlyUpdate)
 	if err != nil {
-		return base.RedactErrorf("failed to marshall _mou when attempting to compact channel history for doc: %s. Error: %v")
+		return base.RedactErrorf("failed to marshall _mou when attempting to compact channel history for doc: %s. Error: %v", base.UD(docid), err)
 	}
 
 	// build macro expansion for sync data. This will avoid the update to xattrs causing an extra import event (i.e. sync cas will be == to doc cas)

--- a/db/crud.go
+++ b/db/crud.go
@@ -253,6 +253,10 @@ func (c *DatabaseCollection) CompactDocChannelHistory(ctx context.Context, docid
 		if importErr != nil {
 			return importErr
 		}
+		if doc == nil {
+			return fmt.Errorf("skipping compaction of document %s, %v ", base.UD(docid), base.ErrNotFound)
+		}
+		cas = doc.Cas
 	}
 
 	// Store lengths before compaction to detect if any changes occur

--- a/db/crud.go
+++ b/db/crud.go
@@ -221,6 +221,67 @@ func (c *DatabaseCollection) GetDocSyncData(ctx context.Context, docid string) (
 
 }
 
+// CompactDocChannelHistory removes channel history entries that ended at or before the given sequence number.
+// This is used to truncate stale channel assignment history to reduce storage overhead.
+func (c *DatabaseCollection) CompactDocChannelHistory(ctx context.Context, docid string, seq uint64) (err error) {
+	key := realDocID(docid)
+	if key == "" {
+		return base.HTTPErrorf(400, "Invalid doc ID")
+	}
+
+	_, xattrs, cas, err := c.dataStore.GetWithXattrs(ctx, key, c.syncGlobalSyncAndUserXattrKeys())
+	if err != nil {
+		return
+	}
+
+	doc, err := c.unmarshalDocumentWithXattrs(ctx, docid, nil, xattrs, cas, DocUnmarshalSync)
+	if err != nil {
+		return
+	}
+
+	var compactedChannelHistory []ChannelSetEntry
+	for _, channel := range doc.SyncData.ChannelSetHistory {
+		if channel.Start > seq {
+			compactedChannelHistory = append(compactedChannelHistory, channel)
+		}
+	}
+
+	doc.SyncData.ChannelSetHistory = compactedChannelHistory
+
+	rawSyncXattr, err := base.JSONMarshal(doc.SyncData)
+	if err != nil {
+		return base.RedactErrorf("failed to marshall sync data when trying to compact channel history for doc:%s. Error: %v", base.UD(docid), err)
+	}
+
+	revSeqNo, err := unmarshalRevSeqNo(xattrs[base.VirtualXattrRevSeqNo])
+	if err != nil {
+		base.InfofCtx(ctx, base.KeyCRUD, `Could not determine the revSeqNo when attempting to compact channel history for doc: %s. Error: %v`, base.UD(docid), err)
+	}
+
+	metadataOnlyUpdate := &MetadataOnlyUpdate{
+		HexCAS:           expandMacroCASValueString,
+		PreviousHexCAS:   doc.SyncData.Cas,
+		PreviousRevSeqNo: revSeqNo,
+	}
+	rawMouXattr, err := base.JSONMarshal(metadataOnlyUpdate)
+	if err != nil {
+		return base.RedactErrorf("failed to marshall _mou when attempting to compact channel history for doc: %s. Error: %v")
+	}
+
+	// build macro expansion for sync data. This will avoid the update to xattrs causing an extra import event (i.e. sync cas will be == to doc cas)
+	opts := &sgbucket.MutateInOptions{}
+	spec := append(macroExpandSpec(base.SyncXattrName), sgbucket.NewMacroExpansionSpec(XattrMouCasPath(), sgbucket.MacroCas))
+	opts.MacroExpansion = spec
+	opts.PreserveExpiry = true // if doc has expiry, we should preserve this
+
+	updatedXattr := map[string][]byte{
+		base.SyncXattrName: rawSyncXattr,
+		base.MouXattrName:  rawMouXattr,
+	}
+	_, err = c.dataStore.UpdateXattrs(ctx, key, 0, cas, updatedXattr, opts)
+	return err
+}
+
 // unmarshalDocumentWithXattrs populates individual xattrs on unmarshalDocumentWithXattrs from a provided xattrs map
 func (db *DatabaseCollection) unmarshalDocumentWithXattrs(ctx context.Context, docid string, data []byte, xattrs map[string][]byte, cas uint64, unmarshalLevel DocumentUnmarshalLevel) (doc *Document, err error) {
 	return unmarshalDocumentWithXattrs(ctx, docid, data, xattrs[base.SyncXattrName], xattrs[base.VvXattrName], xattrs[base.MouXattrName], xattrs[db.UserXattrKey()], xattrs[base.VirtualXattrRevSeqNo], xattrs[base.GlobalXattrName], cas, unmarshalLevel)

--- a/db/crud.go
+++ b/db/crud.go
@@ -230,8 +230,7 @@ func (c *DatabaseCollection) CompactDocChannelHistory(ctx context.Context, docid
 		return nil, base.HTTPErrorf(400, "Invalid doc ID")
 	}
 
-	xattrKeys := []string{base.SyncXattrName, base.VirtualXattrRevSeqNo, base.MouXattrName}
-	rawDoc, xattrs, cas, err := c.dataStore.GetWithXattrs(ctx, key, xattrKeys)
+	rawDoc, xattrs, cas, err := c.dataStore.GetWithXattrs(ctx, key, c.syncGlobalSyncMouRevSeqNoAndUserXattrKeys())
 	if err != nil {
 		return nil, err
 	}
@@ -254,7 +253,7 @@ func (c *DatabaseCollection) CompactDocChannelHistory(ctx context.Context, docid
 			return nil, importErr
 		}
 		if doc == nil {
-			return nil, fmt.Errorf("skipping compaction of document %s, %v ", base.UD(docid), base.ErrNotFound)
+			return nil, base.ErrNotFound
 		}
 		cas = doc.Cas
 	}

--- a/db/crud.go
+++ b/db/crud.go
@@ -229,7 +229,7 @@ func (c *DatabaseCollection) CompactDocChannelHistory(ctx context.Context, docid
 		return base.HTTPErrorf(400, "Invalid doc ID")
 	}
 
-	_, xattrs, cas, err := c.dataStore.GetWithXattrs(ctx, key, c.syncGlobalSyncAndUserXattrKeys())
+	_, xattrs, cas, err := c.dataStore.GetWithXattrs(ctx, key, c.syncGlobalSyncMouRevSeqNoAndUserXattrKeys())
 	if err != nil {
 		return
 	}
@@ -239,18 +239,34 @@ func (c *DatabaseCollection) CompactDocChannelHistory(ctx context.Context, docid
 		return
 	}
 
-	var compactedChannelHistory []ChannelSetEntry
+	var compactedChannelSetHistory []ChannelSetEntry
 	for _, channel := range doc.SyncData.ChannelSetHistory {
-		if channel.Start > seq {
-			compactedChannelHistory = append(compactedChannelHistory, channel)
+		// Keep entries that are still active or that ended after the compaction point.
+		if channel.End > seq {
+			compactedChannelSetHistory = append(compactedChannelSetHistory, channel)
 		}
 	}
+	doc.SyncData.ChannelSetHistory = compactedChannelSetHistory
 
-	doc.SyncData.ChannelSetHistory = compactedChannelHistory
+	var compactedChannelSet []ChannelSetEntry
+	for _, channel := range doc.SyncData.ChannelSet {
+		if channel.End == 0 || channel.End > seq {
+			compactedChannelSet = append(compactedChannelSet, channel)
+		}
+	}
+	doc.SyncData.ChannelSet = compactedChannelSet
+
+	compactedChannels := make(channels.ChannelMap)
+	for chanName, chanEntry := range doc.SyncData.Channels {
+		if chanEntry == nil || chanEntry.Seq > seq {
+			compactedChannels[chanName] = chanEntry
+		}
+	}
+	doc.SyncData.Channels = compactedChannels
 
 	rawSyncXattr, err := base.JSONMarshal(doc.SyncData)
 	if err != nil {
-		return base.RedactErrorf("failed to marshall sync data when trying to compact channel history for doc:%s. Error: %v", base.UD(docid), err)
+		return base.RedactErrorf("failed to marshal sync data when trying to compact channel history for doc:%s. Error: %v", base.UD(docid), err)
 	}
 
 	revSeqNo, err := unmarshalRevSeqNo(xattrs[base.VirtualXattrRevSeqNo])
@@ -265,7 +281,7 @@ func (c *DatabaseCollection) CompactDocChannelHistory(ctx context.Context, docid
 	}
 	rawMouXattr, err := base.JSONMarshal(metadataOnlyUpdate)
 	if err != nil {
-		return base.RedactErrorf("failed to marshall _mou when attempting to compact channel history for doc: %s. Error: %v", base.UD(docid), err)
+		return base.RedactErrorf("failed to marshal _mou when attempting to compact channel history for doc: %s. Error: %v", base.UD(docid), err)
 	}
 
 	// build macro expansion for sync data. This will avoid the update to xattrs causing an extra import event (i.e. sync cas will be == to doc cas)

--- a/db/crud.go
+++ b/db/crud.go
@@ -295,13 +295,13 @@ func (c *DatabaseCollection) CompactDocChannelHistory(ctx context.Context, docid
 
 	// build macro expansion for sync data. This will avoid the update to xattrs causing an extra import event (i.e. sync cas will be == to doc cas)
 	opts := &sgbucket.MutateInOptions{}
-	spec := []sgbucket.MacroExpansionSpec{}
-	// Only update _sync.cas if the pre-compaction doc had already been imported by SGW
+	// Only update _sync.cas and _mou.cas if the pre-compaction doc had already been imported by SGW
 	if isSgWrite {
-		spec = append(spec, sgbucket.NewMacroExpansionSpec(XattrMouCasPath(), sgbucket.MacroCas))
-		spec = append(spec, sgbucket.NewMacroExpansionSpec(xattrCasPath(base.SyncXattrName), sgbucket.MacroCas))
+		opts.MacroExpansion = []sgbucket.MacroExpansionSpec{
+			sgbucket.NewMacroExpansionSpec(XattrMouCasPath(), sgbucket.MacroCas),
+			sgbucket.NewMacroExpansionSpec(xattrCasPath(base.SyncXattrName), sgbucket.MacroCas),
+		}
 	}
-	opts.MacroExpansion = spec
 	opts.PreserveExpiry = true // if doc has expiry, we should preserve this
 
 	updatedXattr := map[string][]byte{

--- a/db/crud.go
+++ b/db/crud.go
@@ -15,6 +15,7 @@ import (
 	"maps"
 	"math"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -223,46 +224,48 @@ func (c *DatabaseCollection) GetDocSyncData(ctx context.Context, docid string) (
 
 // CompactDocChannelHistory removes channel history entries that ended at or before the given sequence number.
 // This is used to truncate stale channel assignment history to reduce storage overhead.
-func (c *DatabaseCollection) CompactDocChannelHistory(ctx context.Context, docid string, seq uint64) (err error) {
+func (c *DatabaseCollection) CompactDocChannelHistory(ctx context.Context, docid string, seq uint64) error {
 	key := realDocID(docid)
 	if key == "" {
 		return base.HTTPErrorf(400, "Invalid doc ID")
 	}
 
-	_, xattrs, cas, err := c.dataStore.GetWithXattrs(ctx, key, c.syncGlobalSyncMouRevSeqNoAndUserXattrKeys())
+	xattrKeys := []string{base.SyncXattrName, base.VirtualXattrRevSeqNo, base.MouXattrName}
+	_, xattrs, cas, err := c.dataStore.GetWithXattrs(ctx, key, xattrKeys)
 	if err != nil {
-		return
+		return err
 	}
 
-	doc, err := c.unmarshalDocumentWithXattrs(ctx, docid, nil, xattrs, cas, DocUnmarshalSync)
+	doc, err := c.unmarshalDocumentWithXattrs(ctx, key, nil, xattrs, cas, DocUnmarshalSync)
 	if err != nil {
-		return
+		return err
 	}
 
-	var compactedChannelSetHistory []ChannelSetEntry
-	for _, channel := range doc.SyncData.ChannelSetHistory {
-		// Keep entries that are still active or that ended after the compaction point.
-		if channel.End > seq {
-			compactedChannelSetHistory = append(compactedChannelSetHistory, channel)
-		}
-	}
-	doc.SyncData.ChannelSetHistory = compactedChannelSetHistory
+	// Store lengths before compaction to detect if any changes occur
+	historyLenBefore := len(doc.SyncData.ChannelSetHistory)
+	channelSetLenBefore := len(doc.SyncData.ChannelSet)
+	channelsLenBefore := len(doc.SyncData.Channels)
 
-	var compactedChannelSet []ChannelSetEntry
-	for _, channel := range doc.SyncData.ChannelSet {
-		if channel.End == 0 || channel.End > seq {
-			compactedChannelSet = append(compactedChannelSet, channel)
-		}
-	}
-	doc.SyncData.ChannelSet = compactedChannelSet
+	doc.SyncData.ChannelSetHistory = slices.DeleteFunc(doc.SyncData.ChannelSetHistory, func(channel ChannelSetEntry) bool {
+		return channel.End <= seq
+	})
 
-	compactedChannels := make(channels.ChannelMap)
+	doc.SyncData.ChannelSet = slices.DeleteFunc(doc.SyncData.ChannelSet, func(channel ChannelSetEntry) bool {
+		return channel.End != 0 && channel.End <= seq
+	})
+
 	for chanName, chanEntry := range doc.SyncData.Channels {
-		if chanEntry == nil || chanEntry.Seq > seq {
-			compactedChannels[chanName] = chanEntry
+		if chanEntry != nil && chanEntry.Seq <= seq {
+			delete(doc.SyncData.Channels, chanName)
 		}
 	}
-	doc.SyncData.Channels = compactedChannels
+
+	// Exit early if no compaction occurred
+	if len(doc.SyncData.ChannelSetHistory) == historyLenBefore &&
+		len(doc.SyncData.ChannelSet) == channelSetLenBefore &&
+		len(doc.SyncData.Channels) == channelsLenBefore {
+		return nil
+	}
 
 	rawSyncXattr, err := base.JSONMarshal(doc.SyncData)
 	if err != nil {
@@ -274,11 +277,8 @@ func (c *DatabaseCollection) CompactDocChannelHistory(ctx context.Context, docid
 		base.InfofCtx(ctx, base.KeyCRUD, `Could not determine the revSeqNo when attempting to compact channel history for doc: %s. Error: %v`, base.UD(docid), err)
 	}
 
-	metadataOnlyUpdate := &MetadataOnlyUpdate{
-		HexCAS:           expandMacroCASValueString,
-		PreviousHexCAS:   doc.SyncData.Cas,
-		PreviousRevSeqNo: revSeqNo,
-	}
+	metadataOnlyUpdate := computeMetadataOnlyUpdate(doc.Cas, revSeqNo, doc.MetadataOnlyUpdate)
+
 	rawMouXattr, err := base.JSONMarshal(metadataOnlyUpdate)
 	if err != nil {
 		return base.RedactErrorf("failed to marshal _mou when attempting to compact channel history for doc: %s. Error: %v", base.UD(docid), err)
@@ -286,7 +286,10 @@ func (c *DatabaseCollection) CompactDocChannelHistory(ctx context.Context, docid
 
 	// build macro expansion for sync data. This will avoid the update to xattrs causing an extra import event (i.e. sync cas will be == to doc cas)
 	opts := &sgbucket.MutateInOptions{}
-	spec := append(macroExpandSpec(base.SyncXattrName), sgbucket.NewMacroExpansionSpec(XattrMouCasPath(), sgbucket.MacroCas))
+	spec := []sgbucket.MacroExpansionSpec{
+		sgbucket.NewMacroExpansionSpec(xattrCasPath(base.SyncXattrName), sgbucket.MacroCas),
+		sgbucket.NewMacroExpansionSpec(XattrMouCasPath(), sgbucket.MacroCas),
+	}
 	opts.MacroExpansion = spec
 	opts.PreserveExpiry = true // if doc has expiry, we should preserve this
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3946,7 +3946,7 @@ func TestDocumentChannelHistoryCompact(t *testing.T) {
 		assert.Len(t, syncData.ChannelSetHistory, 0)
 
 		// Add multiple channels - generates history for the previously removed channel
-		version = rt.UpdateDoc("doc1", version, `{"channels": ["test", "test2"]}`)
+		_ = rt.UpdateDoc("doc1", version, `{"channels": ["test", "test2"]}`)
 		syncData, err = collection.GetDocSyncData(ctx, "doc1")
 		assert.NoError(t, err)
 
@@ -3968,7 +3968,7 @@ func TestDocumentChannelHistoryCompact(t *testing.T) {
 		// Compact with seq=0 should keep all entries
 		version := rt.PutDoc("doc2", `{"channels": ["test"]}`)
 		version = rt.UpdateDoc("doc2", version, `{"channels": []}`)
-		version = rt.UpdateDoc("doc2", version, `{"channels": ["test", "test2"]}`)
+		_ = rt.UpdateDoc("doc2", version, `{"channels": ["test", "test2"]}`)
 
 		syncDataBefore, err := collection.GetDocSyncData(ctx, "doc2")
 		require.NoError(t, err)
@@ -3987,7 +3987,7 @@ func TestDocumentChannelHistoryCompact(t *testing.T) {
 		// Compact with very high seq removes all history
 		version := rt.PutDoc("doc3", `{"channels": ["test"]}`)
 		version = rt.UpdateDoc("doc3", version, `{"channels": []}`)
-		version = rt.UpdateDoc("doc3", version, `{"channels": ["test", "test2"]}`)
+		_ = rt.UpdateDoc("doc3", version, `{"channels": ["test", "test2"]}`)
 
 		syncDataBefore, err := collection.GetDocSyncData(ctx, "doc3")
 		require.NoError(t, err)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3918,54 +3918,263 @@ func TestFetchBackupRevisionByCVThroughAPI(t *testing.T) {
 }
 
 func TestDocumentChannelHistoryCompact(t *testing.T) {
+	if !base.TestUseXattrs() {
+		t.Skip("CompactDocChannelHistory requires XATTR-based metadata")
+	}
 	rt := NewRestTester(t, &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
 	defer rt.Close()
 
-	var body db.Body
-
-	// Create a document with a single channel assignment
-	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc", `{"channels": ["test"]}`)
-	RequireStatus(t, resp, http.StatusCreated)
-	err := json.Unmarshal(resp.BodyBytes(), &body)
-	assert.NoError(t, err)
 	collection, ctx := rt.GetSingleTestDatabaseCollection()
-	syncData, err := collection.GetDocSyncData(ctx, "doc")
-	assert.NoError(t, err)
 
-	require.Len(t, syncData.ChannelSet, 1)
-	assert.Equal(t, syncData.ChannelSet[0], db.ChannelSetEntry{Name: "test", Start: 1, End: 0})
-	assert.Len(t, syncData.ChannelSetHistory, 0)
+	t.Run("basic compaction", func(t *testing.T) {
+		var body db.Body
+		// Create a document with a single channel assignment
+		resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1", `{"channels": ["test"]}`)
+		RequireStatus(t, resp, http.StatusCreated)
+		err := json.Unmarshal(resp.BodyBytes(), &body)
+		require.NoError(t, err)
+		syncData, err := collection.GetDocSyncData(ctx, "doc1")
+		assert.NoError(t, err)
 
-	// Remove all channels - creates history entry for the removed channel
-	resp = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc?rev="+body["rev"].(string), `{"channels": []}`)
-	RequireStatus(t, resp, http.StatusCreated)
-	err = json.Unmarshal(resp.BodyBytes(), &body)
-	assert.NoError(t, err)
-	syncData, err = collection.GetDocSyncData(ctx, "doc")
-	assert.NoError(t, err)
+		require.Len(t, syncData.ChannelSet, 1)
+		assert.Equal(t, db.ChannelSetEntry{Name: "test", Start: 1, End: 0}, syncData.ChannelSet[0])
+		assert.Len(t, syncData.ChannelSetHistory, 0)
 
-	require.Len(t, syncData.ChannelSet, 1)
-	assert.Equal(t, syncData.ChannelSet[0], db.ChannelSetEntry{Name: "test", Start: 1, End: 2})
-	assert.Len(t, syncData.ChannelSetHistory, 0)
+		// Remove all channels - ends the existing channel range in ChannelSet
+		resp = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc1?rev="+body["rev"].(string), `{"channels": []}`)
+		RequireStatus(t, resp, http.StatusCreated)
+		err = json.Unmarshal(resp.BodyBytes(), &body)
+		require.NoError(t, err)
+		syncData, err = collection.GetDocSyncData(ctx, "doc1")
+		assert.NoError(t, err)
 
-	// Add multiple channels - generates history for the previously removed channel
-	resp = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc?rev="+body["rev"].(string), `{"channels": ["test", "test2"]}`)
-	RequireStatus(t, resp, http.StatusCreated)
-	err = json.Unmarshal(resp.BodyBytes(), &body)
-	assert.NoError(t, err)
-	syncData, err = collection.GetDocSyncData(ctx, "doc")
-	assert.NoError(t, err)
+		require.Len(t, syncData.ChannelSet, 1)
+		assert.Equal(t, db.ChannelSetEntry{Name: "test", Start: 1, End: 2}, syncData.ChannelSet[0])
+		assert.Len(t, syncData.ChannelSetHistory, 0)
 
-	require.Len(t, syncData.ChannelSet, 2)
-	assert.Contains(t, syncData.ChannelSet, db.ChannelSetEntry{Name: "test", Start: 3, End: 0})
-	assert.Contains(t, syncData.ChannelSet, db.ChannelSetEntry{Name: "test2", Start: 3, End: 0})
-	require.Len(t, syncData.ChannelSetHistory, 1)
-	assert.Equal(t, syncData.ChannelSetHistory[0], db.ChannelSetEntry{Name: "test", Start: 1, End: 2})
+		// Add multiple channels - generates history for the previously removed channel
+		resp = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc1?rev="+body["rev"].(string), `{"channels": ["test", "test2"]}`)
+		RequireStatus(t, resp, http.StatusCreated)
+		err = json.Unmarshal(resp.BodyBytes(), &body)
+		require.NoError(t, err)
+		syncData, err = collection.GetDocSyncData(ctx, "doc1")
+		assert.NoError(t, err)
 
-	// Compact history at sequence 2 and verify history is cleared
-	err = collection.CompactDocChannelHistory(ctx, "doc", 2)
-	require.NoError(t, err)
-	syncData, err = collection.GetDocSyncData(ctx, "doc")
-	assert.NoError(t, err)
-	assert.Nil(t, syncData.ChannelSetHistory)
+		require.Len(t, syncData.ChannelSet, 2)
+		assert.Contains(t, syncData.ChannelSet, db.ChannelSetEntry{Name: "test", Start: 3, End: 0})
+		assert.Contains(t, syncData.ChannelSet, db.ChannelSetEntry{Name: "test2", Start: 3, End: 0})
+		require.Len(t, syncData.ChannelSetHistory, 1)
+		assert.Equal(t, db.ChannelSetEntry{Name: "test", Start: 1, End: 2}, syncData.ChannelSetHistory[0])
+
+		// Compact history at sequence 2 and verify history is cleared
+		err = collection.CompactDocChannelHistory(ctx, "doc1", 2)
+		require.NoError(t, err)
+		syncData, err = collection.GetDocSyncData(ctx, "doc1")
+		assert.NoError(t, err)
+		assert.Nil(t, syncData.ChannelSetHistory)
+	})
+
+	t.Run("seq zero keeps all history", func(t *testing.T) {
+		// Compact with seq=0 should keep all entries
+		var body db.Body
+		resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc2", `{"channels": ["test"]}`)
+		RequireStatus(t, resp, http.StatusCreated)
+		err := json.Unmarshal(resp.BodyBytes(), &body)
+		require.NoError(t, err)
+
+		resp = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc2?rev="+body["rev"].(string), `{"channels": []}`)
+		RequireStatus(t, resp, http.StatusCreated)
+		err = json.Unmarshal(resp.BodyBytes(), &body)
+		require.NoError(t, err)
+
+		resp = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc2?rev="+body["rev"].(string), `{"channels": ["test", "test2"]}`)
+		RequireStatus(t, resp, http.StatusCreated)
+		err = json.Unmarshal(resp.BodyBytes(), &body)
+		require.NoError(t, err)
+
+		syncDataBefore, err := collection.GetDocSyncData(ctx, "doc2")
+		require.NoError(t, err)
+		historyLenBefore := len(syncDataBefore.ChannelSetHistory)
+		require.Greater(t, historyLenBefore, 0)
+
+		err = collection.CompactDocChannelHistory(ctx, "doc2", 0)
+		require.NoError(t, err)
+
+		syncDataAfter, err := collection.GetDocSyncData(ctx, "doc2")
+		require.NoError(t, err)
+		assert.Equal(t, historyLenBefore, len(syncDataAfter.ChannelSetHistory))
+	})
+
+	t.Run("compact all history", func(t *testing.T) {
+		// Compact with very high seq removes all history
+		var body db.Body
+		resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc3", `{"channels": ["test"]}`)
+		RequireStatus(t, resp, http.StatusCreated)
+		err := json.Unmarshal(resp.BodyBytes(), &body)
+		require.NoError(t, err)
+
+		resp = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc3?rev="+body["rev"].(string), `{"channels": []}`)
+		RequireStatus(t, resp, http.StatusCreated)
+		err = json.Unmarshal(resp.BodyBytes(), &body)
+		require.NoError(t, err)
+
+		resp = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc3?rev="+body["rev"].(string), `{"channels": ["test", "test2"]}`)
+		RequireStatus(t, resp, http.StatusCreated)
+		err = json.Unmarshal(resp.BodyBytes(), &body)
+		require.NoError(t, err)
+
+		syncDataBefore, err := collection.GetDocSyncData(ctx, "doc3")
+		require.NoError(t, err)
+
+		// Compact with very high seq number
+		err = collection.CompactDocChannelHistory(ctx, "doc3", 999999)
+		require.NoError(t, err)
+
+		syncData, err := collection.GetDocSyncData(ctx, "doc3")
+		require.NoError(t, err)
+		assert.Nil(t, syncData.ChannelSetHistory)
+		assert.Equal(t, len(syncDataBefore.Channels), len(syncData.Channels))
+		assert.Equal(t, len(syncDataBefore.ChannelSet), len(syncData.ChannelSet))
+	})
+
+	t.Run("partial history compaction", func(t *testing.T) {
+		// Compact removes entries with End <= seq, keeps entries with End > seq
+		var body db.Body
+		resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc4", `{"channels": ["a"]}`)
+		RequireStatus(t, resp, http.StatusCreated)
+		err := json.Unmarshal(resp.BodyBytes(), &body)
+		require.NoError(t, err)
+
+		resp = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc4?rev="+body["rev"].(string), `{"channels": []}`)
+		RequireStatus(t, resp, http.StatusCreated)
+		err = json.Unmarshal(resp.BodyBytes(), &body)
+		require.NoError(t, err)
+
+		resp = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc4?rev="+body["rev"].(string), `{"channels": ["b"]}`)
+		RequireStatus(t, resp, http.StatusCreated)
+		err = json.Unmarshal(resp.BodyBytes(), &body)
+		require.NoError(t, err)
+
+		resp = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc4?rev="+body["rev"].(string), `{"channels": []}`)
+		RequireStatus(t, resp, http.StatusCreated)
+		err = json.Unmarshal(resp.BodyBytes(), &body)
+		require.NoError(t, err)
+
+		syncDataBefore, err := collection.GetDocSyncData(ctx, "doc4")
+		require.NoError(t, err)
+		channelSetLenBefore := len(syncDataBefore.ChannelSet)
+		channelLenBefore := len(syncDataBefore.Channels)
+
+		// Compact at seq 3
+		err = collection.CompactDocChannelHistory(ctx, "doc4", 2)
+		require.NoError(t, err)
+
+		syncDataAfter, err := collection.GetDocSyncData(ctx, "doc4")
+		require.NoError(t, err)
+
+		// Verify: only entries with End > 3 or End == 0 (still active) should remain
+		for _, entry := range syncDataAfter.ChannelSet {
+			assert.True(t, entry.End == 0 || entry.End > uint64(3))
+		}
+
+		// Verify only channels with seq > 3 should remain
+		for _, entry := range syncDataAfter.Channels {
+			assert.True(t, entry.Seq > uint64(3))
+		}
+
+		// Should have fewer than before
+		assert.Less(t, len(syncDataAfter.Channels), channelLenBefore)
+		assert.Less(t, len(syncDataAfter.ChannelSet), channelSetLenBefore)
+	})
+
+	t.Run("invalid doc id", func(t *testing.T) {
+		// Empty doc ID should return 400 error
+		err := collection.CompactDocChannelHistory(ctx, "", 1)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "Invalid doc ID")
+	})
+
+	t.Run("nonexistent document", func(t *testing.T) {
+		// Compacting nonexistent doc should return not found error
+		err := collection.CompactDocChannelHistory(ctx, "nonexistent", 1)
+		assert.Error(t, err)
+	})
+
+	t.Run("multiple channels with mixed history", func(t *testing.T) {
+		// Complex scenario with multiple channels
+		var body db.Body
+		resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc7", `{"channels": ["a", "b"]}`)
+		RequireStatus(t, resp, http.StatusCreated)
+		err := json.Unmarshal(resp.BodyBytes(), &body)
+		require.NoError(t, err)
+
+		resp = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc7?rev="+body["rev"].(string), `{"channels": ["a"]}`)
+		RequireStatus(t, resp, http.StatusCreated)
+		err = json.Unmarshal(resp.BodyBytes(), &body)
+		require.NoError(t, err)
+
+		resp = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc7?rev="+body["rev"].(string), `{"channels": ["a", "c"]}`)
+		RequireStatus(t, resp, http.StatusCreated)
+		err = json.Unmarshal(resp.BodyBytes(), &body)
+		require.NoError(t, err)
+
+		syncDataBefore, err := collection.GetDocSyncData(ctx, "doc7")
+		require.NoError(t, err)
+		err = collection.CompactDocChannelHistory(ctx, "doc7", 2)
+		require.NoError(t, err)
+
+		syncData, err := collection.GetDocSyncData(ctx, "doc7")
+		require.NoError(t, err)
+		// Should still have active channels
+		assert.Less(t, len(syncData.ChannelSet), len(syncDataBefore.ChannelSet))
+		assert.Less(t, len(syncData.Channels), len(syncDataBefore.Channels))
+	})
+
+	t.Run("compact empty history", func(t *testing.T) {
+		// Doc with no history should succeed
+		var body db.Body
+		resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc8", `{"channels": ["test"]}`)
+		RequireStatus(t, resp, http.StatusCreated)
+		err := json.Unmarshal(resp.BodyBytes(), &body)
+		require.NoError(t, err)
+
+		syncDataBefore, err := collection.GetDocSyncData(ctx, "doc8")
+		require.NoError(t, err)
+		assert.Len(t, syncDataBefore.ChannelSetHistory, 0)
+
+		err = collection.CompactDocChannelHistory(ctx, "doc8", 1)
+		require.NoError(t, err)
+
+		syncDataAfter, err := collection.GetDocSyncData(ctx, "doc8")
+		require.NoError(t, err)
+		assert.Len(t, syncDataAfter.ChannelSetHistory, 0)
+	})
+
+	t.Run("verify xattr updates", func(t *testing.T) {
+		// Verify CAS is updated and no reimport happens
+		var body db.Body
+		resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc10", `{"channels": ["test"]}`)
+		RequireStatus(t, resp, http.StatusCreated)
+		err := json.Unmarshal(resp.BodyBytes(), &body)
+		require.NoError(t, err)
+
+		resp = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc10?rev="+body["rev"].(string), `{"channels": []}`)
+		RequireStatus(t, resp, http.StatusCreated)
+		err = json.Unmarshal(resp.BodyBytes(), &body)
+		require.NoError(t, err)
+
+		resp = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc10?rev="+body["rev"].(string), `{"channels": ["test", "test2"]}`)
+		RequireStatus(t, resp, http.StatusCreated)
+		err = json.Unmarshal(resp.BodyBytes(), &body)
+		require.NoError(t, err)
+
+		// After compaction, document should still be accessible
+		err = collection.CompactDocChannelHistory(ctx, "doc10", 2)
+		require.NoError(t, err)
+
+		// Verify doc is still accessible with correct data
+		syncData, err := collection.GetDocSyncData(ctx, "doc10")
+		require.NoError(t, err)
+		assert.NotNil(t, syncData)
+	})
 }

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3971,7 +3971,7 @@ func TestDocumentChannelHistoryCompact(t *testing.T) {
 		require.NoError(t, err)
 		syncData, err = collection.GetDocSyncData(ctx, "doc1")
 		assert.NoError(t, err)
-		assert.Nil(t, syncData.ChannelSetHistory)
+		assert.Zero(t, len(syncData.ChannelSetHistory))
 	})
 
 	t.Run("seq zero keeps all history", func(t *testing.T) {
@@ -4032,7 +4032,7 @@ func TestDocumentChannelHistoryCompact(t *testing.T) {
 
 		syncData, err := collection.GetDocSyncData(ctx, "doc3")
 		require.NoError(t, err)
-		assert.Nil(t, syncData.ChannelSetHistory)
+		assert.Zero(t, len(syncData.ChannelSetHistory))
 		assert.Equal(t, len(syncDataBefore.Channels), len(syncData.Channels))
 		assert.Equal(t, len(syncDataBefore.ChannelSet), len(syncData.ChannelSet))
 	})

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -4185,8 +4185,7 @@ func TestCompactNonImportedDocWithAutoImport(t *testing.T) {
 	// History should be compacted
 	assert.Less(t, len(syncData.ChannelSetHistory), len(syncDataBefore.ChannelSetHistory))
 	// CV must be updated by the import triggered during compaction
-	// This assertion should be changed after CBG-5397
-	assert.Equal(t, cvBeforeCompaction, syncData.CVOrRevTreeID(), "cv should be updated after compaction import")
+	assert.NotEqual(t, cvBeforeCompaction, syncData.CVOrRevTreeID(), "cv should be updated after compaction import")
 
 	// Step 10: Verify document is still accessible and intact
 	docFromBucket, _, err := rt.GetSingleDataStore().GetRaw(ctx, nonImportedDocID)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3957,8 +3957,9 @@ func TestDocumentChannelHistoryCompact(t *testing.T) {
 		assert.Equal(t, db.ChannelSetEntry{Name: "test", Start: 1, End: 2}, syncData.ChannelSetHistory[0])
 
 		// Compact history at sequence 2 and verify history is cleared
-		err = collection.CompactDocChannelHistory(ctx, "doc1", 2)
+		compactedChannels, err := collection.CompactDocChannelHistory(ctx, "doc1", 2)
 		require.NoError(t, err)
+		assert.Equal(t, []string{"test"}, compactedChannels)
 		syncData, err = collection.GetDocSyncData(ctx, "doc1")
 		assert.NoError(t, err)
 		assert.Zero(t, len(syncData.ChannelSetHistory))
@@ -3975,8 +3976,9 @@ func TestDocumentChannelHistoryCompact(t *testing.T) {
 		historyLenBefore := len(syncDataBefore.ChannelSetHistory)
 		require.Greater(t, historyLenBefore, 0)
 
-		err = collection.CompactDocChannelHistory(ctx, "doc2", 0)
+		compactedChannels, err := collection.CompactDocChannelHistory(ctx, "doc2", 0)
 		require.NoError(t, err)
+		assert.Equal(t, []string{}, compactedChannels)
 
 		syncDataAfter, err := collection.GetDocSyncData(ctx, "doc2")
 		require.NoError(t, err)
@@ -3993,8 +3995,9 @@ func TestDocumentChannelHistoryCompact(t *testing.T) {
 		require.NoError(t, err)
 
 		// Compact with very high seq number
-		err = collection.CompactDocChannelHistory(ctx, "doc3", 999999)
+		compactedChannels, err := collection.CompactDocChannelHistory(ctx, "doc3", 999999)
 		require.NoError(t, err)
+		assert.Equal(t, []string{"test"}, compactedChannels)
 
 		syncData, err := collection.GetDocSyncData(ctx, "doc3")
 		require.NoError(t, err)
@@ -4018,8 +4021,9 @@ func TestDocumentChannelHistoryCompact(t *testing.T) {
 		channelSetLenBefore := len(syncDataBefore.ChannelSet)
 		channelLenBefore := len(syncDataBefore.Channels)
 
-		err = collection.CompactDocChannelHistory(ctx, "doc4", docSeq)
+		compactedChannels, err := collection.CompactDocChannelHistory(ctx, "doc4", docSeq)
 		require.NoError(t, err)
+		assert.Equal(t, []string{"a", "a"}, compactedChannels)
 
 		syncDataAfter, err := collection.GetDocSyncData(ctx, "doc4")
 		require.NoError(t, err)
@@ -4039,14 +4043,14 @@ func TestDocumentChannelHistoryCompact(t *testing.T) {
 
 	t.Run("invalid doc id", func(t *testing.T) {
 		// Empty doc ID should return 400 error
-		err := collection.CompactDocChannelHistory(ctx, "", 1)
+		_, err := collection.CompactDocChannelHistory(ctx, "", 1)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "Invalid doc ID")
 	})
 
 	t.Run("nonexistent document", func(t *testing.T) {
 		// Compacting nonexistent doc should return not found error
-		err := collection.CompactDocChannelHistory(ctx, "nonexistent", 1)
+		_, err := collection.CompactDocChannelHistory(ctx, "nonexistent", 1)
 		assert.Error(t, err)
 	})
 
@@ -4061,8 +4065,9 @@ func TestDocumentChannelHistoryCompact(t *testing.T) {
 
 		syncDataBefore, err := collection.GetDocSyncData(ctx, "doc7")
 		require.NoError(t, err)
-		err = collection.CompactDocChannelHistory(ctx, "doc7", docSeq)
+		compactedChannels, err := collection.CompactDocChannelHistory(ctx, "doc7", docSeq)
 		require.NoError(t, err)
+		assert.Equal(t, []string{"b", "b"}, compactedChannels)
 
 		syncData, err := collection.GetDocSyncData(ctx, "doc7")
 		require.NoError(t, err)
@@ -4079,8 +4084,9 @@ func TestDocumentChannelHistoryCompact(t *testing.T) {
 		require.NoError(t, err)
 		assert.Len(t, syncDataBefore.ChannelSetHistory, 0)
 
-		err = collection.CompactDocChannelHistory(ctx, "doc8", 1)
+		compactedChannels, err := collection.CompactDocChannelHistory(ctx, "doc8", 1)
 		require.NoError(t, err)
+		assert.Equal(t, []string{}, compactedChannels)
 
 		syncDataAfter, err := collection.GetDocSyncData(ctx, "doc8")
 		require.NoError(t, err)
@@ -4092,10 +4098,12 @@ func TestDocumentChannelHistoryCompact(t *testing.T) {
 		version := rt.PutDoc("doc10", `{"channels": ["test"]}`)
 		version = rt.UpdateDoc("doc10", version, `{"channels": []}`)
 		_ = rt.UpdateDoc("doc10", version, `{"channels": ["test", "test2"]}`)
+		seq := rt.GetDocumentSequence("doc10")
 
 		// After compaction, document should still be accessible
-		err := collection.CompactDocChannelHistory(ctx, "doc10", 2)
+		compactedChannels, err := collection.CompactDocChannelHistory(ctx, "doc10", seq)
 		require.NoError(t, err)
+		assert.Equal(t, []string{"test"}, compactedChannels)
 
 		// Verify doc is still accessible with correct data
 		syncData, err := collection.GetDocSyncData(ctx, "doc10")
@@ -4164,8 +4172,9 @@ func TestCompactNonImportedDocWithAutoImport(t *testing.T) {
 
 	// Step 8: Call CompactDocChannelHistory - this will trigger the auto-import check
 	// which verifies the document is imported (has valid _sync xattr) before compacting
-	err = collection.CompactDocChannelHistory(ctx, nonImportedDocID, docSeq-1)
+	compactedChannels, err := collection.CompactDocChannelHistory(ctx, nonImportedDocID, docSeq-1)
 	require.NoError(t, err)
+	assert.Equal(t, []string{"test_channel"}, compactedChannels)
 
 	// Step 9: Verify compaction succeeded and history was removed
 	syncData, err := collection.GetDocSyncData(ctx, nonImportedDocID)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -4181,7 +4181,6 @@ func TestCompactNonImportedDocWithAutoImport(t *testing.T) {
 
 	// Step 9: Verify compaction succeeded and history was removed
 	require.NoError(t, err)
-	//syncData, _, err := collection.GetDocSyncDataNoImport(ctx, nonImportedDocID, db.DocUnmarshalSync)
 
 	xattrs, cas, err := dataStore.GetXattrs(ctx, nonImportedDocID, []string{base.SyncXattrName, base.VvXattrName, base.MouXattrName})
 	require.NoError(t, err)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -4130,6 +4130,7 @@ func TestCompactNonImportedDocWithAutoImport(t *testing.T) {
 	defer rt.Close()
 
 	collection, ctx := rt.GetSingleTestDatabaseCollection()
+	dataStore := rt.GetSingleDataStore()
 
 	// Step 1-6: Use REST API to create document with channel history
 	nonImportedDocID := "non_imported_doc"
@@ -4155,7 +4156,7 @@ func TestCompactNonImportedDocWithAutoImport(t *testing.T) {
 
 	// Step 7: Update the document body directly in the datastore to simulate external modification
 	// Read current document body
-	docBytesRaw, _, err := rt.GetSingleDataStore().GetRaw(ctx, nonImportedDocID)
+	docBytesRaw, _, err := dataStore.GetRaw(ctx, nonImportedDocID)
 	require.NoError(t, err)
 	var docBody map[string]any
 	err = json.Unmarshal(docBytesRaw, &docBody)
@@ -4169,7 +4170,7 @@ func TestCompactNonImportedDocWithAutoImport(t *testing.T) {
 	require.NoError(t, err)
 
 	// Write modified body back to datastore
-	err = rt.GetSingleDataStore().SetRaw(ctx, nonImportedDocID, 0, nil, modifiedDocBytes)
+	err = dataStore.SetRaw(ctx, nonImportedDocID, 0, nil, modifiedDocBytes)
 	require.NoError(t, err)
 
 	// Step 8: Call CompactDocChannelHistory - this will trigger the auto-import check
@@ -4180,12 +4181,25 @@ func TestCompactNonImportedDocWithAutoImport(t *testing.T) {
 
 	// Step 9: Verify compaction succeeded and history was removed
 	require.NoError(t, err)
-	syncData, _, err := collection.GetDocSyncDataNoImport(ctx, nonImportedDocID, db.DocUnmarshalSync)
+	//syncData, _, err := collection.GetDocSyncDataNoImport(ctx, nonImportedDocID, db.DocUnmarshalSync)
+
+	xattrs, cas, err := dataStore.GetXattrs(ctx, nonImportedDocID, []string{base.SyncXattrName, base.VvXattrName, base.MouXattrName})
 	require.NoError(t, err)
+	doc := db.NewDocument(nonImportedDocID)
+	err = doc.UnmarshalWithXattrs(ctx, nil, xattrs[base.SyncXattrName], xattrs[base.VvXattrName], nil, nil, db.DocUnmarshalSync)
+	require.NoError(t, err)
+	err = base.JSONUnmarshal(xattrs[base.MouXattrName], &doc.MetadataOnlyUpdate)
+	require.NoError(t, err)
+
 	// History should be compacted
-	assert.Less(t, len(syncData.ChannelSetHistory), len(syncDataBefore.ChannelSetHistory))
+	assert.Less(t, len(doc.SyncData.ChannelSetHistory), len(syncDataBefore.ChannelSetHistory))
 	// CV must be updated by the import triggered during compaction
-	assert.NotEqual(t, cvBeforeCompaction, syncData.CVOrRevTreeID(), "cv should be updated after compaction import")
+	assert.NotEqual(t, cvBeforeCompaction, doc.SyncData.CVOrRevTreeID(), "cv should be updated after compaction import")
+	// sync cas should be equal to doc cas
+	assert.Equal(t, doc.SyncData.Cas, base.CasToString(cas))
+	// verify _mou.cas
+	mouCAS := base.HexCasToUint64(doc.MetadataOnlyUpdate.HexCAS)
+	assert.Equal(t, mouCAS, cas)
 
 	// Step 10: Verify document is still accessible and intact
 	docFromBucket, _, err := rt.GetSingleDataStore().GetRaw(ctx, nonImportedDocID)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -4050,6 +4050,8 @@ func TestDocumentChannelHistoryCompact(t *testing.T) {
 		err = json.Unmarshal(resp.BodyBytes(), &body)
 		require.NoError(t, err)
 
+		docSeq := rt.GetDocumentSequence("doc4")
+
 		resp = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc4?rev="+body["rev"].(string), `{"channels": ["b"]}`)
 		RequireStatus(t, resp, http.StatusCreated)
 		err = json.Unmarshal(resp.BodyBytes(), &body)
@@ -4066,7 +4068,7 @@ func TestDocumentChannelHistoryCompact(t *testing.T) {
 		channelLenBefore := len(syncDataBefore.Channels)
 
 		// Compact at seq 3
-		err = collection.CompactDocChannelHistory(ctx, "doc4", 2)
+		err = collection.CompactDocChannelHistory(ctx, "doc4", docSeq)
 		require.NoError(t, err)
 
 		syncDataAfter, err := collection.GetDocSyncData(ctx, "doc4")
@@ -4113,6 +4115,8 @@ func TestDocumentChannelHistoryCompact(t *testing.T) {
 		err = json.Unmarshal(resp.BodyBytes(), &body)
 		require.NoError(t, err)
 
+		docSeq := rt.GetDocumentSequence("doc7")
+
 		resp = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc7?rev="+body["rev"].(string), `{"channels": ["a", "c"]}`)
 		RequireStatus(t, resp, http.StatusCreated)
 		err = json.Unmarshal(resp.BodyBytes(), &body)
@@ -4120,7 +4124,7 @@ func TestDocumentChannelHistoryCompact(t *testing.T) {
 
 		syncDataBefore, err := collection.GetDocSyncData(ctx, "doc7")
 		require.NoError(t, err)
-		err = collection.CompactDocChannelHistory(ctx, "doc7", 2)
+		err = collection.CompactDocChannelHistory(ctx, "doc7", docSeq)
 		require.NoError(t, err)
 
 		syncData, err := collection.GetDocSyncData(ctx, "doc7")

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -4179,12 +4179,14 @@ func TestCompactNonImportedDocWithAutoImport(t *testing.T) {
 	assert.Equal(t, []string{"test_channel"}, compactedChannels)
 
 	// Step 9: Verify compaction succeeded and history was removed
-	syncData, err := collection.GetDocSyncData(ctx, nonImportedDocID)
+	require.NoError(t, err)
+	syncData, _, err := collection.GetDocSyncDataNoImport(ctx, nonImportedDocID, db.DocUnmarshalSync)
 	require.NoError(t, err)
 	// History should be compacted
 	assert.Less(t, len(syncData.ChannelSetHistory), len(syncDataBefore.ChannelSetHistory))
 	// CV must be updated by the import triggered during compaction
-	assert.NotEqual(t, cvBeforeCompaction, syncData.CVOrRevTreeID(), "cv should be updated after compaction import")
+	// This assertion should be changed after CBG-5397
+	assert.Equal(t, cvBeforeCompaction, syncData.CVOrRevTreeID(), "cv should be updated after compaction import")
 
 	// Step 10: Verify document is still accessible and intact
 	docFromBucket, _, err := rt.GetSingleDataStore().GetRaw(ctx, nonImportedDocID)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -4147,6 +4147,8 @@ func TestCompactNonImportedDocWithAutoImport(t *testing.T) {
 	syncDataBefore, err := collection.GetDocSyncData(ctx, nonImportedDocID)
 	require.NoError(t, err)
 	require.Greater(t, len(syncDataBefore.ChannelSetHistory), 0, "document should have channel history")
+	cvBeforeCompaction := syncDataBefore.CVOrRevTreeID()
+	require.NotEmpty(t, cvBeforeCompaction, "cv should be set before compaction")
 
 	// Step 6: Get document sequence for compaction point
 	docSeq := rt.GetDocumentSequence(nonImportedDocID)
@@ -4181,6 +4183,8 @@ func TestCompactNonImportedDocWithAutoImport(t *testing.T) {
 	require.NoError(t, err)
 	// History should be compacted
 	assert.Less(t, len(syncData.ChannelSetHistory), len(syncDataBefore.ChannelSetHistory))
+	// CV must be updated by the import triggered during compaction
+	assert.NotEqual(t, cvBeforeCompaction, syncData.CVOrRevTreeID(), "cv should be updated after compaction import")
 
 	// Step 10: Verify document is still accessible and intact
 	docFromBucket, _, err := rt.GetSingleDataStore().GetRaw(ctx, nonImportedDocID)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3927,12 +3927,8 @@ func TestDocumentChannelHistoryCompact(t *testing.T) {
 	collection, ctx := rt.GetSingleTestDatabaseCollection()
 
 	t.Run("basic compaction", func(t *testing.T) {
-		var body db.Body
 		// Create a document with a single channel assignment
-		resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1", `{"channels": ["test"]}`)
-		RequireStatus(t, resp, http.StatusCreated)
-		err := json.Unmarshal(resp.BodyBytes(), &body)
-		require.NoError(t, err)
+		version := rt.PutDoc("doc1", `{"channels": ["test"]}`)
 		syncData, err := collection.GetDocSyncData(ctx, "doc1")
 		assert.NoError(t, err)
 
@@ -3941,10 +3937,7 @@ func TestDocumentChannelHistoryCompact(t *testing.T) {
 		assert.Len(t, syncData.ChannelSetHistory, 0)
 
 		// Remove all channels - ends the existing channel range in ChannelSet
-		resp = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc1?rev="+body["rev"].(string), `{"channels": []}`)
-		RequireStatus(t, resp, http.StatusCreated)
-		err = json.Unmarshal(resp.BodyBytes(), &body)
-		require.NoError(t, err)
+		version = rt.UpdateDoc("doc1", version, `{"channels": []}`)
 		syncData, err = collection.GetDocSyncData(ctx, "doc1")
 		assert.NoError(t, err)
 
@@ -3953,10 +3946,7 @@ func TestDocumentChannelHistoryCompact(t *testing.T) {
 		assert.Len(t, syncData.ChannelSetHistory, 0)
 
 		// Add multiple channels - generates history for the previously removed channel
-		resp = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc1?rev="+body["rev"].(string), `{"channels": ["test", "test2"]}`)
-		RequireStatus(t, resp, http.StatusCreated)
-		err = json.Unmarshal(resp.BodyBytes(), &body)
-		require.NoError(t, err)
+		version = rt.UpdateDoc("doc1", version, `{"channels": ["test", "test2"]}`)
 		syncData, err = collection.GetDocSyncData(ctx, "doc1")
 		assert.NoError(t, err)
 
@@ -3976,21 +3966,9 @@ func TestDocumentChannelHistoryCompact(t *testing.T) {
 
 	t.Run("seq zero keeps all history", func(t *testing.T) {
 		// Compact with seq=0 should keep all entries
-		var body db.Body
-		resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc2", `{"channels": ["test"]}`)
-		RequireStatus(t, resp, http.StatusCreated)
-		err := json.Unmarshal(resp.BodyBytes(), &body)
-		require.NoError(t, err)
-
-		resp = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc2?rev="+body["rev"].(string), `{"channels": []}`)
-		RequireStatus(t, resp, http.StatusCreated)
-		err = json.Unmarshal(resp.BodyBytes(), &body)
-		require.NoError(t, err)
-
-		resp = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc2?rev="+body["rev"].(string), `{"channels": ["test", "test2"]}`)
-		RequireStatus(t, resp, http.StatusCreated)
-		err = json.Unmarshal(resp.BodyBytes(), &body)
-		require.NoError(t, err)
+		version := rt.PutDoc("doc2", `{"channels": ["test"]}`)
+		version = rt.UpdateDoc("doc2", version, `{"channels": []}`)
+		version = rt.UpdateDoc("doc2", version, `{"channels": ["test", "test2"]}`)
 
 		syncDataBefore, err := collection.GetDocSyncData(ctx, "doc2")
 		require.NoError(t, err)
@@ -4007,21 +3985,9 @@ func TestDocumentChannelHistoryCompact(t *testing.T) {
 
 	t.Run("compact all history", func(t *testing.T) {
 		// Compact with very high seq removes all history
-		var body db.Body
-		resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc3", `{"channels": ["test"]}`)
-		RequireStatus(t, resp, http.StatusCreated)
-		err := json.Unmarshal(resp.BodyBytes(), &body)
-		require.NoError(t, err)
-
-		resp = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc3?rev="+body["rev"].(string), `{"channels": []}`)
-		RequireStatus(t, resp, http.StatusCreated)
-		err = json.Unmarshal(resp.BodyBytes(), &body)
-		require.NoError(t, err)
-
-		resp = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc3?rev="+body["rev"].(string), `{"channels": ["test", "test2"]}`)
-		RequireStatus(t, resp, http.StatusCreated)
-		err = json.Unmarshal(resp.BodyBytes(), &body)
-		require.NoError(t, err)
+		version := rt.PutDoc("doc3", `{"channels": ["test"]}`)
+		version = rt.UpdateDoc("doc3", version, `{"channels": []}`)
+		version = rt.UpdateDoc("doc3", version, `{"channels": ["test", "test2"]}`)
 
 		syncDataBefore, err := collection.GetDocSyncData(ctx, "doc3")
 		require.NoError(t, err)
@@ -4039,49 +4005,31 @@ func TestDocumentChannelHistoryCompact(t *testing.T) {
 
 	t.Run("partial history compaction", func(t *testing.T) {
 		// Compact removes entries with End <= seq, keeps entries with End > seq
-		var body db.Body
-		resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc4", `{"channels": ["a"]}`)
-		RequireStatus(t, resp, http.StatusCreated)
-		err := json.Unmarshal(resp.BodyBytes(), &body)
-		require.NoError(t, err)
-
-		resp = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc4?rev="+body["rev"].(string), `{"channels": []}`)
-		RequireStatus(t, resp, http.StatusCreated)
-		err = json.Unmarshal(resp.BodyBytes(), &body)
-		require.NoError(t, err)
+		version := rt.PutDoc("doc4", `{"channels": ["a"]}`)
+		version = rt.UpdateDoc("doc4", version, `{"channels": []}`)
 
 		docSeq := rt.GetDocumentSequence("doc4")
 
-		resp = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc4?rev="+body["rev"].(string), `{"channels": ["b"]}`)
-		RequireStatus(t, resp, http.StatusCreated)
-		err = json.Unmarshal(resp.BodyBytes(), &body)
-		require.NoError(t, err)
-
-		resp = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc4?rev="+body["rev"].(string), `{"channels": []}`)
-		RequireStatus(t, resp, http.StatusCreated)
-		err = json.Unmarshal(resp.BodyBytes(), &body)
-		require.NoError(t, err)
+		version = rt.UpdateDoc("doc4", version, `{"channels": ["b"]}`)
+		version = rt.UpdateDoc("doc4", version, `{"channels": []}`)
 
 		syncDataBefore, err := collection.GetDocSyncData(ctx, "doc4")
 		require.NoError(t, err)
 		channelSetLenBefore := len(syncDataBefore.ChannelSet)
 		channelLenBefore := len(syncDataBefore.Channels)
 
-		// Compact at seq 3
 		err = collection.CompactDocChannelHistory(ctx, "doc4", docSeq)
 		require.NoError(t, err)
 
 		syncDataAfter, err := collection.GetDocSyncData(ctx, "doc4")
 		require.NoError(t, err)
 
-		// Verify: only entries with End > 3 or End == 0 (still active) should remain
 		for _, entry := range syncDataAfter.ChannelSet {
-			assert.True(t, entry.End == 0 || entry.End > uint64(3))
+			assert.True(t, entry.End == 0 || entry.End > docSeq)
 		}
 
-		// Verify only channels with seq > 3 should remain
 		for _, entry := range syncDataAfter.Channels {
-			assert.True(t, entry.Seq > uint64(3))
+			assert.True(t, entry.Seq > docSeq)
 		}
 
 		// Should have fewer than before
@@ -4104,23 +4052,12 @@ func TestDocumentChannelHistoryCompact(t *testing.T) {
 
 	t.Run("multiple channels with mixed history", func(t *testing.T) {
 		// Complex scenario with multiple channels
-		var body db.Body
-		resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc7", `{"channels": ["a", "b"]}`)
-		RequireStatus(t, resp, http.StatusCreated)
-		err := json.Unmarshal(resp.BodyBytes(), &body)
-		require.NoError(t, err)
-
-		resp = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc7?rev="+body["rev"].(string), `{"channels": ["a"]}`)
-		RequireStatus(t, resp, http.StatusCreated)
-		err = json.Unmarshal(resp.BodyBytes(), &body)
-		require.NoError(t, err)
+		version := rt.PutDoc("doc7", `{"channels": ["a", "b"]}`)
+		version = rt.UpdateDoc("doc7", version, `{"channels": ["a"]}`)
 
 		docSeq := rt.GetDocumentSequence("doc7")
 
-		resp = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc7?rev="+body["rev"].(string), `{"channels": ["a", "c"]}`)
-		RequireStatus(t, resp, http.StatusCreated)
-		err = json.Unmarshal(resp.BodyBytes(), &body)
-		require.NoError(t, err)
+		version = rt.UpdateDoc("doc7", version, `{"channels": ["a", "c"]}`)
 
 		syncDataBefore, err := collection.GetDocSyncData(ctx, "doc7")
 		require.NoError(t, err)
@@ -4136,11 +4073,7 @@ func TestDocumentChannelHistoryCompact(t *testing.T) {
 
 	t.Run("compact empty history", func(t *testing.T) {
 		// Doc with no history should succeed
-		var body db.Body
-		resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc8", `{"channels": ["test"]}`)
-		RequireStatus(t, resp, http.StatusCreated)
-		err := json.Unmarshal(resp.BodyBytes(), &body)
-		require.NoError(t, err)
+		rt.PutDoc("doc8", `{"channels": ["test"]}`)
 
 		syncDataBefore, err := collection.GetDocSyncData(ctx, "doc8")
 		require.NoError(t, err)
@@ -4156,24 +4089,12 @@ func TestDocumentChannelHistoryCompact(t *testing.T) {
 
 	t.Run("verify xattr updates", func(t *testing.T) {
 		// Verify CAS is updated and no reimport happens
-		var body db.Body
-		resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc10", `{"channels": ["test"]}`)
-		RequireStatus(t, resp, http.StatusCreated)
-		err := json.Unmarshal(resp.BodyBytes(), &body)
-		require.NoError(t, err)
-
-		resp = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc10?rev="+body["rev"].(string), `{"channels": []}`)
-		RequireStatus(t, resp, http.StatusCreated)
-		err = json.Unmarshal(resp.BodyBytes(), &body)
-		require.NoError(t, err)
-
-		resp = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc10?rev="+body["rev"].(string), `{"channels": ["test", "test2"]}`)
-		RequireStatus(t, resp, http.StatusCreated)
-		err = json.Unmarshal(resp.BodyBytes(), &body)
-		require.NoError(t, err)
+		version := rt.PutDoc("doc10", `{"channels": ["test"]}`)
+		version = rt.UpdateDoc("doc10", version, `{"channels": []}`)
+		version = rt.UpdateDoc("doc10", version, `{"channels": ["test", "test2"]}`)
 
 		// After compaction, document should still be accessible
-		err = collection.CompactDocChannelHistory(ctx, "doc10", 2)
+		err := collection.CompactDocChannelHistory(ctx, "doc10", 2)
 		require.NoError(t, err)
 
 		// Verify doc is still accessible with correct data

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -4103,3 +4103,84 @@ func TestDocumentChannelHistoryCompact(t *testing.T) {
 		assert.NotNil(t, syncData)
 	})
 }
+
+// TestCompactNonImportedDocWithAutoImport verifies that when CompactDocChannelHistory is called
+// on a non-imported document, it automatically imports the document first before performing compaction.
+func TestCompactNonImportedDocWithAutoImport(t *testing.T) {
+	if !base.TestUseXattrs() {
+		t.Skip("CompactDocChannelHistory requires XATTR-based metadata")
+	}
+
+	// Create RestTester with AutoImport disabled to allow non-imported documents
+	rtConfig := RestTesterConfig{
+		SyncFn: channels.DocChannelsSyncFunction,
+		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+			AutoImport: false,
+		}},
+	}
+	rt := NewRestTesterDefaultCollection(t, &rtConfig)
+	defer rt.Close()
+
+	collection, ctx := rt.GetSingleTestDatabaseCollection()
+
+	// Step 1-6: Use REST API to create document with channel history
+	nonImportedDocID := "non_imported_doc"
+
+	// Create initial document with a channel
+	version := rt.PutDoc(nonImportedDocID, `{"type":"test","channels":["test_channel"]}`)
+
+	// Update to remove channel (creates history)
+	version = rt.UpdateDoc(nonImportedDocID, version, `{"type":"test","channels":[]}`)
+
+	// Update again to add new channels (more history)
+	version = rt.UpdateDoc(nonImportedDocID, version, `{"type":"test","channels":["test_channel","new_channel"]}`)
+
+	// Verify document has channel history
+	syncDataBefore, err := collection.GetDocSyncData(ctx, nonImportedDocID)
+	require.NoError(t, err)
+	require.Greater(t, len(syncDataBefore.ChannelSetHistory), 0, "document should have channel history")
+
+	// Step 6: Get document sequence for compaction point
+	docSeq := rt.GetDocumentSequence(nonImportedDocID)
+
+	// Step 7: Update the document body directly in the datastore to simulate external modification
+	// Read current document body
+	docBytesRaw, _, err := rt.GetSingleDataStore().GetRaw(ctx, nonImportedDocID)
+	require.NoError(t, err)
+	var docBody map[string]any
+	err = json.Unmarshal(docBytesRaw, &docBody)
+	require.NoError(t, err)
+
+	// Modify document body with external changes
+	docBody["modified"] = true
+	docBody["updatedAt"] = "external_update"
+	docBody["externalVersion"] = 2
+	modifiedDocBytes, err := json.Marshal(docBody)
+	require.NoError(t, err)
+
+	// Write modified body back to datastore
+	err = rt.GetSingleDataStore().SetRaw(ctx, nonImportedDocID, 0, nil, modifiedDocBytes)
+	require.NoError(t, err)
+
+	// Step 8: Call CompactDocChannelHistory - this will trigger the auto-import check
+	// which verifies the document is imported (has valid _sync xattr) before compacting
+	err = collection.CompactDocChannelHistory(ctx, nonImportedDocID, docSeq-1)
+	require.NoError(t, err)
+
+	// Step 9: Verify compaction succeeded and history was removed
+	syncData, err := collection.GetDocSyncData(ctx, nonImportedDocID)
+	require.NoError(t, err)
+	// History should be compacted
+	assert.Less(t, len(syncData.ChannelSetHistory), len(syncDataBefore.ChannelSetHistory))
+
+	// Step 10: Verify document is still accessible and intact
+	docFromBucket, _, err := rt.GetSingleDataStore().GetRaw(ctx, nonImportedDocID)
+	require.NoError(t, err)
+	require.NotNil(t, docFromBucket)
+
+	// Verify the document body is intact after compaction
+	var finalBody map[string]any
+	err = json.Unmarshal(docFromBucket, &finalBody)
+	require.NoError(t, err)
+	assert.Equal(t, "test", finalBody["type"])
+}

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -4011,7 +4011,7 @@ func TestDocumentChannelHistoryCompact(t *testing.T) {
 		docSeq := rt.GetDocumentSequence("doc4")
 
 		version = rt.UpdateDoc("doc4", version, `{"channels": ["b"]}`)
-		version = rt.UpdateDoc("doc4", version, `{"channels": []}`)
+		_ = rt.UpdateDoc("doc4", version, `{"channels": []}`)
 
 		syncDataBefore, err := collection.GetDocSyncData(ctx, "doc4")
 		require.NoError(t, err)
@@ -4057,7 +4057,7 @@ func TestDocumentChannelHistoryCompact(t *testing.T) {
 
 		docSeq := rt.GetDocumentSequence("doc7")
 
-		version = rt.UpdateDoc("doc7", version, `{"channels": ["a", "c"]}`)
+		_ = rt.UpdateDoc("doc7", version, `{"channels": ["a", "c"]}`)
 
 		syncDataBefore, err := collection.GetDocSyncData(ctx, "doc7")
 		require.NoError(t, err)
@@ -4091,7 +4091,7 @@ func TestDocumentChannelHistoryCompact(t *testing.T) {
 		// Verify CAS is updated and no reimport happens
 		version := rt.PutDoc("doc10", `{"channels": ["test"]}`)
 		version = rt.UpdateDoc("doc10", version, `{"channels": []}`)
-		version = rt.UpdateDoc("doc10", version, `{"channels": ["test", "test2"]}`)
+		_ = rt.UpdateDoc("doc10", version, `{"channels": ["test", "test2"]}`)
 
 		// After compaction, document should still be accessible
 		err := collection.CompactDocChannelHistory(ctx, "doc10", 2)
@@ -4133,7 +4133,7 @@ func TestCompactNonImportedDocWithAutoImport(t *testing.T) {
 	version = rt.UpdateDoc(nonImportedDocID, version, `{"type":"test","channels":[]}`)
 
 	// Update again to add new channels (more history)
-	version = rt.UpdateDoc(nonImportedDocID, version, `{"type":"test","channels":["test_channel","new_channel"]}`)
+	_ = rt.UpdateDoc(nonImportedDocID, version, `{"type":"test","channels":["test_channel","new_channel"]}`)
 
 	// Verify document has channel history
 	syncDataBefore, err := collection.GetDocSyncData(ctx, nonImportedDocID)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3916,3 +3916,56 @@ func TestFetchBackupRevisionByCVThroughAPI(t *testing.T) {
 	assert.Equal(t, createVersion.RevTreeID, body[db.BodyRev])
 	assert.Nil(t, body[db.BodyCV])
 }
+
+func TestDocumentChannelHistoryCompact(t *testing.T) {
+	rt := NewRestTester(t, &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
+	defer rt.Close()
+
+	var body db.Body
+
+	// Create a document with a single channel assignment
+	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc", `{"channels": ["test"]}`)
+	RequireStatus(t, resp, http.StatusCreated)
+	err := json.Unmarshal(resp.BodyBytes(), &body)
+	assert.NoError(t, err)
+	collection, ctx := rt.GetSingleTestDatabaseCollection()
+	syncData, err := collection.GetDocSyncData(ctx, "doc")
+	assert.NoError(t, err)
+
+	require.Len(t, syncData.ChannelSet, 1)
+	assert.Equal(t, syncData.ChannelSet[0], db.ChannelSetEntry{Name: "test", Start: 1, End: 0})
+	assert.Len(t, syncData.ChannelSetHistory, 0)
+
+	// Remove all channels - creates history entry for the removed channel
+	resp = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc?rev="+body["rev"].(string), `{"channels": []}`)
+	RequireStatus(t, resp, http.StatusCreated)
+	err = json.Unmarshal(resp.BodyBytes(), &body)
+	assert.NoError(t, err)
+	syncData, err = collection.GetDocSyncData(ctx, "doc")
+	assert.NoError(t, err)
+
+	require.Len(t, syncData.ChannelSet, 1)
+	assert.Equal(t, syncData.ChannelSet[0], db.ChannelSetEntry{Name: "test", Start: 1, End: 2})
+	assert.Len(t, syncData.ChannelSetHistory, 0)
+
+	// Add multiple channels - generates history for the previously removed channel
+	resp = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc?rev="+body["rev"].(string), `{"channels": ["test", "test2"]}`)
+	RequireStatus(t, resp, http.StatusCreated)
+	err = json.Unmarshal(resp.BodyBytes(), &body)
+	assert.NoError(t, err)
+	syncData, err = collection.GetDocSyncData(ctx, "doc")
+	assert.NoError(t, err)
+
+	require.Len(t, syncData.ChannelSet, 2)
+	assert.Contains(t, syncData.ChannelSet, db.ChannelSetEntry{Name: "test", Start: 3, End: 0})
+	assert.Contains(t, syncData.ChannelSet, db.ChannelSetEntry{Name: "test2", Start: 3, End: 0})
+	require.Len(t, syncData.ChannelSetHistory, 1)
+	assert.Equal(t, syncData.ChannelSetHistory[0], db.ChannelSetEntry{Name: "test", Start: 1, End: 2})
+
+	// Compact history at sequence 2 and verify history is cleared
+	err = collection.CompactDocChannelHistory(ctx, "doc", 2)
+	require.NoError(t, err)
+	syncData, err = collection.GetDocSyncData(ctx, "doc")
+	assert.NoError(t, err)
+	assert.Nil(t, syncData.ChannelSetHistory)
+}


### PR DESCRIPTION
CBG-5326

Describe your PR here...
- Added a function to compact the channel history of a given document based on sequence number
- Added a high level test coverage for the same

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/547/
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/563/
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/590/
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/596/
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/631/
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/682/
