### PR TITLE
CBG-5375 fix FlushChannelCache test data races

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -759,24 +759,6 @@ func waitForBGTCompletion(ctx context.Context, waitTimeMax time.Duration, tasks 
 	}
 }
 
-// For testing only!
-func (context *DatabaseContext) RestartListener(ctx context.Context) error {
-	context.mutationListener.Stop(ctx)
-	// Delay needed to properly stop
-	time.Sleep(2 * time.Second)
-	var err error
-	context.mutationListener, err = newChangeListener(context.Bucket.GetName(), context.Options.GroupID, context)
-	if err != nil {
-		return err
-	}
-	context.mutationListener.OnChangeCallback = context.changeCache.DocChanged
-	cacheFeedStatsMap := context.DbStats.Database().CacheFeedMapStats
-	if err := context.mutationListener.Start(ctx, context.Bucket, cacheFeedStatsMap.Map, context.Scopes, context.MetadataStore); err != nil {
-		return err
-	}
-	return nil
-}
-
 // Removes previous versions of Sync Gateway's design docs found on the server
 func (dbCtx *DatabaseContext) RemoveObsoleteDesignDocs(ctx context.Context, previewOnly bool) (removedDesignDocs []string, err error) {
 	ds := dbCtx.Bucket.DefaultDataStore(ctx)

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -211,12 +211,6 @@ func (c *DatabaseCollection) GetRevisionCacheForTest() *collectionRevisionCache 
 	return &c.revisionCache
 }
 
-// FlushChannelCache flush support. Currently test-only - added for unit test access from rest package
-func (c *DatabaseCollection) FlushChannelCache(ctx context.Context) error {
-	base.InfofCtx(ctx, base.KeyCache, "Flushing channel cache")
-	return c.dbCtx.changeCache.Clear(ctx)
-}
-
 // ForceAPIForbiddenErrors returns true if we return 403 vs empty docs. This is controlled at the database level.
 func (c *DatabaseCollection) ForceAPIForbiddenErrors() bool {
 	return c.dbCtx.Options.UnsupportedOptions != nil && c.dbCtx.Options.UnsupportedOptions.ForceAPIForbiddenErrors

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -1169,3 +1169,22 @@ func InitializeDualMetadataStoreIndexes(t *testing.T, ctx context.Context, metad
 	}
 	return nil
 }
+
+// RestartChangeListener stops and restarts the changes feed. If flushCache is true, clear the cache.
+func (db *DatabaseContext) RestartChangeListener(t testing.TB, flushCache bool) {
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db.mutationListener.Stop(ctx)
+
+	require.NoError(t, db.changeCache.Clear(ctx))
+	var err error
+	db.mutationListener, err = newChangeListener(db.Bucket.GetName(), db.Options.GroupID, db)
+	require.NoError(t, err)
+	db.mutationListener.OnChangeCallback = db.changeCache.DocChanged
+	cacheFeedStatsMap := db.DbStats.Database().CacheFeedMapStats
+	require.NoError(t, db.mutationListener.Start(ctx, db.Bucket, cacheFeedStatsMap.Map, db.Scopes, db.MetadataStore))
+}
+
+// FlushChannelCache stops the changes feed, clears the channel and change cache, and restarts the changes feed.
+func (db *DatabaseContext) FlushChannelCache(t testing.TB) {
+	db.RestartChangeListener(t, true)
+}

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -1175,7 +1175,9 @@ func (db *DatabaseContext) RestartChangeListener(t testing.TB, flushCache bool) 
 	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
 	db.mutationListener.Stop(ctx)
 
-	require.NoError(t, db.changeCache.Clear(ctx))
+	if flushCache {
+		require.NoError(t, db.changeCache.Clear(ctx))
+	}
 	var err error
 	db.mutationListener, err = newChangeListener(db.Bucket.GetName(), db.Options.GroupID, db)
 	require.NoError(t, err)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1789,9 +1789,6 @@ func TestWriteTombstonedDocUsingXattrs(t *testing.T) {
 
 }
 
-// Reproduces https://github.com/couchbase/sync_gateway/issues/916.  The test-only RestartListener operation used to simulate a
-// SG restart isn't race-safe, so disabling the test for now.  Should be possible to reinstate this as a proper unit test
-// once we add the ability to take a bucket offline/online.
 func TestLongpollWithWildcard(t *testing.T) {
 	base.LongRunningTest(t)
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1812,10 +1812,7 @@ func TestLongpollWithWildcard(t *testing.T) {
 	// Issue is only reproducible when the wait counter is zero for all requested channels (including the user channel) - the count=0
 	// triggers early termination of the changes loop.  This can only be reproduced if the feed is restarted after the user is created -
 	// otherwise the count for the user pseudo-channel will always be non-zero
-	db, err := rt.ServerContext().GetDatabase(ctx, "db")
-	require.NoError(t, err)
-	err = db.RestartListener(base.TestCtx(t))
-	require.NoError(t, err)
+	rt.GetDatabase().RestartChangeListener(t, false)
 	// Put a document to increment the counter for the * channel
 	rt.PutDoc("lost", `{"channel":["ABC"]}`)
 

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -3432,9 +3432,7 @@ func TestChangesFeedExitDisconnect(t *testing.T) {
 		rt.CreateUser(alice, []string{"*"})
 		rt.CreateTestDoc("doc1")
 		rt.WaitForPendingChanges()
-		collection, ctx := rt.GetSingleTestDatabaseCollection()
-		err := collection.FlushChannelCache(ctx)
-		require.NoError(t, err)
+		rt.GetDatabase().FlushChannelCache(t)
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt,
 			&BlipTesterClientOpts{Username: alice},
 		)

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -931,7 +931,6 @@ func TestChangeWaiterExitOnChangesTermination(t *testing.T) {
 // subsequent requests for the current low sequence value don't return results (avoids loops for
 // longpoll as well as clients doing repeated one-off changes requests - see #1309)
 func TestChangesLoopingWhenLowSequence(t *testing.T) {
-	t.Skip("FIXME")
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyChanges)
 
 	pendingMaxWait := uint32(5)

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -59,8 +59,7 @@ func TestReproduce2383(t *testing.T) {
 	rest.RequireStatus(t, response, 201)
 
 	cacheWaiter.Wait()
-	collection, _ := rt.GetSingleTestDatabaseCollection()
-	assert.NoError(t, collection.FlushChannelCache(ctx))
+	rt.GetDatabase().FlushChannelCache(t)
 
 	leakyDataStore, ok := base.AsLeakyDataStore(rt.TestBucket.GetSingleDataStore())
 	require.True(t, ok)
@@ -932,6 +931,7 @@ func TestChangeWaiterExitOnChangesTermination(t *testing.T) {
 // subsequent requests for the current low sequence value don't return results (avoids loops for
 // longpoll as well as clients doing repeated one-off changes requests - see #1309)
 func TestChangesLoopingWhenLowSequence(t *testing.T) {
+	t.Skip("FIXME")
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyChanges)
 
 	pendingMaxWait := uint32(5)
@@ -1967,9 +1967,7 @@ func TestChangesViewBackfillFromQueryOnly(t *testing.T) {
 
 	cacheWaiter.Wait()
 
-	collection, ctx := rt.GetSingleTestDatabaseCollection()
-	// Flush the channel cache
-	assert.NoError(t, collection.FlushChannelCache(ctx))
+	rt.GetDatabase().FlushChannelCache(t)
 
 	// Initialize query count
 	queryCount := testDb.DbStats.Cache().ViewQueries.Value()
@@ -2025,9 +2023,7 @@ func TestChangesViewBackfillNonContiguousQueryResults(t *testing.T) {
 	}
 	cacheWaiter.Wait()
 
-	collection, ctx := rt.GetSingleTestDatabaseCollection()
-	// Flush the channel cache
-	assert.NoError(t, collection.FlushChannelCache(ctx))
+	rt.GetDatabase().FlushChannelCache(t)
 
 	// Issue a since=0 changes request, with limit less than the number of PBS documents
 
@@ -2099,9 +2095,7 @@ func TestChangesViewBackfillFromPartialQueryOnly(t *testing.T) {
 
 	cacheWaiter.Wait()
 
-	collection, ctx := rt.GetSingleTestDatabaseCollection()
-	// Flush the channel cache
-	assert.NoError(t, collection.FlushChannelCache(ctx))
+	rt.GetDatabase().FlushChannelCache(t)
 
 	// Issue a since=n changes request, where n > 0 and is a non-PBS sequence.  Validate that there's a view-based backfill
 	changesJSON := `{"since":15, "limit":50}`
@@ -2163,9 +2157,7 @@ func TestChangesViewBackfillNoOverlap(t *testing.T) {
 
 	cacheWaiter.Wait()
 
-	collection, ctx := rt.GetSingleTestDatabaseCollection()
-	// Flush the channel cache
-	assert.NoError(t, collection.FlushChannelCache(ctx))
+	rt.GetDatabase().FlushChannelCache(t)
 
 	// Write some more docs to the bucket, with a gap before the first PBS sequence
 	response := rt.SendAdminRequest("PUT", "/{{.keyspace}}/abc11", `{"channels":["ABC"]}`)
@@ -2229,9 +2221,7 @@ func TestChangesViewBackfill(t *testing.T) {
 
 	cacheWaiter.AddAndWait(3)
 
-	collection, ctx := rt.GetSingleTestDatabaseCollection()
-	// Flush the channel cache
-	assert.NoError(t, collection.FlushChannelCache(ctx))
+	rt.GetDatabase().FlushChannelCache(t)
 
 	// Add a few more docs (to increment the channel cache's validFrom)
 	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc4", `{"channels":["PBS"]}`)
@@ -2286,9 +2276,7 @@ func TestChangesViewBackfillStarChannel(t *testing.T) {
 	cacheWaiter.Add(3)
 	cacheWaiter.Wait()
 
-	collection, ctx := rt.GetSingleTestDatabaseCollection()
-	// Flush the channel cache
-	assert.NoError(t, collection.FlushChannelCache(ctx))
+	rt.GetDatabase().FlushChannelCache(t)
 
 	// Add a few more docs (to increment the channel cache's validFrom)
 	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc2", `{"channels":["PBS"]}`)
@@ -2467,9 +2455,7 @@ func TestChangesQueryBackfillWithLimit(t *testing.T) {
 			}
 			cacheWaiter.AddAndWait(test.totalDocuments * 2)
 
-			collection, ctx := rt.GetSingleTestDatabaseCollection()
-			// Flush the channel cache
-			assert.NoError(t, collection.FlushChannelCache(ctx))
+			rt.GetDatabase().FlushChannelCache(t)
 			startQueryCount := testDb.GetChannelQueryCount()
 
 			// Issue a since=0 changes request.
@@ -2525,9 +2511,7 @@ func TestMultichannelChangesQueryBackfillWithLimit(t *testing.T) {
 	}
 	cacheWaiter.AddAndWait(50)
 
-	collection, ctx := rt.GetSingleTestDatabaseCollection()
-	// Flush the channel cache
-	assert.NoError(t, collection.FlushChannelCache(ctx))
+	rt.GetDatabase().FlushChannelCache(t)
 
 	// 1. Issue a since=0 changes request, validate results
 	changesJSON := fmt.Sprintf(`{"since":0}`)
@@ -2540,7 +2524,7 @@ func TestMultichannelChangesQueryBackfillWithLimit(t *testing.T) {
 	}
 
 	// 2. Same again, but with limit on the changes request
-	assert.NoError(t, collection.FlushChannelCache(ctx))
+	rt.GetDatabase().FlushChannelCache(t)
 	changesJSON = fmt.Sprintf(`{"since":0, "limit":25}`)
 	changes = rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, username)
 	require.Len(t, changes.Results, 25)
@@ -2582,9 +2566,7 @@ func TestChangesQueryStarChannelBackfillLimit(t *testing.T) {
 
 	cacheWaiter.AddAndWait(10)
 
-	collection, ctx := rt.GetSingleTestDatabaseCollection()
-	// Flush the channel cache
-	assert.NoError(t, collection.FlushChannelCache(ctx))
+	rt.GetDatabase().FlushChannelCache(t)
 	startQueryCount := testDb.DbStats.Cache().ViewQueries.Value()
 
 	// Issue a since=0 changes request.  Validate that there's a view-based backfill
@@ -2629,9 +2611,7 @@ func TestChangesViewBackfillSlowQuery(t *testing.T) {
 
 	cacheWaiter.Wait()
 
-	collection, ctx := rt.GetSingleTestDatabaseCollection()
-	// Flush the channel cache
-	assert.NoError(t, collection.FlushChannelCache(ctx))
+	rt.GetDatabase().FlushChannelCache(t)
 
 	// Write another doc, to initialize the cache (and guarantee overlap)
 	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc2", `{"channels":["PBS"]}`)
@@ -2953,9 +2933,8 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 		}
 	}
 
-	collection, ctx := rt.GetSingleTestDatabaseCollection()
 	// Active only NO Limit, POST
-	assert.NoError(t, collection.FlushChannelCache(ctx))
+	rt.GetDatabase().FlushChannelCache(t)
 
 	changesJSON = `{"style":"all_docs", "active_only":true}`
 	changes = rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
@@ -2969,7 +2948,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	}
 
 	// Active only with Limit, POST
-	assert.NoError(t, collection.FlushChannelCache(ctx))
+	rt.GetDatabase().FlushChannelCache(t)
 	changesJSON = `{"style":"all_docs", "active_only":true, "limit":5}`
 	changes = rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 5)
@@ -2982,7 +2961,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	}
 
 	// Active only with Limit, GET
-	assert.NoError(t, collection.FlushChannelCache(ctx))
+	rt.GetDatabase().FlushChannelCache(t)
 	changes = rt.GetChanges("/{{.keyspace}}/_changes?style=all_docs&active_only=true&limit=5", "bernard")
 	require.Len(t, changes.Results, 5)
 	for _, entry := range changes.Results {
@@ -2993,7 +2972,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	}
 
 	// Active only with Limit set higher than number of revisions, POST
-	assert.NoError(t, collection.FlushChannelCache(ctx))
+	rt.GetDatabase().FlushChannelCache(t)
 	changesJSON = `{"style":"all_docs", "active_only":true, "limit":15}`
 	changes = rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 8)
@@ -3006,7 +2985,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	}
 
 	// No limit active only, GET, followed by normal (https://github.com/couchbase/sync_gateway/issues/2955)
-	assert.NoError(t, collection.FlushChannelCache(ctx))
+	rt.GetDatabase().FlushChannelCache(t)
 	changes = rt.GetChanges("/{{.keyspace}}/_changes?style=all_docs&active_only=true", "bernard")
 	require.Len(t, changes.Results, 8)
 	for _, entry := range changes.Results {

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -4791,7 +4791,6 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 		remoteURL, err := url.Parse(remoteURLString)
 		require.NoError(t, err)
 
-		ctx2 := passiveRT.Context()
 		ctx1 := activeRT.Context()
 
 		// Create doc1 on activeRT
@@ -4893,7 +4892,7 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		require.NoError(t, passiveRTCollection.FlushChannelCache(ctx2))
+		passiveRT.GetDatabase().FlushChannelCache(t)
 		passiveRT.GetDatabase().FlushRevisionCacheForTest()
 
 		require.NoError(t, ar.Start(ctx1))


### PR DESCRIPTION
CBG-5375 fix FlushChannelCache test data races

- (Refactor only): Moved `RestartListener` to db/util_testing.go so it could directly take `testing.TB`. This function is moved verbatim except removing the unnecessary sleep.
- (Refactor only): Moved `FlushChannelCache` to Database level, since this does not flush a collection level channel cache.
- (Guts of change): Stop the DCP feed before flushing the cache to avoid the data race.

The data race here occurs when flushing the cache resets `c.initialSequence` and `processPrincipalDocument` hits https://github.com/couchbase/sync_gateway/blob/e75b7c206759fe76d44728f19dac67b15f72bcf0/db/change_cache.go#L749 which accesses `c.initialSequence`. This is reproducible with `SG_TEST_CACHING_FEED_DELAY=10ms` or some other non zero values. When I tried to fix one of the tests, I discovered there are issues with all tests that called `FlushChannelCache`.

Initially I thought that a `WaitForPendingSequences` after creating a user would address the problem, but it is more subtle than this.

Given a user "bernard" with access to "ch1", "ch2", "ch3"

If a user is created directly using an authenticator object, using:

```
	a := testDb.Authenticator(ctx)
	testUser, err := a.NewUser(username, "letmein", channels.BaseSetOf(t, "ch1", "ch2", "ch3"))
	assert.NoError(t, err)
	assert.NoError(t, a.Save(testUser))
```

the output would look like this:

```
{
  "name": "user_TestMultichannelChangesQueryBackfillWithLimit",
  "admin_channels": { "ch1": 1, "ch2": 1, "ch3": 1 },
  "all_channels": { "ch3": 1, "!": 1, "ch1": 1, "ch2": 1 },
  "sequence": 0,
  "updated_at": "0001-01-01T00:00:00Z",
  "created_at": "0001-01-01T00:00:00Z",
  "passwordhash_bcrypt": "JDJhJDA0JE04RUc4bkRDeFhCZlgybi44YjQxTmU0WENtemd0by5QaDYwWm5Edm1QbTdYenM2dTYwL1lp",
  "jwt_last_updated": "0001-01-01T00:00:00Z",
  "rolesSince": {},
  "session_uuid": "5d5ba6c2-fc76-48e7-90e9-46bf9a2ef54e"
}
```

This isn't allocated a sequence correctly, so waiting for a sequence isn't right because it would never come so a `WaitForPendingSequence` wouldn't happen.

If the instead the user is created using `rt.CreateUser("bernard", []string{"ch1", "ch2", "ch3"}` then the object will look like this, with sequence=1 and cas=1:

```
{
  "name": "bernard",
  "admin_channels": { "ch2": 1, "ch3": 1, "ch1": 1 },
  "all_channels": { "!": 1 },
  "sequence": 1,
  "channel_inval_seq": 1,
  "updated_at": "2026-05-22T14:17:55.275095Z",
  "created_at": "2026-05-22T14:17:55.263436Z",
  "passwordhash_bcrypt": "JDJhJDA0JEV6TThjLnd1OXpRUmZrTEl3M09ESi5PRmI3MVBBRElGU000NjU3WE9uLjRtdFlqN3VTcDVh",
  "jwt_last_updated": "0001-01-01T00:00:00Z",
  "rolesSince": {},
  "session_uuid": "1fdbcac5-9682-4280-a3d6-09289258fae1"
}
```

Naively, you might think that you could `WaitForPendingSequence` and have the DCP waiter find the principal document. However, this principal document gets mutated on the first login of `bernard` to have cas=2 but sequence=1, in order to turn `channel_inval_seq` to `all_channels`.

```
{
  "name": "bernard",
  "admin_channels": { "ch1": 1, "ch2": 1, "ch3": 1 },
  "all_channels": { "ch2": 1, "ch3": 1, "ch1": 1, "!": 1 },
  "sequence": 1,
  "updated_at": "2026-05-22T14:17:55.275095Z",
  "created_at": "2026-05-22T14:17:55.263436Z",
  "passwordhash_bcrypt": "JDJhJDA0JEV6TThjLnd1OXpRUmZrTEl3M09ESi5PRmI3MVBBRElGU000NjU3WE9uLjRtdFlqN3VTcDVh",
  "jwt_last_updated": "0001-01-01T00:00:00Z",
  "rolesSince": {},
  "session_uuid": "1fdbcac5-9682-4280-a3d6-09289258fae1"
}
```

This means that we can't wait for sequence 1, since we already saw this with cas=1, but we can't be sure that cas=2 document will hit. So `WaitForPendingSequences` doesn't solve this problem. The `DCPReceivedCount` stat isn't incremented for principal documents https://github.com/couchbase/sync_gateway/blob/f36131e06dbb0b7d659ae1aa500a0b56b85febb5/db/change_cache.go#L446 so this also doesn't work.

Since I don't think it is necessary to change the code for the authenticator, I solve both problems by stopping the DCP feed before flushing the cache, so that we know that second DCP entry isn't active. In these tests, it is expected that all the DCP events were received. This is a test-only change that preserves the functionality of the tests without modifying any other code.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/669/
