### PR TITLE
CBG-5212: Fix requests dropping context information for NonCancellableContext type

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -67,7 +67,7 @@ func NewNonCancelCtx() NonCancellableContext {
 	return ctxStruct
 }
 
-// NewNonCancelCtx creates a new background context struct for operations that require a fresh context, with database logging context added
+// NewNonCancelCtxForDatabase creates a new background context struct for operations that require a fresh context, with database logging context added
 func NewNonCancelCtxForDatabase(parentContext context.Context) NonCancellableContext {
 	ctx := getLogCtx(parentContext)
 

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -211,7 +211,7 @@ func connect(arc *activeReplicatorCommon, idSuffix string) (blipSender *blip.Sen
 	arc.replicationStats.NumConnectAttempts.Add(1)
 
 	ctx := base.CorrelationIDLogCtx(
-		arc.config.ActiveDB.AddDatabaseLogContext(base.NewNonCancelCtx().Ctx),
+		arc.config.ActiveDB.AddDatabaseLogContext(base.NewNonCancelCtxForDatabase(arc.ctx).Ctx),
 		arc.config.ID+idSuffix)
 	if arc.config.RunAs != "" {
 		ctx = base.UserLogCtx(ctx, arc.config.RunAs, base.UserDomainSyncGateway, nil)

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -211,7 +211,7 @@ func connect(arc *activeReplicatorCommon, idSuffix string) (blipSender *blip.Sen
 	arc.replicationStats.NumConnectAttempts.Add(1)
 
 	ctx := base.CorrelationIDLogCtx(
-		arc.config.ActiveDB.AddDatabaseLogContext(base.NewNonCancelCtxForDatabase(arc.ctx).Ctx),
+		arc.config.ActiveDB.AddDatabaseLogContext(base.NewNonCancelCtx().Ctx),
 		arc.config.ID+idSuffix)
 	if arc.config.RunAs != "" {
 		ctx = base.UserLogCtx(ctx, arc.config.RunAs, base.UserDomainSyncGateway, nil)

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -42,7 +42,7 @@ const paramDeleted = "deleted"
 
 // "Create" a database (actually just register an existing bucket)
 func (h *handler) handleCreateDB() error {
-	contextNoCancel := base.NewNonCancelCtx()
+	contextNoCancel := base.NewNonCancelCtxForDatabase(h.ctx())
 	h.assertAdminOnly()
 	dbName := h.PathVar("newdb")
 	rawBytes, config, err := h.readSanitizeDbConfigJSON()
@@ -829,7 +829,7 @@ func (h *handler) updateNonPersistentDbConfig(ctx base.NonCancellableContext, db
 // handlePutDbConfig Upserts a new database config
 func (h *handler) handlePutDbConfig() (err error) {
 	h.assertAdminOnly()
-	contextNoCancel := base.NewNonCancelCtx()
+	contextNoCancel := base.NewNonCancelCtxForDatabase(h.ctx())
 
 	var dbConfig *DbConfig
 

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -42,9 +42,10 @@ const paramDeleted = "deleted"
 
 // "Create" a database (actually just register an existing bucket)
 func (h *handler) handleCreateDB() error {
-	contextNoCancel := base.NewNonCancelCtxForDatabase(h.ctx())
 	h.assertAdminOnly()
 	dbName := h.PathVar("newdb")
+	dbctx := base.DatabaseLogCtx(h.ctx(), dbName, nil)
+	contextNoCancel := base.NewNonCancelCtxForDatabase(dbctx)
 	rawBytes, config, err := h.readSanitizeDbConfigJSON()
 	if err != nil {
 		return err

--- a/rest/config.go
+++ b/rest/config.go
@@ -2081,7 +2081,7 @@ func (sc *ServerContext) FetchConfigs(ctx context.Context, isInitialStartup bool
 // _applyConfigs takes a map of dbName->DatabaseConfig and loads them into the ServerContext where necessary.
 func (sc *ServerContext) _applyConfigs(ctx context.Context, dbNameConfigs map[string]DatabaseConfig, loadFromBucket bool) (count int) {
 	for dbName, cnf := range dbNameConfigs {
-		applied, err := sc._applyConfig(base.NewNonCancelCtx(), cnf, true, loadFromBucket)
+		applied, err := sc._applyConfig(base.NewNonCancelCtxForDatabase(ctx), cnf, true, loadFromBucket)
 		if err != nil {
 			base.ErrorfCtx(ctx, "Couldn't apply config for database %q: %v", base.MD(dbName), err)
 			continue

--- a/rest/config.go
+++ b/rest/config.go
@@ -2081,7 +2081,7 @@ func (sc *ServerContext) FetchConfigs(ctx context.Context, isInitialStartup bool
 // _applyConfigs takes a map of dbName->DatabaseConfig and loads them into the ServerContext where necessary.
 func (sc *ServerContext) _applyConfigs(ctx context.Context, dbNameConfigs map[string]DatabaseConfig, loadFromBucket bool) (count int) {
 	for dbName, cnf := range dbNameConfigs {
-		applied, err := sc._applyConfig(base.NewNonCancelCtxForDatabase(base.DatabaseLogCtx(ctx, dbName,nil)), cnf, true, loadFromBucket)
+		applied, err := sc._applyConfig(base.NewNonCancelCtxForDatabase(base.DatabaseLogCtx(ctx, dbName, nil)), cnf, true, loadFromBucket)
 		if err != nil {
 			base.ErrorfCtx(ctx, "Couldn't apply config for database %q: %v", base.MD(dbName), err)
 			continue

--- a/rest/config.go
+++ b/rest/config.go
@@ -2081,7 +2081,7 @@ func (sc *ServerContext) FetchConfigs(ctx context.Context, isInitialStartup bool
 // _applyConfigs takes a map of dbName->DatabaseConfig and loads them into the ServerContext where necessary.
 func (sc *ServerContext) _applyConfigs(ctx context.Context, dbNameConfigs map[string]DatabaseConfig, loadFromBucket bool) (count int) {
 	for dbName, cnf := range dbNameConfigs {
-		applied, err := sc._applyConfig(base.NewNonCancelCtxForDatabase(ctx), cnf, true, loadFromBucket)
+		applied, err := sc._applyConfig(base.NewNonCancelCtxForDatabase(base.DatabaseLogCtx(ctx, dbName,nil)), cnf, true, loadFromBucket)
 		if err != nil {
 			base.ErrorfCtx(ctx, "Couldn't apply config for database %q: %v", base.MD(dbName), err)
 			continue

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -387,7 +387,7 @@ func (sc *ServerContext) GetInactiveDatabase(ctx context.Context, name string) (
 			dbConfigFound, _ = sc.fetchAndLoadDatabaseSince(ctx, name, sc.Config.Unsupported.Serverless.MinConfigFetchInterval)
 
 		} else {
-			dbConfigFound, _ = sc.fetchAndLoadDatabase(base.NewNonCancelCtx(), name, false)
+			dbConfigFound, _ = sc.fetchAndLoadDatabase(base.NewNonCancelCtxForDatabase(ctx), name, false)
 		}
 		if dbConfigFound {
 			sc._databasesLock.RLock()


### PR DESCRIPTION
CBG-5212

Describe your PR here...
- replace instances of NewNonCancelCtx with NewNonCancelCtxForDatabase

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/656/
