### PR TITLE
CBG-5360 add context to FatalPanicHandler

### DIFF
--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -679,7 +679,7 @@ func (p *cfgNodePoller) poll(ctx context.Context) {
 func (p *cfgNodePoller) startPolling(ctx context.Context) {
 	ticker := time.NewTicker(p.pollInterval)
 	go func() {
-		defer FatalPanicHandler()
+		defer FatalPanicHandler(ctx)
 		for {
 			select {
 			case <-ctx.Done():
@@ -760,7 +760,7 @@ func (l *shardedDCPHeartbeatListener) subscribeNodeChanges(ctx context.Context) 
 		return err
 	}
 	go func() {
-		defer FatalPanicHandler()
+		defer FatalPanicHandler(ctx)
 		for {
 			select {
 			case <-cfgEvents:

--- a/base/heartbeat.go
+++ b/base/heartbeat.go
@@ -149,7 +149,7 @@ func (h *couchbaseHeartBeater) StartSendingHeartbeats(ctx context.Context) error
 
 	ticker := time.NewTicker(h.heartbeatSendInterval)
 	go func() {
-		defer FatalPanicHandler()
+		defer FatalPanicHandler(ctx)
 		defer func() {
 			h.sendActive.Set(false)
 		}()
@@ -178,7 +178,7 @@ func (h *couchbaseHeartBeater) StartCheckingHeartbeats(ctx context.Context) erro
 
 	ticker := time.NewTicker(h.heartbeatPollInterval)
 	go func() {
-		defer FatalPanicHandler()
+		defer FatalPanicHandler(ctx)
 		defer func() { h.checkActive.Set(false) }()
 		for {
 			select {

--- a/base/util.go
+++ b/base/util.go
@@ -1466,10 +1466,10 @@ type JSONEncoderI interface {
 	SetEscapeHTML(on bool)
 }
 
-func FatalPanicHandler() {
+func FatalPanicHandler(ctx context.Context) {
 	// Log any panics using the built-in loggers so that the stacktraces end up in SG log files before exiting.
 	if r := recover(); r != nil {
-		FatalfCtx(context.TODO(), "Unexpected panic: %v - stopping process\n%v", r, string(debug.Stack()))
+		FatalfCtx(ctx, "Unexpected panic: %v - stopping process\n%v", r, string(debug.Stack()))
 	}
 }
 

--- a/db/changes.go
+++ b/db/changes.go
@@ -254,7 +254,7 @@ func (db *DatabaseCollectionWithUser) buildRevokedFeed(ctx context.Context, ch c
 	}
 
 	go func() {
-		defer base.FatalPanicHandler()
+		defer base.FatalPanicHandler(ctx)
 		defer close(feed)
 		var itemsSent int
 		var lastSeq uint64
@@ -456,7 +456,7 @@ func (db *DatabaseCollectionWithUser) changesFeed(ctx context.Context, singleCha
 	paginationOptions.Since.LowSeq = 0
 
 	go func() {
-		defer base.FatalPanicHandler()
+		defer base.FatalPanicHandler(ctx)
 		defer close(feed)
 		var itemsSent int
 		var lastSeq uint64

--- a/db/pindex.go
+++ b/db/pindex.go
@@ -79,7 +79,7 @@ func getCbgtDest(ctx context.Context, indexParams string, restart func()) (cbgt.
 // getNewPIndexImplType finds the correct cbgt.Dest based on the indexParams provided. Looks up the dest based on a key in params set by Sync Gateway.
 func getNewPIndexImplType(ctx context.Context) func(indexType, indexParams, path string, restart func()) (cbgt.PIndexImpl, cbgt.Dest, error) {
 	newPIndexImpl := func(indexType, indexParams, path string, restart func()) (cbgt.PIndexImpl, cbgt.Dest, error) {
-		defer base.FatalPanicHandler()
+		defer base.FatalPanicHandler(ctx)
 
 		dest, err := getCbgtDest(ctx, indexParams, restart)
 		if err != nil {

--- a/db/sequence_allocator.go
+++ b/db/sequence_allocator.go
@@ -84,7 +84,7 @@ func newSequenceAllocator(ctx context.Context, datastore base.DataStore, dbStats
 		return nil, err
 	}
 	go func() {
-		defer base.FatalPanicHandler()
+		defer base.FatalPanicHandler(ctx)
 		s.releaseSequenceMonitor(ctx)
 	}()
 	return s, err

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -889,7 +889,7 @@ func (m *sgReplicateManager) SubscribeCfgChanges(ctx context.Context) error {
 	}
 	m.closeWg.Add(1)
 	go func() {
-		defer base.FatalPanicHandler()
+		defer base.FatalPanicHandler(ctx)
 		defer m.closeWg.Done()
 		for {
 			select {
@@ -899,7 +899,7 @@ func (m *sgReplicateManager) SubscribeCfgChanges(ctx context.Context) error {
 				}
 				err := m.RefreshReplicationCfg(ctx)
 				if err != nil {
-					base.WarnfCtx(m.loggingCtx, "Error while updating replications based on latest cfg: %v", err)
+					base.WarnfCtx(ctx, "Error while updating replications based on latest cfg: %v", err)
 				}
 			case <-m.clusterSubscribeTerminator:
 				return
@@ -1643,24 +1643,25 @@ func (l *ReplicationHeartbeatListener) subscribeNodeSetChanges() error {
 
 	cfgEvents := make(chan cbgt.CfgEvent)
 
+	ctx := l.mgr.loggingCtx
 	err := l.mgr.cfg.Subscribe(cfgKeySGRCluster, cfgEvents)
 	if err != nil {
-		base.DebugfCtx(l.mgr.loggingCtx, base.KeyCluster, "Error subscribing to %s key changes: %v", cfgKeySGRCluster, err)
+		base.DebugfCtx(ctx, base.KeyCluster, "Error subscribing to %s key changes: %v", cfgKeySGRCluster, err)
 		return err
 	}
 	go func() {
-		defer base.FatalPanicHandler()
+		defer base.FatalPanicHandler(ctx)
 		for {
 			select {
 			case <-cfgEvents:
 				localNodeRegistered, err := l.reloadNodes()
 				if err != nil {
-					base.WarnfCtx(l.mgr.loggingCtx, "Error while reloading heartbeat node definitions: %v", err)
+					base.WarnfCtx(ctx, "Error while reloading heartbeat node definitions: %v", err)
 				}
 				if !localNodeRegistered {
 					registerErr := l.mgr.RegisterNode(l.mgr.localNodeUUID)
 					if registerErr != nil {
-						base.WarnfCtx(l.mgr.loggingCtx, "Error attempting to re-register node, node will not participate in sg-replicate until restarted or replication cfg is next updated: %v", registerErr)
+						base.WarnfCtx(ctx, "Error attempting to re-register node, node will not participate in sg-replicate until restarted or replication cfg is next updated: %v", registerErr)
 					}
 				}
 			case <-l.terminator:

--- a/db/utils.go
+++ b/db/utils.go
@@ -36,7 +36,7 @@ func NewBackgroundTask(ctx context.Context, taskName string, task BackgroundTask
 	base.InfofCtx(ctx, base.KeyAll, "Created background task: %q with interval %v", taskName, interval)
 	go func() {
 		defer close(bgt.doneChan)
-		defer base.FatalPanicHandler()
+		defer base.FatalPanicHandler(ctx)
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 		for {

--- a/rest/main.go
+++ b/rest/main.go
@@ -40,7 +40,7 @@ func ServerMain() {
 // TODO: Pass ctx down into HTTP servers so that serverMain can be stopped.
 func serverMain(ctx context.Context, osArgs []string) error {
 	sigChan := RegisterSignalHandler(ctx, "")
-	defer base.FatalPanicHandler()
+	defer base.FatalPanicHandler(ctx)
 
 	base.InitializeMemoryLoggers()
 	base.LogSyncGatewayVersion(ctx)


### PR DESCRIPTION
CBG-5360 add context to FatalPanicHandler

- Allows logging additional contextual information if there is a fatal panic, so we know the database or correlation ID.
- Copy the ctx on the struct before pushing it into a goroutine in case it is modified later