### PR TITLE
undo temp assertion error for bad gocb version

### DIFF
--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -3101,7 +3101,7 @@ func TestLegacyCredentialInheritance(t *testing.T) {
 			tb.GetName(), base.TestUseXattrs(), base.TestsDisableGSI(),
 		),
 	)
-	resp.RequireStatus(http.StatusBadGateway) // gocb v2.12.1 returns a timeout error instead of an auth error here
+	resp.RequireStatus(http.StatusForbidden)
 
 	// Wrong credentials should fail
 	resp = rest.BootstrapAdminRequest(t, sc, http.MethodPut, "/db2/",


### PR DESCRIPTION
undo assertion to work around a bad gocb version made in #8120 now it's fixed upstream

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  `^TestLegacyCredentialInheritance$` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/549 
