### PR TITLE
CBG-5353: No-op stub for `bootstrap.use_system_metadata_collection` config

### DIFF
--- a/base/audit_events.go
+++ b/base/audit_events.go
@@ -189,6 +189,7 @@ var AuditEvents = events{
 			AuditFieldSGVersion:                      "version string",
 			AuditFieldUseTLSServer:                   true,
 			AuditFieldServerTLSSkipVerify:            true,
+			AuditFieldUseSystemMetadataCollection:    true,
 			AuditFieldAdminInterfaceAuthentication:   true,
 			AuditFieldMetricsInterfaceAuthentication: true,
 			AuditFieldLogFilePath:                    "/log/file/path",

--- a/base/audit_events_fields.go
+++ b/base/audit_events_fields.go
@@ -46,6 +46,7 @@ const (
 	AuditFieldSGVersion                      = "sg_version"
 	AuditFieldUseTLSServer                   = "use_tls_server"
 	AuditFieldServerTLSSkipVerify            = "server_tls_skip_verify"
+	AuditFieldUseSystemMetadataCollection    = "use_system_metadata_collection"
 	AuditFieldAdminInterfaceAuthentication   = "admin_interface_authentication"
 	AuditFieldMetricsInterfaceAuthentication = "metrics_interface_authentication"
 	AuditFieldLogFilePath                    = "log_file_path"

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -2298,6 +2298,10 @@ Startup-config:
           description: Allow empty server CA Cert Path without attempting to use system root pool
           type: boolean
           default: false
+        use_system_metadata_collection:
+          description: If true, Sync Gateway uses the `_system._mobile` metadata collection and triggers a one-time migration of any metadata in the default collection.
+          type: boolean
+          default: false
         use_tls_server:
           description: Enforces a secure or non-secure server scheme
           type: boolean

--- a/rest/config.go
+++ b/rest/config.go
@@ -69,6 +69,11 @@ const (
 
 	DefaultUseTLSServer = true
 
+	// DefaultUseSystemMetadataCollection is the default for BootstrapConfig.UseSystemMetadataCollection
+	// in this version of Sync Gateway. Subject to change in future versions as part of the
+	// opt-in -> opt-out -> remove lifecycle for the system metadata collection feature.
+	DefaultUseSystemMetadataCollection = false
+
 	DefaultMinConfigFetchInterval = time.Second
 
 	tapFeedType = "tap"
@@ -1644,6 +1649,7 @@ func (sc *ServerContext) StartupAuditFields() base.AuditFields {
 		base.AuditFieldSGVersion:                      base.LongVersionString,
 		base.AuditFieldUseTLSServer:                   sc.Config.Bootstrap.UseTLSServer,
 		base.AuditFieldServerTLSSkipVerify:            sc.Config.Bootstrap.ServerTLSSkipVerify,
+		base.AuditFieldUseSystemMetadataCollection:    sc.Config.Bootstrap.UseSystemMetadataCollection,
 		base.AuditFieldAdminInterfaceAuthentication:   sc.Config.API.AdminInterfaceAuthentication,
 		base.AuditFieldMetricsInterfaceAuthentication: sc.Config.API.MetricsInterfaceAuthentication,
 		base.AuditFieldLogFilePath:                    sc.Config.Logging.LogFilePath,

--- a/rest/config_flags.go
+++ b/rest/config_flags.go
@@ -31,16 +31,17 @@ type configFlag struct {
 // (which stores the corresponding config field pointer and flag value).
 func registerConfigFlags(config *StartupConfig, fs *flag.FlagSet) map[string]configFlag {
 	return map[string]configFlag{
-		"bootstrap.group_id":                {config: &config.Bootstrap.ConfigGroupID, flagValue: fs.String("bootstrap.group_id", "", "The config group ID to use when discovering databases. Allows for non-homogenous configuration")},
-		"bootstrap.config_update_frequency": {config: &config.Bootstrap.ConfigUpdateFrequency, flagValue: fs.String("bootstrap.config_update_frequency", persistentConfigDefaultUpdateFrequency.String(), "How often to poll Couchbase Server for new config changes")},
-		"bootstrap.server":                  {config: &config.Bootstrap.Server, flagValue: fs.String("bootstrap.server", "", "Couchbase Server connection string/URL")},
-		"bootstrap.username":                {config: &config.Bootstrap.Username, flagValue: fs.String("bootstrap.username", "", "Username for authenticating to server")},
-		"bootstrap.password":                {config: nil, disabled: true, disabledErrorMessage: "Use config file to specify bootstrap password, or use X.509 cert/key path flags instead.", flagValue: fs.String("bootstrap.password", "", "Deprecated and disabled. Do not use. Use config file or X.509 auth.")},
-		"bootstrap.ca_cert_path":            {config: &config.Bootstrap.CACertPath, flagValue: fs.String("bootstrap.ca_cert_path", "", "Root CA cert path for TLS connection")},
-		"bootstrap.server_tls_skip_verify":  {config: &config.Bootstrap.ServerTLSSkipVerify, flagValue: fs.Bool("bootstrap.server_tls_skip_verify", false, "Allow empty server CA Cert Path without attempting to use system root pool")},
-		"bootstrap.x509_cert_path":          {config: &config.Bootstrap.X509CertPath, flagValue: fs.String("bootstrap.x509_cert_path", "", "Cert path (public key) for X.509 bucket auth")},
-		"bootstrap.x509_key_path":           {config: &config.Bootstrap.X509KeyPath, flagValue: fs.String("bootstrap.x509_key_path", "", "Key path (private key) for X.509 bucket auth")},
-		"bootstrap.use_tls_server":          {config: &config.Bootstrap.UseTLSServer, flagValue: fs.Bool("bootstrap.use_tls_server", false, "Forces the connection to Couchbase Server to use TLS")},
+		"bootstrap.group_id":                       {config: &config.Bootstrap.ConfigGroupID, flagValue: fs.String("bootstrap.group_id", "", "The config group ID to use when discovering databases. Allows for non-homogenous configuration")},
+		"bootstrap.config_update_frequency":        {config: &config.Bootstrap.ConfigUpdateFrequency, flagValue: fs.String("bootstrap.config_update_frequency", persistentConfigDefaultUpdateFrequency.String(), "How often to poll Couchbase Server for new config changes")},
+		"bootstrap.server":                         {config: &config.Bootstrap.Server, flagValue: fs.String("bootstrap.server", "", "Couchbase Server connection string/URL")},
+		"bootstrap.username":                       {config: &config.Bootstrap.Username, flagValue: fs.String("bootstrap.username", "", "Username for authenticating to server")},
+		"bootstrap.password":                       {config: nil, disabled: true, disabledErrorMessage: "Use config file to specify bootstrap password, or use X.509 cert/key path flags instead.", flagValue: fs.String("bootstrap.password", "", "Deprecated and disabled. Do not use. Use config file or X.509 auth.")},
+		"bootstrap.ca_cert_path":                   {config: &config.Bootstrap.CACertPath, flagValue: fs.String("bootstrap.ca_cert_path", "", "Root CA cert path for TLS connection")},
+		"bootstrap.server_tls_skip_verify":         {config: &config.Bootstrap.ServerTLSSkipVerify, flagValue: fs.Bool("bootstrap.server_tls_skip_verify", false, "Allow empty server CA Cert Path without attempting to use system root pool")},
+		"bootstrap.x509_cert_path":                 {config: &config.Bootstrap.X509CertPath, flagValue: fs.String("bootstrap.x509_cert_path", "", "Cert path (public key) for X.509 bucket auth")},
+		"bootstrap.x509_key_path":                  {config: &config.Bootstrap.X509KeyPath, flagValue: fs.String("bootstrap.x509_key_path", "", "Key path (private key) for X.509 bucket auth")},
+		"bootstrap.use_tls_server":                 {config: &config.Bootstrap.UseTLSServer, flagValue: fs.Bool("bootstrap.use_tls_server", false, "Forces the connection to Couchbase Server to use TLS")},
+		"bootstrap.use_system_metadata_collection": {config: &config.Bootstrap.UseSystemMetadataCollection, flagValue: fs.Bool("bootstrap.use_system_metadata_collection", false, "If true, Sync Gateway uses the _system._mobile metadata collection and triggers a one-time migration of any metadata in the default collection.")},
 
 		"api.public_interface":                              {config: &config.API.PublicInterface, flagValue: fs.String("api.public_interface", "", "Network interface to bind public API to")},
 		"api.admin_interface":                               {config: &config.API.AdminInterface, flagValue: fs.String("api.admin_interface", "", "Network interface to bind admin API to")},

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -31,10 +31,11 @@ const (
 func DefaultStartupConfig(defaultLogFilePath string) StartupConfig {
 	config := StartupConfig{
 		Bootstrap: BootstrapConfig{
-			ConfigGroupID:         PersistentConfigDefaultGroupID,
-			ConfigUpdateFrequency: base.NewConfigDuration(persistentConfigDefaultUpdateFrequency),
-			ServerTLSSkipVerify:   base.Ptr(false),
-			UseTLSServer:          base.Ptr(DefaultUseTLSServer),
+			ConfigGroupID:               PersistentConfigDefaultGroupID,
+			ConfigUpdateFrequency:       base.NewConfigDuration(persistentConfigDefaultUpdateFrequency),
+			ServerTLSSkipVerify:         base.Ptr(false),
+			UseTLSServer:                base.Ptr(DefaultUseTLSServer),
+			UseSystemMetadataCollection: base.Ptr(DefaultUseSystemMetadataCollection),
 		},
 		API: APIConfig{
 			PublicInterface:    DefaultPublicInterface,
@@ -110,6 +111,8 @@ type BootstrapConfig struct {
 	X509CertPath          string               `json:"x509_cert_path,omitempty"          help:"Cert path (public key) for X.509 bucket auth"`
 	X509KeyPath           string               `json:"x509_key_path,omitempty"           help:"Key path (private key) for X.509 bucket auth"`
 	UseTLSServer          *bool                `json:"use_tls_server,omitempty"          help:"Enforces a secure or non-secure server scheme"`
+
+	UseSystemMetadataCollection *bool `json:"use_system_metadata_collection,omitempty" help:"If true, Sync Gateway uses the _system._mobile metadata collection and triggers a one-time migration of any metadata in the default collection."`
 }
 
 type APIConfig struct {


### PR DESCRIPTION
CBG-5353

No-op stub for `bootstrap.use_system_metadata_collection` config option (App Services targeted)

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- n/a