### PR TITLE
CBG-5398: Track heartbeat listener goroutine in sgReplicateManager.closeWg

### DIFF
--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -1649,8 +1649,10 @@ func (l *ReplicationHeartbeatListener) subscribeNodeSetChanges() error {
 		base.DebugfCtx(ctx, base.KeyCluster, "Error subscribing to %s key changes: %v", cfgKeySGRCluster, err)
 		return err
 	}
+	l.mgr.closeWg.Add(1)
 	go func() {
 		defer base.FatalPanicHandler(ctx)
+		defer l.mgr.closeWg.Done()
 		for {
 			select {
 			case <-cfgEvents:


### PR DESCRIPTION
CBG-5398

The goroutine spawned by `ReplicationHeartbeatListener.subscribeNodeSetChanges()` was not registered with `sgReplicateManager.closeWg`, so `sgReplicateManager.Stop()` could return while the listener was still executing `RegisterNode` -> `registerNodeForHost`, racing teardown of state that callers (notably tests) mutate after `Stop` returns.
Mirror the `Add(1)`/`defer Done()` pattern already used for the cfg-subscribe goroutine.

Couldn't repro the race locally but should be reproducible in integration tests with `-count` set

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `-count=100 TestReplicationRebalancePush` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/654/
