### PR TITLE
CBG-5376 skip test temporarily

### DIFF
--- a/db/background_mgr_test.go
+++ b/db/background_mgr_test.go
@@ -141,6 +141,7 @@ func TestBackgroundManagerModes(t *testing.T) {
 }
 
 func TestBackgroundManagerMultiNodeTransitions(t *testing.T) {
+	t.Skip("CBG-5376 temporarily skip test which flakes in CI")
 	testBucket := base.GetTestBucket(t)
 	ctx := context.Background()
 	defer testBucket.Close(ctx)


### PR DESCRIPTION
CBG-5376 skip test temporarily

I think this is a test only issue, but in case it isn't I will look into this when I come back from vacation. I tried to reproduce with a t3.medium and the race detector and was not able to yet.
