### PR TITLE
CBG-5382: [3.3.5 backport] fix resync regenerate sequences set sync info no-op

### DIFF
--- a/base/constants_syncdocs.go
+++ b/base/constants_syncdocs.go
@@ -21,6 +21,8 @@ const MetadataIdPrefix = "m_"                                  // Prefix for met
 const SyncDocMetadataPrefix = SyncDocPrefix + MetadataIdPrefix // Prefix for all namespaced Sync Gateway metadata documents
 const DCPCheckpointPrefix = "dcp_ck:"
 
+const DefaultMetadataID = "_default" // MetadataID assigned to databases that include _default._default, signalling legacy (unprefixed) metadata key format.
+
 // Sync Gateway Metadata document types
 type metadataKey int
 
@@ -135,10 +137,11 @@ var DefaultMetadataKeys = &MetadataKeys{
 	sessionPrefix:             formatDefaultMetadataKey(MetaKeySessionPrefix),
 }
 
-// NewMetadataKeys returns MetadataKeys for the specified MetadataID  If metadataID is empty string, returns the default (legacy) metadata keys.
+// NewMetadataKeys returns MetadataKeys for the specified MetadataID. If metadataID is empty string or DefaultMetadataID,
+// returns the default (legacy) metadata keys with no prefix.
 // Key and prefix formatting is done in this constructor to minimize the work done per retrieval.
 func NewMetadataKeys(metadataID string) *MetadataKeys {
-	if metadataID == "" {
+	if metadataID == "" || metadataID == DefaultMetadataID {
 		return DefaultMetadataKeys
 	} else {
 		return &MetadataKeys{

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -3795,7 +3795,7 @@ func TestSetSyncInfoDefaultMetadataID(t *testing.T) {
 
 	require.Equal(t, base.DefaultMetadataID, db.DatabaseContext.Options.MetadataID)
 
-	// Simulate a collection previously owned by a different database, including metadata_version for realism
+	// Simulate a collection previously owned by a different database
 	oldSyncInfo := &base.SyncInfo{MetadataID: "previous_database"}
 	require.NoError(t, ds.Set(base.SGSyncInfo, 0, nil, oldSyncInfo))
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -3776,3 +3776,39 @@ func TestDatabaseCloseIdempotent(t *testing.T) {
 	defer db.BucketLock.Unlock()
 	db._stopOnlineProcesses(ctx)
 }
+
+// TestSetSyncInfoDefaultMetadataID verifies that a database created with the default collection gets
+// MetadataID="_default" on its DatabaseContextOptions, and that this value correctly updates the syncInfo
+// document via SetSyncInfoMetadataID so that subsequent InitSyncInfo calls do not require resync.
+func TestSetSyncInfoDefaultMetadataID(t *testing.T) {
+	cacheOptions := DefaultCacheOptions()
+	dbcOptions := DatabaseContextOptions{
+		Scopes:       GetScopesOptionsDefaultCollectionOnly(t),
+		CacheOptions: &cacheOptions,
+		MetadataID:   base.DefaultMetadataID,
+	}
+	db, ctx := SetupTestDBWithOptions(t, dbcOptions)
+	defer db.Close(ctx)
+
+	collection, _ := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+	ds := collection.GetCollectionDatastore()
+
+	require.Equal(t, base.DefaultMetadataID, db.DatabaseContext.Options.MetadataID)
+
+	// Simulate a collection previously owned by a different database, including metadata_version for realism
+	oldSyncInfo := &base.SyncInfo{MetadataID: "previous_database"}
+	require.NoError(t, ds.Set(base.SGSyncInfo, 0, nil, oldSyncInfo))
+
+	// InitSyncInfo should detect the mismatch and require resync
+	requiresResync, err := base.InitSyncInfo(ds, db.DatabaseContext.Options.MetadataID)
+	require.NoError(t, err)
+	require.True(t, requiresResync)
+
+	// SetSyncInfoMetadataID with the same Options.MetadataID should update the syncInfo document
+	require.NoError(t, base.SetSyncInfo(ds, db.DatabaseContext.Options.MetadataID))
+
+	// Subsequent InitSyncInfo should find a match and not require resync
+	requiresResync, err = base.InitSyncInfo(ds, db.DatabaseContext.Options.MetadataID)
+	require.NoError(t, err)
+	assert.False(t, requiresResync)
+}

--- a/rest/adminapitest/resync_test.go
+++ b/rest/adminapitest/resync_test.go
@@ -369,3 +369,104 @@ function sync(doc, oldDoc){
 	require.NoError(t, err)
 	assert.Equal(t, string(bodyGet), string(specBody))
 }
+
+// TestResyncRequireResyncDefaultMetadataID
+//
+// Setup: db1 owns _default.sg_test_0 (gets non-default metadataID). db2 owns _default._default (default metadata id).
+// Delete db1, update db2 to include _default.sg_test_0. Because db2 includes _default._default,
+// it gets metadataID="_default". Assert that after resync regenerate sequences, db2 comes online successfully.
+func TestResyncRequireResyncDefaultMetadataID(t *testing.T) {
+	base.TestRequiresCollections(t)
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
+
+	ctx := base.TestCtx(t)
+	tb := base.GetTestBucket(t)
+	defer tb.Close(ctx)
+
+	const namedCollectionName = "sg_test_0"
+	require.NoError(t, tb.CreateDataStore(ctx, base.ScopeAndCollectionName{Scope: base.DefaultScope, Collection: namedCollectionName}))
+	defer func() {
+		assert.NoError(t, tb.DropDataStore(ctx, base.ScopeAndCollectionName{Scope: base.DefaultScope, Collection: namedCollectionName}))
+	}()
+
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		CustomTestBucket: tb.NoCloseClone(),
+		PersistentConfig: true,
+	})
+	defer rt.Close()
+
+	db1Name := "db1"
+	db2Name := "db2"
+
+	// Create db1 with _default scope and sg_test_0 collection only — gets metadataID="db1"
+	db1Cfg := rt.NewDbConfig()
+	db1Cfg.Scopes = rest.ScopesConfig{
+		base.DefaultScope: rest.ScopeConfig{
+			Collections: rest.CollectionsConfig{
+				namedCollectionName: {},
+			},
+		},
+	}
+	rest.RequireStatus(t, rt.CreateDatabase(db1Name, db1Cfg), http.StatusCreated)
+
+	// Write a doc to the sg_test_0 collection in db1
+	keyspace := db1Name + "._default." + namedCollectionName
+	resp := rt.SendAdminRequest("PUT", "/"+keyspace+"/testDoc1", `{"foo":"bar"}`)
+	rest.RequireStatus(t, resp, http.StatusCreated)
+
+	// Create db2 with _default scope and _default collection only — gets metadataID="_default"
+	db2Cfg := rt.NewDbConfig()
+	db2Cfg.Scopes = rest.ScopesConfig{
+		base.DefaultScope: rest.ScopeConfig{
+			Collections: rest.CollectionsConfig{
+				base.DefaultCollection: {},
+			},
+		},
+	}
+	rest.RequireStatus(t, rt.CreateDatabase(db2Name, db2Cfg), http.StatusCreated)
+
+	// Delete db1 to free the sg_test_0 collection
+	resp = rt.SendAdminRequest("DELETE", "/"+db1Name+"/", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+
+	// Update db2 to include both _default._default AND _default.sg_test_0.
+	// db2 keeps metadataID="_default" because it includes _default._default.
+	// The sg_test_0 collection's syncInfo still has db1's non-default metadataID — requires resync.
+	db2Cfg.Scopes = rest.ScopesConfig{
+		base.DefaultScope: rest.ScopeConfig{
+			Collections: rest.CollectionsConfig{
+				base.DefaultCollection: {},
+				namedCollectionName:    {},
+			},
+		},
+	}
+	rest.RequireStatus(t, rt.UpsertDbConfig(db2Name, db2Cfg), http.StatusCreated)
+
+	// db2 should now require resync for the sg_test_0 collection and be offline
+	rt.WaitForDatabaseState(db2Name, db.RunStateString[db.DBOffline])
+
+	dbRoot := rt.GetDatabaseRoot(db2Name)
+	expectedResyncCollection := base.DefaultScope + "." + namedCollectionName
+	require.Contains(t, dbRoot.RequireResync, expectedResyncCollection,
+		"sg_test_0 collection should require resync after moving from db1 to db2")
+
+	// Run resync with regenerate_sequences=true on the sg_test_0 collection only
+	resyncBody := fmt.Sprintf(`{"scopes": {"_default": ["%s"]}}`, namedCollectionName)
+	resp = rt.SendAdminRequest("POST", "/"+db2Name+"/_resync?action=start&regenerate_sequences=true", resyncBody)
+	rest.RequireStatus(t, resp, http.StatusOK)
+
+	// Wait for resync to complete
+	rt.WaitForResyncDCPStatusForDB(db.BackgroundProcessStateCompleted, db2Name)
+
+	// Verify in-memory RequireResync is cleared — this passes because Run() updated db.RequireResync
+	dbRoot = rt.GetDatabaseRoot(db2Name)
+	assert.Empty(t, dbRoot.RequireResync, "RequireResync should be empty after resync completed")
+
+	// Bring db2 online via POST /_config with offline:false.
+	// TakeDbOnline calls ReloadDatabase which re-runs InitSyncInfo for every collection.
+	// Requires resync should evaluate to false so syncInfo should be updated with the new metadataID and the database should come online successfully.
+	resp = rt.SendAdminRequest("POST", "/"+db2Name+"/_config", `{"offline":false}`)
+	rest.RequireStatus(t, resp, http.StatusCreated)
+
+	rt.WaitForDatabaseState(db2Name, db.RunStateString[db.DBOnline])
+}

--- a/rest/adminapitest/resync_test.go
+++ b/rest/adminapitest/resync_test.go
@@ -376,6 +376,9 @@ function sync(doc, oldDoc){
 // Delete db1, update db2 to include _default.sg_test_0. Because db2 includes _default._default,
 // it gets metadataID="_default". Assert that after resync regenerate sequences, db2 comes online successfully.
 func TestResyncRequireResyncDefaultMetadataID(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("Test requires Couchbase Server")
+	}
 	base.TestRequiresCollections(t)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
@@ -386,7 +389,7 @@ func TestResyncRequireResyncDefaultMetadataID(t *testing.T) {
 	const namedCollectionName = "sg_test_0"
 	require.NoError(t, tb.CreateDataStore(ctx, base.ScopeAndCollectionName{Scope: base.DefaultScope, Collection: namedCollectionName}))
 	defer func() {
-		assert.NoError(t, tb.DropDataStore(ctx, base.ScopeAndCollectionName{Scope: base.DefaultScope, Collection: namedCollectionName}))
+		assert.NoError(t, tb.DropDataStore(base.ScopeAndCollectionName{Scope: base.DefaultScope, Collection: namedCollectionName}))
 	}()
 
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{

--- a/rest/config_manager.go
+++ b/rest/config_manager.go
@@ -46,7 +46,7 @@ var _ ConfigManager = &bootstrapContext{}
 const configUpdateMaxRetryAttempts = 5 // Maximum number of retries due to conflicting updates or rollback
 const configFetchMaxRetryAttempts = 5  // Maximum number of retries due to registry rollback
 
-const defaultMetadataID = "_default"
+const defaultMetadataID = base.DefaultMetadataID
 
 // GetConfig fetches a database name for a given bucket and config group ID.
 func (b *bootstrapContext) GetConfigName(ctx context.Context, bucketName, groupID, dbName string, configName *dbConfigNameOnly) (cas uint64, err error) {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -901,10 +901,8 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		}
 	}
 
-	// If identified as default database, use metadataID of "" so legacy non namespaced docs are used
-	if config.MetadataID != defaultMetadataID {
-		contextOptions.MetadataID = config.MetadataID
-	}
+	// NewMetadataKeys handles the "_default" -> legacy (unprefixed) key mapping, so we can pass config.MetadataID through directly.
+	contextOptions.MetadataID = config.MetadataID
 
 	contextOptions.BlipStatsReportingInterval = defaultBytesStatsReportingInterval.Milliseconds()
 	contextOptions.ImportVersion = config.ImportVersion

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -284,7 +284,7 @@ func (rt *RestTester) WaitForResyncDCPStatusForDB(status db.BackgroundProcessSta
 	return rt.waitForResyncDCPStatus(status, dbName)
 }
 
-// WaitForResyncDCPStatus waits for the resync status to reach the expected status and returns the final status.
+// waitForResyncDCPStatus waits for the resync status to reach the expected status and returns the final status.
 func (rt *RestTester) waitForResyncDCPStatus(status db.BackgroundProcessState, dbName string) db.ResyncManagerResponseDCP {
 	var resyncStatus db.ResyncManagerResponseDCP
 	require.EventuallyWithT(rt.TB(), func(c *assert.CollectT) {

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -276,9 +276,19 @@ func (rt *RestTester) RunResync() db.ResyncManagerResponseDCP {
 
 // WaitForResyncDCPStatus waits for the resync status to reach the expected status and returns the final status.
 func (rt *RestTester) WaitForResyncDCPStatus(status db.BackgroundProcessState) db.ResyncManagerResponseDCP {
+	return rt.waitForResyncDCPStatus(status, "{{.db}}")
+}
+
+// WaitForResyncDCPStatusForDB waits for the resync status for a specific database name to reach the expected status.
+func (rt *RestTester) WaitForResyncDCPStatusForDB(status db.BackgroundProcessState, dbName string) db.ResyncManagerResponseDCP {
+	return rt.waitForResyncDCPStatus(status, dbName)
+}
+
+// WaitForResyncDCPStatus waits for the resync status to reach the expected status and returns the final status.
+func (rt *RestTester) waitForResyncDCPStatus(status db.BackgroundProcessState, dbName string) db.ResyncManagerResponseDCP {
 	var resyncStatus db.ResyncManagerResponseDCP
 	require.EventuallyWithT(rt.TB(), func(c *assert.CollectT) {
-		response := rt.SendAdminRequest("GET", "/{{.db}}/_resync", "")
+		response := rt.SendAdminRequest("GET", "/"+dbName+"/_resync", "")
 		err := json.Unmarshal(response.BodyBytes(), &resyncStatus)
 		assert.NoError(c, err)
 


### PR DESCRIPTION
CBG-5382

Backports https://github.com/couchbase/sync_gateway/pull/8267

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/624/
