### PR TITLE
CBG-5371: create num partitions config option for resync

### DIFF
--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -282,10 +282,18 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 		if err != nil {
 			return fmt.Errorf("Error generating CBGT index name: %v", err)
 		}
+		var partitionCount uint16
+		if db.Options.UnsupportedOptions.ResyncImportPartitions != nil && *db.Options.UnsupportedOptions.ResyncImportPartitions > 0 {
+			partitionCount = *db.Options.UnsupportedOptions.ResyncImportPartitions
+		} else {
+			partitionCount = db.Options.ImportOptions.ImportPartitions
+		}
+		base.DebugfCtx(ctx, base.KeyAll, "Using %d partitions for resync", partitionCount)
+
 		opts := base.ShardedDCPOptions{
 			DBName:        db.Name,
 			UUID:          db.UUID,
-			NumPartitions: db.Options.ImportOptions.ImportPartitions,
+			NumPartitions: partitionCount,
 			Collections:   collectionNamesByScope,
 			Cfg:           resyncCfg,
 			Heartbeater:   resyncHB,

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -283,8 +283,11 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 			return fmt.Errorf("Error generating CBGT index name: %v", err)
 		}
 		var partitionCount uint16
-		if db.Options.UnsupportedOptions.ResyncImportPartitions != nil && *db.Options.UnsupportedOptions.ResyncImportPartitions > 0 {
+		if db.Options.UnsupportedOptions != nil && db.Options.UnsupportedOptions.ResyncImportPartitions != nil && *db.Options.UnsupportedOptions.ResyncImportPartitions > 0 {
 			partitionCount = *db.Options.UnsupportedOptions.ResyncImportPartitions
+			if partitionCount > 1024 {
+				return fmt.Errorf("resync_import_partitions must be between 1 and 1024, got %d", partitionCount)
+			}
 		} else {
 			partitionCount = db.Options.ImportOptions.ImportPartitions
 		}

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -283,8 +283,8 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 			return fmt.Errorf("Error generating CBGT index name: %v", err)
 		}
 		var partitionCount uint16
-		if db.Options.UnsupportedOptions != nil && db.Options.UnsupportedOptions.ResyncImportPartitions != nil && *db.Options.UnsupportedOptions.ResyncImportPartitions > 0 {
-			partitionCount = *db.Options.UnsupportedOptions.ResyncImportPartitions
+		if db.Options.UnsupportedOptions != nil && db.Options.UnsupportedOptions.ResyncPartitions != nil && *db.Options.UnsupportedOptions.ResyncPartitions > 0 {
+			partitionCount = *db.Options.UnsupportedOptions.ResyncPartitions
 			if partitionCount > 1024 {
 				return fmt.Errorf("resync_partitions must be between 1 and 1024, got %d", partitionCount)
 			}

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -285,9 +285,6 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 		var partitionCount uint16
 		if db.Options.UnsupportedOptions != nil && db.Options.UnsupportedOptions.ResyncPartitions != nil && *db.Options.UnsupportedOptions.ResyncPartitions > 0 {
 			partitionCount = *db.Options.UnsupportedOptions.ResyncPartitions
-			if partitionCount > 1024 {
-				return fmt.Errorf("resync_partitions must be between 1 and 1024, got %d", partitionCount)
-			}
 		} else {
 			partitionCount = db.Options.ImportOptions.ImportPartitions
 		}

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -286,7 +286,7 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 		if db.Options.UnsupportedOptions != nil && db.Options.UnsupportedOptions.ResyncImportPartitions != nil && *db.Options.UnsupportedOptions.ResyncImportPartitions > 0 {
 			partitionCount = *db.Options.UnsupportedOptions.ResyncImportPartitions
 			if partitionCount > 1024 {
-				return fmt.Errorf("resync_import_partitions must be between 1 and 1024, got %d", partitionCount)
+				return fmt.Errorf("resync_partitions must be between 1 and 1024, got %d", partitionCount)
 			}
 		} else {
 			partitionCount = db.Options.ImportOptions.ImportPartitions

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -826,4 +826,3 @@ func TestResyncImportPartitionsPassthrough(t *testing.T) {
 	require.Len(t, planPIndexes.PlanPIndexes, int(numPartitions),
 		"expected %d pindexes matching ResyncPartitions", numPartitions)
 }
-

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/couchbase/cbgt"
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/google/uuid"
@@ -760,4 +761,67 @@ func TestResyncCheckpointPrefix(t *testing.T) {
 			require.Equal(t, test.expected, dcpClient.GetMetadataKeyPrefix())
 		})
 	}
+}
+
+// TestResyncImportPartitionsPassthrough verifies that ResyncImportPartitions from UnsupportedOptions
+// is passed through to StartShardedDCPFeed by inspecting the persisted CBGT plan pindexes
+// in the metadata store after a distributed resync runs.
+func TestResyncImportPartitionsPassthrough(t *testing.T) {
+	if !base.IsEnterpriseEdition() {
+		t.Skip("Distributed resync requires EE")
+	}
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("Distributed resync not supported for rosmar")
+	}
+
+	// Must evenly divide 1024 vbuckets, otherwise CBGT creates an extra pindex for the remainder.
+	numPartitions := uint16(4)
+	dbcOptions := DatabaseContextOptions{
+		UnsupportedOptions: &UnsupportedOptions{
+			ResyncImportPartitions: &numPartitions,
+		},
+	}
+	db, ctx := SetupTestDBWithOptions(t, dbcOptions)
+	defer db.Close(ctx)
+
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+	body := map[string]any{"foo": "bar"}
+	// have some work for resync to perform
+	for i := range 10 {
+		key := fmt.Sprintf("%s_%d", t.Name(), i)
+		_, _, err := collection.Put(ctx, key, body)
+		require.NoError(t, err)
+	}
+
+	syncFn := `function sync(doc, oldDoc) { channel("resyncChannel"); }`
+	_, err := collection.UpdateSyncFun(ctx, syncFn)
+	require.NoError(t, err)
+
+	rs, ok := db.ResyncManager.Process.(*ResyncManagerDCP)
+	require.True(t, ok)
+	rs.Distributed = true
+
+	options := map[string]any{
+		"database":            db,
+		"regenerateSequences": false,
+		"collections":         base.NewCollectionNames(),
+	}
+	require.NoError(t, db.ResyncManager.Start(ctx, options))
+
+	waitForResyncDocsChanged(t, db, int64(10))
+
+	// Read the persisted CBGT plan pindexes from the resync cfg in the metadata store.
+	resyncCfgPrefix := db.MetadataKeys.ResyncCfgPrefix()
+	cfgKey := resyncCfgPrefix + cbgt.PLAN_PINDEXES_KEY
+
+	var planPIndexesJSON []byte
+	_, err = db.MetadataStore.Get(ctx, cfgKey, &planPIndexesJSON)
+	require.NoError(t, err)
+
+	var planPIndexes cbgt.PlanPIndexes
+	require.NoError(t, base.JSONUnmarshal(planPIndexesJSON, &planPIndexes))
+	require.Len(t, planPIndexes.PlanPIndexes, int(numPartitions),
+		"expected %d pindexes matching ResyncImportPartitions", numPartitions)
+
+	require.NoError(t, db.ResyncManager.Stop(ctx))
 }

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -763,7 +763,7 @@ func TestResyncCheckpointPrefix(t *testing.T) {
 	}
 }
 
-// TestResyncImportPartitionsPassthrough verifies that ResyncImportPartitions from UnsupportedOptions
+// TestResyncImportPartitionsPassthrough verifies that ResyncPartitions from UnsupportedOptions
 // is passed through to StartShardedDCPFeed by inspecting the persisted CBGT plan pindexes
 // in the metadata store after a distributed resync runs.
 func TestResyncImportPartitionsPassthrough(t *testing.T) {
@@ -778,7 +778,7 @@ func TestResyncImportPartitionsPassthrough(t *testing.T) {
 	numPartitions := uint16(4)
 	dbcOptions := DatabaseContextOptions{
 		UnsupportedOptions: &UnsupportedOptions{
-			ResyncImportPartitions: &numPartitions,
+			ResyncPartitions: &numPartitions,
 		},
 	}
 	db, ctx := SetupTestDBWithOptions(t, dbcOptions)
@@ -824,5 +824,39 @@ func TestResyncImportPartitionsPassthrough(t *testing.T) {
 	var planPIndexes cbgt.PlanPIndexes
 	require.NoError(t, base.JSONUnmarshal(planPIndexesJSON, &planPIndexes))
 	require.Len(t, planPIndexes.PlanPIndexes, int(numPartitions),
-		"expected %d pindexes matching ResyncImportPartitions", numPartitions)
+		"expected %d pindexes matching ResyncPartitions", numPartitions)
+}
+
+// TestResyncPartitionsMaximumValidation verifies that Run returns an error when
+// ResyncPartitions exceeds the maximum allowed value of 1024.
+func TestResyncPartitionsMaximumValidation(t *testing.T) {
+	if !base.IsEnterpriseEdition() {
+		t.Skip("Distributed resync requires EE")
+	}
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("Distributed resync not supported for rosmar")
+	}
+
+	numPartitions := uint16(1025)
+	dbcOptions := DatabaseContextOptions{
+		UnsupportedOptions: &UnsupportedOptions{
+			ResyncPartitions: &numPartitions,
+		},
+	}
+	db, ctx := SetupTestDBWithOptions(t, dbcOptions)
+	defer db.Close(ctx)
+
+	rs, ok := db.ResyncManager.Process.(*ResyncManagerDCP)
+	require.True(t, ok)
+	rs.Distributed = true
+
+	options := map[string]any{
+		"database":            db,
+		"regenerateSequences": false,
+		"collections":         base.NewCollectionNames(),
+	}
+	require.NoError(t, db.ResyncManager.Start(ctx, options))
+
+	status := RequireBackgroundManagerState(t, db.ResyncManager, BackgroundProcessStateError)
+	require.Contains(t, status.LastErrorMessage, "resync_partitions must be between 1 and 1024")
 }

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -807,6 +807,9 @@ func TestResyncImportPartitionsPassthrough(t *testing.T) {
 		"collections":         base.NewCollectionNames(),
 	}
 	require.NoError(t, db.ResyncManager.Start(ctx, options))
+	defer func() {
+		require.NoError(t, db.ResyncManager.Stop(ctx))
+	}()
 
 	waitForResyncDocsChanged(t, db, int64(10))
 
@@ -822,6 +825,4 @@ func TestResyncImportPartitionsPassthrough(t *testing.T) {
 	require.NoError(t, base.JSONUnmarshal(planPIndexesJSON, &planPIndexes))
 	require.Len(t, planPIndexes.PlanPIndexes, int(numPartitions),
 		"expected %d pindexes matching ResyncImportPartitions", numPartitions)
-
-	require.NoError(t, db.ResyncManager.Stop(ctx))
 }

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -827,36 +827,3 @@ func TestResyncImportPartitionsPassthrough(t *testing.T) {
 		"expected %d pindexes matching ResyncPartitions", numPartitions)
 }
 
-// TestResyncPartitionsMaximumValidation verifies that Run returns an error when
-// ResyncPartitions exceeds the maximum allowed value of 1024.
-func TestResyncPartitionsMaximumValidation(t *testing.T) {
-	if !base.IsEnterpriseEdition() {
-		t.Skip("Distributed resync requires EE")
-	}
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("Distributed resync not supported for rosmar")
-	}
-
-	numPartitions := uint16(1025)
-	dbcOptions := DatabaseContextOptions{
-		UnsupportedOptions: &UnsupportedOptions{
-			ResyncPartitions: &numPartitions,
-		},
-	}
-	db, ctx := SetupTestDBWithOptions(t, dbcOptions)
-	defer db.Close(ctx)
-
-	rs, ok := db.ResyncManager.Process.(*ResyncManagerDCP)
-	require.True(t, ok)
-	rs.Distributed = true
-
-	options := map[string]any{
-		"database":            db,
-		"regenerateSequences": false,
-		"collections":         base.NewCollectionNames(),
-	}
-	require.NoError(t, db.ResyncManager.Start(ctx, options))
-
-	status := RequireBackgroundManagerState(t, db.ResyncManager, BackgroundProcessStateError)
-	require.Contains(t, status.LastErrorMessage, "resync_partitions must be between 1 and 1024")
-}

--- a/db/database.go
+++ b/db/database.go
@@ -283,7 +283,7 @@ type UnsupportedOptions struct {
 	BlipSendDocsWithChannelRemoval   bool                     `json:"blip_send_docs_with_channel_removal,omitempty"`  // Enables sending docs with channel removals using channel filters
 	RejectWritesWithSkippedSequences bool                     `json:"reject_writes_with_skipped_sequences,omitempty"` // Reject writes if there are skipped sequences in the database
 	SameSiteCookie                   *string                  `json:"same_site_cookie,omitempty"`                     // Sets the SameSite attribute on session cookies.
-	ResyncImportPartitions           *uint16                  `json:"resync_import_partitions,omitempty"`             // Number of partitions to use for resync import, if query based resync manager is enabled
+	ResyncImportPartitions           *uint16                  `json:"resync_import_partitions,omitempty"`             // Number of partitions to use for distributed DCP resync
 }
 
 type WarningThresholds struct {

--- a/db/database.go
+++ b/db/database.go
@@ -283,6 +283,7 @@ type UnsupportedOptions struct {
 	BlipSendDocsWithChannelRemoval   bool                     `json:"blip_send_docs_with_channel_removal,omitempty"`  // Enables sending docs with channel removals using channel filters
 	RejectWritesWithSkippedSequences bool                     `json:"reject_writes_with_skipped_sequences,omitempty"` // Reject writes if there are skipped sequences in the database
 	SameSiteCookie                   *string                  `json:"same_site_cookie,omitempty"`                     // Sets the SameSite attribute on session cookies.
+	ResyncImportPartitions           *uint16                  `json:"resync_import_partitions,omitempty"`             // Number of partitions to use for resync import, if query based resync manager is enabled
 }
 
 type WarningThresholds struct {

--- a/db/database.go
+++ b/db/database.go
@@ -2604,6 +2604,10 @@ func (db *DatabaseContext) distributedDCPFeedMode() base.DCPFeedMode {
 // This enables the database to detect state changes (such as resync requests) from other nodes in the cluster
 // while it is offline. The polling mechanism watches the metadata store for updates to the database state
 // document and invokes registered handlers when changes are detected.
+func (db *DatabaseContext) NumVBuckets() uint16 {
+	return db.numVBuckets
+}
+
 func (db *DatabaseContext) InitializeOfflineMode() {
 	// TODO: Add the appropriate handler function to handle this - CBG-5183
 	db.DBStateManager.SetResyncFunc(TempResyncHandler)

--- a/db/database.go
+++ b/db/database.go
@@ -283,7 +283,7 @@ type UnsupportedOptions struct {
 	BlipSendDocsWithChannelRemoval   bool                     `json:"blip_send_docs_with_channel_removal,omitempty"`  // Enables sending docs with channel removals using channel filters
 	RejectWritesWithSkippedSequences bool                     `json:"reject_writes_with_skipped_sequences,omitempty"` // Reject writes if there are skipped sequences in the database
 	SameSiteCookie                   *string                  `json:"same_site_cookie,omitempty"`                     // Sets the SameSite attribute on session cookies.
-	ResyncImportPartitions           *uint16                  `json:"resync_import_partitions,omitempty"`             // Number of partitions to use for distributed DCP resync
+	ResyncImportPartitions           *uint16                  `json:"resync_resync_partitionspartitions,omitempty"`   // Number of partitions to use for distributed DCP resync
 }
 
 type WarningThresholds struct {

--- a/db/database.go
+++ b/db/database.go
@@ -2600,14 +2600,15 @@ func (db *DatabaseContext) distributedDCPFeedMode() base.DCPFeedMode {
 	return base.DCPFeedGocb
 }
 
-// InitializeOfflineMode starts polling the database state when the database transitions to offline mode.
-// This enables the database to detect state changes (such as resync requests) from other nodes in the cluster
-// while it is offline. The polling mechanism watches the metadata store for updates to the database state
-// document and invokes registered handlers when changes are detected.
+// NumVBuckets return number of vBuckets on the databases bucket.
 func (db *DatabaseContext) NumVBuckets() uint16 {
 	return db.numVBuckets
 }
 
+// InitializeOfflineMode starts polling the database state when the database transitions to offline mode.
+// This enables the database to detect state changes (such as resync requests) from other nodes in the cluster
+// while it is offline. The polling mechanism watches the metadata store for updates to the database state
+// document and invokes registered handlers when changes are detected.
 func (db *DatabaseContext) InitializeOfflineMode() {
 	// TODO: Add the appropriate handler function to handle this - CBG-5183
 	db.DBStateManager.SetResyncFunc(TempResyncHandler)

--- a/db/database.go
+++ b/db/database.go
@@ -283,7 +283,7 @@ type UnsupportedOptions struct {
 	BlipSendDocsWithChannelRemoval   bool                     `json:"blip_send_docs_with_channel_removal,omitempty"`  // Enables sending docs with channel removals using channel filters
 	RejectWritesWithSkippedSequences bool                     `json:"reject_writes_with_skipped_sequences,omitempty"` // Reject writes if there are skipped sequences in the database
 	SameSiteCookie                   *string                  `json:"same_site_cookie,omitempty"`                     // Sets the SameSite attribute on session cookies.
-	ResyncImportPartitions           *uint16                  `json:"resync_resync_partitionspartitions,omitempty"`   // Number of partitions to use for distributed DCP resync
+	ResyncPartitions                 *uint16                  `json:"resync_partitions,omitempty"`                    // Number of partitions to use for distributed DCP resync
 }
 
 type WarningThresholds struct {

--- a/db/database_error.go
+++ b/db/database_error.go
@@ -26,6 +26,7 @@ var DatabaseErrorMap = map[databaseErrorCode]string{
 	DatabaseAllowConflictsError:         "Allow conflicts is set to true",
 	DatabaseEnableStarChannelFalseError: "Enable star channel is set to false",
 	DatabaseClusterCompatVersionError:   "Bucket has metadata from a newer Sync Gateway cluster compat version",
+	DatabaseInvalidResyncPartitions:     "resync_partitions exceeds number of vBuckets",
 }
 
 type databaseErrorCode uint8
@@ -43,6 +44,7 @@ const (
 	DatabaseAllowConflictsError         databaseErrorCode = 9
 	DatabaseEnableStarChannelFalseError databaseErrorCode = 10
 	DatabaseClusterCompatVersionError   databaseErrorCode = 11
+	DatabaseInvalidResyncPartitions     databaseErrorCode = 12
 )
 
 func NewDatabaseError(code databaseErrorCode) *DatabaseError {

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1723,6 +1723,12 @@ Database:
         remote_config_tls_skip_verify:
           description: Enable self-signed certificates for external JavaScript load.
           type: boolean
+        resync_partitions:
+          description: |-
+            Number of partitions to use for distributed DCP resync. If not set, defaults to the import partitions value.
+          type: integer
+          minimum: 1
+          maximum: 1024
         same_site_cookie:
           description: |-
             Override the session cookie SameSite behavior. By default, a session cookie will have SameSite:None if CORS is enabled, and will have no SameSite attribute if CORS is not enabled.  Setting this property to`Default` will omit the SameSite attribute from the cookie.

--- a/rest/adminapitest/resync_test.go
+++ b/rest/adminapitest/resync_test.go
@@ -464,3 +464,22 @@ func TestResyncRequireResyncDefaultMetadataID(t *testing.T) {
 
 	rt.WaitForDatabaseState(db2Name, db.RunStateString[db.DBOnline])
 }
+
+func TestResyncPartitionsMaximumValidation(t *testing.T) {
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		PersistentConfig: true,
+	})
+	defer rt.Close()
+
+	dbConfig := rt.NewDbConfig()
+	numVBuckets, err := rt.TestBucket.GetMaxVbno(base.TestCtx(t))
+	require.NoError(t, err)
+	invalidPartitions := numVBuckets + 1
+	dbConfig.Unsupported = &db.UnsupportedOptions{
+		ResyncPartitions: &invalidPartitions,
+	}
+
+	resp := rt.CreateDatabase("db1", dbConfig)
+	rest.RequireStatus(t, resp, http.StatusInternalServerError)
+	assert.Contains(t, resp.Body.String(), "resync_partitions must be between 1 and")
+}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -985,6 +985,13 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	dbcontext.RequireResync = collectionsRequiringResync
 	dbcontext.RequireAttachmentMigration = collectionsRequiringAttachmentMigration
 
+	if config.Unsupported != nil && config.Unsupported.ResyncPartitions != nil && *config.Unsupported.ResyncPartitions > dbcontext.NumVBuckets() {
+		if options.loadFromBucket {
+			sc._handleInvalidDatabaseConfig(ctx, spec.BucketName, config, db.NewDatabaseError(db.DatabaseInvalidResyncPartitions))
+		}
+		return nil, fmt.Errorf("resync_partitions must be between 1 and %d, got %d", dbcontext.NumVBuckets(), *config.Unsupported.ResyncPartitions)
+	}
+
 	if config.CORS != nil {
 		dbcontext.CORS = config.DbConfig.CORS
 	} else {


### PR DESCRIPTION
CBG-5371

Adds unsupported option to toggle partition count for distributed resync.

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/647/
