### PR TITLE
Fix issues from go vet:

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.11.4
+          version: v2.12.2
           args: --config=.golangci-strict.yml
 
   test:

--- a/base/bootstrap.go
+++ b/base/bootstrap.go
@@ -590,7 +590,7 @@ type mergoNilTransformer struct{}
 var _ mergo.Transformers = &mergoNilTransformer{}
 
 func (t *mergoNilTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
-	if typ.Kind() == reflect.Ptr {
+	if typ.Kind() == reflect.Pointer {
 		if typ.Elem().Kind() == reflect.Struct {
 			// skip nilTransformer for structs, to allow recursion
 			return nil

--- a/base/util.go
+++ b/base/util.go
@@ -10,6 +10,7 @@ package base
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"crypto/rand"
 	"crypto/sha1"
@@ -45,7 +46,6 @@ import (
 	"github.com/couchbase/gomemcached"
 	"github.com/gorilla/mux"
 	pkgerrors "github.com/pkg/errors"
-	"golang.org/x/exp/constraints"
 )
 
 const (
@@ -1473,14 +1473,14 @@ func FatalPanicHandler(ctx context.Context) {
 	}
 }
 
-func Min[T constraints.Ordered](a, b T) T {
+func Min[T cmp.Ordered](a, b T) T {
 	if a < b {
 		return a
 	}
 	return b
 }
 
-func Max[T constraints.Ordered](a, b T) T {
+func Max[T cmp.Ordered](a, b T) T {
 	if a > b {
 		return a
 	}

--- a/rest/config_flags.go
+++ b/rest/config_flags.go
@@ -193,7 +193,7 @@ func fillConfigWithFlags(fs *flag.FlagSet, flags map[string]configFlag) error {
 
 			pointer := true // Distinguish if to use rval.Set or *val.config
 			// Convert to pointer if not already
-			if rval.Kind() != reflect.Ptr && rval.CanAddr() {
+			if rval.Kind() != reflect.Pointer && rval.CanAddr() {
 				rval = rval.Addr()
 				pointer = false
 			}

--- a/rest/config_flags_test.go
+++ b/rest/config_flags_test.go
@@ -37,7 +37,7 @@ func TestAllConfigFlags(t *testing.T) {
 		switch rFlagVal.Interface().(type) {
 		case string: // Test different types of strings
 			rConfigVal := reflect.ValueOf(flagConfig.config).Elem()
-			if rConfigVal.Kind() != reflect.Ptr && rConfigVal.CanAddr() {
+			if rConfigVal.Kind() != reflect.Pointer && rConfigVal.CanAddr() {
 				rConfigVal = rConfigVal.Addr()
 			}
 			val := "TestString"
@@ -157,7 +157,7 @@ func TestAllConfigOptionsAsFlags(t *testing.T) {
 
 func countFields(cfg any) (fields int) {
 	rField := reflect.ValueOf(cfg)
-	if rField.Kind() == reflect.Ptr {
+	if rField.Kind() == reflect.Pointer {
 		rField = rField.Elem()
 	}
 	if rField.Kind() != reflect.Struct {

--- a/tools/stats-definition-exporter/stat_traverser.go
+++ b/tools/stats-definition-exporter/stat_traverser.go
@@ -24,7 +24,7 @@ func traverseAndRetrieveStats(logger *log.Logger, s any) statDefinitions {
 		logger.Println("Nil value for", topLevel.String())
 		return nil
 	}
-	if topLevel.Kind() == reflect.Ptr {
+	if topLevel.Kind() == reflect.Pointer {
 		// Dereference the pointer so the value can be manipulated
 		topLevel = topLevel.Elem()
 	}


### PR DESCRIPTION
flagged by golangci-lint 2.12.2

inline: Type alias constraints.Ordered should be inlined (govet)
inline: Type alias reflect.Ptr should be inlined (govet)CBG-0000
