### PR TITLE
CBG-5365-followup-backport: fix escaping issue

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -3906,10 +3906,10 @@ func xattrRevokedChannelVersionPath(xattrKey string, channelName string) (string
 }
 
 // escapeSubdocPathComponent wraps a Couchbase subdocument path component in backticks when it
-// contains a dot (the subdoc path separator), preventing the server from interpreting the dots
-// as nested key references. Any backticks within the component are doubled to escape them.
+// contains characters that are special in subdoc paths: dots (path separator) or square brackets
+// (array index syntax). Any backticks within the component are doubled to escape them.
 func escapeSubdocPathComponent(component string) string {
-	if !strings.Contains(component, ".") {
+	if !strings.ContainsAny(component, ".[]`") {
 		return component
 	}
 	return "`" + strings.ReplaceAll(component, "`", "``") + "`"

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -2382,6 +2382,31 @@ func TestXattrRevokedChannelVersionPath(t *testing.T) {
 			expected:    "_sync.channels.`user@example.com`.rev.ver",
 		},
 		{
+			name:        "channel name with brackets and index",
+			channelName: "example[10]ChannelName",
+			expected:    "_sync.channels.`example[10]ChannelName`.rev.ver",
+		},
+		{
+			name:        "channel name with brackets at end",
+			channelName: "exampleChannelName[10]",
+			expected:    "_sync.channels.`exampleChannelName[10]`.rev.ver",
+		},
+		{
+			name:        "channel name with empty brackets",
+			channelName: "literal[]bracketchannel",
+			expected:    "_sync.channels.`literal[]bracketchannel`.rev.ver",
+		},
+		{
+			name:        "channel name with brackets and dots",
+			channelName: "example[10].ChannelName",
+			expected:    "_sync.channels.`example[10].ChannelName`.rev.ver",
+		},
+		{
+			name:        "channel name with backtick",
+			channelName: "foo`bar",
+			expected:    "_sync.channels.`foo``bar`.rev.ver",
+		},
+		{
 			// Scaffold "_sync.channels." (15) + ".rev.ver" (8) = 23 chars; a name of 1002 chars
 			// produces a path of 1025 bytes, exceeding the CBS subdoc path limit of 1024.
 			name:        "channel name exceeding subdoc path limit",

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -3858,16 +3858,17 @@ func TestChannelRemovalWithSpecialCharsInName(t *testing.T) {
 	btcRunner := NewBlipTesterClientRunner(t)
 
 	btcRunner.Run(func(t *testing.T) {
-		// Sync function assigns each doc to "chan.<doc.chan>" and grants alice access
-		// via a per-doc "test.<docID>" channel, ensuring every channel under test has
-		// a dot (triggering backtick-escaping of the subdoc path component).
+		// Sync function assigns each doc to "chan<doc.chan>" and grants alice access
+		// via a per-doc "test.<docID>" channel, so the channels under test exercise
+		// subdoc-path backtick escaping for special characters such as dots and/or
+		// square brackets.
 		rtConfig := RestTesterConfig{
 			SyncFn: `function (doc, oldDoc) {
   var testChannel = "test." + doc._id;
   access("alice", testChannel);
 
   if (doc.chan && doc.chan.length > 0) {
-    var testChannel2 = "chan." + doc.chan;
+    var testChannel2 = "chan" + doc.chan;
     channel(testChannel2);
   }}`,
 		}
@@ -3921,7 +3922,7 @@ func TestChannelRemovalWithSpecialCharsInName(t *testing.T) {
 			"38839af8-7874-4e28-b369-51b265d7e6ce",
 			"1-abc", "channel.test1",
 			"2-abc", "channel.test2",
-			"chan.channel.test1",
+			"chanchannel.test1",
 		)
 		// Brackets with an index — e.g. "example[10]ChannelName". Brackets are CBS
 		// array-index syntax in subdoc paths; the dot prefix means the component is
@@ -3930,14 +3931,14 @@ func TestChannelRemovalWithSpecialCharsInName(t *testing.T) {
 			"bracket-index-7874-4e28-b369-51b265d7e6ce",
 			"1-abc", "example[10]ChannelName",
 			"2-abc", "example[11]ChannelName",
-			"chan.example[10]ChannelName",
+			"chanexample[10]ChannelName",
 		)
 		// Empty brackets — same escaping concern as above.
 		assertChannelRemoval(
 			"bracket-empty-7874-4e28-b369-51b265d7e6ce",
 			"1-abc", "literal[]bracketchannel",
 			"2-abc", "literalbothchannels",
-			"chan.literal[]bracketchannel",
+			"chanliteral[]bracketchannel",
 		)
 		// Brackets with index at end of name — CBS would interpret this as an array
 		// index operator if not escaped; the dot prefix ensures backtick-wrapping.
@@ -3945,7 +3946,7 @@ func TestChannelRemovalWithSpecialCharsInName(t *testing.T) {
 			"bracket-suffix-7874-4e28-b369-51b265d7e6ce",
 			"1-abc", "exampleChannelName[10]",
 			"2-abc", "exampleChannelName[11]",
-			"chan.exampleChannelName[10]",
+			"chanexampleChannelName[10]",
 		)
 	})
 }


### PR DESCRIPTION


Backports https://github.com/couchbase/sync_gateway/pull/8256

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
