### PR TITLE
CBG-5386: Grafana generator: Stamp `"version": 1`

### DIFF
--- a/tools/stats-definition-exporter/grafana.go
+++ b/tools/stats-definition-exporter/grafana.go
@@ -279,6 +279,6 @@ func writeGrafanaDashboard(stats statDefinitions, config grafanaFormatConfig, wr
 	}
 
 	encoder := json.NewEncoder(writer)
-	encoder.SetIndent("", "\t")
+	encoder.SetIndent("", "  ")
 	return encoder.Encode(dashboard)
 }

--- a/tools/stats-definition-exporter/grafana.go
+++ b/tools/stats-definition-exporter/grafana.go
@@ -168,6 +168,7 @@ func generateGrafanaDashboard(stats statDefinitions, config grafanaFormatConfig)
 
 	b := sdkdashboard.NewDashboardBuilder(config.dashboardTitle).
 		Uid(config.dashboardUID).
+		Version(1).
 		Tags([]string{"Sync Gateway"}).
 		Tooltip(sdkdashboard.DashboardCursorSyncCrosshair).
 		Time("now-7d", "now").

--- a/tools/stats-definition-exporter/grafana_test.go
+++ b/tools/stats-definition-exporter/grafana_test.go
@@ -108,6 +108,20 @@ func TestGenerateDashboardEmptyStats(t *testing.T) {
 	assert.Equal(t, "sync-gateway-all", *d.Uid)
 }
 
+func TestGenerateDashboardVersionStamped(t *testing.T) {
+	// Terraform-based provisioning rejects dashboards whose top-level
+	// "version" field is null or omitted, so guard against a regression
+	// where the SDK builder stops emitting Version(1).
+	for _, cfg := range []grafanaFormatConfig{supportalConfig, capellaConfig} {
+		t.Run(cfg.dashboardUID, func(t *testing.T) {
+			d, err := generateGrafanaDashboard(statDefinitions{}, cfg)
+			require.NoError(t, err)
+			require.NotNil(t, d.Version)
+			assert.Equal(t, uint32(1), *d.Version)
+		})
+	}
+}
+
 func TestSubsystemGrouping(t *testing.T) {
 	stats := getTestStats(t)
 


### PR DESCRIPTION
CBG-5386

A `null` version is fine for manual import via UI, which will automatically set the version number, but we need an initial version number stamped if loading directly from JSON as the Terraform-based Grafana provisioning currently does.

E.g.
https://github.com/couchbasecloud/couchbase-cloud/blob/696e3bbfe800c842cbfc7aa12dedc51b85a7fbf8/terraform/modules/grafana/provisioning/dashboards/cluster-node-overview-v2.json#L6610 

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- n/a