### PR TITLE
CBG-5310: [3.3.5 backport] Cleanup for GetUser

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -719,6 +719,9 @@ func (auth *Authenticator) casUpdatePrincipal(p Principal, callback casUpdatePri
 		if err != nil {
 			return fmt.Errorf("Error reloading principal after CAS failure: %w", err)
 		}
+		if p == nil {
+			return base.ErrNotFound
+		}
 	}
 	base.InfofCtx(auth.LogCtx, base.KeyAuth, "Unable to update principal after %d attempts.  Principal:%s Error:%v", PrincipalUpdateMaxCasRetries, base.UD(p.Name()), err)
 	return err
@@ -929,7 +932,7 @@ func (auth *Authenticator) authenticateJWTIdentity(identity *Identity, provider 
 	if common.Register {
 		base.DebugfCtx(auth.LogCtx, base.KeyAuth, "Registering new user: %v with email: %v", base.UD(username), base.UD(identity.Email))
 		user, err := auth.RegisterNewUser(username, identity.Email)
-		if err != nil && !base.IsCasMismatch(err) {
+		if err != nil {
 			base.InfofCtx(auth.LogCtx, base.KeyAuth, "Error registering new user: %v", err)
 			return nil, PrincipalConfig{}, time.Time{}, err
 		}
@@ -941,8 +944,8 @@ func (auth *Authenticator) authenticateJWTIdentity(identity *Identity, provider 
 }
 
 // Registers a new user account based on the given verified username and optional email address.
-// Password will be random. The user will have access to no channels.  If the user already exists,
-// returns the existing user along with the cas failure error
+// Password will be random. The user will have access to no channels.  If the user already exists
+// (race with a concurrent registration), returns the existing user with a nil error.
 func (auth *Authenticator) RegisterNewUser(username, email string) (User, error) {
 	secret, err := base.GenerateRandomSecret()
 	if err != nil {
@@ -964,7 +967,14 @@ func (auth *Authenticator) RegisterNewUser(username, email string) (User, error)
 
 	err = auth.Save(user)
 	if base.IsCasMismatch(err) {
-		return auth.GetUser(username)
+		existing, getErr := auth.GetUser(username)
+		if getErr != nil {
+			return nil, getErr
+		}
+		if existing == nil {
+			return nil, err
+		}
+		return existing, nil
 	} else if err != nil {
 		return nil, err
 	}

--- a/auth/session.go
+++ b/auth/session.go
@@ -72,8 +72,7 @@ func (auth *Authenticator) AuthenticateCookie(rq *http.Request, response http.Re
 	if err != nil {
 		return nil, err
 	}
-
-	if session.SessionUUID != user.GetSessionUUID() {
+	if user == nil || session.SessionUUID != user.GetSessionUUID() {
 		base.InfofCtx(auth.LogCtx, base.KeyAuth, "Session no longer valid for user %s", base.UD(session.Username))
 		return nil, base.HTTPErrorf(http.StatusUnauthorized, "Session no longer valid for user")
 	}

--- a/db/crud.go
+++ b/db/crud.go
@@ -2369,6 +2369,8 @@ func (db *DatabaseCollectionWithUser) MarkPrincipalsChanged(ctx context.Context,
 		user, err := db.Authenticator(ctx).GetUser(db.user.Name())
 		if err != nil {
 			base.WarnfCtx(ctx, "Error reloading active db.user[%s], security information will not be recalculated until next authentication --> %+v", base.UD(db.user.Name()), err)
+		} else if user == nil {
+			base.WarnfCtx(ctx, "Active db.user[%s] no longer exists; security information will not be recalculated until next authentication", base.UD(db.user.Name()))
 		} else {
 			db.user = user
 		}

--- a/db/database.go
+++ b/db/database.go
@@ -1611,10 +1611,13 @@ func (c *DatabaseCollection) updateAllPrincipalsSequences(ctx context.Context) e
 
 	authr := c.Authenticator(ctx)
 
-	for _, role := range roles {
-		role, err := authr.GetRole(role)
+	for _, roleName := range roles {
+		role, err := authr.GetRole(roleName)
 		if err != nil {
 			return err
+		}
+		if role == nil {
+			continue
 		}
 		err = c.regeneratePrincipalSequences(ctx, authr, role)
 		if err != nil {
@@ -1622,10 +1625,13 @@ func (c *DatabaseCollection) updateAllPrincipalsSequences(ctx context.Context) e
 		}
 	}
 
-	for _, user := range users {
-		user, err := authr.GetUser(user)
+	for _, userName := range users {
+		user, err := authr.GetUser(userName)
 		if err != nil {
 			return err
+		}
+		if user == nil {
+			continue
 		}
 		err = c.regeneratePrincipalSequences(ctx, authr, user)
 		if err != nil {

--- a/rest/diagnostic_api.go
+++ b/rest/diagnostic_api.go
@@ -194,9 +194,10 @@ func getHistoricRoleChanEntryOverlap(roleEntries []auth.GrantHistorySequencePair
 
 func (h *handler) handleGetAllChannels() error {
 	h.assertAdminOnly()
-	user, err := h.db.Authenticator(h.ctx()).GetUser(internalUserName(mux.Vars(h.rq)["name"]))
+	name := internalUserName(mux.Vars(h.rq)["name"])
+	user, err := h.db.Authenticator(h.ctx()).GetUser(name)
 	if err != nil {
-		return fmt.Errorf("could not get user %s: %w", user.Name(), err)
+		return fmt.Errorf("could not get user %s: %w", name, err)
 	}
 	if user == nil {
 		return kNotFoundError
@@ -218,9 +219,10 @@ func (h *handler) handleGetAllChannels() error {
 
 func (h *handler) handleGetUserDocAccessSpan() error {
 	h.assertAdminOnly()
-	user, err := h.db.Authenticator(h.ctx()).GetUser(internalUserName(mux.Vars(h.rq)["name"]))
+	name := internalUserName(mux.Vars(h.rq)["name"])
+	user, err := h.db.Authenticator(h.ctx()).GetUser(name)
 	if err != nil {
-		return fmt.Errorf("could not get user %s: %w", user.Name(), err)
+		return fmt.Errorf("could not get user %s: %w", name, err)
 	}
 	if user == nil {
 		return kNotFoundError

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -537,10 +537,13 @@ func (h *handler) validateAndWriteHeaders(method handlerMethod, accessPermission
 				return fmt.Errorf("failed to revoke stale OIDC roles/channels: %w", err)
 			}
 			// TODO: could avoid this extra fetch if UpdatePrincipal returned the new principal
-			h.user, err = dbContext.Authenticator(h.ctx()).GetUser(*updates.Name)
+			user, err := dbContext.Authenticator(h.ctx()).GetUser(*updates.Name)
 			if err != nil {
 				return err
+			} else if user == nil {
+				return ErrInvalidLogin
 			}
+			h.user = user
 		}
 	}
 
@@ -968,7 +971,13 @@ func (h *handler) checkPublicAuth(dbCtx *db.DatabaseContext) (err error) {
 			}
 			// TODO: could avoid this extra fetch if UpdatePrincipal returned the newly updated principal
 			if updates.Name != nil {
-				h.user, err = dbCtx.Authenticator(h.ctx()).GetUser(*updates.Name)
+				user, err := dbCtx.Authenticator(h.ctx()).GetUser(*updates.Name)
+				if err != nil {
+					return auditFields, err
+				} else if user == nil {
+					return auditFields, ErrInvalidLogin
+				}
+				h.user = user
 			}
 			return err
 		}

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -973,9 +973,9 @@ func (h *handler) checkPublicAuth(dbCtx *db.DatabaseContext) (err error) {
 			if updates.Name != nil {
 				user, err := dbCtx.Authenticator(h.ctx()).GetUser(*updates.Name)
 				if err != nil {
-					return auditFields, err
+					return err
 				} else if user == nil {
-					return auditFields, ErrInvalidLogin
+					return ErrInvalidLogin
 				}
 				h.user = user
 			}

--- a/rest/session_api.go
+++ b/rest/session_api.go
@@ -194,9 +194,8 @@ func (h *handler) makeSessionFromNameAndEmail(username, email string, createUser
 		}
 
 		// Create a User with the given username, email address, and a random password.
-		// CAS mismatch indicates the user has been created by another request underneath us, can continue with session creation
 		user, err = h.db.Authenticator(h.ctx()).RegisterNewUser(username, email)
-		if err != nil && !base.IsCasMismatch(err) {
+		if err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
CBG-5310

Backports https://github.com/couchbase/sync_gateway/pull/8259

`auditFields` does not exist as return value in this branch for `checkPublicAuth` so we will just return error

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
