### PR TITLE
CBG-5368: [4.0.5 backport] escape . characters for channel removal macro expansion

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -2774,7 +2774,10 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 			// update the mutate in options based on the above logic
 			updatedDoc.Spec = doc.HLV.computeMacroExpansions()
 
-			updatedDoc.Spec = appendRevocationMacroExpansions(updatedDoc.Spec, revokedChannelsRequiringExpansion)
+			updatedDoc.Spec, err = appendRevocationMacroExpansions(updatedDoc.Spec, revokedChannelsRequiringExpansion)
+			if err != nil {
+				return
+			}
 
 			updatedDoc.IsTombstone = currentRevFromHistory.Deleted
 			if doc.MetadataOnlyUpdate != nil {
@@ -3855,6 +3858,9 @@ const (
 
 	expandMacroCASValueUint64 = math.MaxUint64 // static value that indicates that a CAS macro expansion should be applied to a property
 	expandMacroCASValueString = "expand"
+
+	// cbsSubdocPathMaxLength is the maximum number of bytes allowed in a Couchbase Server subdocument path.
+	cbsSubdocPathMaxLength = 1024
 )
 
 func macroExpandSpec(xattrName string) []sgbucket.MacroExpansionSpec {
@@ -3891,6 +3897,20 @@ func xattrCurrentVersionCASPath(xattrKey string) string {
 	return xattrKey + "." + versionVectorCVCASMacro
 }
 
-func xattrRevokedChannelVersionPath(xattrKey string, channelName string) string {
-	return xattrKey + ".channels." + channelName + "." + xattrMacroCurrentRevVersion
+func xattrRevokedChannelVersionPath(xattrKey string, channelName string) (string, error) {
+	path := xattrKey + ".channels." + escapeSubdocPathComponent(channelName) + "." + xattrMacroCurrentRevVersion
+	if len(path) > cbsSubdocPathMaxLength {
+		return "", base.RedactErrorf("subdoc path for channel %s exceeds maximum length of %d bytes", base.UD(channelName), cbsSubdocPathMaxLength)
+	}
+	return path, nil
+}
+
+// escapeSubdocPathComponent wraps a Couchbase subdocument path component in backticks when it
+// contains a dot (the subdoc path separator), preventing the server from interpreting the dots
+// as nested key references. Any backticks within the component are doubled to escape them.
+func escapeSubdocPathComponent(component string) string {
+	if !strings.Contains(component, ".") {
+		return component
+	}
+	return "`" + strings.ReplaceAll(component, "`", "``") + "`"
 }

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"log"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -2279,6 +2280,124 @@ func TestSyncDataCVEqual(t *testing.T) {
 				Value:    testCase.cvValue,
 			}
 			require.Equal(t, testCase.cvEqual, testCase.syncData.CVEqual(cv))
+		})
+	}
+}
+
+func TestXattrRevokedChannelVersionPath(t *testing.T) {
+	tests := []struct {
+		name        string
+		channelName string
+		expected    string
+		wantErr     bool
+	}{
+		{
+			name:        "simple channel name",
+			channelName: "mychannel",
+			expected:    "_sync.channels.mychannel.rev.ver",
+		},
+		{
+			name:        "channel name with dots",
+			channelName: "location.com.subscriber.default_location",
+			expected:    "_sync.channels.`location.com.subscriber.default_location`.rev.ver",
+		},
+		{
+			name:        "channel name with dots and backticks",
+			channelName: "channel.with`backtick",
+			expected:    "_sync.channels.`channel.with``backtick`.rev.ver",
+		},
+		{
+			name:        "channel name with uppercase letters",
+			channelName: "MyChannel",
+			expected:    "_sync.channels.MyChannel.rev.ver",
+		},
+		{
+			name:        "channel name with uppercase letters and dots",
+			channelName: "My.Channel",
+			expected:    "_sync.channels.`My.Channel`.rev.ver",
+		},
+		{
+			name:        "channel name with digits",
+			channelName: "channel123",
+			expected:    "_sync.channels.channel123.rev.ver",
+		},
+		{
+			name:        "channel name with digits and dots",
+			channelName: "channel.123",
+			expected:    "_sync.channels.`channel.123`.rev.ver",
+		},
+		{
+			name:        "channel name with underscore only",
+			channelName: "my_channel",
+			expected:    "_sync.channels.my_channel.rev.ver",
+		},
+		{
+			name:        "channel name with equals sign",
+			channelName: "key=value",
+			expected:    "_sync.channels.key=value.rev.ver",
+		},
+		{
+			name:        "channel name with equals sign and dots",
+			channelName: "config.key=value",
+			expected:    "_sync.channels.`config.key=value`.rev.ver",
+		},
+		{
+			name:        "channel name with plus sign",
+			channelName: "a+b",
+			expected:    "_sync.channels.a+b.rev.ver",
+		},
+		{
+			name:        "channel name with plus sign and dots",
+			channelName: "a.b+c",
+			expected:    "_sync.channels.`a.b+c`.rev.ver",
+		},
+		{
+			name:        "channel name with forward slash",
+			channelName: "scope/channel",
+			expected:    "_sync.channels.scope/channel.rev.ver",
+		},
+		{
+			name:        "channel name with forward slash and dots",
+			channelName: "scope/channel.sub",
+			expected:    "_sync.channels.`scope/channel.sub`.rev.ver",
+		},
+		{
+			name:        "channel name with comma",
+			channelName: "a,b",
+			expected:    "_sync.channels.a,b.rev.ver",
+		},
+		{
+			name:        "channel name with comma and dots",
+			channelName: "a.b,c",
+			expected:    "_sync.channels.`a.b,c`.rev.ver",
+		},
+		{
+			name:        "channel name with at sign",
+			channelName: "user@example",
+			expected:    "_sync.channels.user@example.rev.ver",
+		},
+		{
+			name:        "channel name with at sign and dots",
+			channelName: "user@example.com",
+			expected:    "_sync.channels.`user@example.com`.rev.ver",
+		},
+		{
+			// Scaffold "_sync.channels." (15) + ".rev.ver" (8) = 23 chars; a name of 1002 chars
+			// produces a path of 1025 bytes, exceeding the CBS subdoc path limit of 1024.
+			name:        "channel name exceeding subdoc path limit",
+			channelName: strings.Repeat("a", 1002),
+			wantErr:     true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := xattrRevokedChannelVersionPath("_sync", tc.channelName)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expected, result)
+			}
 		})
 	}
 }

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -564,13 +564,15 @@ func (hlv *HybridLogicalVector) toHistoryForHLV(sortFunc func(HLVVersions) iter.
 
 // appendRevocationMacroExpansions adds macro expansions for the channel map.  Not strictly an HLV operation
 // but putting the function here as it's required when the HLV's current version is being macro expanded
-func appendRevocationMacroExpansions(currentSpec []sgbucket.MacroExpansionSpec, channelNames []string) (updatedSpec []sgbucket.MacroExpansionSpec) {
+func appendRevocationMacroExpansions(currentSpec []sgbucket.MacroExpansionSpec, channelNames []string) ([]sgbucket.MacroExpansionSpec, error) {
 	for _, channelName := range channelNames {
-		spec := sgbucket.NewMacroExpansionSpec(xattrRevokedChannelVersionPath(base.SyncXattrName, channelName), sgbucket.MacroCas)
-		currentSpec = append(currentSpec, spec)
+		path, err := xattrRevokedChannelVersionPath(base.SyncXattrName, channelName)
+		if err != nil {
+			return nil, err
+		}
+		currentSpec = append(currentSpec, sgbucket.NewMacroExpansionSpec(path, sgbucket.MacroCas))
 	}
-	return currentSpec
-
+	return currentSpec, nil
 }
 
 // extractHLVFromBlipMessage extracts the full HLV a string in the format seen over Blip

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -3849,3 +3849,166 @@ func TestBlipNoRevOnCorruptHistoryDelta(t *testing.T) {
 		require.Equal(t, db.MessageNoRev, msg.Profile())
 	})
 }
+
+func TestChannelRemovalWithSpecialCharsInName(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("rosmar doesn't support escaping characters in sub doc keys")
+	}
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+	btcRunner := NewBlipTesterClientRunner(t)
+
+	btcRunner.Run(func(t *testing.T) {
+		// Sync function assigns each doc to "chan.<doc.chan>" and grants alice access
+		// via a per-doc "test.<docID>" channel, ensuring every channel under test has
+		// a dot (triggering backtick-escaping of the subdoc path component).
+		rtConfig := RestTesterConfig{
+			SyncFn: `function (doc, oldDoc) {
+  var testChannel = "test." + doc._id;
+  access("alice", testChannel);
+
+  if (doc.chan && doc.chan.length > 0) {
+    var testChannel2 = "chan." + doc.chan;
+    channel(testChannel2);
+  }}`,
+		}
+		rt := NewRestTester(t, &rtConfig)
+		defer rt.Close()
+
+		collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
+
+		const username = "alice"
+		rt.CreateUser(username, nil)
+
+		opts := &BlipTesterClientOpts{Username: username}
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer client.Close()
+
+		btcRunner.StartPush(client.id)
+
+		// assertChannelRemoval pushes two revisions of a document so that the first
+		// channel is revoked, then checks that the removal version is recorded correctly.
+		assertChannelRemoval := func(docID, rev1, initialChan, rev2, updatedChan, expectedRemovedChannel string) {
+			t.Helper()
+			v := btcRunner.AddRevTreeRev(client.id, docID, rev1, EmptyDocVersion(), []byte(fmt.Sprintf(`{"chan": %q}`, initialChan)))
+			rt.WaitForVersion(docID, v)
+
+			v = btcRunner.AddRevTreeRev(client.id, docID, rev2, &v, []byte(fmt.Sprintf(`{"chan": %q}`, updatedChan)))
+			rt.WaitForVersion(docID, v)
+
+			xattrs, _, err := collection.GetCollectionDatastore().GetXattrs(ctx, docID, []string{base.SyncXattrName, base.VvXattrName})
+			require.NoError(t, err)
+
+			var syncData db.SyncData
+			syncXattr, ok := xattrs[base.SyncXattrName]
+			require.True(t, ok, "missing _sync xattr")
+			require.NoError(t, base.JSONUnmarshal(syncXattr, &syncData))
+
+			var hlv db.HybridLogicalVector
+			vvXattr, ok := xattrs[base.VvXattrName]
+			require.True(t, ok, "missing _vv xattr")
+			require.NoError(t, base.JSONUnmarshal(vvXattr, &hlv))
+
+			removalData, ok := syncData.Channels[expectedRemovedChannel]
+			require.True(t, ok, "channel %q not found in sync data", expectedRemovedChannel)
+
+			assert.Equal(t, hlv.Version, base.HexCasToUint64(removalData.Rev.CurrentVersion))
+			assert.Equal(t, hlv.SourceID, removalData.Rev.CurrentSource)
+			assert.Equal(t, syncData.RevAndVersion.RevTreeID, removalData.Rev.RevTreeID)
+		}
+
+		// Dots in channel name — path component must be backtick-escaped.
+		assertChannelRemoval(
+			"38839af8-7874-4e28-b369-51b265d7e6ce",
+			"1-abc", "channel.test1",
+			"2-abc", "channel.test2",
+			"chan.channel.test1",
+		)
+		// Brackets with an index — e.g. "example[10]ChannelName". Brackets are CBS
+		// array-index syntax in subdoc paths; the dot prefix means the component is
+		// backtick-wrapped so the brackets are treated as literals.
+		assertChannelRemoval(
+			"bracket-index-7874-4e28-b369-51b265d7e6ce",
+			"1-abc", "example[10]ChannelName",
+			"2-abc", "example[11]ChannelName",
+			"chan.example[10]ChannelName",
+		)
+		// Empty brackets — same escaping concern as above.
+		assertChannelRemoval(
+			"bracket-empty-7874-4e28-b369-51b265d7e6ce",
+			"1-abc", "literal[]bracketchannel",
+			"2-abc", "literalbothchannels",
+			"chan.literal[]bracketchannel",
+		)
+		// Brackets with index at end of name — CBS would interpret this as an array
+		// index operator if not escaped; the dot prefix ensures backtick-wrapping.
+		assertChannelRemoval(
+			"bracket-suffix-7874-4e28-b369-51b265d7e6ce",
+			"1-abc", "exampleChannelName[10]",
+			"2-abc", "exampleChannelName[11]",
+			"chan.exampleChannelName[10]",
+		)
+	})
+}
+
+func TestChannelRemovalWithLongChannelName(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("rosmar doesn't support escaping characters in sub doc keys")
+	}
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+	btcRunner := NewBlipTesterClientRunner(t)
+
+	btcRunner.Run(func(t *testing.T) {
+		// Use the channel name directly (no prefix) so the test controls the exact length.
+		rtConfig := RestTesterConfig{
+			SyncFn: `function (doc, oldDoc) {
+  access("alice", "test." + doc._id);
+  if (doc.chan && doc.chan.length > 0) {
+    channel(doc.chan);
+  }}`,
+		}
+		rt := NewRestTester(t, &rtConfig)
+		defer rt.Close()
+
+		const username = "alice"
+		rt.CreateUser(username, nil)
+
+		opts := &BlipTesterClientOpts{Username: username}
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer client.Close()
+
+		btcRunner.StartPush(client.id)
+
+		longChannelName := strings.Repeat("a", 1025)
+		const docID = "long-channel-name-doc"
+
+		// Rev 1: assign the doc to the long channel. No channel is revoked on a new
+		// document, so no macro expansion path is built and the write succeeds.
+		v := btcRunner.AddRevTreeRev(client.id, docID, "1-abc", EmptyDocVersion(), []byte(fmt.Sprintf(`{"chan": %q}`, longChannelName)))
+		rt.WaitForVersion(docID, v)
+
+		// Rev 2: move the doc to a short channel, revoking the long channel. Building
+		// the subdoc macro expansion path for the revoked channel exceeds the CBS
+		// 1024-byte limit, so the write must fail. We construct the rev message manually
+		// so we can inspect the error response directly rather than via WaitForVersion.
+		revRequest := blip.NewRequest()
+		revRequest.SetProfile(db.MessageRev)
+		revRequest.Properties[db.RevMessageID] = docID
+		revRequest.Properties[db.RevMessageRev] = "2-abc"
+		revRequest.Properties[db.RevMessageHistory] = v.RevTreeID
+		revRequest.SetBody([]byte(`{"chan": "shortchannel"}`))
+		btcRunner.SingleCollection(client.id).sendPushMsg(revRequest)
+
+		revResp := revRequest.Response()
+		if btcRunner.SingleCollection(client.id).UseHLV() {
+			// HLV replication does not use subdoc macro expansion for revoked channels,
+			// so the write succeeds.
+			require.NotEqual(t, blip.ErrorType, revResp.Type())
+			require.NotContains(t, revResp.Properties, "Error-Code")
+		} else {
+			// RevTree replication builds a subdoc macro expansion path for revoked
+			// channels; a 1025-char channel name exceeds the CBS 1024-byte path limit.
+			require.Equal(t, blip.ErrorType, revResp.Type())
+			require.Equal(t, strconv.Itoa(http.StatusInternalServerError), revResp.Properties["Error-Code"])
+		}
+	})
+}


### PR DESCRIPTION
CBG-5368

Backports https://github.com/couchbase/sync_gateway/pull/8241

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
