### PR TITLE
Rosmar Bootstrap `TouchMetadataDocument` CAS fix

### DIFF
--- a/base/bootstrap_test.go
+++ b/base/bootstrap_test.go
@@ -9,7 +9,6 @@
 package base
 
 import (
-	"context"
 	"sort"
 	"strings"
 	"sync"
@@ -219,7 +218,7 @@ func TestTouchMetadataDocument(t *testing.T) {
 	bucket := GetTestBucket(t)
 	defer bucket.Close(ctx)
 
-	cluster := newTestBootstrapConnection(t, ctx)
+	cluster := newTestBootstrapConnection(t)
 	defer cluster.Close()
 
 	bucketName := bucket.BucketSpec.BucketName
@@ -244,18 +243,4 @@ func TestTouchMetadataDocument(t *testing.T) {
 	_, err = cluster.TouchMetadataDocument(ctx, bucketName, docID, "name", "db2", originalCAS)
 	require.Error(t, err)
 	require.True(t, IsCasMismatch(err), "expected CasMismatch on stale CAS retry, got %T: %v", err, err)
-}
-
-// newTestBootstrapConnection constructs a BootstrapConnection matching the current test backing
-// store (Rosmar or Couchbase Server).
-func newTestBootstrapConnection(t *testing.T, ctx context.Context) BootstrapConnection {
-	t.Helper()
-	if UnitTestUrlIsWalrus() {
-		cluster, err := NewRosmarCluster(UnitTestUrl())
-		require.NoError(t, err)
-		return cluster
-	}
-	cluster, err := NewCouchbaseCluster(ctx, TestClusterSpec(t), false, nil, TestUseXattrs(), CachedClusterConnections)
-	require.NoError(t, err)
-	return cluster
 }

--- a/base/bootstrap_test.go
+++ b/base/bootstrap_test.go
@@ -9,6 +9,7 @@
 package base
 
 import (
+	"context"
 	"sort"
 	"strings"
 	"sync"
@@ -208,4 +209,53 @@ func TestBootstrapConnectionGetDocumentExists(t *testing.T) {
 	exists, err := cluster.GetDocument(ctx, bucketName, docID, &got)
 	require.NoError(t, err)
 	require.True(t, exists, "expected GetDocument to report exists=true for an existing doc")
+}
+
+// TestTouchMetadataDocument verifies that BootstrapConnection.TouchMetadataDocument honours the supplied CAS
+// (rejecting stale-CAS callers with a CasMismatch error) and bumps the document's CAS on success.
+// This is the mechanism rest/config_manager.go relies on to block racing writers during registry rollback.
+func TestTouchMetadataDocument(t *testing.T) {
+	ctx := TestCtx(t)
+	bucket := GetTestBucket(t)
+	defer bucket.Close(ctx)
+
+	cluster := newTestBootstrapConnection(t, ctx)
+	defer cluster.Close()
+
+	bucketName := bucket.BucketSpec.BucketName
+	docID := t.Name()
+	body := map[string]any{"name": "original"}
+
+	originalCAS, err := cluster.InsertMetadataDocument(ctx, bucketName, docID, body)
+	require.NoError(t, err)
+	defer func() { _ = cluster.DeleteMetadataDocument(ctx, bucketName, docID, 0) }()
+
+	// Stale CAS must be rejected with CasMismatch (mirrors CBS subdoc Touch with Cas option).
+	_, err = cluster.TouchMetadataDocument(ctx, bucketName, docID, "name", "db1", originalCAS+1)
+	require.Error(t, err)
+	require.True(t, IsCasMismatch(err), "expected CasMismatch, got %T: %v", err, err)
+
+	// Correct CAS succeeds and returns a new (different) CAS.
+	newCAS, err := cluster.TouchMetadataDocument(ctx, bucketName, docID, "name", "db1", originalCAS)
+	require.NoError(t, err)
+	require.NotEqual(t, originalCAS, newCAS, "TouchMetadataDocument should bump CAS")
+
+	// The previously-valid CAS is now stale.
+	_, err = cluster.TouchMetadataDocument(ctx, bucketName, docID, "name", "db2", originalCAS)
+	require.Error(t, err)
+	require.True(t, IsCasMismatch(err), "expected CasMismatch on stale CAS retry, got %T: %v", err, err)
+}
+
+// newTestBootstrapConnection constructs a BootstrapConnection matching the current test backing
+// store (Rosmar or Couchbase Server).
+func newTestBootstrapConnection(t *testing.T, ctx context.Context) BootstrapConnection {
+	t.Helper()
+	if UnitTestUrlIsWalrus() {
+		cluster, err := NewRosmarCluster(UnitTestUrl())
+		require.NoError(t, err)
+		return cluster
+	}
+	cluster, err := NewCouchbaseCluster(ctx, TestClusterSpec(t), false, nil, TestUseXattrs(), CachedClusterConnections)
+	require.NoError(t, err)
+	return cluster
 }

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -361,6 +361,84 @@ func TestGetAndTouchRaw(t *testing.T) {
 
 }
 
+// TestTouchPreservesCAS verifies that Touch and GetAndTouchRaw do NOT bump the document's CAS,
+// matching Couchbase Server's memcached TOUCH/GAT semantics.
+// Callers needing to force a CAS bump (e.g. config rollback) must use a real mutation; see TestTouchMetadataDocument.
+func TestTouchPreservesCAS(t *testing.T) {
+	ctx := TestCtx(t)
+	bucket := GetTestBucket(t)
+	defer bucket.Close(ctx)
+	dataStore := bucket.GetSingleDataStore()
+
+	key := t.Name()
+	val := []byte("hello")
+
+	require.NoError(t, dataStore.SetRaw(ctx, key, 0, nil, val))
+	defer func() { assert.NoError(t, dataStore.Delete(ctx, key)) }()
+
+	_, originalCAS, err := dataStore.GetRaw(ctx, key)
+	require.NoError(t, err)
+	require.NotZero(t, originalCAS)
+
+	getTouchVal, getTouchCAS, err := dataStore.GetAndTouchRaw(ctx, key, 0)
+	require.NoError(t, err)
+	require.Equal(t, val, getTouchVal)
+	require.Equal(t, originalCAS, getTouchCAS, "GetAndTouchRaw should not bump CAS")
+
+	touchCAS, err := dataStore.Touch(ctx, key, 0)
+	require.NoError(t, err)
+	require.Equal(t, originalCAS, touchCAS, "Touch should not bump CAS")
+}
+
+// TestTouchMetadataDocument verifies that BootstrapConnection.TouchMetadataDocument honours the supplied CAS
+// (rejecting stale-CAS callers with a CasMismatch error) and bumps the document's CAS on success.
+// This is the mechanism rest/config_manager.go relies on to block racing writers during registry rollback.
+func TestTouchMetadataDocument(t *testing.T) {
+	ctx := TestCtx(t)
+	bucket := GetTestBucket(t)
+	defer bucket.Close(ctx)
+
+	cluster := newTestBootstrapConnection(t, ctx)
+	defer cluster.Close()
+
+	bucketName := bucket.BucketSpec.BucketName
+	docID := t.Name()
+	body := map[string]any{"name": "original"}
+
+	originalCAS, err := cluster.InsertMetadataDocument(ctx, bucketName, docID, body)
+	require.NoError(t, err)
+	defer func() { _ = cluster.DeleteMetadataDocument(ctx, bucketName, docID, 0) }()
+
+	// Stale CAS must be rejected with CasMismatch (mirrors CBS subdoc Touch with Cas option).
+	_, err = cluster.TouchMetadataDocument(ctx, bucketName, docID, "name", "db1", originalCAS+1)
+	require.Error(t, err)
+	require.True(t, IsCasMismatch(err), "expected CasMismatch, got %T: %v", err, err)
+
+	// Correct CAS succeeds and returns a new (different) CAS.
+	newCAS, err := cluster.TouchMetadataDocument(ctx, bucketName, docID, "name", "db1", originalCAS)
+	require.NoError(t, err)
+	require.NotEqual(t, originalCAS, newCAS, "TouchMetadataDocument should bump CAS")
+
+	// The previously-valid CAS is now stale.
+	_, err = cluster.TouchMetadataDocument(ctx, bucketName, docID, "name", "db2", originalCAS)
+	require.Error(t, err)
+	require.True(t, IsCasMismatch(err), "expected CasMismatch on stale CAS retry, got %T: %v", err, err)
+}
+
+// newTestBootstrapConnection constructs a BootstrapConnection matching the current test backing
+// store (Rosmar or Couchbase Server).
+func newTestBootstrapConnection(t *testing.T, ctx context.Context) BootstrapConnection {
+	t.Helper()
+	if UnitTestUrlIsWalrus() {
+		cluster, err := NewRosmarCluster(UnitTestUrl())
+		require.NoError(t, err)
+		return cluster
+	}
+	cluster, err := NewCouchbaseCluster(ctx, TestClusterSpec(t), false, nil, TestUseXattrs(), CachedClusterConnections)
+	require.NoError(t, err)
+	return cluster
+}
+
 func SkipXattrTestsIfNotEnabled(t *testing.T) {
 
 	if !TestUseXattrs() {

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -390,55 +390,6 @@ func TestTouchPreservesCAS(t *testing.T) {
 	require.Equal(t, originalCAS, touchCAS, "Touch should not bump CAS")
 }
 
-// TestTouchMetadataDocument verifies that BootstrapConnection.TouchMetadataDocument honours the supplied CAS
-// (rejecting stale-CAS callers with a CasMismatch error) and bumps the document's CAS on success.
-// This is the mechanism rest/config_manager.go relies on to block racing writers during registry rollback.
-func TestTouchMetadataDocument(t *testing.T) {
-	ctx := TestCtx(t)
-	bucket := GetTestBucket(t)
-	defer bucket.Close(ctx)
-
-	cluster := newTestBootstrapConnection(t, ctx)
-	defer cluster.Close()
-
-	bucketName := bucket.BucketSpec.BucketName
-	docID := t.Name()
-	body := map[string]any{"name": "original"}
-
-	originalCAS, err := cluster.InsertMetadataDocument(ctx, bucketName, docID, body)
-	require.NoError(t, err)
-	defer func() { _ = cluster.DeleteMetadataDocument(ctx, bucketName, docID, 0) }()
-
-	// Stale CAS must be rejected with CasMismatch (mirrors CBS subdoc Touch with Cas option).
-	_, err = cluster.TouchMetadataDocument(ctx, bucketName, docID, "name", "db1", originalCAS+1)
-	require.Error(t, err)
-	require.True(t, IsCasMismatch(err), "expected CasMismatch, got %T: %v", err, err)
-
-	// Correct CAS succeeds and returns a new (different) CAS.
-	newCAS, err := cluster.TouchMetadataDocument(ctx, bucketName, docID, "name", "db1", originalCAS)
-	require.NoError(t, err)
-	require.NotEqual(t, originalCAS, newCAS, "TouchMetadataDocument should bump CAS")
-
-	// The previously-valid CAS is now stale.
-	_, err = cluster.TouchMetadataDocument(ctx, bucketName, docID, "name", "db2", originalCAS)
-	require.Error(t, err)
-	require.True(t, IsCasMismatch(err), "expected CasMismatch on stale CAS retry, got %T: %v", err, err)
-}
-
-// newTestBootstrapConnection constructs a BootstrapConnection matching the current test backing
-// store (Rosmar or Couchbase Server).
-func newTestBootstrapConnection(t *testing.T, ctx context.Context) BootstrapConnection {
-	t.Helper()
-	if UnitTestUrlIsWalrus() {
-		cluster, err := NewRosmarCluster(UnitTestUrl())
-		require.NoError(t, err)
-		return cluster
-	}
-	cluster, err := NewCouchbaseCluster(ctx, TestClusterSpec(t), false, nil, TestUseXattrs(), CachedClusterConnections)
-	require.NoError(t, err)
-	return cluster
-}
-
 func SkipXattrTestsIfNotEnabled(t *testing.T) {
 
 	if !TestUseXattrs() {

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -361,10 +361,10 @@ func TestGetAndTouchRaw(t *testing.T) {
 
 }
 
-// TestTouchPreservesCAS verifies that Touch and GetAndTouchRaw do NOT bump the document's CAS,
-// matching Couchbase Server's memcached TOUCH/GAT semantics.
-// Callers needing to force a CAS bump (e.g. config rollback) must use a real mutation; see TestTouchMetadataDocument.
-func TestTouchPreservesCAS(t *testing.T) {
+// TestTouchCASSemantics verifies Touch/GetAndTouchRaw CAS behavior against CB Server's
+// memcached TOUCH/GAT semantics: when the expiry value is unchanged the op is a no-op
+// and CAS is preserved; when the expiry value changes, CAS is bumped.
+func TestTouchCASSemantics(t *testing.T) {
 	ctx := TestCtx(t)
 	bucket := GetTestBucket(t)
 	defer bucket.Close(ctx)
@@ -380,14 +380,28 @@ func TestTouchPreservesCAS(t *testing.T) {
 	require.NoError(t, err)
 	require.NotZero(t, originalCAS)
 
+	// No-op: doc has exp=0, GAT/Touch with exp=0 should preserve CAS.
 	getTouchVal, getTouchCAS, err := dataStore.GetAndTouchRaw(ctx, key, 0)
 	require.NoError(t, err)
 	require.Equal(t, val, getTouchVal)
-	require.Equal(t, originalCAS, getTouchCAS, "GetAndTouchRaw should not bump CAS")
+	require.Equal(t, originalCAS, getTouchCAS, "no-op GetAndTouchRaw should not bump CAS")
 
 	touchCAS, err := dataStore.Touch(ctx, key, 0)
 	require.NoError(t, err)
-	require.Equal(t, originalCAS, touchCAS, "Touch should not bump CAS")
+	require.Equal(t, originalCAS, touchCAS, "no-op Touch should not bump CAS")
+
+	// Changing the expiry is a metadata mutation: CAS is bumped each time.
+	touchCAS, err = dataStore.Touch(ctx, key, 60)
+	require.NoError(t, err)
+	require.NotEqual(t, originalCAS, touchCAS, "Touch should bump CAS when setting a new TTL")
+
+	_, getTouchCAS, err = dataStore.GetAndTouchRaw(ctx, key, 120)
+	require.NoError(t, err)
+	require.NotEqual(t, touchCAS, getTouchCAS, "GetAndTouchRaw should bump CAS when changing TTL")
+
+	clearTouchCAS, err := dataStore.Touch(ctx, key, 0)
+	require.NoError(t, err)
+	require.NotEqual(t, getTouchCAS, clearTouchCAS, "Touch should bump CAS when clearing TTL")
 }
 
 func SkipXattrTestsIfNotEnabled(t *testing.T) {

--- a/base/rosmar_cluster.go
+++ b/base/rosmar_cluster.go
@@ -78,9 +78,8 @@ func (c *RosmarCluster) openBucket(bucketName string) (*rosmar.Bucket, error) {
 	return rosmar.OpenBucketIn(c.serverURL, bucketName, rosmar.CreateOrOpen)
 }
 
-// getDefaultDataStore returns the default datastore for the specified bucket. Returns a bucket close function and an
-// error.
-func (c *RosmarCluster) getDefaultDataStore(ctx context.Context, bucketName string) (sgbucket.DataStore, func(ctx context.Context), error) {
+// getDefaultDataStore returns the default datastore for the specified bucket. Returns a bucket close function and an error.
+func (c *RosmarCluster) getDefaultDataStore(ctx context.Context, bucketName string) (*rosmar.Collection, func(ctx context.Context), error) {
 	bucket, err := rosmar.OpenBucketIn(c.serverURL, bucketName, rosmar.CreateOrOpen)
 	if err != nil {
 		return nil, nil, err
@@ -93,7 +92,13 @@ func (c *RosmarCluster) getDefaultDataStore(ctx context.Context, bucketName stri
 		closeFn(ctx)
 		return nil, nil, err
 	}
-	return ds, closeFn, nil
+	rosmarCollection, ok := ds.(*rosmar.Collection)
+	if !ok {
+		AssertfCtx(ctx, "Unexpected type for default collection for bucket %q: %T", bucketName, ds)
+		closeFn(ctx)
+		return nil, nil, fmt.Errorf("unexpected type for default collection for bucket %q: %T", bucketName, ds)
+	}
+	return rosmarCollection, closeFn, nil
 }
 
 // GetMetadataDocument returns a metadata document from the default collection for the specified bucket.
@@ -130,7 +135,6 @@ func (c *RosmarCluster) WriteMetadataDocument(ctx context.Context, location, doc
 
 // TouchMetadataDocument sets the specified property in a bootstrap metadata document for a given bucket and key.  Used to
 // trigger CAS update on the document, to block any racing updates. Does not retry on CAS failure.
-
 func (c *RosmarCluster) TouchMetadataDocument(ctx context.Context, location, docID string, property, value string, cas uint64) (newCAS uint64, err error) {
 	ds, closer, err := c.getDefaultDataStore(ctx, location)
 	if err != nil {
@@ -138,8 +142,7 @@ func (c *RosmarCluster) TouchMetadataDocument(ctx context.Context, location, doc
 	}
 	defer closer(ctx)
 
-	// FIXME to not touch the whole document?
-	return ds.Touch(ctx, docID, 0)
+	return ds.TouchXattrWithCas(ctx, docID, cfgXattrKey, property, value, cas)
 }
 
 // DeleteMetadataDocument deletes an existing bootstrap metadata document for a given bucket and key.

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/couchbasedeps/fast-skiplist v0.0.0-20250722125747-e0dd031fe2ac
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338
 	github.com/couchbaselabs/gocbconnstr v1.0.5
-	github.com/couchbaselabs/rosmar v0.0.0-20260519130433-967376be7244
+	github.com/couchbaselabs/rosmar v0.0.0-20260522133614-eef7ba1bcfb4
 	github.com/elastic/gosigar v0.14.4
 	github.com/felixge/fgprof v0.9.5
 	github.com/go-jose/go-jose/v4 v4.1.4

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/couchbasedeps/fast-skiplist v0.0.0-20250722125747-e0dd031fe2ac
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338
 	github.com/couchbaselabs/gocbconnstr v1.0.5
-	github.com/couchbaselabs/rosmar v0.0.0-20260522154900-f5966898bbe8
+	github.com/couchbaselabs/rosmar v0.0.0-20260522160802-db93c1c3935f
 	github.com/elastic/gosigar v0.14.4
 	github.com/felixge/fgprof v0.9.5
 	github.com/go-jose/go-jose/v4 v4.1.4

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/couchbasedeps/fast-skiplist v0.0.0-20250722125747-e0dd031fe2ac
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338
 	github.com/couchbaselabs/gocbconnstr v1.0.5
-	github.com/couchbaselabs/rosmar v0.0.0-20260522133614-eef7ba1bcfb4
+	github.com/couchbaselabs/rosmar v0.0.0-20260522154900-f5966898bbe8
 	github.com/elastic/gosigar v0.14.4
 	github.com/felixge/fgprof v0.9.5
 	github.com/go-jose/go-jose/v4 v4.1.4

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/couchbaselabs/gocbconnstr v1.0.5 h1:e0JokB5qbcz7rfnxEhNRTKz8q1svoRvDo
 github.com/couchbaselabs/gocbconnstr v1.0.5/go.mod h1:KV3fnIKMi8/AzX0O9zOrO9rofEqrRF1d2rG7qqjxC7o=
 github.com/couchbaselabs/gocbconnstr/v2 v2.0.0 h1:HU9DlAYYWR69jQnLN6cpg0fh0hxW/8d5hnglCXXjW78=
 github.com/couchbaselabs/gocbconnstr/v2 v2.0.0/go.mod h1:o7T431UOfFVHDNvMBUmUxpHnhivwv7BziUao/nMl81E=
-github.com/couchbaselabs/rosmar v0.0.0-20260519130433-967376be7244 h1:FcgPhQDxgfUA6n3f3FRQ/+SCNfHZsQva23+3ntqgT0g=
-github.com/couchbaselabs/rosmar v0.0.0-20260519130433-967376be7244/go.mod h1:ozhv5+nbL11OjaaoGwzNasfcmrG1AFr2DLPpvgNhH3U=
+github.com/couchbaselabs/rosmar v0.0.0-20260522133614-eef7ba1bcfb4 h1:aLom6+41n8b32ZQJAQAcTBg0V6hU5k35aUc8GpBEYM0=
+github.com/couchbaselabs/rosmar v0.0.0-20260522133614-eef7ba1bcfb4/go.mod h1:ozhv5+nbL11OjaaoGwzNasfcmrG1AFr2DLPpvgNhH3U=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/couchbaselabs/gocbconnstr v1.0.5 h1:e0JokB5qbcz7rfnxEhNRTKz8q1svoRvDo
 github.com/couchbaselabs/gocbconnstr v1.0.5/go.mod h1:KV3fnIKMi8/AzX0O9zOrO9rofEqrRF1d2rG7qqjxC7o=
 github.com/couchbaselabs/gocbconnstr/v2 v2.0.0 h1:HU9DlAYYWR69jQnLN6cpg0fh0hxW/8d5hnglCXXjW78=
 github.com/couchbaselabs/gocbconnstr/v2 v2.0.0/go.mod h1:o7T431UOfFVHDNvMBUmUxpHnhivwv7BziUao/nMl81E=
-github.com/couchbaselabs/rosmar v0.0.0-20260522133614-eef7ba1bcfb4 h1:aLom6+41n8b32ZQJAQAcTBg0V6hU5k35aUc8GpBEYM0=
-github.com/couchbaselabs/rosmar v0.0.0-20260522133614-eef7ba1bcfb4/go.mod h1:ozhv5+nbL11OjaaoGwzNasfcmrG1AFr2DLPpvgNhH3U=
+github.com/couchbaselabs/rosmar v0.0.0-20260522154900-f5966898bbe8 h1:cAfve1djATVNYl7uhZob6nYn/53LzZCUhgRrrX8xQfc=
+github.com/couchbaselabs/rosmar v0.0.0-20260522154900-f5966898bbe8/go.mod h1:ozhv5+nbL11OjaaoGwzNasfcmrG1AFr2DLPpvgNhH3U=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/couchbaselabs/gocbconnstr v1.0.5 h1:e0JokB5qbcz7rfnxEhNRTKz8q1svoRvDo
 github.com/couchbaselabs/gocbconnstr v1.0.5/go.mod h1:KV3fnIKMi8/AzX0O9zOrO9rofEqrRF1d2rG7qqjxC7o=
 github.com/couchbaselabs/gocbconnstr/v2 v2.0.0 h1:HU9DlAYYWR69jQnLN6cpg0fh0hxW/8d5hnglCXXjW78=
 github.com/couchbaselabs/gocbconnstr/v2 v2.0.0/go.mod h1:o7T431UOfFVHDNvMBUmUxpHnhivwv7BziUao/nMl81E=
-github.com/couchbaselabs/rosmar v0.0.0-20260522154900-f5966898bbe8 h1:cAfve1djATVNYl7uhZob6nYn/53LzZCUhgRrrX8xQfc=
-github.com/couchbaselabs/rosmar v0.0.0-20260522154900-f5966898bbe8/go.mod h1:ozhv5+nbL11OjaaoGwzNasfcmrG1AFr2DLPpvgNhH3U=
+github.com/couchbaselabs/rosmar v0.0.0-20260522160802-db93c1c3935f h1:STvaO6qpfFS2MnA0J5fURzoSeftkIYpGZM/FkrtDWE8=
+github.com/couchbaselabs/rosmar v0.0.0-20260522160802-db93c1c3935f/go.mod h1:ozhv5+nbL11OjaaoGwzNasfcmrG1AFr2DLPpvgNhH3U=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=


### PR DESCRIPTION
This pull request introduces improved testing and correctness for document touch and CAS  behavior across both Couchbase Server and Rosmar implementations.

It adds new tests to verify that CAS handling is consistent and correct, and updates the Rosmar cluster logic to ensure type safety and correct CAS mutation semantics.

**Testing and validation of CAS behavior:**

* Added `TestTouchMetadataDocument` in `bootstrap_test.go` to verify that `BootstrapConnection.TouchMetadataDocument` enforces CAS correctness—rejecting stale CAS values and bumping the CAS on successful mutation, which is critical for blocking racing writers during registry rollback.
* Added `TestTouchPreservesCAS` in `bucket_gocb_test.go` to confirm that standard `Touch` and `GetAndTouchRaw` operations do not bump the CAS, matching Couchbase Server's memcached semantics. This clarifies that callers needing a CAS bump must use a real mutation.

**Rosmar cluster improvements:**

* Updated `getDefaultDataStore` in `rosmar_cluster.go` to perform a type assertion, ensuring the returned data store is a `*rosmar.Collection`. This allows us to run Rosmar specific methods without doing type assertions elsewhere.
* Modified `TouchMetadataDocument` in `rosmar_cluster.go` to use `TouchXattrWithCas`, ensuring that property updates in metadata documents are CAS-checked and mutate only the intended property rather than the entire document.

## Dependencies (if applicable)
- [x] https://github.com/couchbaselabs/rosmar/pull/75

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/672/
  - known flake: `TestChangeIndexPartitionsStartStopAndRestart`
