### PR TITLE
Allow longer timeout while waiting fora bucket to get ready

### DIFF
--- a/base/main_test_bucket_pool_config.go
+++ b/base/main_test_bucket_pool_config.go
@@ -59,7 +59,7 @@ const (
 	tbpEnvAllowIncompatibleServerVersion = "SG_TEST_SKIP_SERVER_VERSION_CHECK"
 
 	// wait this long when requesting a test bucket from the pool before giving up and failing the test.
-	waitForReadyBucketTimeout = time.Minute
+	waitForReadyBucketTimeout = 2 * time.Minute
 
 	// Creates buckets with a specific number of number of replicas
 	tbpEnvBucketNumReplicas = "SG_TEST_BUCKET_NUM_REPLICAS"

--- a/base/main_test_bucket_pool_util.go
+++ b/base/main_test_bucket_pool_util.go
@@ -23,7 +23,7 @@ func (tbp *TestBucketPool) Fatalf(ctx context.Context, format string, args ...an
 		_ = fmt.Sprintf(format, args...)
 	}
 	format = addPrefixes(format, ctx, LevelNone, KeySGTest)
-	FatalfCtx(ctx, format, args...)
+	FatalfCtx(ctx, "TestBucketPool Fatal Error, exiting test harness: "+format, args...)
 }
 
 // Logf formats the given test bucket logging and logs to stderr.


### PR DESCRIPTION
Sometimes in the jenkins test harness a bucket is not quite ready yet, https://jenkins.sgwdev.com/job/SyncGatewayIntegration/573/ when opening the initial buckets. Other buckets have opened OK so I'm not sure why this particular bucket takes a longer time to open. I do not think it is worth figuring this out because it is hard to reproduce and subject to performance of couchbase server. 

Make it more clear when there's a fatal error in the TestBucketPool and that's why the tests failed.
