### PR TITLE
Improve/fix status assertions for BackgroundManager tests

### DIFF
--- a/db/background_mgr_attachment_migration_test.go
+++ b/db/background_mgr_attachment_migration_test.go
@@ -77,7 +77,7 @@ func waitForAttachmentMigrationDocsProcessed(t testing.TB, db *Database, count i
 		// Poll the local status so the wait can stop as soon as the requested progress is observed,
 		// without waiting for the cluster status' periodic update.
 		rawStatus, _, err := db.AttachmentMigrationManager.Process.GetProcessStatus(BackgroundManagerStatus{})
-		require.NoError(c, err)
+		assert.NoError(c, err)
 		var stats AttachmentMigrationManagerResponse
 		require.NoError(c, base.JSONUnmarshal(rawStatus, &stats))
 		assert.GreaterOrEqual(c, stats.DocsProcessed, count)

--- a/db/background_mgr_attachment_migration_test.go
+++ b/db/background_mgr_attachment_migration_test.go
@@ -81,7 +81,6 @@ func waitForAttachmentMigrationDocsProcessed(t testing.TB, db *Database, count i
 		var stats AttachmentMigrationManagerResponse
 		require.NoError(c, base.JSONUnmarshal(rawStatus, &stats))
 		assert.GreaterOrEqual(c, stats.DocsProcessed, count)
-		assert.GreaterOrEqual(c, stats.DocsChanged, int64(0))
 	}, 1*time.Minute, 10*time.Millisecond)
 }
 

--- a/db/background_mgr_attachment_migration_test.go
+++ b/db/background_mgr_attachment_migration_test.go
@@ -70,16 +70,17 @@ func getAttachmentMigrationStats(t *testing.T, db *Database) AttachmentMigration
 	return resp
 }
 
-// waitForAttachmentMigrationDocsProcessed waits until the resync manager has processed more than the specified count of documents.
+// waitForAttachmentMigrationDocsProcessed waits until the resync manager has processed at least the specified count of documents.
 func waitForAttachmentMigrationDocsProcessed(t testing.TB, db *Database, count int64) {
 	// this intentionally uses a very short poll interval to catch progress as quickly as possible
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		// to stop the document, poll the local status rather than the cluster status which is updated on a timer
+		// Poll the local status so the wait can stop as soon as the requested progress is observed,
+		// without waiting for the cluster status' periodic update.
 		rawStatus, _, err := db.AttachmentMigrationManager.Process.GetProcessStatus(BackgroundManagerStatus{})
 		require.NoError(c, err)
 		var stats AttachmentMigrationManagerResponse
-		require.NoError(t, base.JSONUnmarshal(rawStatus, &stats))
-		assert.Greater(c, stats.DocsProcessed, count)
+		require.NoError(c, base.JSONUnmarshal(rawStatus, &stats))
+		assert.GreaterOrEqual(c, stats.DocsProcessed, count)
 		assert.GreaterOrEqual(c, stats.DocsChanged, int64(0))
 	}, 1*time.Minute, 10*time.Millisecond)
 }

--- a/db/background_mgr_attachment_migration_test.go
+++ b/db/background_mgr_attachment_migration_test.go
@@ -46,17 +46,14 @@ func TestAttachmentMigrationTaskMixMigratedAndNonMigratedDocs(t *testing.T) {
 		MoveAttachmentXattrFromGlobalToSync(t, collection.dataStore, key, value, true)
 	}
 
-	attachMigrationMgr := NewAttachmentMigrationManager(db.DatabaseContext)
-	require.NotNil(t, attachMigrationMgr)
-
-	err := attachMigrationMgr.Start(ctx, nil)
+	err := db.AttachmentMigrationManager.Start(ctx, nil)
 	require.NoError(t, err)
 
 	// wait for task to complete
-	RequireBackgroundManagerState(t, attachMigrationMgr, BackgroundProcessStateCompleted)
+	RequireBackgroundManagerState(t, db.AttachmentMigrationManager, BackgroundProcessStateCompleted)
 
 	// assert that the subset (5) of the docs were changed, all created docs were processed (10)
-	stats := getAttachmentMigrationStats(t, attachMigrationMgr.Process)
+	stats := getAttachmentMigrationStats(t, db)
 	assert.Equal(t, int64(10), stats.DocsProcessed)
 	assert.Equal(t, int64(5), stats.DocsChanged)
 
@@ -65,12 +62,26 @@ func TestAttachmentMigrationTaskMixMigratedAndNonMigratedDocs(t *testing.T) {
 
 }
 
-func getAttachmentMigrationStats(t *testing.T, migrationManager BackgroundManagerProcessI) AttachmentMigrationManagerResponse {
+func getAttachmentMigrationStats(t *testing.T, db *Database) AttachmentMigrationManagerResponse {
 	var resp AttachmentMigrationManagerResponse
-	rawStatus, _, err := migrationManager.GetProcessStatus(BackgroundManagerStatus{})
+	rawStatus, err := db.AttachmentMigrationManager.GetStatus(base.TestCtx(t))
 	require.NoError(t, err)
 	require.NoError(t, base.JSONUnmarshal(rawStatus, &resp))
 	return resp
+}
+
+// waitForAttachmentMigrationDocsProcessed waits until the resync manager has processed more than the specified count of documents.
+func waitForAttachmentMigrationDocsProcessed(t testing.TB, db *Database, count int64) {
+	// this intentionally uses a very short poll interval to catch progress as quickly as possible
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		// to stop the document, poll the local status rather than the cluster status which is updated on a timer
+		rawStatus, _, err := db.AttachmentMigrationManager.Process.GetProcessStatus(BackgroundManagerStatus{})
+		require.NoError(c, err)
+		var stats AttachmentMigrationManagerResponse
+		require.NoError(t, base.JSONUnmarshal(rawStatus, &stats))
+		assert.Greater(c, stats.DocsProcessed, count)
+		assert.GreaterOrEqual(c, stats.DocsChanged, int64(0))
+	}, 1*time.Minute, 10*time.Millisecond)
 }
 
 func TestAttachmentMigrationManagerResumeStoppedMigration(t *testing.T) {
@@ -90,10 +101,8 @@ func TestAttachmentMigrationManagerResumeStoppedMigration(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, doc.Attachments())
 	}
-	attachMigrationMgr := NewAttachmentMigrationManager(db.DatabaseContext)
-	require.NotNil(t, attachMigrationMgr)
 
-	err := attachMigrationMgr.Start(ctx, nil)
+	err := db.AttachmentMigrationManager.Start(ctx, nil)
 	require.NoError(t, err)
 
 	// Attempt to Stop Process
@@ -101,20 +110,14 @@ func TestAttachmentMigrationManagerResumeStoppedMigration(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		for {
-			stats := getAttachmentMigrationStats(t, attachMigrationMgr.Process)
-			if stats.DocsProcessed >= 200 {
-				err = attachMigrationMgr.Stop(ctx)
-				require.NoError(t, err)
-				break
-			}
-			time.Sleep(1 * time.Microsecond)
-		}
+		waitForAttachmentMigrationDocsProcessed(t, db, 200)
+		err = db.AttachmentMigrationManager.Stop(ctx)
+		require.NoError(t, err)
 	}()
 
-	RequireBackgroundManagerState(t, attachMigrationMgr, BackgroundProcessStateStopped)
+	RequireBackgroundManagerState(t, db.AttachmentMigrationManager, BackgroundProcessStateStopped)
 
-	stats := getAttachmentMigrationStats(t, attachMigrationMgr.Process)
+	stats := getAttachmentMigrationStats(t, db)
 	require.Less(t, stats.DocsProcessed, int64(4000))
 
 	// assert that the sync info metadata version is not present
@@ -123,12 +126,12 @@ func TestAttachmentMigrationManagerResumeStoppedMigration(t *testing.T) {
 	require.Error(t, err)
 
 	// Resume process
-	err = attachMigrationMgr.Start(ctx, nil)
+	err = db.AttachmentMigrationManager.Start(ctx, nil)
 	require.NoError(t, err)
 
-	RequireBackgroundManagerState(t, attachMigrationMgr, BackgroundProcessStateCompleted)
+	RequireBackgroundManagerState(t, db.AttachmentMigrationManager, BackgroundProcessStateCompleted)
 
-	stats = getAttachmentMigrationStats(t, attachMigrationMgr.Process)
+	stats = getAttachmentMigrationStats(t, db)
 	require.GreaterOrEqual(t, stats.DocsProcessed, int64(4000))
 
 	// assert that the sync info metadata version doc has been written to the database collection
@@ -153,17 +156,14 @@ func TestAttachmentMigrationManagerNoDocsToMigrate(t *testing.T) {
 	_, err = collection.dataStore.Add(ctx, key, 0, []byte(`{"test":"doc"}`))
 	require.NoError(t, err)
 
-	attachMigrationMgr := NewAttachmentMigrationManager(db.DatabaseContext)
-	require.NotNil(t, attachMigrationMgr)
-
-	err = attachMigrationMgr.Start(ctx, nil)
+	err = db.AttachmentMigrationManager.Start(ctx, nil)
 	require.NoError(t, err)
 
 	// wait for task to complete
-	RequireBackgroundManagerState(t, attachMigrationMgr, BackgroundProcessStateCompleted)
+	RequireBackgroundManagerState(t, db.AttachmentMigrationManager, BackgroundProcessStateCompleted)
 
 	// assert that the two added docs above were processed but not changed
-	stats := getAttachmentMigrationStats(t, attachMigrationMgr.Process)
+	stats := getAttachmentMigrationStats(t, db)
 	// no docs should be changed, only one has xattr defined thus should only have one of the two docs processed
 	assert.Equal(t, int64(1), stats.DocsProcessed)
 	assert.Equal(t, int64(0), stats.DocsChanged)
@@ -208,17 +208,14 @@ func TestMigrationManagerDocWithSyncAndGlobalAttachmentMetadata(t *testing.T) {
 	_, err = collection.dataStore.UpdateXattrs(ctx, key, 0, cas, updateXattrs, DefaultMutateInOpts())
 	require.NoError(t, err)
 
-	attachMigrationMgr := NewAttachmentMigrationManager(db.DatabaseContext)
-	require.NotNil(t, attachMigrationMgr)
-
-	err = attachMigrationMgr.Start(ctx, nil)
+	err = db.AttachmentMigrationManager.Start(ctx, nil)
 	require.NoError(t, err)
 
 	// wait for task to complete
-	RequireBackgroundManagerState(t, attachMigrationMgr, BackgroundProcessStateCompleted)
+	RequireBackgroundManagerState(t, db.AttachmentMigrationManager, BackgroundProcessStateCompleted)
 
 	// assert that the two added docs above were processed but not changed
-	stats := getAttachmentMigrationStats(t, attachMigrationMgr.Process)
+	stats := getAttachmentMigrationStats(t, db)
 	assert.Equal(t, int64(1), stats.DocsProcessed)
 	assert.Equal(t, int64(1), stats.DocsChanged)
 

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -654,7 +654,7 @@ func waitForResyncDocsProcessed(t testing.TB, db *Database, count int64) {
 		rawStatus, _, err := db.ResyncManager.Process.GetProcessStatus(BackgroundManagerStatus{})
 		require.NoError(c, err)
 		var stats ResyncManagerResponseDCP
-		require.NoError(t, base.JSONUnmarshal(rawStatus, &stats))
+		assert.NoError(c, base.JSONUnmarshal(rawStatus, &stats))
 		assert.Greater(c, stats.DocsProcessed, count)
 	}, 1*time.Minute, 100*time.Millisecond)
 }

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -656,7 +656,6 @@ func waitForResyncDocsProcessed(t testing.TB, db *Database, count int64) {
 		var stats ResyncManagerResponseDCP
 		require.NoError(t, base.JSONUnmarshal(rawStatus, &stats))
 		assert.Greater(c, stats.DocsProcessed, count)
-		assert.GreaterOrEqual(c, stats.DocsChanged, int64(0))
 	}, 1*time.Minute, 100*time.Millisecond)
 }
 

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -165,6 +165,9 @@ func TestResyncDCPInit(t *testing.T) {
 				assert.Equal(t, testCase.initialClusterState.DocsChanged, response.DocsChanged)
 				assert.Equal(t, testCase.initialClusterState.DocsProcessed, response.DocsProcessed)
 			}
+
+			assert.Equal(t, int64(0), db.DbStats.Database().ResyncNumChanged.Value())
+			assert.Equal(t, int64(0), db.DbStats.Database().ResyncNumProcessed.Value())
 		})
 	}
 }
@@ -197,6 +200,9 @@ func TestResyncManagerDCPStopInMidWay(t *testing.T) {
 	stats := waitForResyncState(t, db, BackgroundProcessStateStopped)
 	assert.Less(t, stats.DocsProcessed, int64(docsToCreate), "DocsProcessed is equal to docs created. Consider setting docsToCreate > %d.", docsToCreate)
 	assert.Less(t, stats.DocsChanged, int64(docsToCreate))
+
+	assert.Less(t, db.DbStats.Database().ResyncNumProcessed.Value(), int64(docsToCreate))
+	assert.Less(t, db.DbStats.Database().ResyncNumChanged.Value(), int64(docsToCreate))
 
 	assert.Less(t, db.DbStats.Database().SyncFunctionCount.Value(), int64(docsToCreate))
 	assert.Greater(t, db.DbStats.Database().SyncFunctionCount.Value(), int64(300))
@@ -339,6 +345,9 @@ func TestResyncManagerDCPRunTwice(t *testing.T) {
 	require.GreaterOrEqual(t, stats.DocsProcessed, int64(docsToCreate))
 	assert.Equal(t, int64(0), stats.DocsChanged)
 
+	assert.GreaterOrEqual(t, db.DbStats.Database().ResyncNumProcessed.Value(), int64(docsToCreate))
+	assert.Equal(t, int64(0), db.DbStats.Database().ResyncNumChanged.Value())
+
 	assert.Equal(t, db.DbStats.Database().SyncFunctionCount.Value(), int64(docsToCreate))
 	wg.Wait()
 }
@@ -371,6 +380,9 @@ func TestResyncManagerDCPResumeStoppedProcess(t *testing.T) {
 	require.Less(t, stats.DocsProcessed, int64(docsToCreate), "DocsProcessed is equal to docs created. Consider setting docsToCreate > %d.", docsToCreate)
 	assert.Less(t, stats.DocsChanged, int64(docsToCreate))
 
+	assert.Less(t, db.DbStats.Database().ResyncNumProcessed.Value(), int64(docsToCreate))
+	assert.Less(t, db.DbStats.Database().ResyncNumChanged.Value(), int64(docsToCreate))
+
 	// Resume process
 	err = db.ResyncManager.Start(ctx, options)
 	require.NoError(t, err)
@@ -379,6 +391,9 @@ func TestResyncManagerDCPResumeStoppedProcess(t *testing.T) {
 
 	assert.GreaterOrEqual(t, stats.DocsProcessed, int64(docsToCreate))
 	assert.Equal(t, int64(docsToCreate), stats.DocsChanged)
+
+	assert.GreaterOrEqual(t, db.DbStats.Database().ResyncNumProcessed.Value(), int64(docsToCreate))
+	assert.Equal(t, int64(docsToCreate), db.DbStats.Database().ResyncNumChanged.Value())
 
 	assert.GreaterOrEqual(t, db.DbStats.Database().SyncFunctionCount.Value(), int64(docsToCreate))
 	wg.Wait()
@@ -441,21 +456,18 @@ func TestResyncManagerDCPResumeStoppedProcessChangeCollections(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		for {
-			stats := getResyncStats(t, db)
-			if stats.DocsProcessed >= (docsPerCollection / 5) {
-				err = db.ResyncManager.Stop(ctx)
-				require.NoError(t, err)
-				break
-			}
-			time.Sleep(1 * time.Microsecond)
-		}
+		waitForResyncDocsProcessed(t, db, docsPerCollection/5)
+		err = db.ResyncManager.Stop(ctx)
+		require.NoError(t, err)
 	}()
 
 	stats := waitForResyncState(t, db, BackgroundProcessStateStopped)
 
 	require.Less(t, stats.DocsProcessed, docsPerCollection, "DocsProcessed is equal to docs created. Consider setting docsPerCollection > %d.", docsPerCollection)
 	assert.Less(t, stats.DocsChanged, docsPerCollection)
+
+	assert.Less(t, db.DbStats.Database().ResyncNumProcessed.Value(), docsPerCollection)
+	assert.Less(t, db.DbStats.Database().ResyncNumChanged.Value(), docsPerCollection)
 
 	firstDocsChanged := stats.DocsChanged
 
@@ -470,6 +482,9 @@ func TestResyncManagerDCPResumeStoppedProcessChangeCollections(t *testing.T) {
 
 	assert.GreaterOrEqual(t, stats.DocsProcessed, totalDocCount)
 	assert.Equal(t, totalDocCount, stats.DocsChanged+firstDocsChanged)
+
+	assert.GreaterOrEqual(t, db.DbStats.Database().ResyncNumProcessed.Value(), totalDocCount)
+	assert.Equal(t, totalDocCount, db.DbStats.Database().ResyncNumChanged.Value())
 
 	assert.GreaterOrEqual(t, db.DbStats.Database().SyncFunctionCount.Value(), totalDocCount)
 	wg.Wait()
@@ -552,7 +567,11 @@ function sync(doc, oldDoc){
 	channel("resync_channel");
 }`
 	resyncStats := runResync(t, ctx, db, collection, syncFn)
+	assert.GreaterOrEqual(t, resyncStats.DocsProcessed, int64(2))
 	assert.Equal(t, int64(2), resyncStats.DocsChanged)
+
+	assert.GreaterOrEqual(t, db.DbStats.Database().ResyncNumProcessed.Value(), int64(2))
+	assert.Equal(t, int64(2), db.DbStats.Database().ResyncNumChanged.Value())
 
 	var cas uint64
 	syncData, mou, cas = getSyncAndMou(t, collection, "sgWrite")
@@ -574,7 +593,11 @@ function sync(doc, oldDoc){
 	channel("resync_channel_again");
 }`
 	resyncStats = runResync(t, ctx, db, collection, syncFn)
+	assert.GreaterOrEqual(t, resyncStats.DocsProcessed, int64(2))
 	assert.Equal(t, int64(2), resyncStats.DocsChanged)
+
+	assert.GreaterOrEqual(t, db.DbStats.Database().ResyncNumProcessed.Value(), int64(4))
+	assert.Equal(t, int64(4), db.DbStats.Database().ResyncNumChanged.Value())
 
 	syncData, mou, cas = getSyncAndMou(t, collection, "sgWrite")
 	require.NotNil(t, syncData)
@@ -611,7 +634,7 @@ func runResync(t *testing.T, ctx context.Context, db *Database, collection *Data
 // helper function to Unmarshal BackgroundProcess state into ResyncManagerResponseDCP
 func getResyncStats(t testing.TB, db *Database) ResyncManagerResponseDCP {
 	var resp ResyncManagerResponseDCP
-	rawStatus, _, err := db.ResyncManager.Process.GetProcessStatus(BackgroundManagerStatus{})
+	rawStatus, err := db.ResyncManager.GetStatus(base.TestCtx(t))
 	require.NoError(t, err)
 	require.NoError(t, json.Unmarshal(rawStatus, &resp))
 	return resp
@@ -627,8 +650,13 @@ func waitForResyncState(t testing.TB, db *Database, desiredState BackgroundProce
 func waitForResyncDocsProcessed(t testing.TB, db *Database, count int64) {
 	// this intentionally uses a very short poll interval to catch progress as quickly as possible
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		stats := getResyncStats(t, db)
+		// to stop the document, poll the local status rather than the cluster status which is updated on a timer
+		rawStatus, _, err := db.ResyncManager.Process.GetProcessStatus(BackgroundManagerStatus{})
+		require.NoError(c, err)
+		var stats ResyncManagerResponseDCP
+		require.NoError(t, base.JSONUnmarshal(rawStatus, &stats))
 		assert.Greater(c, stats.DocsProcessed, count)
+		assert.GreaterOrEqual(c, stats.DocsChanged, int64(0))
 	}, 1*time.Minute, 100*time.Millisecond)
 }
 
@@ -637,6 +665,7 @@ func waitForResyncDocsChanged(t testing.TB, db *Database, count int64) {
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		stats := getResyncStats(t, db)
 		assert.Equal(c, stats.DocsChanged, count)
+		assert.GreaterOrEqual(c, stats.DocsProcessed, count)
 	}, 5*time.Minute, 100*time.Millisecond)
 }
 


### PR DESCRIPTION
Improve/fix status assertions for BackgroundManager tests

- Prep for https://github.com/couchbase/sync_gateway/pull/8242 which was missing assertions for the status documents in addition to expvar stats
- Fix the `BackgroundManagerProcessI.GetProcessStatus` to use `BackgroundManager.GetStatus` since the former doesn't have the actual `status` fields updated. This doesn't affect any tests but it perilous for future tests.
- Don't create/overwrite `AttachmentMigrationManager` on a db to simplify API.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/661/
