### PR TITLE
Skip flaky TestServerlessFetchConfigsLimited ahead of removal

### DIFF
--- a/rest/serverless_test.go
+++ b/rest/serverless_test.go
@@ -395,6 +395,7 @@ func TestServerlessUnsuspendFetchFallback(t *testing.T) {
 
 // Confirms that ServerContext.fetchConfigsWithTTL works correctly
 func TestServerlessFetchConfigsLimited(t *testing.T) {
+	t.Skip("flaky, and serverless mode is no longer a supported test target")
 	ctx := base.TestCtx(t)
 	tb := base.GetTestBucket(t)
 	defer tb.Close(ctx)


### PR DESCRIPTION
This test flakes on Windows CI quite often - we don't need/support any serverless code so let's just skip until it is fully removed.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- n/a