### PR TITLE
CBG-5249: collect value of GOMEMLIMIT in sgcollect

### DIFF
--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -2989,7 +2989,7 @@ Status:
     runtime:
       description: |-
         Runtime environment information for this Sync Gateway node. Includes Go runtime
-        settings and container memory limits. Omitted if `api.hide_product_version=true`.
+        settings and container memory limits.
       type: object
       properties:
         go_memlimit_bytes:
@@ -3016,7 +3016,7 @@ Status:
     node_uid:
       description: |-
         Stable identifier for this Sync Gateway node, derived deterministically from host
-        fingerprint. Omitted if `api.hide_product_version=true`.
+        fingerprint.
       type: string
     cluster_compat_version:
       description: |-
@@ -3055,13 +3055,12 @@ NodeInfo:
     node_uid:
       description: |-
         Stable identifier for this Sync Gateway node, derived deterministically from host
-        fingerprint. Omitted if `api.hide_product_version=true`.
+        fingerprint.
       type: string
     cluster_compat_version:
       description: |-
         The minimum cluster compatibility version (`"major.minor"`) across all nodes in the
-        cluster. Omitted if `api.hide_product_version=true`, or when no version has been
-        computed yet (e.g. first startup before nodes have registered).
+        cluster.
       type: string
       example: '4.1'
   required:

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -2986,6 +2986,33 @@ Status:
     vendor:
       allOf:
         - $ref: '#/Vendor'
+    runtime:
+      description: |-
+        Runtime environment information for this Sync Gateway node. Includes Go runtime
+        settings and container memory limits. Omitted if `api.hide_product_version=true`.
+      type: object
+      properties:
+        go_memlimit_bytes:
+          description: |-
+            The effective Go memory limit (`GOMEMLIMIT`) in bytes. This is the soft memory
+            limit that the Go garbage collector targets. A value of `9223372036854775807`
+            (`math.MaxInt64`) indicates no limit is set.
+          type: integer
+          format: int64
+          example: 1073741824
+        go_maxprocs:
+          description: The effective number of OS threads (`GOMAXPROCS`) that can execute Go code simultaneously.
+          type: integer
+          minimum: 1
+          example: 4
+        cgroup_memory_limit_bytes:
+          description: |-
+            The cgroup memory hard limit in bytes, as reported by the container runtime
+            (cgroupv2 `memory.max` or cgroupv1 `memory.limit_in_bytes`). Only present when
+            running inside a cgroup with a memory limit configured.
+          type: integer
+          format: uint64
+          example: 2147483648
     node_uid:
       description: |-
         Stable identifier for this Sync Gateway node, derived deterministically from host

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -1677,6 +1677,7 @@ func (h *handler) handleGetStatus() error {
 	var status = Status{
 		Databases: make(map[string]DatabaseStatus),
 		Vendor:    vendor{Name: base.ProductNameString},
+		Runtime:   h.server.RuntimeStatus,
 	}
 
 	// This handler is supposed to be admin-only anyway, but being defensive if this is opened up in the routes file.
@@ -1684,7 +1685,6 @@ func (h *handler) handleGetStatus() error {
 		status.Version = base.LongVersionString
 		status.Vendor.Version = base.ProductAPIVersion
 		status.NodeUID = h.server.NodeUID
-		status.Runtime = h.server.RuntimeStatus
 		if h.server.ClusterCompat != nil {
 			if v := h.server.ClusterCompat.ClusterCompatVersion(); v != nil {
 				status.ClusterCompatVersion = v.String()

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -1657,10 +1657,17 @@ type DatabaseStatus struct {
 	SGRCluster        *db.SGRCluster          `json:"cluster"`
 }
 
+type RuntimeStatus struct {
+	GoMemlimitBytes        int64   `json:"go_memlimit_bytes"`
+	GoMaxprocs             int     `json:"go_maxprocs"`
+	CgroupMemoryLimitBytes *uint64 `json:"cgroup_memory_limit_bytes,omitempty"`
+}
+
 type Status struct {
 	Databases            map[string]DatabaseStatus `json:"databases"`
 	Version              string                    `json:"version"`
 	Vendor               vendor                    `json:"vendor"`
+	Runtime              *RuntimeStatus            `json:"runtime,omitempty"`
 	NodeUID              string                    `json:"node_uid,omitempty"`
 	ClusterCompatVersion string                    `json:"cluster_compat_version,omitempty"`
 }
@@ -1677,6 +1684,7 @@ func (h *handler) handleGetStatus() error {
 		status.Version = base.LongVersionString
 		status.Vendor.Version = base.ProductAPIVersion
 		status.NodeUID = h.server.NodeUID
+		status.Runtime = h.server.RuntimeStatus
 		if h.server.ClusterCompat != nil {
 			if v := h.server.ClusterCompat.ClusterCompatVersion(); v != nil {
 				status.ClusterCompatVersion = v.String()

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -17,6 +17,8 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"runtime"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
@@ -360,6 +362,24 @@ func TestGetStatus(t *testing.T) {
 	response = rt.SendAdminRequest("OPTIONS", "/_status", "")
 	rest.RequireStatus(t, response, 204)
 	assert.Equal(t, "GET", response.Header().Get("Allow"))
+}
+
+func TestGetStatusRuntimeInfo(t *testing.T) {
+	rt := rest.NewRestTester(t, nil)
+	defer rt.Close()
+
+	response := rt.SendAdminRequest("GET", "/_status", "")
+	rest.RequireStatus(t, response, http.StatusOK)
+
+	var responseBody rest.Status
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &responseBody))
+
+	require.NotNil(t, responseBody.Runtime)
+	assert.Greater(t, responseBody.Runtime.GoMaxprocs, 0)
+	assert.NotZero(t, responseBody.Runtime.GoMemlimitBytes)
+
+	assert.Equal(t, runtime.GOMAXPROCS(0), responseBody.Runtime.GoMaxprocs)
+	assert.Equal(t, debug.SetMemoryLimit(-1), responseBody.Runtime.GoMemlimitBytes)
 }
 
 func TestFlush(t *testing.T) {

--- a/rest/config.go
+++ b/rest/config.go
@@ -1634,6 +1634,7 @@ func SetupServerContext(ctx context.Context, config *StartupConfig, persistentCo
 	}
 
 	sc := NewServerContext(ctx, config, persistentConfig)
+	logRuntimeEnvironment(ctx, sc.RuntimeStatus)
 
 	nodeUID, err := base.GenerateNodeUID(ctx, sc.Config.API.PublicInterface, sc.Config.API.AdminInterface)
 	if err != nil {

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -10,6 +10,7 @@ package rest
 
 import (
 	"context"
+	"math"
 	"os"
 	"runtime"
 	"time"
@@ -300,7 +301,13 @@ func logRuntimeEnvironment(ctx context.Context, rs *RuntimeStatus) {
 	}
 
 	gomemlimitEnv := os.Getenv("GOMEMLIMIT")
-	if gomemlimitEnv != "" {
+	if rs.GoMemlimitBytes == math.MaxInt64 {
+		if gomemlimitEnv != "" {
+			base.InfofCtx(ctx, base.KeyAll, "GOMEMLIMIT: env=%s, effective=no limit", gomemlimitEnv)
+		} else {
+			base.InfofCtx(ctx, base.KeyAll, "GOMEMLIMIT: no limit set")
+		}
+	} else if gomemlimitEnv != "" {
 		base.InfofCtx(ctx, base.KeyAll, "GOMEMLIMIT: env=%s, effective=%d bytes", gomemlimitEnv, rs.GoMemlimitBytes)
 	} else {
 		base.InfofCtx(ctx, base.KeyAll, "GOMEMLIMIT: effective=%d bytes (env not set)", rs.GoMemlimitBytes)

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -289,6 +289,28 @@ func setGlobalConfig(ctx context.Context, sc *StartupConfig) error {
 	return nil
 }
 
+// logRuntimeEnvironment logs Go runtime and system memory configuration at startup.
+// Logs both environment variable values and effective runtime values for diagnostics.
+func logRuntimeEnvironment(ctx context.Context, rs *RuntimeStatus) {
+	gomaxprocsEnv := os.Getenv("GOMAXPROCS")
+	if gomaxprocsEnv != "" {
+		base.InfofCtx(ctx, base.KeyAll, "GOMAXPROCS: env=%s, effective=%d", gomaxprocsEnv, rs.GoMaxprocs)
+	} else {
+		base.InfofCtx(ctx, base.KeyAll, "GOMAXPROCS: effective=%d (env not set)", rs.GoMaxprocs)
+	}
+
+	gomemlimitEnv := os.Getenv("GOMEMLIMIT")
+	if gomemlimitEnv != "" {
+		base.InfofCtx(ctx, base.KeyAll, "GOMEMLIMIT: env=%s, effective=%d bytes", gomemlimitEnv, rs.GoMemlimitBytes)
+	} else {
+		base.InfofCtx(ctx, base.KeyAll, "GOMEMLIMIT: effective=%d bytes (env not set)", rs.GoMemlimitBytes)
+	}
+
+	if rs.CgroupMemoryLimitBytes != nil {
+		base.InfofCtx(ctx, base.KeyAll, "Cgroup memory limit: %d bytes", *rs.CgroupMemoryLimitBytes)
+	}
+}
+
 // Merge applies non-empty fields from new onto non-empty fields on sc
 func (sc *StartupConfig) Merge(new *StartupConfig) error {
 	return base.ConfigMerge(sc, new)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -20,6 +20,8 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"runtime"
+	"runtime/debug"
 	"slices"
 	"sort"
 	"strconv"
@@ -105,6 +107,7 @@ type ServerContext struct {
 	invalidDatabaseConfigTracking invalidDatabaseConfigs
 	SGCollect                     *sgCollect            // singleton instance for this server's sgcollect_info process
 	NodeUID                       string                // Stable identifier for this SG node, derived deterministically from host fingerprint
+	RuntimeStatus                 *RuntimeStatus        // Cached runtime environment info (GOMEMLIMIT, GOMAXPROCS, cgroup), computed once at startup
 	ClusterCompat                 *clusterCompatManager // Tracks cluster-wide minimum SG version for compat gating
 	connectToBucketFn             db.OpenBucketFn       // supply a custom function for buckets, used for testing only
 }
@@ -215,6 +218,8 @@ func NewServerContext(ctx context.Context, config *StartupConfig, persistentConf
 			sc.statsContext.heapProfileEnabled = false
 		}
 	}
+
+	sc.RuntimeStatus = getRuntimeStatus()
 
 	sc.startStatsLogger(ctx)
 
@@ -2303,6 +2308,21 @@ func (sc *ServerContext) SetContextLogID(parent context.Context, id string) cont
 		return base.LogContextWith(parent, &base.ServerLogContext{LogContextID: sc.LogContextID})
 	}
 	return parent
+}
+
+// getRuntimeStatus returns runtime memory and CPU information, computed once at startup and cached on ServerContext.
+func getRuntimeStatus() *RuntimeStatus {
+	rs := &RuntimeStatus{
+		GoMemlimitBytes: debug.SetMemoryLimit(-1),
+		GoMaxprocs:      runtime.GOMAXPROCS(0),
+	}
+
+	cgroupLimit, err := memlimit.FromCgroup()
+	if err == nil {
+		rs.CgroupMemoryLimitBytes = &cgroupLimit
+	}
+
+	return rs
 }
 
 // getTotalMemory returns the total memory available on the system. If a cgroup is detected, it will use the cgroup memory max.


### PR DESCRIPTION
CBG-5249

Change to log values of `GOMAXPROCS`, `GOMEMLIMIT` and Cgroup memory limit if one is set. For `GOMAXPROCS` and `GOMEMLIMIT` I have logged the configured runtime value but also the env variable. 
In addition, we store this on server context for use in `_status` endpoint so sgcollect finds it. 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/623/ (test flake)
