### PR TITLE
CBG-5354 fix flake in TestDeltaReplicationWithBypassRevCacheAndInflightRevChanged

### DIFF
--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -1384,6 +1384,7 @@ func TestDeltaReplicationWithBypassRevCacheAndInflightRevChanged(t *testing.T) {
 				// import doc
 				version1, _ := rt.GetDoc(docID)
 
+				rt.WaitForPendingChanges()
 				if tc.filteredChannels != "" {
 					btcRunner.StartPullSince(client.id, BlipTesterPullOptions{Channels: tc.filteredChannels, Continuous: true})
 				} else {


### PR DESCRIPTION
CBG-5354 fix flake in TestDeltaReplicationWithBypassRevCacheAndInflightRevChanged

I'm not sure this is the only problem since some of the stack traces from failures look different. However, I can repro this problem with `env SG_TEST_CACHING_DELAY=1s` and this definitely fixes some flakes.
