### PR TITLE
Move a db scoped function from DatabaseCollection

### DIFF
--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -336,15 +336,10 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 			}
 		}
 		if regenerateSequences && resyncCollections == nil {
-			var multiError *base.MultiError
-			for _, databaseCollection := range db.CollectionByID {
-				if updateErr := databaseCollection.updateAllPrincipalsSequences(ctx); updateErr != nil {
-					multiError = multiError.Append(updateErr)
-				}
-			}
+			err := db.updateAllPrincipalsSequences(ctx)
 
-			if multiError.Len() > 0 {
-				return fmt.Errorf("Error updating principal sequences: %s", multiError.Error())
+			if err != nil {
+				return fmt.Errorf("Error updating principal sequences: %w", err)
 			}
 		}
 

--- a/db/database.go
+++ b/db/database.go
@@ -1675,13 +1675,13 @@ func (db *DatabaseContext) updateCCVSettings(ctx context.Context) error {
 	return nil
 }
 
-func (c *DatabaseCollection) updateAllPrincipalsSequences(ctx context.Context) error {
-	users, roles, err := c.allPrincipalIDs(ctx)
+func (db *Database) updateAllPrincipalsSequences(ctx context.Context) error {
+	users, roles, err := db.AllPrincipalIDs(ctx)
 	if err != nil {
 		return err
 	}
 
-	authr := c.Authenticator(ctx)
+	authr := db.Authenticator(ctx)
 
 	for _, roleName := range roles {
 		role, err := authr.GetRole(roleName)
@@ -1691,7 +1691,7 @@ func (c *DatabaseCollection) updateAllPrincipalsSequences(ctx context.Context) e
 		if role == nil {
 			continue
 		}
-		err = c.regeneratePrincipalSequences(ctx, authr, role)
+		err = db.regeneratePrincipalSequences(ctx, authr, role)
 		if err != nil {
 			return err
 		}
@@ -1705,7 +1705,7 @@ func (c *DatabaseCollection) updateAllPrincipalsSequences(ctx context.Context) e
 		if user == nil {
 			continue
 		}
-		err = c.regeneratePrincipalSequences(ctx, authr, user)
+		err = db.regeneratePrincipalSequences(ctx, authr, user)
 		if err != nil {
 			return err
 		}
@@ -1713,8 +1713,8 @@ func (c *DatabaseCollection) updateAllPrincipalsSequences(ctx context.Context) e
 	return nil
 }
 
-func (c *DatabaseCollection) regeneratePrincipalSequences(ctx context.Context, authr *auth.Authenticator, princ auth.Principal) error {
-	nextSeq, err := c.sequences().nextSequence(ctx)
+func (db *Database) regeneratePrincipalSequences(ctx context.Context, authr *auth.Authenticator, princ auth.Principal) error {
+	nextSeq, err := db.sequences.nextSequence(ctx)
 	if err != nil {
 		return err
 	}

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -139,11 +139,6 @@ func (c *DatabaseCollection) GetCollectionDatastore() base.DataStore {
 	return c.dataStore
 }
 
-// allPrincipalIDs returns the IDs of all users and roles, including deleted Roles
-func (c *DatabaseCollection) allPrincipalIDs(ctx context.Context) (users, roles []string, err error) {
-	return c.dbCtx.AllPrincipalIDs(ctx)
-}
-
 // Authenticator returns authentication options associated with the collection's database.
 func (c *DatabaseCollection) Authenticator(ctx context.Context) *auth.Authenticator {
 	return c.dbCtx.Authenticator(ctx)

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -3951,8 +3951,6 @@ func Test_updateAllPrincipalsSequences(t *testing.T) {
 	roleSequences := [5]uint64{}
 	userSequences := [5]uint64{}
 
-	collection := GetSingleDatabaseCollection(t, db.DatabaseContext)
-
 	for i := range 5 {
 		role, err := auth.NewRole(fmt.Sprintf("role%d", i), base.SetOf("ABC"))
 		require.NoError(t, err)
@@ -3968,7 +3966,7 @@ func Test_updateAllPrincipalsSequences(t *testing.T) {
 		require.NoError(t, err)
 		userSequences[i] = user.Sequence()
 	}
-	err := collection.updateAllPrincipalsSequences(ctx)
+	err := db.updateAllPrincipalsSequences(ctx)
 	require.NoError(t, err)
 
 	for i := range 5 {


### PR DESCRIPTION
Move a db scoped function from DatabaseCollection

Slight optimization for resync with regenerate sequences. Principal documents are always database scoped, so mark the function to reflect that and only run it once.
