### PR TITLE
CBG-5355: fix panic for on demand get when ErrImportCancelled is returned from import

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -193,6 +193,12 @@ func (c *DatabaseCollection) GetDocSyncData(ctx context.Context, docid string) (
 			if importErr != nil {
 				return emptySyncData, importErr
 			}
+			// importDoc swallows ErrImportCancelled (e.g. SG purge race), returning
+			// (nil, nil). Treat that the same as not found.
+			if doc == nil {
+				base.DebugfCtx(ctx, base.KeyImport, "Unable to import doc %q during on demand import for get - will be treated as not found.", base.UD(docid))
+				return emptySyncData, base.ErrNotFound
+			}
 		}
 
 		return doc.SyncData, nil

--- a/db/crud.go
+++ b/db/crud.go
@@ -196,7 +196,6 @@ func (c *DatabaseCollection) GetDocSyncData(ctx context.Context, docid string) (
 			// importDoc swallows ErrImportCancelled (e.g. SG purge race), returning
 			// (nil, nil). Treat that the same as not found.
 			if doc == nil {
-				base.DebugfCtx(ctx, base.KeyImport, "Unable to import doc %q during on demand import for get - will be treated as not found.", base.UD(docid))
 				return emptySyncData, base.ErrNotFound
 			}
 		}

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -17,6 +17,7 @@ import (
 	"log"
 	"math"
 	"net/http"
+	"sync"
 	"testing"
 	"time"
 
@@ -1486,6 +1487,74 @@ func TestImportWithSyncCVAndNoVV(t *testing.T) {
 
 	base.RequireWaitForStat(t, db.DbStats.Database().Crc32MatchCount.Value, 1)
 
+}
+
+// TestGetDocSyncDataPanicOnImportCancelled reproduces a race condition where importDoc
+// returns (nil, nil) via ErrImportCancelled when fetching sync data through GetDocSyncData
+//
+// Race setup:
+//  1. An SDK Delete tombstones a doc triggering on demand import for get pathway so OnDemandImportForGet is called with isDelete=true.
+//  2. The first WriteUpdateWithXattrs callback succeeds and produces an updatedDoc for the
+//     import tombstone write.
+//  3. LeakyDataStore.UpdateCallback fires SetRaw resurrects the tombstone as a live document with
+//     no _sync xattr, advancing the CAS.
+//  4. CAS mismatch detected and retries. On retry it reads the now-live doc
+//     (body != nil, no _sync). The CAS mismatch block in the import callback re-fetches
+//     the body. Execution falls through to isDelete && doc.GetRevTreeID() == "", which fires and returns ErrImportCancelled.
+//  5. importDoc's switch has no return statement in the ErrImportCancelled case, so it
+//     falls through to return docOut, nil with docOut==nil.
+func TestGetDocSyncDataPanicOnImportCancelled(t *testing.T) {
+	base.SkipImportTestsIfNotEnabled(t)
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD, base.KeyImport)
+
+	docID := t.Name()
+
+	db, ctx := setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), base.LeakyBucketConfig{})
+	defer db.Close(ctx)
+
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+	docDatastore := collection.GetCollectionDatastore()
+
+	leakyDataStore, ok := base.AsLeakyDataStore(docDatastore)
+	require.True(t, ok)
+
+	// resurrectOnce ensures the SetRaw resurrection only fires on the first
+	// WriteUpdateWithXattrs attempt for the import, not on the CAS-mismatch retry,
+	// preventing an infinite CAS loop.
+	var resurrectOnce sync.Once
+	// importTriggered gates the callback so the SetRaw resurrection only fires
+	// during the import's WriteUpdateWithXattrs call, not during the initial Put.
+	var importTriggered bool
+	leakyDataStore.SetUpdateCallback(func(key string) {
+		// UpdateCallback fires AFTER the import callback returns but BEFORE import
+		// commits the tombstone write. Calling SetRaw here resurrects the tombstone as a
+		// live document with no _sync xattr, advancing the CAS. SGW detects the mismatch and retries. On retry the import
+		// callback sees body != nil and _sync RevTreeID == "", satisfying the
+		// isDelete && GetRevTreeID() == "" condition that returns ErrImportCancelled.
+		if key != docID || !importTriggered {
+			return
+		}
+		resurrectOnce.Do(func() {
+			_ = docDatastore.SetRaw(key, 0, nil, []byte(`{"foo":"resurrected"}`))
+		})
+	})
+
+	// Create doc via SG to establish a _sync xattr with a RevTreeID and a recorded CAS.
+	_, _, err := collection.Put(ctx, docID, Body{"foo": "bar"})
+	require.NoError(t, err)
+	db.WaitForPendingChanges(t)
+
+	// SDK-style Delete triggering isSgWrite=false inside GetDocSyncData
+	// which will trigger on-demand import with isDelete=true (rawDoc==nil).
+	err = docDatastore.Delete(docID)
+	require.NoError(t, err)
+
+	// UpdateCallback now acts only during the import write, not Put.
+	importTriggered = true
+
+	// Ensure GetDocSyncData will handling nil doc returned from on demand import event when ErrImportCancelled returned
+	_, err = collection.GetDocSyncData(ctx, docID)
+	require.Error(t, err, "expected an error when import is cancelled mid-flight, not a panic")
 }
 
 // getBucketDocument reads the current version of a document and turns it into a sgbucket.BucketDocument. This is

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -17,7 +17,7 @@ import (
 	"log"
 	"math"
 	"net/http"
-	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1489,7 +1489,7 @@ func TestImportWithSyncCVAndNoVV(t *testing.T) {
 
 }
 
-// TestGetDocSyncDataPanicOnImportCancelled reproduces a race condition where importDoc
+// TestGetDocSyncDataOnImportCancelled reproduces a race condition where importDoc
 // returns (nil, nil) via ErrImportCancelled when fetching sync data through GetDocSyncData
 //
 // Race setup:
@@ -1503,7 +1503,7 @@ func TestImportWithSyncCVAndNoVV(t *testing.T) {
 //     the body. Execution falls through to isDelete && doc.GetRevTreeID() == "", which fires and returns ErrImportCancelled.
 //  5. importDoc's switch has no return statement in the ErrImportCancelled case, so it
 //     falls through to return docOut, nil with docOut==nil.
-func TestGetDocSyncDataPanicOnImportCancelled(t *testing.T) {
+func TestGetDocSyncDataOnImportCancelled(t *testing.T) {
 	base.SkipImportTestsIfNotEnabled(t)
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD, base.KeyImport)
 
@@ -1518,10 +1518,10 @@ func TestGetDocSyncDataPanicOnImportCancelled(t *testing.T) {
 	leakyDataStore, ok := base.AsLeakyDataStore(docDatastore)
 	require.True(t, ok)
 
-	// resurrectOnce ensures the SetRaw resurrection only fires on the first
+	// resurrectOnce ensures the Set resurrection only fires on the first
 	// WriteUpdateWithXattrs attempt for the import, not on the CAS-mismatch retry,
 	// preventing an infinite CAS loop.
-	var resurrectOnce sync.Once
+	var resurrectOnce atomic.Bool
 	// importTriggered gates the callback so the SetRaw resurrection only fires
 	// during the import's WriteUpdateWithXattrs call, not during the initial Put.
 	var importTriggered bool
@@ -1534,10 +1534,11 @@ func TestGetDocSyncDataPanicOnImportCancelled(t *testing.T) {
 		if key != docID || !importTriggered {
 			return
 		}
-		resurrectOnce.Do(func() {
-			err := docDatastore.SetRaw(key, 0, nil, []byte(`{"foo":"resurrected"}`))
+		if !resurrectOnce.Load() {
+			err := docDatastore.Set(key, 0, nil, []byte(`{"foo":"resurrected"}`))
 			require.NoError(t, err)
-		})
+			resurrectOnce.Store(true)
+		}
 	})
 
 	// Create doc via SG to establish a _sync xattr with a RevTreeID and a recorded CAS.
@@ -1556,7 +1557,8 @@ func TestGetDocSyncDataPanicOnImportCancelled(t *testing.T) {
 	// Ensure GetDocSyncData will handle a nil doc returned from an on-demand import event when ErrImportCancelled is returned.
 	_, err = collection.GetDocSyncData(ctx, docID)
 	require.Error(t, err, "expected an error when import is cancelled mid-flight, not a panic")
-	require.True(t, base.IsDocNotFoundError(err), "expected a document-not-found error after import is cancelled mid-flight, got: %v", err)
+	base.RequireDocNotFoundError(t, err)
+	require.True(t, resurrectOnce.Load())
 }
 
 // getBucketDocument reads the current version of a document and turns it into a sgbucket.BucketDocument. This is

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -1494,7 +1494,7 @@ func TestImportWithSyncCVAndNoVV(t *testing.T) {
 //
 // Race setup:
 //  1. An SDK Delete tombstones a doc triggering on demand import for get pathway so OnDemandImportForGet is called with isDelete=true.
-//  2. The first WriteUpdateWithXattrs callback succeeds and produces an updatedDoc for the
+//  2. The first import callback succeeds and produces an updatedDoc for the
 //     import tombstone write.
 //  3. LeakyDataStore.UpdateCallback fires SetRaw resurrects the tombstone as a live document with
 //     no _sync xattr, advancing the CAS.

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -1535,7 +1535,8 @@ func TestGetDocSyncDataPanicOnImportCancelled(t *testing.T) {
 			return
 		}
 		resurrectOnce.Do(func() {
-			_ = docDatastore.SetRaw(key, 0, nil, []byte(`{"foo":"resurrected"}`))
+			err := docDatastore.SetRaw(key, 0, nil, []byte(`{"foo":"resurrected"}`))
+			require.NoError(t, err)
 		})
 	})
 
@@ -1552,9 +1553,10 @@ func TestGetDocSyncDataPanicOnImportCancelled(t *testing.T) {
 	// UpdateCallback now acts only during the import write, not Put.
 	importTriggered = true
 
-	// Ensure GetDocSyncData will handling nil doc returned from on demand import event when ErrImportCancelled returned
+	// Ensure GetDocSyncData will handle a nil doc returned from an on-demand import event when ErrImportCancelled is returned.
 	_, err = collection.GetDocSyncData(ctx, docID)
 	require.Error(t, err, "expected an error when import is cancelled mid-flight, not a panic")
+	require.True(t, base.IsDocNotFoundError(err), "expected a document-not-found error after import is cancelled mid-flight, got: %v", err)
 }
 
 // getBucketDocument reads the current version of a document and turns it into a sgbucket.BucketDocument. This is


### PR DESCRIPTION

CBG-5355

When `ErrImportCancelled` is encountered in `importDoc` we swallow the error and return silently nil doc but also nil error. This results in us returning nil, nil for `OnDemandImportForGet` inside `GetDocSyncData` which can lead to panic when returning doc.SyncData. 

`GetDocSyncData` is called from `buildRevokedFeed` which when hitting this panic can bring down the whole process via `FatalPanicHandler`. 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/570/
