### PR TITLE
Improve agent instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,3 +11,5 @@ When performing a code review, ensure code comments explain the _intent_ or _rea
 When performing a code review, ensure `for` loops have sufficient exit conditions and are not prone to infinite loops. Prefer expressing the exit condition in the loop declaration itself, rather than relying on `break` statements within the loop body.
 
 When performing a code review, make sure context.WithCancelCause is used instead of context.WithCancel.
+
+When performing a code review, flag any new code that gates behavior on whether xattrs are enabled (e.g. `UseXattrs` checks, non-xattr write/read branches, or config plumbing that exposes xattr-mode as a choice). Since Sync Gateway 4.0, xattr mode is the only supported mode on `main`; new code must assume xattrs are enabled. The exception is read-side migration logic that handles pre-existing non-xattr documents already in a bucket — that gradual-migration path must still be preserved, but no new write paths or config surfaces should produce non-xattr data.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,17 @@ Never add the `cb_sg_enterprise` tag to test commands unless intentionally testi
 ### REST API changes
 - When modifying REST handlers, query parameters, or response schemas, update the OpenAPI specs in `docs/api/`.
 
+### Code review conventions
+- Use `context.WithCancelCause` instead of `context.WithCancel` so cancellation reasons propagate.
+- Prefer expressing loop exit conditions in the `for` declaration itself rather than relying on `break` inside the body; ensure loops have a clear termination condition.
+- Comments should explain *why* / intent, not restate *what* the code does.
+- Watch for concurrency hazards (mutex contention, races) when reviewing.
+
+### Xattrs are mandatory (SG 4.0+)
+- Xattr mode is the only supported mode on `main`. New code must assume xattrs are enabled — do not add `UseXattrs` checks, non-xattr write/read branches, or config surfaces that let xattr-mode be turned off.
+- The one preserved carve-out is **read-side migration of pre-existing non-xattr documents** already present in a bucket: that gradual-migration path must still work so older data is upgraded on access. No new code paths should *produce* non-xattr data.
+- When touching existing `UseXattrs` checks, prefer simplifying toward the xattrs-on branch and deleting the alternative, unless the code is part of the read/migration path described above.
+
 ## Security
 
 - NEVER log credentials, tokens, or keys.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,7 @@
-AGENTS.md
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+The shared agent instructions for this repo live in `AGENTS.md` and are imported below. Claude-specific guidance, if any, can be added beneath the import.
+
+@AGENTS.md


### PR DESCRIPTION
- Improve instructions around redundant xattr guard usage when writing or reviewing code.
- Copy copilot review instructions into `AGENTS.md` for interactive code review sessions.
- Unlink `CLAUDE.md` with own file using `@` import as per [recommendations](https://code.claude.com/docs/en/best-practices#write-an-effective-claude-md)

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- n/a