### PR TITLE
CBG-5184 use cbgt one shot mode for distributed resync

### DIFF
--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -244,7 +244,7 @@ func (c *DCPCommon) shouldProcessSequence(vBucketID uint16, seq uint64) bool {
 // vbucket and log a warning in that case.  The valid case for setting warnOnLowerSeqNo to
 // false is when it's a rollback scenario.  See https://github.com/couchbase/sync_gateway/issues/1098 for dev notes.
 func (c *DCPCommon) updateSeq(vbucketId uint16, seq uint64, warnOnLowerSeqNo bool) {
-	if c.shouldProcessSequence(vbucketId, seq) {
+	if !c.shouldProcessSequence(vbucketId, seq) {
 		return
 	}
 	c.m.Lock()

--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -232,7 +232,8 @@ func (c *DCPCommon) shouldProcessSequence(vBucketID uint16, seq uint64) bool {
 	// DCP will provide mutations that run to the end of the snapshot that contains the end sequence number.
 	endSeq, ok := c.endSeqNos[vBucketID]
 	if !ok {
-		AssertfCtx(c.loggingCtx, "Received DCP event for vbno %d which is not tracked by the expected endSeqNos %#+v. This means that endSeqNos was specified with the incorrect number of vBuckets", vBucketID, c.endSeqNos)
+		AssertfCtx(c.loggingCtx, "Received DCP event for vbno %d which is not tracked by the expected endSeqNos %#+v. This means that endSeqNos was specified with the incorrect number of vBuckets. Processing this sequence anyway", vBucketID, c.endSeqNos)
+		return true
 	}
 	return seq <= endSeq
 }

--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -231,10 +231,8 @@ func (c *DCPCommon) updateSeq(vbucketId uint16, seq uint64, warnOnLowerSeqNo boo
 	if c.endSeqNos != nil {
 		endSeq, ok := c.endSeqNos[vbucketId]
 		if !ok {
-			AssertfCtx(c.loggingCtx, "Received DCP event for vbno %d which is greater than endSeqNos we have for that vbno", vbucketId)
-		}
-		// Checkpoints
-		if seq > endSeq {
+			AssertfCtx(c.loggingCtx, "Received DCP event for vbno %d which is not tracked by the expected endSeqNos %#+v. This means that endSeqNos was specified with the incorrect number of vBuckets", vbucketId, c.endSeqNos)
+		} else if seq > endSeq {
 			return
 		}
 	}

--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -60,30 +60,26 @@ type DCPCommon struct {
 	callback               sgbucket.FeedEventCallbackFunc // Function to callback for mutation processing
 	loggingCtx             context.Context                // Logging context, prefixes feedID
 	checkpointPrefix       string                         // DCP checkpoint key prefix
+	endSeqNos              map[uint16]uint64              // endSeqNos mark the sequence numbers keyed by vBucket ID that are the end sequence numbers for a stream
 }
 
-// NewDCPCommon creates a new DCPCommon which manages updates coming from a cbgt-based DCP feed. The callback function will receive events from a DCP feed. It stores checkpoints in the metaStore starting with checkpointPrefix if persistCheckpoints is true.
-// Specific stats for DCP are stored in expvars rather than SgwStats.
+// NewDCPCommon creates a new DCPCommon instance which manages updates coming from a cbgt-based DCP feed.
 func NewDCPCommon(
 	ctx context.Context,
-	callback sgbucket.FeedEventCallbackFunc,
-	metaStore DataStore,
-	maxVbNo uint16,
-	persistCheckpoints bool,
-	dbStats *expvar.Map,
-	checkpointPrefix string) (*DCPCommon, error) {
+	opts DCPDestOptions) (*DCPCommon, error) {
 
 	c := &DCPCommon{
-		dbStatsExpvars:         dbStats,
-		metaStore:              metaStore,
-		persistCheckpoints:     persistCheckpoints,
-		seqs:                   make([]uint64, maxVbNo),
-		meta:                   make([][]byte, maxVbNo),
-		updatesSinceCheckpoint: make([]uint64, maxVbNo),
-		callback:               callback,
-		lastCheckpointTime:     make([]time.Time, maxVbNo),
-		checkpointPrefix:       checkpointPrefix,
+		dbStatsExpvars:         opts.DcpStats,
+		metaStore:              opts.MetadataStore,
+		persistCheckpoints:     opts.PersistCheckpoints,
+		seqs:                   make([]uint64, opts.MaxVbNo),
+		meta:                   make([][]byte, opts.MaxVbNo),
+		updatesSinceCheckpoint: make([]uint64, opts.MaxVbNo),
+		callback:               opts.Callback,
+		lastCheckpointTime:     make([]time.Time, opts.MaxVbNo),
+		checkpointPrefix:       opts.CheckpointPrefix,
 		loggingCtx:             ctx,
+		endSeqNos:              opts.EndSeqNos,
 	}
 
 	return c, nil
@@ -151,7 +147,9 @@ func (c *DCPCommon) getMetaData(vbucketId uint16) (
 // rollbackEx is called when a DCP open stream issues a rollback. The metadata persisted for a given uuid and sequence number and stream reopening is deferred to cbgt via AutoReconnectAfterRollback feed parameter.
 func (c *DCPCommon) rollbackEx(vbucketId uint16, vbucketUUID uint64, rollbackSeq uint64, rollbackMetaData []byte) error {
 	InfofCtx(c.loggingCtx, KeyDCP, "DCP RollbackEx request - rolling back DCP feed for: vbucketId: %d, rollbackSeq: %x.", vbucketId, rollbackSeq)
-	c.dbStatsExpvars.Add("dcp_rollback_count", 1)
+	if c.dbStatsExpvars != nil {
+		c.dbStatsExpvars.Add("dcp_rollback_count", 1)
+	}
 	c.updateSeq(vbucketId, rollbackSeq, false)
 	err := c.setMetaData(vbucketId, rollbackMetaData, true)
 	if err != nil {
@@ -225,6 +223,21 @@ func (c *DCPCommon) persistCheckpoint(vbNo uint16, value []byte) error {
 func (c *DCPCommon) updateSeq(vbucketId uint16, seq uint64, warnOnLowerSeqNo bool) {
 	c.m.Lock()
 	defer c.m.Unlock()
+
+	// Check the expected maximum sequence number when running a one shot feed. Do not checkpoint if the incoming
+	// sequence is greater than the expected maximum sequence number.
+	//
+	// DCP will provide mutations that run to the end of the snapshot that contains the end sequence number.
+	if c.endSeqNos != nil {
+		endSeq, ok := c.endSeqNos[vbucketId]
+		if !ok {
+			AssertfCtx(c.loggingCtx, "Received DCP event for vbno %d which is greater than endSeqNos we have for that vbno", vbucketId)
+		}
+		// Checkpoints
+		if seq > endSeq {
+			return
+		}
+	}
 
 	previousSequence := c.seqs[vbucketId]
 

--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -86,6 +86,9 @@ func NewDCPCommon(
 }
 
 func (c *DCPCommon) dataUpdate(seq uint64, event sgbucket.FeedEvent) {
+	if !c.shouldProcessSequence(event.VbNo, seq) {
+		return
+	}
 	shouldPersistCheckpoint := c.callback(event)
 	c.updateSeq(event.VbNo, seq, true)
 	if c.persistCheckpoints && shouldPersistCheckpoint {
@@ -215,27 +218,36 @@ func (c *DCPCommon) persistCheckpoint(vbNo uint16, value []byte) error {
 	return c.metaStore.SetRaw(c.loggingCtx, fmt.Sprintf("%s%d", c.checkpointPrefix, vbNo), 0, nil, value)
 }
 
+// shouldProcessSequence checks the incoming sequence number against the expected end sequence number, and returns true
+// if this sequence number is expected.
+//
+// The expected sequences that should not be processed are sequences between the end sequence and any sequences to the end of that sequence's snapshot.
+func (c *DCPCommon) shouldProcessSequence(vBucketID uint16, seq uint64) bool {
+	if c.endSeqNos == nil {
+		return true
+	}
+	// Check the expected maximum sequence number when running a one shot feed. Do not checkpoint if the incoming
+	// sequence is greater than the expected maximum sequence number.
+	//
+	// DCP will provide mutations that run to the end of the snapshot that contains the end sequence number.
+	endSeq, ok := c.endSeqNos[vBucketID]
+	if !ok {
+		AssertfCtx(c.loggingCtx, "Received DCP event for vbno %d which is not tracked by the expected endSeqNos %#+v. This means that endSeqNos was specified with the incorrect number of vBuckets", vBucketID, c.endSeqNos)
+	}
+	return seq <= endSeq
+}
+
 // This updates the value stored in r.seqs with the given seq number for the given partition
 // Setting warnOnLowerSeqNo to true will check
 // if we are setting the seq number to a _lower_ value than we already have stored for that
 // vbucket and log a warning in that case.  The valid case for setting warnOnLowerSeqNo to
 // false is when it's a rollback scenario.  See https://github.com/couchbase/sync_gateway/issues/1098 for dev notes.
 func (c *DCPCommon) updateSeq(vbucketId uint16, seq uint64, warnOnLowerSeqNo bool) {
+	if c.shouldProcessSequence(vbucketId, seq) {
+		return
+	}
 	c.m.Lock()
 	defer c.m.Unlock()
-
-	// Check the expected maximum sequence number when running a one shot feed. Do not checkpoint if the incoming
-	// sequence is greater than the expected maximum sequence number.
-	//
-	// DCP will provide mutations that run to the end of the snapshot that contains the end sequence number.
-	if c.endSeqNos != nil {
-		endSeq, ok := c.endSeqNos[vbucketId]
-		if !ok {
-			AssertfCtx(c.loggingCtx, "Received DCP event for vbno %d which is not tracked by the expected endSeqNos %#+v. This means that endSeqNos was specified with the incorrect number of vBuckets", vbucketId, c.endSeqNos)
-		} else if seq > endSeq {
-			return
-		}
-	}
 
 	previousSequence := c.seqs[vbucketId]
 

--- a/base/dcp_dest.go
+++ b/base/dcp_dest.go
@@ -30,6 +30,7 @@ func init() {
 type SGDest interface {
 	cbgt.Dest
 	cbgt.DestEx
+	ForceCheckpointWrite()
 }
 
 // DCPDest implements SGDest (superset of cbgt.Dest) interface to manage updates coming from a
@@ -41,28 +42,32 @@ type DCPDest struct {
 	metaInitComplete   []bool      // Whether metadata initialization has been completed, per vbNo
 }
 
-// NewDCPDest creates a new DCPDest which manages updates coming from a cbgt-based DCP feed. The callback function will receive events from a DCP feed. If persistCheckpoints is true, stores checkpoints as documents in metadataStore starting with checkpointPrefix.
-// Specific stats for DCP are stored in expvars rather than SgwStats, except for partition stat, which indicates the number of cbgt partitions assigned to this node.
+type DCPDestOptions struct {
+	Callback           sgbucket.FeedEventCallbackFunc // Callback function receives DCP events.
+	MetadataStore      sgbucket.DataStore             // location to store checkpoints in
+	MaxVbNo            uint16                         // number of vBuckets for the backing bucket (does not have to match metadata store)
+	PersistCheckpoints bool                           // if true, write checkpoints to MetadataStore with keys prefixed by CheckpointPrefix
+	DcpStats           *expvar.Map                    // Optional stats for dcp_rollback_count. This is not exposed by prometheus.
+	PartitionStat      *SgwIntStat                    // Optional stat for active partition count, to track cbgt partitions.
+	CheckpointPrefix   string                         // document prefix for checkpoint documents.
+	EndSeqNos          map[uint16]uint64              // If running a one shot DCP feed, these should match the end sequence numbers for each vbNo.
+}
+
+// NewDCPDest creates a new DCPDest which manages updates coming from a cbgt-based DCP feed.
 // Each partition will have its own DCPDest object.
 func NewDCPDest(
 	ctx context.Context,
-	callback sgbucket.FeedEventCallbackFunc,
-	metadataStore sgbucket.DataStore,
-	maxVbNo uint16,
-	persistCheckpoints bool,
-	dcpStats *expvar.Map,
-	partitionStat *SgwIntStat,
-	checkpointPrefix string,
+	opts DCPDestOptions,
 ) (SGDest, error) {
-	dcpCommon, err := NewDCPCommon(ctx, callback, metadataStore, maxVbNo, persistCheckpoints, dcpStats, checkpointPrefix)
+	dcpCommon, err := NewDCPCommon(ctx, opts)
 	if err != nil {
 		return nil, err
 	}
 
 	d := &DCPDest{
 		DCPCommon:          dcpCommon,
-		partitionCountStat: partitionStat,
-		metaInitComplete:   make([]bool, maxVbNo),
+		partitionCountStat: opts.PartitionStat,
+		metaInitComplete:   make([]bool, opts.MaxVbNo),
 	}
 
 	if d.partitionCountStat != nil {
@@ -213,7 +218,7 @@ func (d *DCPDest) RollbackEx(partition string, vbucketUUID uint64, rollbackSeq u
 
 // TODO: Not implemented, review potential usage
 func (d *DCPDest) ConsistencyWait(partition, partitionUUID string,
-	consistencyLevel string, consistencySeq uint64, cancelCh <-chan bool) error {
+	consistencyLevel cbgt.ConsistencyLevel, consistencySeq uint64, cancelCh <-chan bool) error {
 	WarnfCtx(d.loggingCtx, "Dest.ConsistencyWait being invoked by cbgt - not supported by Sync Gateway")
 	return nil
 }
@@ -232,6 +237,23 @@ func (d *DCPDest) Query(pindex *cbgt.PIndex, req []byte, w io.Writer,
 // Stats would allow SG to return SG-specific stats to cbgt's stats reporting - not currently used.
 func (d *DCPDest) Stats(io.Writer) error {
 	return nil
+}
+
+// ForceCheckpointWrite forces a write on all checkpoints.
+func (d *DCPDest) ForceCheckpointWrite() {
+	for vbNo, init := range d.metaInitComplete {
+		if init {
+			value, _, err := d.getMetaData(uint16(vbNo))
+			if err != nil {
+				WarnfCtx(d.loggingCtx, "Could not retrieve metadata for vbNo %d during ForceCheckpointWrite: %v. Skipping checkpoint write", vbNo, err)
+				continue
+			}
+			err = d.setMetaData(uint16(vbNo), value, true)
+			if err != nil {
+				WarnfCtx(d.loggingCtx, "Could not persist metadata for vbNo %d during ForceCheckpointWrite: %v. Skipping checkpoint write", vbNo, err)
+			}
+		}
+	}
 }
 
 func partitionToVbNo(ctx context.Context, partition string) uint16 {
@@ -316,7 +338,7 @@ func (d *DCPLoggingDest) RollbackEx(partition string, vbucketUUID uint64, rollba
 }
 
 func (d *DCPLoggingDest) ConsistencyWait(partition, partitionUUID string,
-	consistencyLevel string, consistencySeq uint64, cancelCh <-chan bool) error {
+	consistencyLevel cbgt.ConsistencyLevel, consistencySeq uint64, cancelCh <-chan bool) error {
 	return d.dest.ConsistencyWait(partition, partitionUUID, consistencyLevel, consistencySeq, cancelCh)
 }
 
@@ -332,3 +354,10 @@ func (d *DCPLoggingDest) Query(pindex *cbgt.PIndex, req []byte, w io.Writer,
 func (d *DCPLoggingDest) Stats(w io.Writer) error {
 	return d.dest.Stats(w)
 }
+
+func (d *DCPLoggingDest) ForceCheckpointWrite() {
+	d.dest.ForceCheckpointWrite()
+}
+
+var _ SGDest = &DCPDest{}
+var _ SGDest = &DCPLoggingDest{}

--- a/base/dcp_feed_type.go
+++ b/base/dcp_feed_type.go
@@ -155,6 +155,7 @@ func init() {
 // SGFeedSourceParams is a wrapper for cbgt's parameters.
 type SGFeedSourceParams struct {
 	cbgt.DCPFeedParams
+	cbgt.StopAfterSourceParams
 
 	// Used to pass the SG database name to SGFeed* shims
 	DbName string `json:"sg_dbname,omitempty"`
@@ -165,20 +166,27 @@ type SGFeedIndexParams struct {
 	DestKey string `json:"destKey,omitempty"`
 }
 
-// cbgtFeedParams returns marshalled cbgt.DCPFeedParams as string, to be passed as feedparams during cbgt.Manager init.
-// Used to pass basic auth credentials and xattr flag to cbgt.
-func cbgtFeedParams(ctx context.Context, collections CollectionNames, dbName string) (string, error) {
+// cbgtFeedParams returns marshalled cbgt.DCPFeedParams as string. This contains information to for a given information , to be passed as feedparams during cbgt.Manager init.
+func cbgtFeedParams(ctx context.Context, opts ShardedDCPOptions) (string, error) {
 	feedParams := &SGFeedSourceParams{
-		DbName: dbName,
+		DbName: opts.DBName,
 		DCPFeedParams: cbgt.DCPFeedParams{
 			AutoReconnectAfterRollback: true,
 			IncludeXAttrs:              true,
 		},
 	}
-	if len(collections) > 1 {
-		return "", RedactErrorf("cbgtFeedParams: multiple scopes not supported, got %v", MD(collections))
-	} else if len(collections) > 0 {
-		for s, c := range collections {
+	if opts.EndSeqNos != nil {
+		feedParams.StopAfterSourceParams.StopAfter = "markReached"
+		seqMap := make(map[string]cbgt.UUIDSeq, len(opts.EndSeqNos))
+		for vbNo, seqNo := range opts.EndSeqNos {
+			seqMap[cbgtVbNoToPartition(vbNo)] = cbgt.UUIDSeq{Seq: seqNo}
+		}
+		feedParams.StopAfterSourceParams.MarkPartitionSeqs = seqMap
+	}
+	if len(opts.Collections) > 1 {
+		return "", RedactErrorf("cbgtFeedParams: multiple scopes not supported, got %v", MD(opts.Collections))
+	} else if len(opts.Collections) > 0 {
+		for s, c := range opts.Collections {
 			feedParams.Scope = s
 			feedParams.Collections = c
 		}
@@ -300,4 +308,24 @@ func getCbgtCredentials(dbName string) (cbgtCreds, bool) {
 	creds, found := cbgtCredentials[dbName]
 	cbgtGlobalsLock.Unlock() // cbgtCreds is not a pointer type, safe to unlock
 	return creds, found
+}
+
+// GetHighSeqNos retrieves the maximum sequence numbers for each vbucket.
+func GetHighSeqNos(ctx context.Context, bucket Bucket) (map[uint16]uint64, error) {
+	b, err := AsGocbV2Bucket(bucket)
+	if err != nil {
+		return nil, fmt.Errorf("GetHighSeqNos: bucket is not a GocbV2Bucket: %w", err)
+	}
+	numVbuckets, err := bucket.GetMaxVbno(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Note: extending to be per collection requires an enhancement in gocbcore to support 0x48 memcached command
+	// for a non dcp agent, see gocbcore.DCPAgent.GetVBucketSeqNos
+	_, highSeqNos, err := b.GetStatsVbSeqno(numVbuckets, true)
+	if err != nil {
+		return nil, fmt.Errorf("unable to obtain high seqnos: %w", err)
+	}
+	return highSeqNos, nil
 }

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -38,6 +38,9 @@ const (
 	CBGTIndexTypeSyncGatewayResync    = "syncGateway-resync"
 )
 
+// CbgtUnregisterFeedCallback is the function invoked by cbgt when a DCP feed shuts down.
+type CbgtUnregisterFeedCallback func(cbgt.Feed)
+
 type ShardedDCPFeedType string
 
 const (
@@ -73,19 +76,21 @@ type CbgtContext struct {
 
 // ShardedDCPOptions contains options for starting a DCP feed for cbgt.
 type ShardedDCPOptions struct {
-	Bucket            Bucket             // bucket to target
-	Cfg               cbgt.Cfg           // cbgt cfg used to coordinate cbgt documents
-	Collections       CollectionNames    // collection names to target
-	DBName            string             // database name is used to look up credentials
-	DestKey           string             // key used in indexParams for this feed, used to look up the feed destination in cbgtDestFactories
-	Heartbeater       Heartbeater        // heartbeater to use to find nodes
-	IndexName         string             // cbgt.Manger.IndexName, used to uniquely identify the index
-	IndexType         string             // cbgt.Manager.IndexType, matches name used by cbgt.RegisterPIndexImplType
-	NumPartitions     uint16             // number of cbgt partitions to use, if 0 will default to DefaultImportPartitions
-	PreviousIndexName string             // previous index name. If specified, marks IndexName as as a replacement for this name.
-	UUID              string             // database uuid, used to uniquely identify nodes
-	Datastore         DataStore          // datastore to perform KV ops
-	FeedType          ShardedDCPFeedType // type of sharded DCP feed to start
+	Bucket                 Bucket                     // bucket to target
+	Cfg                    cbgt.Cfg                   // cbgt cfg used to coordinate cbgt documents
+	Collections            CollectionNames            // collection names to target
+	DBName                 string                     // database name is used to look up credentials
+	DestKey                string                     // key used in indexParams for this feed, used to look up the feed destination in cbgtDestFactories
+	Heartbeater            Heartbeater                // heartbeater to use to find nodes
+	IndexName              string                     // cbgt.Manger.IndexName, used to uniquely identify the index
+	IndexType              string                     // cbgt.Manager.IndexType, matches name used by cbgt.RegisterPIndexImplType
+	NumPartitions          uint16                     // number of cbgt partitions to use, if 0 will default to DefaultImportPartitions
+	PreviousIndexName      string                     // previous index name. If specified, marks IndexName as as a replacement for this name.
+	UUID                   string                     // database uuid, used to uniquely identify nodes
+	Datastore              DataStore                  // datastore to perform KV ops
+	FeedType               ShardedDCPFeedType         // type of sharded DCP feed to start
+	EndSeqNos              map[uint16]uint64          // optional parameter indicating the end sequences to be used for running a one shot feed.
+	UnregisterFeedCallback CbgtUnregisterFeedCallback // optional callback for cbgt.ManagerEventHandlers.OnUnregisterFeed
 }
 
 // Validate makes sure that all options are specified.
@@ -166,7 +171,7 @@ func StartShardedDCPFeed(ctx context.Context, opts ShardedDCPOptions) (*CbgtCont
 		return nil, fmt.Errorf("error asserting bucket as gocb v2 bucket: %w", err)
 	}
 
-	cbgtContext, err := initCBGTManager(ctx, opts.Bucket, b.GetSpec(), opts.Cfg, opts.UUID, opts.DBName)
+	cbgtContext, err := initCBGTManager(ctx, opts.Bucket, b.GetSpec(), opts.Cfg, opts.UUID, opts.DBName, opts.UnregisterFeedCallback)
 	if err != nil {
 		return nil, err
 	}
@@ -221,7 +226,7 @@ func GenerateLegacyImportIndexName(dbName string) string {
 func createCBGTIndex(ctx context.Context, c *CbgtContext, opts ShardedDCPOptions) error {
 	sourceType := SOURCE_DCP_SG
 
-	sourceParams, err := cbgtFeedParams(ctx, opts.Collections, opts.DBName)
+	sourceParams, err := cbgtFeedParams(ctx, opts)
 	if err != nil {
 		return err
 	}
@@ -322,7 +327,7 @@ func getCBGTIndexUUID(manager *cbgt.Manager, indexName string) (previousUUID str
 // createCBGTManager creates a new manager for a given bucket and bucketSpec
 // Inline comments below provide additional detail on how cbgt uses each manager
 // parameter, and the implications for SG
-func initCBGTManager(ctx context.Context, bucket Bucket, spec BucketSpec, cfgSG cbgt.Cfg, dbUUID string, dbName string) (*CbgtContext, error) {
+func initCBGTManager(ctx context.Context, bucket Bucket, spec BucketSpec, cfgSG cbgt.Cfg, dbUUID string, dbName string, unregisterCallback CbgtUnregisterFeedCallback) (*CbgtContext, error) {
 	// uuid: Unique identifier for the node. Used to identify the node in the config.
 	//       Without UUID persistence across SG restarts, a restarted SG node relies on heartbeater to remove
 	// 		 the previous version of that node from the cfg, and assign pindexes to the new one.
@@ -376,7 +381,11 @@ func initCBGTManager(ctx context.Context, bucket Bucket, spec BucketSpec, cfgSG 
 	dataDir := ""
 
 	eventHandlersCtx, eventHandlersCancel := context.WithCancelCause(ctx)
-	eventHandlers := &sgMgrEventHandlers{ctx: eventHandlersCtx, ctxCancel: eventHandlersCancel}
+	eventHandlers := &sgMgrEventHandlers{
+		ctx:                    eventHandlersCtx,
+		ctxCancel:              eventHandlersCancel,
+		unregisterFeedCallback: unregisterCallback,
+	}
 
 	// Specify one feed per pindex
 	options := make(map[string]string)
@@ -917,9 +926,10 @@ func GetDefaultImportPartitions(serverless bool) uint16 {
 }
 
 type sgMgrEventHandlers struct {
-	ctx       context.Context
-	ctxCancel context.CancelCauseFunc
-	manager   *cbgt.Manager
+	ctx                    context.Context
+	ctxCancel              context.CancelCauseFunc
+	manager                *cbgt.Manager
+	unregisterFeedCallback func(cbgt.Feed) // callback function for when a feed is unregistered. This occurs when a feed completes for any reason: Stop is requested, a rebalance of partitions, the feed naturally ends when reaching expected seequence numbers.
 }
 
 func (meh *sgMgrEventHandlers) OnRefreshManagerOptions(options map[string]string) {
@@ -932,6 +942,14 @@ func (meh *sgMgrEventHandlers) OnRegisterPIndex(pindex *cbgt.PIndex) {
 
 func (meh *sgMgrEventHandlers) OnUnregisterPIndex(pindex *cbgt.PIndex) {
 	// No-op for SG
+}
+
+// OnUnregisterFeed is called to indicate that a DCP feed has stopped. This will be called for normal and abnormal
+// terminations.
+func (meh *sgMgrEventHandlers) OnUnregisterFeed(feed cbgt.Feed) {
+	if meh.unregisterFeedCallback != nil {
+		meh.unregisterFeedCallback(feed)
+	}
 }
 
 // OnFeedError is required to trigger reconnection to a feed on a closed connection (EOF).
@@ -968,4 +986,9 @@ func (meh *sgMgrEventHandlers) OnFeedError(_ string, r cbgt.Feed, feedErr error)
 		}
 		dcpFeed.NotifyMgrOnClose()
 	}
+}
+
+// cbgtVbNoToPartition converts a vbucket number to a string partition name for cbgt.
+func cbgtVbNoToPartition(vbNo uint16) string {
+	return fmt.Sprintf("%d", vbNo)
 }

--- a/base/dcp_sharded_test.go
+++ b/base/dcp_sharded_test.go
@@ -1575,13 +1575,12 @@ func TestShardedDCPCheckpointCleanup(t *testing.T) {
 	checkpointPrefix := "test_shared_dcp_checkpoint"
 	dest, err := NewDCPDest(
 		ctx,
-		nil,
-		metadataStore,
-		vBuckets,
-		true,
-		nil,
-		nil,
-		checkpointPrefix,
+		DCPDestOptions{
+			MetadataStore:      metadataStore,
+			MaxVbNo:            vBuckets,
+			PersistCheckpoints: true,
+			CheckpointPrefix:   checkpointPrefix,
+		},
 	)
 	require.NoError(t, err)
 	dcpDest, ok := dest.(*DCPDest)

--- a/base/dcp_test.go
+++ b/base/dcp_test.go
@@ -228,7 +228,7 @@ func TestCBGTIndexCreation(t *testing.T) {
 			ctx = DatabaseLogCtx(ctx, tc.dbName, nil)
 			cfg, err := NewCbgtCfgMem()
 			require.NoError(t, err)
-			context, err := initCBGTManager(ctx, bucket, spec, cfg, "testIndexCreation", tc.dbName)
+			context, err := initCBGTManager(ctx, bucket, spec, cfg, "testIndexCreation", tc.dbName, nil)
 			assert.NoError(t, err)
 			defer context.RemoveFeedCredentials(tc.dbName)
 
@@ -247,7 +247,7 @@ func TestCBGTIndexCreation(t *testing.T) {
 			if tc.existingCurrentIndex {
 				// Define an existing CBGT index with current naming
 				bucketUUID, _ := bucket.UUID(ctx)
-				sourceParams, err := cbgtFeedParams(ctx, nil, tc.dbName)
+				sourceParams, err := cbgtFeedParams(ctx, ShardedDCPOptions{DBName: tc.dbName})
 				require.NoError(t, err)
 				legacyIndexName, err := GenerateCBGTIndexName(tc.dbName, tc.feedType)
 				require.NoError(t, err)
@@ -313,7 +313,7 @@ func TestCBGTIndexCreationSafeLegacyName(t *testing.T) {
 	// Use an in-memory cfg, set up cbgt manager
 	cfg, err := NewCbgtCfgMem()
 	require.NoError(t, err)
-	context, err := initCBGTManager(ctx, bucket, spec, cfg, "testIndexCreation", testDbName)
+	context, err := initCBGTManager(ctx, bucket, spec, cfg, "testIndexCreation", testDbName, nil)
 	assert.NoError(t, err)
 	defer context.RemoveFeedCredentials(testDbName)
 
@@ -330,7 +330,7 @@ func TestCBGTIndexCreationSafeLegacyName(t *testing.T) {
 
 	// Define a CBGT index with legacy naming within safe limits
 	bucketUUID, _ := bucket.UUID(ctx)
-	sourceParams, err := cbgtFeedParams(ctx, nil, testDbName)
+	sourceParams, err := cbgtFeedParams(ctx, ShardedDCPOptions{DBName: testDbName})
 	require.NoError(t, err)
 	legacyIndexName := GenerateLegacyImportIndexName(testDbName)
 	indexParams := `{"name": "` + testDbName + `"}`
@@ -396,7 +396,7 @@ func TestCBGTIndexCreationUnsafeLegacyName(t *testing.T) {
 	// Use an in-memory cfg, set up cbgt manager
 	cfg, err := NewCbgtCfgMem()
 	require.NoError(t, err)
-	context, err := initCBGTManager(ctx, bucket, spec, cfg, "testIndexCreation", unsafeTestDBName)
+	context, err := initCBGTManager(ctx, bucket, spec, cfg, "testIndexCreation", unsafeTestDBName, nil)
 	assert.NoError(t, err)
 	defer context.RemoveFeedCredentials(unsafeTestDBName)
 
@@ -413,7 +413,7 @@ func TestCBGTIndexCreationUnsafeLegacyName(t *testing.T) {
 
 	// Define a CBGT index with legacy naming not within safe limits
 	bucketUUID, _ := bucket.UUID(ctx)
-	sourceParams, err := cbgtFeedParams(ctx, nil, unsafeTestDBName)
+	sourceParams, err := cbgtFeedParams(ctx, ShardedDCPOptions{DBName: unsafeTestDBName})
 	require.NoError(t, err)
 	legacyIndexName := GenerateLegacyImportIndexName(unsafeTestDBName)
 	indexParams := `{"name": "` + unsafeTestDBName + `"}`
@@ -515,7 +515,7 @@ func TestConcurrentCBGTIndexCreation(t *testing.T) {
 
 				ctx := TestCtx(t)
 				managerUUID := fmt.Sprintf("%s%d", t.Name(), i)
-				context, err := initCBGTManager(ctx, bucket, spec, cfg, managerUUID, testDBName)
+				context, err := initCBGTManager(ctx, bucket, spec, cfg, managerUUID, testDBName, nil)
 				assert.NoError(t, err)
 
 				// StartManager starts the manager and creates the index
@@ -558,7 +558,7 @@ func TestCBGTKvPoolSize(t *testing.T) {
 
 	cfg, err := NewCbgtCfgMem()
 	require.NoError(t, err)
-	cbgtContext, err := initCBGTManager(ctx, bucket, spec, cfg, t.Name(), "fakeDb")
+	cbgtContext, err := initCBGTManager(ctx, bucket, spec, cfg, t.Name(), "fakeDb", nil)
 	assert.NoError(t, err)
 	defer cbgtContext.Stop(ctx)
 	require.Contains(t, cbgtContext.Manager.Server(), "kv_pool_size=1")

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -45,8 +45,22 @@ type ResyncManagerDCP struct {
 	useXattrs                    bool
 	ResyncedCollections          base.CollectionNames
 	resyncCollectionInfo
-	lock        sync.RWMutex
-	Distributed bool
+	lock              sync.RWMutex
+	Distributed       bool
+	dcpDoneChan       chan error      // mark when the DCP feed is completed
+	completedvBuckets *vBucketTracker // tracks the number of completed vBuckets for the local
+}
+
+// vBucketTracker tracks completed vBuckets in a thread safe way. It is used to determine when all vBuckets have
+// completed so that the resync process can be marked as complete and the DCP feed can be stopped.
+type vBucketTracker struct {
+	m    map[string]struct{} // map of vBuckets in string format that have been completed
+	lock sync.RWMutex
+}
+
+// newvBucketTracker returns a new instance of vBucketTracker to store completed vBucket numbers.
+func newvBucketTracker() *vBucketTracker {
+	return &vBucketTracker{m: make(map[string]struct{})}
 }
 
 // resyncCollectionInfo contains information on collections included on resync run, populated in init() and used in Run()
@@ -59,8 +73,11 @@ var _ BackgroundManagerProcessI = &ResyncManagerDCP{}
 
 func NewResyncManagerDCP(metadataStore base.DataStore, useXattrs bool, metaKeys *base.MetadataKeys) *BackgroundManager {
 	return &BackgroundManager{
-		name:    "resync",
-		Process: &ResyncManagerDCP{useXattrs: useXattrs},
+		name: "resync",
+		Process: &ResyncManagerDCP{
+			completedvBuckets: newvBucketTracker(),
+			useXattrs:         useXattrs,
+		},
 		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
 			metadataStore: metadataStore,
 			metaKeys:      metaKeys,
@@ -197,7 +214,6 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 		}
 	}()
 
-	var doneChan chan error
 	var dcpClient base.DCPClient
 	var dcpClientClose dcpClientCloser
 	defer func() {
@@ -243,7 +259,11 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 
 		r.docsProcessedLocal.Add(1)
 		db.DbStats.Database().ResyncNumProcessed.Add(1)
-		databaseCollection := db.CollectionByID[event.CollectionID]
+		databaseCollection, ok := db.CollectionByID[event.CollectionID]
+		if !ok {
+			base.AssertfCtx(ctx, "Received DCP event for collection ID %d, but no collection found with that ID, skipping document %q", event.CollectionID, base.UD(docID))
+			return false
+		}
 		databaseCollection.collectionStats.ResyncNumProcessed.Add(1)
 		ctx := databaseCollection.AddCollectionContext(ctx)
 		doc, err := bucketDocumentFromFeed(event)
@@ -292,10 +312,25 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 		sort.Strings(collectionNamesByScope[scopeName])
 		resyncDestKey = base.DestKey(db.Name, scopeName, collectionNamesByScope[scopeName], base.ShardedDCPFeedTypeResync)
 
+		r.dcpDoneChan = make(chan error)
 		checkPointPrefix := GetResyncDCPCheckpointPrefix(db.DatabaseContext, r.ResyncID, true)
+		endSeqNos, err := base.GetHighSeqNos(ctx, db.Bucket)
+		if err != nil {
+			return err
+		}
 
 		resyncDestFunc := func(janitorRollback func()) (cbgt.Dest, error) {
-			resyncDest, err := base.NewDCPDest(ctx, callback, db.MetadataStore, db.numVBuckets, true, nil, nil, checkPointPrefix)
+			resyncDest, err := base.NewDCPDest(
+				ctx,
+				base.DCPDestOptions{
+					Callback:           callback,
+					MetadataStore:      db.MetadataStore,
+					MaxVbNo:            db.numVBuckets,
+					PersistCheckpoints: true,
+					CheckpointPrefix:   checkPointPrefix,
+					EndSeqNos:          endSeqNos,
+				},
+			)
 			if err != nil {
 				return nil, fmt.Errorf("Error creating resync dest: %v", err)
 			}
@@ -329,6 +364,7 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 		if err != nil {
 			return fmt.Errorf("Error generating CBGT index name: %v", err)
 		}
+
 		var partitionCount uint16
 		if db.Options.UnsupportedOptions != nil && db.Options.UnsupportedOptions.ResyncPartitions != nil && *db.Options.UnsupportedOptions.ResyncPartitions > 0 {
 			partitionCount = *db.Options.UnsupportedOptions.ResyncPartitions
@@ -338,18 +374,20 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 		base.DebugfCtx(ctx, base.KeyAll, "Using %d partitions for resync", partitionCount)
 
 		opts := base.ShardedDCPOptions{
-			DBName:        db.Name,
-			UUID:          db.UUID,
-			NumPartitions: partitionCount,
-			Collections:   collectionNamesByScope,
-			Cfg:           resyncCfg,
-			Heartbeater:   resyncHB,
-			Bucket:        db.Bucket,
-			IndexType:     base.CBGTIndexTypeSyncGatewayResync,
-			DestKey:       resyncDestKey,
-			IndexName:     indexName,
-			Datastore:     db.MetadataStore,
-			FeedType:      base.ShardedDCPFeedTypeResync,
+			DBName:                 db.Name,
+			UUID:                   db.UUID,
+			NumPartitions:          partitionCount,
+			Collections:            collectionNamesByScope,
+			Cfg:                    resyncCfg,
+			Heartbeater:            resyncHB,
+			Bucket:                 db.Bucket,
+			IndexType:              base.CBGTIndexTypeSyncGatewayResync,
+			DestKey:                resyncDestKey,
+			IndexName:              indexName,
+			Datastore:              db.MetadataStore,
+			FeedType:               base.ShardedDCPFeedTypeResync,
+			EndSeqNos:              endSeqNos,
+			UnregisterFeedCallback: r.getUnregisterFeedFunc(ctx, db.numVBuckets),
 		}
 		resyncCbgtContext, err := base.StartShardedDCPFeed(ctx, opts)
 		if err != nil {
@@ -362,14 +400,14 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 	} else {
 
 		clientOptions := r.getDCPClientOptions(db.DatabaseContext, r.ResyncID, r.ResyncedCollections.ToCollectionNameSet(), callback, false)
+
 		var err error
 		dcpClient, err = base.NewDCPClient(ctx, db.DatabaseContext.Bucket, clientOptions)
 		if err != nil {
 			base.WarnfCtx(ctx, "Failed to create resync DCP client! %v", err)
 			return err
 		}
-
-		doneChan, err = dcpClient.Start()
+		r.dcpDoneChan, err = dcpClient.Start()
 		if err != nil {
 			base.WarnfCtx(ctx, "Failed to start resync DCP feed! %v", err)
 			_ = dcpClient.Close()
@@ -377,7 +415,7 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 		}
 		dcpClientClose.append(func() error {
 			_ = dcpClient.Close()
-			err := <-doneChan
+			err := <-r.dcpDoneChan
 			return err
 		})
 
@@ -385,9 +423,8 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 
 		r.SetVBUUIDs(base.GetVBUUIDs(dcpClient.GetMetadata()))
 	}
-
 	select {
-	case <-doneChan:
+	case <-r.dcpDoneChan:
 		base.InfofCtx(ctx, base.KeyAll, "Finished running resync. %d/%d docs changed", r.DocsChanged(), r.DocsProcessed())
 		err := dcpClientClose.shutdown()
 		if err != nil {
@@ -595,6 +632,44 @@ func (r *ResyncManagerDCP) GetProcessStatus(status BackgroundManagerStatus, prev
 		return nil, nil, err
 	}
 	return statusJSON, metaJSON, err
+}
+
+// getUnregisterFeedFunc returns a callback function to be called when a cbgt feed exits. This function will close
+// doneChan when all vBuckets have completed, which will allow the resync process to finish.
+func (r *ResyncManagerDCP) getUnregisterFeedFunc(ctx context.Context, totalVBuckets uint16) base.CbgtUnregisterFeedCallback {
+	return func(feed cbgt.Feed) {
+		for _, d := range feed.Dests() {
+			d, ok := d.(base.SGDest)
+			if !ok {
+				base.AssertfCtx(ctx, "Expected dest on cbgt.EventHandler.OnUnregisterFeed to be of type SGDest but is of type %T, resync will can complete but checkpoints may not be written", d)
+			}
+		}
+		f, ok := feed.(cbgt.FeedPartitionCompletion)
+		if !ok {
+			base.AssertfCtx(ctx, "Expected feed on cbgt.EventHandler.OnUnregisterFeed to pass feed of type FeedPartitionCompletion but is of %T, resync will not complete in this state", feed)
+			return
+		}
+		r.markVBucketsCompleted(ctx, f.CompletedPartitions(), totalVBuckets)
+	}
+}
+
+// markVBucketsCompleted marks the provided vBuckets as completed, and if all vBuckets are completed, closes doneChan to
+// allow the resync process to complete. This function is thread safe and can be called multiple times.
+func (r *ResyncManagerDCP) markVBucketsCompleted(ctx context.Context, completedPartitions map[string]struct{}, totalVbuckets uint16) {
+	r.completedvBuckets.lock.Lock()
+	defer r.completedvBuckets.lock.Unlock()
+
+	// All vBuckets are completed, no channels need to be closed. This function could be called twice in the case that a
+	// feed has been reopened.
+	if len(r.completedvBuckets.m) == int(totalVbuckets) {
+		return
+	}
+	for vbNo := range completedPartitions {
+		r.completedvBuckets.m[vbNo] = struct{}{}
+	}
+	if len(r.completedvBuckets.m) == int(totalVbuckets) {
+		close(r.dcpDoneChan)
+	}
 }
 
 // DocsChanged returns the total number of documents changed for the entire resync process. This includes docs

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -45,9 +45,11 @@ type ResyncManagerDCP struct {
 	useXattrs                    bool
 	ResyncedCollections          base.CollectionNames
 	resyncCollectionInfo
-	lock              sync.RWMutex
-	Distributed       bool
-	dcpDoneChan       chan error      // mark when the DCP feed is completed
+	lock        sync.RWMutex
+	Distributed bool
+	dcpDoneChan chan error // mark when the DCP feed is completed
+	// TODO: put this into data set by GetProcessStatus / SetProcessStatus so this can be determined for other nodes
+	// running resync
 	completedvBuckets *vBucketTracker // tracks the number of completed vBuckets for the local
 }
 

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -644,16 +644,23 @@ func (r *ResyncManagerDCP) GetProcessStatus(status BackgroundManagerStatus, prev
 	return statusJSON, metaJSON, err
 }
 
+// writeSharededDCPCheckpoints writes any outstanding DCP checkpoints.
+func writeSharedDCPCheckpoints(ctx context.Context, feed cbgt.Feed) {
+	for _, d := range feed.Dests() {
+		d, ok := d.(base.SGDest)
+		if ok {
+			d.ForceCheckpointWrite()
+			return
+		}
+	}
+	base.AssertfCtx(ctx, "Expected to find a SGDest on cbgt.EventHandler.OnUnregisterFeed. Feed: %#+v Dests: %#+v, resync will complete but  some checkpoints may not be written", feed, slices.Collect(maps.Values(feed.Dests())))
+}
+
 // getUnregisterFeedFunc returns a callback function to be called when a cbgt feed exits. This function will close
 // doneChan when all vBuckets have completed, which will allow the resync process to finish.
 func (r *ResyncManagerDCP) getUnregisterFeedFunc(ctx context.Context, totalVBuckets uint16) base.CbgtUnregisterFeedCallback {
 	return func(feed cbgt.Feed) {
-		for _, d := range feed.Dests() {
-			d, ok := d.(base.SGDest)
-			if !ok {
-				base.AssertfCtx(ctx, "Expected dest on cbgt.EventHandler.OnUnregisterFeed to be of type SGDest but is of type %T, resync will can complete but checkpoints may not be written", d)
-			}
-		}
+		writeSharedDCPCheckpoints(ctx, feed)
 		f, ok := feed.(cbgt.FeedPartitionCompletion)
 		if !ok {
 			base.AssertfCtx(ctx, "Expected feed on cbgt.EventHandler.OnUnregisterFeed to pass feed of type FeedPartitionCompletion but is of %T, resync will not complete in this state", feed)

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -63,6 +63,13 @@ func newvBucketTracker() *vBucketTracker {
 	return &vBucketTracker{m: make(map[string]struct{})}
 }
 
+// clear resets the vBucketTracker to an empty state.
+func (v *vBucketTracker) clear() {
+	v.lock.Lock()
+	defer v.lock.Unlock()
+	v.m = make(map[string]struct{})
+}
+
 // resyncCollectionInfo contains information on collections included on resync run, populated in init() and used in Run()
 type resyncCollectionInfo struct {
 	collectionIDs     []uint32
@@ -515,6 +522,7 @@ func (r *ResyncManagerDCP) ResetStatus() {
 	r.docsErroredLocal.Store(0)
 	r.docsErroredCrossNode.Store(0)
 	r.docsTargeted.Store(0)
+	r.completedvBuckets.clear()
 	r.ResyncedCollections = nil
 }
 

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -298,21 +298,10 @@ func TestResyncManagerDCPStart(t *testing.T) {
 					"collections":         base.NewCollectionNames(),
 				}
 
-				if testCase.Distributed {
-					rs, ok := db.ResyncManager.Process.(*ResyncManagerDCP)
-					require.True(t, ok)
-					rs.Distributed = true
-				}
 				err := db.ResyncManager.Start(ctx, options)
 				require.NoError(t, err)
 
-				if testCase.Distributed {
-					waitForResyncDocsChanged(t, db, int64(docsToCreate))
-					err := db.ResyncManager.Stop(ctx)
-					require.NoError(t, err)
-				} else {
-					RequireBackgroundManagerState(t, db.ResyncManager, BackgroundProcessStateCompleted)
-				}
+				RequireBackgroundManagerState(t, db.ResyncManager, BackgroundProcessStateCompleted)
 
 				stats := getResyncStats(t, db)
 				// If there are tombstones from older docs which have been deleted from the bucket, processed docs will
@@ -329,7 +318,7 @@ func TestResyncManagerDCPStart(t *testing.T) {
 				assert.GreaterOrEqual(t, cs.ResyncNumProcessed.Value(), int64(docsToCreate))
 				assert.Equal(t, int64(docsToCreate), cs.ResyncNumChanged.Value())
 
-				// This is just a temporary check until MB-70378 is implemented
+				// TODO: Not sure why this fails for distributed resync
 				if !testCase.Distributed {
 					deltaOk := assert.InDelta(t, int64(docsToCreate), db.DbStats.Database().SyncFunctionCount.Value(), 2)
 					assert.True(t, deltaOk, "DCP stream has processed some documents more than once than allowed delta. Try rerunning the test.")
@@ -342,9 +331,6 @@ func TestResyncManagerDCPStart(t *testing.T) {
 func TestResyncManagerDCPRunTwice(t *testing.T) {
 	for _, testCase := range ResyncTestModes() {
 		t.Run(testCase.Name, func(t *testing.T) {
-			if testCase.Distributed {
-				t.Skip("Enable in CBG-5184")
-			}
 			docsToCreate := 1000
 			// rosmar runs too quickly, increase doc count
 			if base.UnitTestUrlIsWalrus() {
@@ -372,8 +358,12 @@ func TestResyncManagerDCPRunTwice(t *testing.T) {
 				waitForResyncDocsProcessed(t, db, 100)
 
 				err := db.ResyncManager.Start(ctx, options)
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), "Process already running")
+				if testCase.Distributed {
+					require.NoError(t, err)
+				} else {
+					require.Error(t, err)
+					assert.Contains(t, err.Error(), "Process already running")
+				}
 			})
 
 			stats := waitForResyncState(t, db, BackgroundProcessStateCompleted)
@@ -465,7 +455,7 @@ func TestResyncManagerDCPResumeStoppedProcessChangeCollections(t *testing.T) {
 
 			docsPerCollection := int64(1000)
 			// rosmar runs too quickly, increase doc count
-			if base.UnitTestUrlIsWalrus() {
+			if base.UnitTestUrlIsWalrus() || testCase.Distributed {
 				docsPerCollection *= 5
 			}
 			const numCollections = 2

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -191,7 +191,7 @@ func TestResyncManagerDCPStopInMidWay(t *testing.T) {
 	for _, testCase := range ResyncTestModes() {
 		t.Run(testCase.Name, func(t *testing.T) {
 			if testCase.Distributed {
-				t.Skip("Enable in CBG-5184")
+				t.Skip("Enable in CBG-5419")
 			}
 			docsToCreate := 1000
 			if base.UnitTestUrlIsWalrus() {
@@ -238,7 +238,7 @@ func TestResyncManagerDCPStart(t *testing.T) {
 		t.Run(testCase.Name, func(t *testing.T) {
 			t.Run("Resync without updating sync function", func(t *testing.T) {
 				if testCase.Distributed {
-					t.Skip("Enable in CBG-5184")
+					t.Skip("Enable in CBG-5419")
 				}
 				docsToCreate := 100
 				db, ctx := setupTestDBForResyncWithDocs(t, testDBForResyncOptions{
@@ -318,7 +318,7 @@ func TestResyncManagerDCPStart(t *testing.T) {
 				assert.GreaterOrEqual(t, cs.ResyncNumProcessed.Value(), int64(docsToCreate))
 				assert.Equal(t, int64(docsToCreate), cs.ResyncNumChanged.Value())
 
-				// TODO: Not sure why this fails for distributed resync
+				// CBG-5418: debug flake of why distributed resync sometimes processes more documents than expected
 				if !testCase.Distributed {
 					deltaOk := assert.InDelta(t, int64(docsToCreate), db.DbStats.Database().SyncFunctionCount.Value(), 2)
 					assert.True(t, deltaOk, "DCP stream has processed some documents more than once than allowed delta. Try rerunning the test.")
@@ -331,6 +331,9 @@ func TestResyncManagerDCPStart(t *testing.T) {
 func TestResyncManagerDCPRunTwice(t *testing.T) {
 	for _, testCase := range ResyncTestModes() {
 		t.Run(testCase.Name, func(t *testing.T) {
+			if testCase.Distributed {
+				t.Skip("Enable in CBG-5419")
+			}
 			docsToCreate := 1000
 			// rosmar runs too quickly, increase doc count
 			if base.UnitTestUrlIsWalrus() {
@@ -358,12 +361,8 @@ func TestResyncManagerDCPRunTwice(t *testing.T) {
 				waitForResyncDocsProcessed(t, db, 100)
 
 				err := db.ResyncManager.Start(ctx, options)
-				if testCase.Distributed {
-					require.NoError(t, err)
-				} else {
-					require.Error(t, err)
-					assert.Contains(t, err.Error(), "Process already running")
-				}
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "Process already running")
 			})
 
 			stats := waitForResyncState(t, db, BackgroundProcessStateCompleted)
@@ -384,9 +383,6 @@ func TestResyncManagerDCPRunTwice(t *testing.T) {
 func TestResyncManagerDCPResumeStoppedProcess(t *testing.T) {
 	for _, testCase := range ResyncTestModes() {
 		t.Run(testCase.Name, func(t *testing.T) {
-			if testCase.Distributed {
-				t.Skip("Enable in CBG-5184")
-			}
 			docsToCreate := 5000
 			// rosmar runs too quickly, increase doc count
 			if base.UnitTestUrlIsWalrus() {
@@ -456,6 +452,7 @@ func TestResyncManagerDCPResumeStoppedProcessChangeCollections(t *testing.T) {
 			docsPerCollection := int64(1000)
 			// rosmar runs too quickly, increase doc count
 			if base.UnitTestUrlIsWalrus() || testCase.Distributed {
+				// Evalute in CBG-5419 whether increasing doc count is necessary
 				docsPerCollection *= 5
 			}
 			const numCollections = 2
@@ -733,16 +730,15 @@ func waitForResyncDocsProcessed(t testing.TB, db *Database, count int64) {
 		var stats ResyncManagerResponseDCP
 		assert.NoError(c, base.JSONUnmarshal(rawStatus, &stats))
 		assert.Greater(c, stats.DocsProcessed, count)
-	}, 1*time.Minute, 100*time.Millisecond)
+	}, 1*time.Minute, 10*time.Millisecond)
 }
 
 func waitForResyncDocsChanged(t testing.TB, db *Database, count int64) {
-
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		stats := getResyncStats(t, db)
 		assert.Equal(c, stats.DocsChanged, count)
 		assert.GreaterOrEqual(c, stats.DocsProcessed, count)
-	}, 5*time.Minute, 100*time.Millisecond)
+	}, 5*time.Minute, 10*time.Millisecond)
 }
 
 func TestResyncCheckpointPrefix(t *testing.T) {

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -276,18 +276,16 @@ func getImportDestFactory(
 ) (cbgt.Dest, error) {
 	ctx = base.CorrelationIDLogCtx(ctx, base.DCPImportFeedID)
 	return func(janitorRollback func()) (cbgt.Dest, error) {
-		importFeedStatsMap := dbContext.DbStats.Database().ImportFeedMapStats
-		importPartitionStat := dbContext.DbStats.SharedBucketImport().ImportPartitions
-		persistCheckpoints := true
-
 		return base.NewDCPDest(
 			ctx,
-			callback,
-			dbContext.MetadataStore,
-			dbContext.numVBuckets,
-			persistCheckpoints,
-			importFeedStatsMap.Map,
-			importPartitionStat,
-			checkpointPrefix)
+			base.DCPDestOptions{
+				Callback:           callback,
+				MetadataStore:      dbContext.MetadataStore,
+				MaxVbNo:            dbContext.numVBuckets,
+				PersistCheckpoints: true,
+				DcpStats:           dbContext.DbStats.Database().ImportFeedMapStats.Map,
+				PartitionStat:      dbContext.DbStats.SharedBucketImport().ImportPartitions,
+				CheckpointPrefix:   checkpointPrefix,
+			})
 	}
 }

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -1205,13 +1205,11 @@ func ResyncTestModes() []ResyncTestCase {
 			Distributed: false,
 		},
 	}
-	/* CBG-5184 enable tests
 	if !base.UnitTestUrlIsWalrus() && base.IsEnterpriseEdition() {
 		testCases = append(testCases, ResyncTestCase{
 			Name:        "distributed=true",
 			Distributed: true,
 		})
 	}
-	*/
 	return testCases
 }

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -1205,11 +1205,13 @@ func ResyncTestModes() []ResyncTestCase {
 			Distributed: false,
 		},
 	}
+	/* CBG-5419 enable tests
 	if !base.UnitTestUrlIsWalrus() && base.IsEnterpriseEdition() {
 		testCases = append(testCases, ResyncTestCase{
 			Name:        "distributed=true",
 			Distributed: true,
 		})
 	}
+	*/
 	return testCases
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/KimMachineGun/automemlimit v0.7.5
 	github.com/coder/websocket v1.8.14
 	github.com/coreos/go-oidc/v3 v3.17.0
-	github.com/couchbase/cbgt v1.4.14
+	github.com/couchbase/cbgt v1.4.15-0.20260520122852-6e34ff79a0e6
 	github.com/couchbase/clog v0.1.0
 	github.com/couchbase/go-blip v0.0.0-20260106113615-002c1b20b67a
 	github.com/couchbase/gocb/v2 v2.12.3

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,8 @@ github.com/couchbase/blance v0.1.6 h1:zyNew/SN2AheIoJxQ2LqqA1u3bMp03eGCer6hSDMUD
 github.com/couchbase/blance v0.1.6/go.mod h1:2Sa/nsJSieN/r3T9LsrUYWeQ015qDsuHybhz4F4JcHU=
 github.com/couchbase/cbauth v0.1.13 h1:1MXacfujb5E4g1MabltOjWUz7Ilewbix2mdSADFa358=
 github.com/couchbase/cbauth v0.1.13/go.mod h1:W7zkNXa0B2cTDg90YmmuTSbu+PlYOvMqzQvmNlNH/Mg=
-github.com/couchbase/cbgt v1.4.14 h1:klGrYELNfp2fxd8C37bEKKHNviezf+3l9E8t/dUJlOY=
-github.com/couchbase/cbgt v1.4.14/go.mod h1:ca+cbR0/VjgfCqAmyiopLlIByvAZEKVaEq3p3h1H/hI=
+github.com/couchbase/cbgt v1.4.15-0.20260520122852-6e34ff79a0e6 h1:a1Qkm4WY8ty1lch6g+mJPpYdquvDkn6bFlco3Ms9HuQ=
+github.com/couchbase/cbgt v1.4.15-0.20260520122852-6e34ff79a0e6/go.mod h1:LIqQrXtrsNYuJaxCto0kRsSxo/XPkMGjeFZ1EwxxVEw=
 github.com/couchbase/clog v0.1.0 h1:4Kh/YHkhRjMCbdQuvRVsm39XZh4FtL1d8fAwJsHrEPY=
 github.com/couchbase/clog v0.1.0/go.mod h1:7tzUpEOsE+fgU81yfcjy5N1H6XtbVC8SgOz/3mCjmd4=
 github.com/couchbase/go-blip v0.0.0-20260106113615-002c1b20b67a h1:T1kH9va3FH0SjJQBHtpuwEdwvc1e4xVYAXt3rJTdHOs=


### PR DESCRIPTION
CBG-5184 use cbgt one shot mode

This does not yet work in multi node mode (expected) and all tests are not enabled. I'm working on why some of the tests fail or flake. I do not believe there will be major changes from the failing tests, so I am putting this up for review as is. Most tests do pass in distributed resync mode (where distributed resync is only run on a single node).

- Register high sequence numbers `endSeqNos` with cbgt via `sourceParams`. This marks when cbgt will stop processing documents.
- when specifying a high sequence number to kv, it will always stream sequences to the end of the snapshot, which might be higher than the specified endSeqNo. Avoid checkpointing these sequence numbers in `DCPCommon.updateSeq` to avoid a ERANGE error when re-opening the feed. https://github.com/couchbase/cbgt/blob/6e34ff79a0e6e97d5fb5b548c217a8a9d279a94b/feed_dcp_gocbcore.go#L1034
- Add `ForceCheckpointWrite` when the feed shuts down to force the checkpoints to be written. This is really only helpful for tests, but `DCPCommon.setMetaData` will only be called on a 1 minute interval, so the last checkpoints are not set. For a test that makes sure that some documents are processed, and then resumed from that point, this test fails without this call.
- `cbgt.EventHandler.OnUnregisterFeed` is now used to discover when vBuckets are completed. This is tracked locally (for now, see TODO) and used to close `dcpDoneChan` to indicate when the DCP operations should finish. There are N feeds for N partitions used by cbgt. This function is called whenever a feed (set of vBuckets for a partition) completes. This is true on reaching the endSeqNos, or when unregistering a feed (normal shutdown, such as `/db/resync?action=stop`)

Small fixes:

- Created an options struct for `DCPDestOptions` to avoid having a another nil-able optino.
- cbgt changed a type from string to `ConsistencyLevel`, this is type alias.
- Allow `dbExpVarsStat` to be nil, especially in tests. I do not have a place for this stat yet in distributed resync.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/702/
