### PR TITLE
CBG-5366: set sync info to binary document when cluster compat v4.1+

### DIFF
--- a/base/bootstrap.go
+++ b/base/bootstrap.go
@@ -44,6 +44,9 @@ type BootstrapConnection interface {
 	// GetDocument retrieves the document with the specified key from the bucket's default collection.
 	// Returns exists=false if key is not found, returns error for any other error.
 	GetDocument(ctx context.Context, bucket, docID string, rv any) (exists bool, err error)
+	// GetRawDocument retrieves the document with the specified key from the bucket's default collection as raw bytes.
+	// Returns exists=false if key is not found, returns error for any other error.
+	GetRawDocument(ctx context.Context, bucket, docID string) (value []byte, exists bool, err error)
 	// Close releases any long-lived connections
 	Close()
 }
@@ -473,6 +476,32 @@ func (cc *CouchbaseCluster) GetDocument(ctx context.Context, bucketName, docID s
 	}
 	err = getResult.Content(rv)
 	return true, err
+}
+
+// GetRawDocument fetches a document from the default collection as raw bytes.  Does not use configPersistence - callers
+// requiring configPersistence handling should use GetMetadataDocument.
+func (cc *CouchbaseCluster) GetRawDocument(ctx context.Context, bucketName, docID string) (value []byte, exists bool, err error) {
+	if cc == nil {
+		return nil, false, errors.New("nil CouchbaseCluster")
+	}
+	b, teardown, err := cc.getBucket(ctx, bucketName)
+	if err != nil {
+		return nil, false, err
+	}
+
+	defer teardown()
+	getOptions := &gocb.GetOptions{
+		Transcoder: NewSGRawTranscoder(),
+	}
+	getResult, err := b.DefaultCollection().Get(docID, getOptions)
+	if err != nil {
+		if errors.Is(err, gocb.ErrDocumentNotFound) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	err = getResult.Content(&value)
+	return value, true, err
 }
 
 // Close calls teardown for any cached buckets and removes from cachedBucketConnections

--- a/base/bootstrap_test.go
+++ b/base/bootstrap_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"dario.cat/mergo"
+	"github.com/couchbaselabs/rosmar"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -129,4 +130,82 @@ func TestBootstrapRefCounting(t *testing.T) {
 	// make sure you can "remove" a non existent bucket in the case that bucket removal is called multiple times
 	cluster.cachedBucketConnections.removeOutdatedBuckets(SetOf("not-a-bucket"))
 
+}
+
+// newTestBootstrapConnection returns a BootstrapConnection bound to the current test backing store
+// (Rosmar in-memory or Couchbase Server) so a single test can exercise both implementations.
+func newTestBootstrapConnection(t *testing.T) BootstrapConnection {
+	t.Helper()
+	ctx := TestCtx(t)
+	if UnitTestUrlIsWalrus() {
+		cluster, err := NewRosmarCluster(rosmar.InMemoryURL)
+		require.NoError(t, err)
+		t.Cleanup(cluster.Close)
+		return cluster
+	}
+	cluster, err := NewCouchbaseCluster(ctx, TestClusterSpec(t), false, nil, TestUseXattrs(), CachedClusterConnections)
+	require.NoError(t, err)
+	t.Cleanup(cluster.Close)
+	return cluster
+}
+
+func TestBootstrapConnectionGetRawDocument(t *testing.T) {
+	ctx := TestCtx(t)
+	bucket := GetTestBucket(t)
+	defer bucket.Close(ctx)
+	ds := bucket.DefaultDataStore(ctx)
+	bucketName := bucket.GetName()
+
+	cluster := newTestBootstrapConnection(t)
+	const docID = "test_get_raw_doc"
+
+	t.Run("doc absent", func(t *testing.T) {
+		value, exists, err := cluster.GetRawDocument(ctx, bucketName, docID)
+		require.NoError(t, err)
+		require.False(t, exists)
+		require.Nil(t, value)
+	})
+
+	t.Run("legacy JSON", func(t *testing.T) {
+		defer func() { _ = ds.Delete(ctx, docID) }()
+		legacyJSON := []byte(`{"metadataID":"x"}`)
+		require.NoError(t, ds.SetRaw(ctx, docID, 0, nil, legacyJSON))
+
+		value, exists, err := cluster.GetRawDocument(ctx, bucketName, docID)
+		require.NoError(t, err)
+		require.True(t, exists)
+		require.Equal(t, legacyJSON, value)
+		require.Equal(t, byte('{'), value[0])
+	})
+
+	t.Run("V1 binary", func(t *testing.T) {
+		defer func() { _ = ds.Delete(ctx, docID) }()
+		payload := append([]byte{byte(SyncInfoTypeV1)}, []byte(`{"metadataID":"x"}`)...)
+		require.NoError(t, ds.SetRaw(ctx, docID, 0, nil, payload))
+
+		value, exists, err := cluster.GetRawDocument(ctx, bucketName, docID)
+		require.NoError(t, err)
+		require.True(t, exists)
+		require.Equal(t, payload, value)
+		require.Equal(t, byte(SyncInfoTypeV1), value[0])
+	})
+}
+
+// TestBootstrapConnectionGetDocumentExists GetDocument must report exists=true for a doc that exists.
+func TestBootstrapConnectionGetDocumentExists(t *testing.T) {
+	ctx := TestCtx(t)
+	bucket := GetTestBucket(t)
+	defer bucket.Close(ctx)
+	ds := bucket.DefaultDataStore(ctx)
+	bucketName := bucket.GetName()
+
+	cluster := newTestBootstrapConnection(t)
+
+	const docID = "test_get_doc_exists"
+	require.NoError(t, ds.Set(ctx, docID, 0, nil, []byte(`{"x":1}`)))
+
+	var got map[string]any
+	exists, err := cluster.GetDocument(ctx, bucketName, docID, &got)
+	require.NoError(t, err)
+	require.True(t, exists, "expected GetDocument to report exists=true for an existing doc")
 }

--- a/base/constants_syncdocs.go
+++ b/base/constants_syncdocs.go
@@ -453,9 +453,8 @@ func marshalSyncInfo(syncInfo *SyncInfo, clusterCompatVersion *ClusterCompatVers
 	return payload, nil
 }
 
-// DecodeSyncInfo decodes a raw syncInfo payload, handling the optional version-byte prefix
-// introduced in 4.1. Empty input yields a zero-value SyncInfo with no error so callers can
-// treat "not present" and "present but empty" uniformly.
+// DecodeSyncInfo decodes a raw syncInfo payload, handling the version-byte prefix
+// introduced in ccv 4.1+.
 func DecodeSyncInfo(data []byte) (SyncInfo, error) {
 	var s SyncInfo
 	if len(data) == 0 {

--- a/base/constants_syncdocs.go
+++ b/base/constants_syncdocs.go
@@ -15,6 +15,8 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+
+	sgbucket "github.com/couchbase/sg-bucket"
 )
 
 const SyncDocPrefix = "_sync:"                                 // Prefix for all legacy (non-namespaced) Sync Gateway metadata documents
@@ -453,6 +455,17 @@ func marshalSyncInfo(syncInfo *SyncInfo, clusterCompatVersion *ClusterCompatVers
 	return payload, nil
 }
 
+// syncInfoWriteOpts returns the appropriate WriteOptions for a marshalSyncInfo payload.
+// V1-prefixed payloads must be written as binary datatype. Bare-JSON payloads (ccv < 4.1)
+// continue to be written as JSON datatype so a not-yet-upgraded peer whose reader
+// enforces datatype can still load it.
+func syncInfoWriteOpts(payload []byte) sgbucket.WriteOptions {
+	if len(payload) > 0 && payload[0] == byte(SyncInfoTypeV1) {
+		return sgbucket.Raw
+	}
+	return 0
+}
+
 // DecodeSyncInfo decodes a raw syncInfo payload, handling the version-byte prefix
 // introduced in ccv 4.1+.
 func DecodeSyncInfo(data []byte) (SyncInfo, error) {
@@ -508,9 +521,13 @@ func InitSyncInfo(ctx context.Context, ds DataStore, metadataID string, clusterC
 		if mErr != nil {
 			return true, true, mErr
 		}
-		_, addErr := ds.Add(ctx, SGSyncInfo, 0, payload)
+		// WriteCas with cas=0 inserts the payload, picking the datatype tag from the
+		// payload's prefix (binary for V1, JSON for bare-JSON ccv < 4.1). Using Add here
+		// would unconditionally tag as JSON via SGJSONTranscoder, which loses the binary
+		// datatype needed for V1 payloads.
+		_, writeErr := ds.WriteCas(ctx, SGSyncInfo, 0, 0, payload, syncInfoWriteOpts(payload))
 		switch {
-		case IsCasMismatch(addErr):
+		case IsCasMismatch(writeErr):
 			// attempt new fetch
 			var refound bool
 			syncInfo, refound, err = loadSyncInfo(ctx, ds)
@@ -520,8 +537,8 @@ func InitSyncInfo(ctx context.Context, ds DataStore, metadataID string, clusterC
 			if !refound {
 				return true, true, fmt.Errorf("syncInfo missing after CAS mismatch on add")
 			}
-		case addErr != nil:
-			return true, true, fmt.Errorf("Error adding syncInfo: %v", addErr)
+		case writeErr != nil:
+			return true, true, fmt.Errorf("Error adding syncInfo: %v", writeErr)
 		default:
 			syncInfo = newSyncInfo
 		}
@@ -546,18 +563,39 @@ func (s *SyncInfo) requiresResync(metadataID string) bool {
 }
 
 // updateSyncInfo CAS-updates the syncInfo document by reading it, applying mutate to the
-// decoded value, and writing back in the format dictated by clusterCompatVersion.
+// decoded value, and writing back in the format dictated by clusterCompatVersion. Uses
+// GetRaw + WriteCas with sgbucket.Raw rather than DataStore.Update so the doc can be read
+// and written with binary datatype - gocb's RawJSONTranscoder (used by Update) rejects
+// non-JSON datatypes, and the V1 syncInfo format is byte-prefixed binary. Retries on CAS
+// mismatch indefinitely, mirroring the unbounded retry loop in DataStore.Update.
 func updateSyncInfo(ctx context.Context, ds DataStore, clusterCompatVersion *ClusterCompatVersion, mutate func(*SyncInfo)) error {
-	_, err := ds.Update(ctx, SGSyncInfo, 0, func(current []byte) (updated []byte, expiry *uint32, isDelete bool, err error) {
-		syncInfo, decodeErr := DecodeSyncInfo(current)
-		if decodeErr != nil {
-			return nil, nil, false, decodeErr
+	for {
+		current, cas, getErr := ds.GetRaw(ctx, SGSyncInfo)
+		notFound := IsDocNotFoundError(getErr)
+		if getErr != nil && !notFound {
+			return getErr
+		}
+		var syncInfo SyncInfo
+		if !notFound {
+			decoded, decodeErr := DecodeSyncInfo(current)
+			if decodeErr != nil {
+				return decodeErr
+			}
+			syncInfo = decoded
+		} else {
+			cas = 0
 		}
 		mutate(&syncInfo)
-		bytes, err := marshalSyncInfo(&syncInfo, clusterCompatVersion)
-		return bytes, nil, false, err
-	})
-	return err
+		bytes, marshalErr := marshalSyncInfo(&syncInfo, clusterCompatVersion)
+		if marshalErr != nil {
+			return marshalErr
+		}
+		if _, writeErr := ds.WriteCas(ctx, SGSyncInfo, 0, cas, bytes, syncInfoWriteOpts(bytes)); writeErr == nil {
+			return nil
+		} else if !IsCasMismatch(writeErr) {
+			return writeErr
+		}
+	}
 }
 
 // SetSyncInfoMetadataID sets syncInfo in a DataStore to the specified metadataID, preserving metadata version if present.

--- a/base/constants_syncdocs.go
+++ b/base/constants_syncdocs.go
@@ -28,11 +28,11 @@ const DefaultMetadataID = "_default" // MetadataID assigned to databases that in
 
 const minimumAttachmentMigrationMetadataVersion = "4.0.0" // minimum metadata version that needs to be defined for metadata migration.
 
-type syncInfoMetaVersion byte
+type syncInfoEncodingType byte
 
 const (
 	// SyncInfoTypeUnknown is an unused byte value but here for clarity between the zero value
-	SyncInfoTypeUnknown syncInfoMetaVersion = iota
+	SyncInfoTypeUnknown syncInfoEncodingType = iota
 	// SyncInfoTypeV1 is used to denote a sync info document in version 4.1 and later
 	SyncInfoTypeV1
 )

--- a/base/constants_syncdocs.go
+++ b/base/constants_syncdocs.go
@@ -26,6 +26,15 @@ const DefaultMetadataID = "_default" // MetadataID assigned to databases that in
 
 const minimumAttachmentMigrationMetadataVersion = "4.0.0" // minimum metadata version that needs to be defined for metadata migration.
 
+type syncInfoMetaVersion byte
+
+const (
+	// SyncInfoTypeUnknown is an unused byte value but here for clarity between the zero value
+	SyncInfoTypeUnknown syncInfoMetaVersion = iota
+	// SyncInfoTypeV1 is used to denote a sync info document in version 4.1 and later
+	SyncInfoTypeV1
+)
+
 // Sync Gateway Metadata document types
 type metadataKey int
 
@@ -430,46 +439,100 @@ type SyncInfo struct {
 	MetaDataVersion string  `json:"metadata_version,omitempty"`
 }
 
-// initSyncInfo attempts to initialize syncInfo for a datastore
-//  1. If syncInfo doesn't exist, it is created for the specified metadataID
-//  2. If syncInfo exists with a matching metadataID, returns requiresResync=false
-//  3. If syncInfo exists with a non-matching metadataID, returns requiresResync=true
-//     If syncInfo exists and has metaDataVersion greater than or equal to 4.0, return requiresAttachmentMigration=false, else requiresAttachmentMigration=true to bring migrate metadata attachments.
-func InitSyncInfo(ctx context.Context, ds DataStore, metadataID string) (requiresResync bool, requiresAttachmentMigration bool, err error) {
+// marshalSyncInfo serialises a SyncInfo, prepending the V1 version byte when the cluster
+// has rolled forward to 4.1+. Older clusters keep writing bare JSON so a not-yet-upgraded
+// peer can still read the document.
+func marshalSyncInfo(syncInfo *SyncInfo, clusterCompatVersion *ClusterCompatVersion) ([]byte, error) {
+	payload, err := JSONMarshal(syncInfo)
+	if err != nil {
+		return nil, fmt.Errorf("Error marshalling syncInfo: %v", err)
+	}
+	if clusterCompatVersion != nil && clusterCompatVersion.AtLeast(4, 1) {
+		payload = append([]byte{byte(SyncInfoTypeV1)}, payload...)
+	}
+	return payload, nil
+}
 
-	var syncInfo SyncInfo
-	_, fetchErr := ds.Get(ctx, SGSyncInfo, &syncInfo)
+// DecodeSyncInfo decodes a raw syncInfo payload, handling the optional version-byte prefix
+// introduced in 4.1. Empty input yields a zero-value SyncInfo with no error so callers can
+// treat "not present" and "present but empty" uniformly.
+func DecodeSyncInfo(data []byte) (SyncInfo, error) {
+	var s SyncInfo
+	if len(data) == 0 {
+		return s, nil
+	}
+	switch {
+	case data[0] == '{':
+		// legacy bare-JSON encoding
+	case data[0] == byte(SyncInfoTypeV1):
+		data = data[1:]
+	default:
+		return s, fmt.Errorf("unrecognized syncInfo version byte: 0x%02x", data[0])
+	}
+	if err := JSONUnmarshal(data, &s); err != nil {
+		return s, fmt.Errorf("Error unmarshalling syncInfo: %v", err)
+	}
+	return s, nil
+}
+
+// loadSyncInfo fetches and decodes syncInfo for a datastore. found=false means the doc does
+// not exist; found=true with a zero-value SyncInfo means the doc exists but is empty.
+func loadSyncInfo(ctx context.Context, ds DataStore) (syncInfo SyncInfo, found bool, err error) {
+	raw, _, fetchErr := ds.GetRaw(ctx, SGSyncInfo)
 	if IsDocNotFoundError(fetchErr) {
+		return SyncInfo{}, false, nil
+	}
+	if fetchErr != nil {
+		return SyncInfo{}, false, fmt.Errorf("Error retrieving syncInfo: %v", fetchErr)
+	}
+	s, err := DecodeSyncInfo(raw)
+	return s, true, err
+}
+
+// InitSyncInfo attempts to initialize syncInfo for a datastore.
+//  1. If syncInfo doesn't exist, it is created for the specified metadataID.
+//  2. If syncInfo exists with a matching metadataID, returns requiresResync=false.
+//  3. If syncInfo exists with a non-matching metadataID, returns requiresResync=true.
+//     If syncInfo exists and has metaDataVersion >= 4.0, returns requiresAttachmentMigration=false,
+//     otherwise requiresAttachmentMigration=true to migrate metadata attachments.
+func InitSyncInfo(ctx context.Context, ds DataStore, metadataID string, clusterCompatVersion *ClusterCompatVersion) (requiresResync bool, requiresAttachmentMigration bool, err error) {
+	syncInfo, found, err := loadSyncInfo(ctx, ds)
+	if err != nil {
+		return true, true, err
+	}
+	if !found {
 		if metadataID == "" {
 			return false, true, nil
 		}
-		newSyncInfo := &SyncInfo{MetadataID: Ptr(metadataID)}
-		_, addErr := ds.Add(ctx, SGSyncInfo, 0, newSyncInfo)
-		if IsCasMismatch(addErr) {
+		newSyncInfo := SyncInfo{MetadataID: Ptr(metadataID)}
+		payload, mErr := marshalSyncInfo(&newSyncInfo, clusterCompatVersion)
+		if mErr != nil {
+			return true, true, mErr
+		}
+		_, addErr := ds.Add(ctx, SGSyncInfo, 0, payload)
+		switch {
+		case IsCasMismatch(addErr):
 			// attempt new fetch
-			_, fetchErr = ds.Get(ctx, SGSyncInfo, &syncInfo)
-			if fetchErr != nil {
-				return true, true, fmt.Errorf("Error retrieving syncInfo (after failed add): %v", fetchErr)
+			var refound bool
+			syncInfo, refound, err = loadSyncInfo(ctx, ds)
+			if err != nil {
+				return true, true, fmt.Errorf("Error retrieving syncInfo (after failed add): %v", err)
 			}
-		} else if addErr != nil {
+			if !refound {
+				return true, true, fmt.Errorf("syncInfo missing after CAS mismatch on add")
+			}
+		case addErr != nil:
 			return true, true, fmt.Errorf("Error adding syncInfo: %v", addErr)
+		default:
+			syncInfo = newSyncInfo
 		}
-		requiresResync = syncInfo.requiresResync(metadataID)
-		requiresAttachmentMigration, err = CompareMetadataVersion(ctx, syncInfo.MetaDataVersion)
-		if err != nil {
-			return requiresResync, true, err
-		}
-		return requiresResync, requiresAttachmentMigration, nil
-	} else if fetchErr != nil {
-		return true, true, fmt.Errorf("Error retrieving syncInfo: %v", fetchErr)
 	}
+
 	requiresResync = syncInfo.requiresResync(metadataID)
-	// check for meta version, if we don't have meta version of 4.0 we need to run migration job
 	requiresAttachmentMigration, err = CompareMetadataVersion(ctx, syncInfo.MetaDataVersion)
 	if err != nil {
 		return requiresResync, true, err
 	}
-
 	return requiresResync, requiresAttachmentMigration, nil
 }
 
@@ -483,48 +546,40 @@ func (s *SyncInfo) requiresResync(metadataID string) bool {
 	return *s.MetadataID != metadataID
 }
 
-// SetSyncInfoMetadataID sets syncInfo in a DataStore to the specified metadataID, preserving metadata version if present
-func SetSyncInfoMetadataID(ctx context.Context, ds DataStore, metadataID string) error {
-
-	// If the metadataID isn't defined, don't persist SyncInfo.  Defensive handling for legacy use cases.
-	if metadataID == "" {
-		return nil
-	}
+// updateSyncInfo CAS-updates the syncInfo document by reading it, applying mutate to the
+// decoded value, and writing back in the format dictated by clusterCompatVersion.
+func updateSyncInfo(ctx context.Context, ds DataStore, clusterCompatVersion *ClusterCompatVersion, mutate func(*SyncInfo)) error {
 	_, err := ds.Update(ctx, SGSyncInfo, 0, func(current []byte) (updated []byte, expiry *uint32, isDelete bool, err error) {
-		var syncInfo SyncInfo
-		if current != nil {
-			parseErr := JSONUnmarshal(current, &syncInfo)
-			if parseErr != nil {
-				return nil, nil, false, parseErr
-			}
+		syncInfo, decodeErr := DecodeSyncInfo(current)
+		if decodeErr != nil {
+			return nil, nil, false, decodeErr
 		}
-		// if we have a metadataID to set, set it preserving the metadata version if present
-		syncInfo.MetadataID = Ptr(metadataID)
-		bytes, err := JSONMarshal(&syncInfo)
+		mutate(&syncInfo)
+		bytes, err := marshalSyncInfo(&syncInfo, clusterCompatVersion)
 		return bytes, nil, false, err
 	})
 	return err
 }
 
-// SetSyncInfoMetaVersion sets sync info in DataStore to specified metadata version, preserving metadataID if present
-func SetSyncInfoMetaVersion(ctx context.Context, ds DataStore, metaVersion string) error {
+// SetSyncInfoMetadataID sets syncInfo in a DataStore to the specified metadataID, preserving metadata version if present.
+func SetSyncInfoMetadataID(ctx context.Context, ds DataStore, metadataID string, clusterCompatVersion *ClusterCompatVersion) error {
+	// If the metadataID isn't defined, don't persist SyncInfo.  Defensive handling for legacy use cases.
+	if metadataID == "" {
+		return nil
+	}
+	return updateSyncInfo(ctx, ds, clusterCompatVersion, func(s *SyncInfo) {
+		s.MetadataID = Ptr(metadataID)
+	})
+}
+
+// SetSyncInfoMetaVersion sets syncInfo in a DataStore to the specified metadata version, preserving metadataID if present.
+func SetSyncInfoMetaVersion(ctx context.Context, ds DataStore, metaVersion string, clusterCompatVersion *ClusterCompatVersion) error {
 	if metaVersion == "" {
 		return nil
 	}
-	_, err := ds.Update(ctx, SGSyncInfo, 0, func(current []byte) (updated []byte, expiry *uint32, isDelete bool, err error) {
-		var syncInfo SyncInfo
-		if current != nil {
-			parseErr := JSONUnmarshal(current, &syncInfo)
-			if parseErr != nil {
-				return nil, nil, false, parseErr
-			}
-		}
-		// if we have a meta version to set, set it preserving the metadata ID if present
-		syncInfo.MetaDataVersion = metaVersion
-		bytes, err := JSONMarshal(&syncInfo)
-		return bytes, nil, false, err
+	return updateSyncInfo(ctx, ds, clusterCompatVersion, func(s *SyncInfo) {
+		s.MetaDataVersion = metaVersion
 	})
-	return err
 }
 
 // SerializeIfLonger returns name as a sha1 string if the length of the name is greater or equal to the length specified. Otherwise, returns the original string.

--- a/base/constants_syncdocs_test.go
+++ b/base/constants_syncdocs_test.go
@@ -296,10 +296,6 @@ func TestInitSyncInfoErrors(t *testing.T) {
 	shouldFailAdd := atomic.Bool{}
 	expectedMetadataID := "metadataID"
 
-	missingErrorMsg := "missing"
-	if !UnitTestUrlIsWalrus() {
-		missingErrorMsg = "not found"
-	}
 	testCases := []struct {
 		name                        string
 		expectedError               string
@@ -324,7 +320,7 @@ func TestInitSyncInfoErrors(t *testing.T) {
 			addCallback: func(docID string) (bool, error) {
 				return false, sgbucket.CasMismatchErr{}
 			},
-			expectedError: missingErrorMsg,
+			expectedError: "syncInfo missing after CAS mismatch on add",
 		},
 		{
 			name:                        "single cas error, get replacement with metadataID=match, no metadataVersion",
@@ -449,7 +445,7 @@ func TestInitSyncInfoErrors(t *testing.T) {
 			}()
 			shouldFailAdd.Store(false)
 			ds.config.AddCallback = test.addCallback
-			requiresResync, requiresAttachmentMigration, err := InitSyncInfo(ctx, ds, expectedMetadataID)
+			requiresResync, requiresAttachmentMigration, err := InitSyncInfo(ctx, ds, expectedMetadataID, nil)
 			if test.expectedError != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), test.expectedError)
@@ -458,6 +454,196 @@ func TestInitSyncInfoErrors(t *testing.T) {
 			}
 			require.Equal(t, test.requiresResync, requiresResync, "Expected requiresResync to be %t", test.requiresResync)
 			require.Equal(t, test.requiresAttachmentMigration, requiresAttachmentMigration, "Expected requiresAttachmentMigration to be %t", test.requiresAttachmentMigration)
+		})
+	}
+}
+
+func TestInitSyncInfoBinaryFormat(t *testing.T) {
+	ctx := TestCtx(t)
+	bucket := GetTestBucket(t)
+	defer bucket.Close(ctx)
+	ds := bucket.DefaultDataStore(ctx)
+
+	ccv40 := NewClusterCompatVersion(4, 0)
+	ccv41 := NewClusterCompatVersion(4, 1)
+
+	resetDoc := func(t *testing.T) {
+		err := ds.Delete(ctx, SGSyncInfo)
+		if err != nil && !IsDocNotFoundError(err) {
+			require.NoError(t, err)
+		}
+	}
+
+	t.Run("no doc, ccv 4.1 writes V1 prefix", func(t *testing.T) {
+		resetDoc(t)
+		_, _, err := InitSyncInfo(ctx, ds, "x", &ccv41)
+		require.NoError(t, err)
+		raw, _, err := ds.GetRaw(ctx, SGSyncInfo)
+		require.NoError(t, err)
+		require.NotEmpty(t, raw)
+		require.Equal(t, byte(SyncInfoTypeV1), raw[0], "expected V1 prefix byte")
+		decoded, err := DecodeSyncInfo(raw)
+		require.NoError(t, err)
+		require.Equal(t, "x", *decoded.MetadataID)
+	})
+
+	t.Run("no doc, ccv 4.0 writes legacy JSON", func(t *testing.T) {
+		resetDoc(t)
+		_, _, err := InitSyncInfo(ctx, ds, "x", &ccv40)
+		require.NoError(t, err)
+		raw, _, err := ds.GetRaw(ctx, SGSyncInfo)
+		require.NoError(t, err)
+		require.NotEmpty(t, raw)
+		require.Equal(t, byte('{'), raw[0], "expected legacy JSON")
+	})
+
+	t.Run("V1 prefixed doc readable with ccv=nil (forward-compat)", func(t *testing.T) {
+		resetDoc(t)
+		payload := append([]byte{byte(SyncInfoTypeV1)}, []byte(`{"metadataID":"x"}`)...)
+		require.NoError(t, ds.SetRaw(ctx, SGSyncInfo, 0, nil, payload))
+		requiresResync, _, err := InitSyncInfo(ctx, ds, "x", nil)
+		require.NoError(t, err)
+		require.False(t, requiresResync)
+	})
+
+	t.Run("V1 prefixed doc round-trip at ccv=4.1", func(t *testing.T) {
+		resetDoc(t)
+		payload := append([]byte{byte(SyncInfoTypeV1)}, []byte(`{"metadataID":"x","metadata_version":"4.0.0"}`)...)
+		require.NoError(t, ds.SetRaw(ctx, SGSyncInfo, 0, nil, payload))
+		requiresResync, requiresAttachmentMigration, err := InitSyncInfo(ctx, ds, "x", &ccv41)
+		require.NoError(t, err)
+		require.False(t, requiresResync)
+		require.False(t, requiresAttachmentMigration)
+	})
+
+	t.Run("corrupt leading byte propagates decode error", func(t *testing.T) {
+		resetDoc(t)
+		payload := append([]byte{0xff}, []byte(`{"metadataID":"x"}`)...)
+		require.NoError(t, ds.SetRaw(ctx, SGSyncInfo, 0, nil, payload))
+		_, _, err := InitSyncInfo(ctx, ds, "x", nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unrecognized syncInfo version byte")
+	})
+}
+
+func TestSetSyncInfoBinaryFormat(t *testing.T) {
+	ctx := TestCtx(t)
+	bucket := GetTestBucket(t)
+	defer bucket.Close(ctx)
+	ds := bucket.DefaultDataStore(ctx)
+
+	ccv41 := NewClusterCompatVersion(4, 1)
+
+	resetDoc := func(t *testing.T) {
+		err := ds.Delete(ctx, SGSyncInfo)
+		if err != nil && !IsDocNotFoundError(err) {
+			require.NoError(t, err)
+		}
+	}
+
+	t.Run("legacy JSON doc upgraded to V1 on SetSyncInfoMetadataID at ccv 4.1", func(t *testing.T) {
+		resetDoc(t)
+		require.NoError(t, ds.SetRaw(ctx, SGSyncInfo, 0, nil, []byte(`{"metadataID":"y","metadata_version":"4.0.0"}`)))
+
+		require.NoError(t, SetSyncInfoMetadataID(ctx, ds, "x", &ccv41))
+
+		raw, _, err := ds.GetRaw(ctx, SGSyncInfo)
+		require.NoError(t, err)
+		require.NotEmpty(t, raw)
+		require.Equal(t, byte(SyncInfoTypeV1), raw[0], "expected V1 prefix byte after Set at ccv 4.1")
+		decoded, err := DecodeSyncInfo(raw)
+		require.NoError(t, err)
+		require.Equal(t, "x", *decoded.MetadataID, "metadataID should be updated")
+		require.Equal(t, "4.0.0", decoded.MetaDataVersion, "metaVersion should be preserved")
+	})
+
+	t.Run("legacy JSON doc upgraded to V1 on SetSyncInfoMetaVersion at ccv 4.1", func(t *testing.T) {
+		resetDoc(t)
+		require.NoError(t, ds.SetRaw(ctx, SGSyncInfo, 0, nil, []byte(`{"metadataID":"y","metadata_version":"3.0.0"}`)))
+
+		require.NoError(t, SetSyncInfoMetaVersion(ctx, ds, "4.0.0", &ccv41))
+
+		raw, _, err := ds.GetRaw(ctx, SGSyncInfo)
+		require.NoError(t, err)
+		require.NotEmpty(t, raw)
+		require.Equal(t, byte(SyncInfoTypeV1), raw[0], "expected V1 prefix byte after Set at ccv 4.1")
+		decoded, err := DecodeSyncInfo(raw)
+		require.NoError(t, err)
+		require.Equal(t, "y", *decoded.MetadataID, "metadataID should be preserved")
+		require.Equal(t, "4.0.0", decoded.MetaDataVersion, "metaVersion should be updated")
+	})
+
+	t.Run("corrupt doc surfaces decode error via Set", func(t *testing.T) {
+		resetDoc(t)
+		require.NoError(t, ds.SetRaw(ctx, SGSyncInfo, 0, nil, append([]byte{0xff}, []byte(`{"metadataID":"y"}`)...)))
+
+		err := SetSyncInfoMetadataID(ctx, ds, "x", nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unrecognized syncInfo version byte")
+	})
+
+	t.Run("empty arg is a no-op", func(t *testing.T) {
+		resetDoc(t)
+
+		require.NoError(t, SetSyncInfoMetadataID(ctx, ds, "", nil))
+		require.NoError(t, SetSyncInfoMetaVersion(ctx, ds, "", nil))
+
+		_, _, err := ds.GetRaw(ctx, SGSyncInfo)
+		require.True(t, IsDocNotFoundError(err), "expected no syncInfo doc to be written, got err=%v", err)
+	})
+}
+
+func TestDecodeSyncInfo(t *testing.T) {
+	populated := SyncInfo{MetadataID: Ptr("x"), MetaDataVersion: "4.0.0"}
+	populatedJSON := `{"metadataID":"x","metadata_version":"4.0.0"}`
+
+	testCases := []struct {
+		name        string
+		input       []byte
+		expected    SyncInfo
+		expectedErr string
+	}{
+		{
+			name:     "nil input",
+			input:    nil,
+			expected: SyncInfo{},
+		},
+		{
+			name:     "legacy JSON",
+			input:    []byte(populatedJSON),
+			expected: populated,
+		},
+		{
+			name:     "V1 prefix + JSON",
+			input:    append([]byte{byte(SyncInfoTypeV1)}, []byte(populatedJSON)...),
+			expected: populated,
+		},
+		{
+			name:        "V1 prefix + malformed JSON",
+			input:       append([]byte{byte(SyncInfoTypeV1)}, []byte(`{not json`)...),
+			expectedErr: "Error unmarshalling syncInfo",
+		},
+		{
+			name:        "unknown discriminator 0xFF",
+			input:       append([]byte{0xff}, []byte(populatedJSON)...),
+			expectedErr: "unrecognized syncInfo version byte",
+		},
+		{
+			name:        "SyncInfoTypeUnknown (0x00) is not silently accepted",
+			input:       append([]byte{byte(SyncInfoTypeUnknown)}, []byte(populatedJSON)...),
+			expectedErr: "unrecognized syncInfo version byte",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := DecodeSyncInfo(tc.input)
+			if tc.expectedErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, got)
 		})
 	}
 }

--- a/base/constants_syncdocs_test.go
+++ b/base/constants_syncdocs_test.go
@@ -301,15 +301,15 @@ func TestInitSyncInfoErrors(t *testing.T) {
 		expectedError               string
 		requiresResync              bool
 		requiresAttachmentMigration bool
-		addCallback                 func(docID string) (bool, error)
+		writeCasCallback            func(docID string) (uint64, error)
 	}{
 		{
 
 			name:                        "generic error",
 			requiresResync:              true,
 			requiresAttachmentMigration: true,
-			addCallback: func(docID string) (bool, error) {
-				return false, fmt.Errorf("generic error")
+			writeCasCallback: func(docID string) (uint64, error) {
+				return 0, fmt.Errorf("generic error")
 			},
 			expectedError: "generic error",
 		},
@@ -317,8 +317,8 @@ func TestInitSyncInfoErrors(t *testing.T) {
 			name:                        "single cas error, then empty",
 			requiresResync:              true,
 			requiresAttachmentMigration: true,
-			addCallback: func(docID string) (bool, error) {
-				return false, sgbucket.CasMismatchErr{}
+			writeCasCallback: func(docID string) (uint64, error) {
+				return 0, sgbucket.CasMismatchErr{}
 			},
 			expectedError: "syncInfo missing after CAS mismatch on add",
 		},
@@ -326,15 +326,15 @@ func TestInitSyncInfoErrors(t *testing.T) {
 			name:                        "single cas error, get replacement with metadataID=match, no metadataVersion",
 			requiresResync:              false,
 			requiresAttachmentMigration: true,
-			addCallback: func(docID string) (bool, error) {
+			writeCasCallback: func(docID string) (uint64, error) {
 				if shouldFailAdd.CompareAndSwap(false, true) {
 					newSyncInfo := &SyncInfo{MetadataID: Ptr(expectedMetadataID)}
 					added, err := ds.Add(ctx, docID, 0, newSyncInfo)
 					require.True(t, added)
 					require.NoError(t, err)
-					return false, sgbucket.CasMismatchErr{}
+					return 0, sgbucket.CasMismatchErr{}
 				}
-				return false, nil
+				return 0, nil
 			},
 			expectedError: "",
 		},
@@ -342,7 +342,7 @@ func TestInitSyncInfoErrors(t *testing.T) {
 			name:                        "single cas error, get replacement with metadataID=mismatch, no metadataVersion",
 			requiresResync:              true,
 			requiresAttachmentMigration: true,
-			addCallback: func(docID string) (bool, error) {
+			writeCasCallback: func(docID string) (uint64, error) {
 				if shouldFailAdd.CompareAndSwap(false, true) {
 					newSyncInfo := &SyncInfo{
 						MetadataID: Ptr("another metadataID"),
@@ -350,9 +350,9 @@ func TestInitSyncInfoErrors(t *testing.T) {
 					added, err := ds.Add(ctx, docID, 0, newSyncInfo)
 					require.True(t, added)
 					require.NoError(t, err)
-					return false, sgbucket.CasMismatchErr{}
+					return 0, sgbucket.CasMismatchErr{}
 				}
-				return false, nil
+				return 0, nil
 			},
 			expectedError: "",
 		},
@@ -360,7 +360,7 @@ func TestInitSyncInfoErrors(t *testing.T) {
 			name:                        "single cas error, get replacement with metadataID=match, correct metadataVersion",
 			requiresResync:              false,
 			requiresAttachmentMigration: false,
-			addCallback: func(docID string) (bool, error) {
+			writeCasCallback: func(docID string) (uint64, error) {
 				if shouldFailAdd.CompareAndSwap(false, true) {
 					newSyncInfo := &SyncInfo{
 						MetadataID:      Ptr(expectedMetadataID),
@@ -369,9 +369,9 @@ func TestInitSyncInfoErrors(t *testing.T) {
 					added, err := ds.Add(ctx, docID, 0, newSyncInfo)
 					require.True(t, added)
 					require.NoError(t, err)
-					return false, sgbucket.CasMismatchErr{}
+					return 0, sgbucket.CasMismatchErr{}
 				}
-				return false, nil
+				return 0, nil
 			},
 			expectedError: "",
 		},
@@ -379,7 +379,7 @@ func TestInitSyncInfoErrors(t *testing.T) {
 			name:                        "single cas error, get replacement with metadataID=mismatch, correct metadataVersion",
 			requiresResync:              true,
 			requiresAttachmentMigration: false,
-			addCallback: func(docID string) (bool, error) {
+			writeCasCallback: func(docID string) (uint64, error) {
 				if shouldFailAdd.CompareAndSwap(false, true) {
 					newSyncInfo := &SyncInfo{
 						MetadataID:      Ptr("another metadataID"),
@@ -388,9 +388,9 @@ func TestInitSyncInfoErrors(t *testing.T) {
 					added, err := ds.Add(ctx, docID, 0, newSyncInfo)
 					require.True(t, added)
 					require.NoError(t, err)
-					return false, sgbucket.CasMismatchErr{}
+					return 0, sgbucket.CasMismatchErr{}
 				}
-				return false, nil
+				return 0, nil
 			},
 			expectedError: "",
 		},
@@ -398,7 +398,7 @@ func TestInitSyncInfoErrors(t *testing.T) {
 			name:                        "single cas error, get replacement with metadataID=match, incorrect metadataVersion",
 			requiresResync:              false,
 			requiresAttachmentMigration: true,
-			addCallback: func(docID string) (bool, error) {
+			writeCasCallback: func(docID string) (uint64, error) {
 				if shouldFailAdd.CompareAndSwap(false, true) {
 					newSyncInfo := &SyncInfo{
 						MetadataID:      Ptr(expectedMetadataID),
@@ -407,9 +407,9 @@ func TestInitSyncInfoErrors(t *testing.T) {
 					added, err := ds.Add(ctx, docID, 0, newSyncInfo)
 					require.True(t, added)
 					require.NoError(t, err)
-					return false, sgbucket.CasMismatchErr{}
+					return 0, sgbucket.CasMismatchErr{}
 				}
-				return false, nil
+				return 0, nil
 			},
 			expectedError: "",
 		},
@@ -417,7 +417,7 @@ func TestInitSyncInfoErrors(t *testing.T) {
 			name:                        "single cas error, get replacement with metadataID=mismatch, incorrect metadataVersion",
 			requiresResync:              true,
 			requiresAttachmentMigration: true,
-			addCallback: func(docID string) (bool, error) {
+			writeCasCallback: func(docID string) (uint64, error) {
 				if shouldFailAdd.CompareAndSwap(false, true) {
 					newSyncInfo := &SyncInfo{
 						MetadataID:      Ptr("another metadataID"),
@@ -426,9 +426,9 @@ func TestInitSyncInfoErrors(t *testing.T) {
 					added, err := ds.Add(ctx, docID, 0, newSyncInfo)
 					require.True(t, added)
 					require.NoError(t, err)
-					return false, sgbucket.CasMismatchErr{}
+					return 0, sgbucket.CasMismatchErr{}
 				}
-				return false, nil
+				return 0, nil
 			},
 			expectedError: "",
 		},
@@ -444,7 +444,7 @@ func TestInitSyncInfoErrors(t *testing.T) {
 				assert.NoError(t, err)
 			}()
 			shouldFailAdd.Store(false)
-			ds.config.AddCallback = test.addCallback
+			ds.config.WriteCasCallback = test.writeCasCallback
 			requiresResync, requiresAttachmentMigration, err := InitSyncInfo(ctx, ds, expectedMetadataID, nil)
 			if test.expectedError != "" {
 				require.Error(t, err)

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -160,6 +160,11 @@ type LeakyBucketConfig struct {
 	// AddCallback issues a callback during Add.
 	AddCallback func(key string) (bool, error)
 
+	// WriteCasCallback issues a callback during WriteCas. If it returns a non-nil error,
+	// the underlying WriteCas is skipped and the error is returned as-is. Useful for
+	// injecting CasMismatchErr on the insert/replace path.
+	WriteCasCallback func(key string) (uint64, error)
+
 	CreateIndexIfNotExistsCallback func(indexName string)
 
 	// When IgnoreClose is set to true, bucket.Close() is a no-op.  Used when multiple references to a bucket are active.

--- a/base/leaky_datastore.go
+++ b/base/leaky_datastore.go
@@ -156,6 +156,12 @@ func (lds *LeakyDataStore) Remove(ctx context.Context, k string, cas uint64) (ca
 	return lds.dataStore.Remove(ctx, k, cas)
 }
 func (lds *LeakyDataStore) WriteCas(ctx context.Context, k string, exp uint32, cas uint64, v any, opt sgbucket.WriteOptions) (uint64, error) {
+	if lds.config.WriteCasCallback != nil {
+		casOut, err := lds.config.WriteCasCallback(k)
+		if err != nil {
+			return casOut, err
+		}
+	}
 	return lds.dataStore.WriteCas(ctx, k, exp, cas, v, opt)
 }
 func (lds *LeakyDataStore) Update(ctx context.Context, k string, exp uint32, callback sgbucket.UpdateFunc) (casOut uint64, err error) {

--- a/base/rosmar_cluster.go
+++ b/base/rosmar_cluster.go
@@ -222,8 +222,23 @@ func (c *RosmarCluster) GetDocument(ctx context.Context, bucketName, docID strin
 	if IsDocNotFoundError(err) {
 		return false, nil
 	}
-	return err != nil, err
+	return err == nil, err
+}
 
+// GetRawDocument fetches a document from the default collection as raw bytes.  Does not use configPersistence - callers
+// requiring configPersistence handling should use GetMetadataDocument.
+func (c *RosmarCluster) GetRawDocument(ctx context.Context, bucket, docID string) (value []byte, exists bool, err error) {
+	ds, closer, err := c.getDefaultDataStore(ctx, bucket)
+	if err != nil {
+		return nil, false, err
+	}
+	defer closer(ctx)
+
+	value, _, err = ds.GetRaw(ctx, docID)
+	if IsDocNotFoundError(err) {
+		return nil, false, nil
+	}
+	return value, err == nil, err
 }
 
 // Close calls teardown for any cached buckets and removes from cachedBucketConnections

--- a/db/background_mgr_attachment_migration.go
+++ b/db/background_mgr_attachment_migration.go
@@ -197,7 +197,11 @@ func (a *AttachmentMigrationManager) Run(ctx context.Context, options map[string
 		// set sync info metadata version
 		for _, collectionID := range currCollectionIDs {
 			dbc := db.CollectionByID[collectionID]
-			if err := base.SetSyncInfoMetaVersion(ctx, dbc.dataStore, MetaVersionValue); err != nil {
+			var ccv *base.ClusterCompatVersion
+			if a.databaseCtx.Options.ClusterCompatVersion != nil {
+				ccv = a.databaseCtx.Options.ClusterCompatVersion()
+			}
+			if err := base.SetSyncInfoMetaVersion(ctx, dbc.dataStore, MetaVersionValue, ccv); err != nil {
 				base.WarnfCtx(ctx, "[%s] Completed attachment migration, but unable to update syncInfo for collection %s: %v", migrationLoggingID, dbc.Name, err)
 				return err
 			}

--- a/db/background_mgr_attachment_migration_test.go
+++ b/db/background_mgr_attachment_migration_test.go
@@ -311,3 +311,42 @@ func TestAttachmentMigrationCheckpointPrefix(t *testing.T) {
 		})
 	}
 }
+
+// TestAttachmentMigrationWritesV1SyncInfoAtCcv41 verifies the end-to-end wiring from
+// DatabaseContextOptions.ClusterCompatVersion through AttachmentMigrationManager.Run into
+// base.SetSyncInfoMetaVersion — when ccv>=4.1 the syncInfo doc is written with the V1
+// version-byte prefix.
+func TestAttachmentMigrationWritesV1SyncInfoAtCcv41(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
+
+	ccv := base.NewClusterCompatVersion(4, 1)
+	db.Options.ClusterCompatVersion = func() *base.ClusterCompatVersion { return &ccv }
+
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+
+	for i := range 3 {
+		docBody := Body{
+			"value":         1234,
+			BodyAttachments: map[string]any{"myatt": map[string]any{"content_type": "text/plain", "data": "SGVsbG8gV29ybGQh"}},
+		}
+		key := fmt.Sprintf("%s_%d", t.Name(), i)
+		_, _, err := collection.Put(ctx, key, docBody)
+		require.NoError(t, err)
+	}
+	// move one doc's attachment metadata so the migration has work to do
+	key := fmt.Sprintf("%s_0", t.Name())
+	value, _, err := collection.dataStore.GetRaw(ctx, key)
+	require.NoError(t, err)
+	MoveAttachmentXattrFromGlobalToSync(t, collection.dataStore, key, value, true)
+
+	mgr := NewAttachmentMigrationManager(db.DatabaseContext)
+	require.NotNil(t, mgr)
+	require.NoError(t, mgr.Start(ctx, nil))
+	RequireBackgroundManagerState(t, mgr, BackgroundProcessStateCompleted)
+
+	raw, _, err := collection.dataStore.GetRaw(ctx, base.SGSyncInfo)
+	require.NoError(t, err)
+	require.NotEmpty(t, raw)
+	require.Equal(t, byte(base.SyncInfoTypeV1), raw[0], "expected V1 prefix byte from attachment migration write at ccv 4.1")
+}

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -384,7 +384,11 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 				if !ok {
 					base.WarnfCtx(ctx, "Completed resync, but unable to update syncInfo for collection %v (not found)", collectionID)
 				}
-				if err := base.SetSyncInfoMetadataID(ctx, dbc.dataStore, db.DatabaseContext.Options.MetadataID); err != nil {
+				var ccv *base.ClusterCompatVersion
+				if db.Options.ClusterCompatVersion != nil {
+					ccv = db.Options.ClusterCompatVersion()
+				}
+				if err := base.SetSyncInfoMetadataID(ctx, dbc.dataStore, db.DatabaseContext.Options.MetadataID, ccv); err != nil {
 					base.WarnfCtx(ctx, "Completed resync, but unable to update syncInfo for collection %v: %v", collectionID, err)
 				}
 				updatedDsNames[base.ScopeAndCollectionName{Scope: dbc.ScopeName, Collection: dbc.Name}] = struct{}{}

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -937,3 +937,33 @@ func resyncTestModes() []resyncTestCase {
 	}
 	return testCases
 }
+
+// TestResyncManagerDCPWritesV1SyncInfoAtCcv41 verifies the end-to-end wiring from
+// DatabaseContextOptions.ClusterCompatVersion through ResyncManagerDCP.Run into
+// base.SetSyncInfoMetadataID — when ccv>=4.1 the syncInfo doc is written with the V1
+// version-byte prefix. regenerateSequences=true is required so the syncInfo update path runs.
+func TestResyncManagerDCPWritesV1SyncInfoAtCcv41(t *testing.T) {
+	docsToCreate := 10
+	db, ctx := setupTestDBForResyncWithDocs(t, docsToCreate, true)
+	defer db.Close(ctx)
+
+	ccv := base.NewClusterCompatVersion(4, 1)
+	db.Options.ClusterCompatVersion = func() *base.ClusterCompatVersion { return &ccv }
+	// Resync only writes syncInfo when MetadataID is non-empty (SetSyncInfoMetadataID is a no-op otherwise).
+	db.Options.MetadataID = "test_resync_md_id"
+
+	dbc, _ := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+
+	options := map[string]any{
+		"database":            db,
+		"regenerateSequences": true,
+		"collections":         base.NewCollectionNames(),
+	}
+	require.NoError(t, db.ResyncManager.Start(ctx, options))
+	RequireBackgroundManagerState(t, db.ResyncManager, BackgroundProcessStateCompleted)
+
+	raw, _, err := dbc.dataStore.GetRaw(ctx, base.SGSyncInfo)
+	require.NoError(t, err)
+	require.NotEmpty(t, raw)
+	require.Equal(t, byte(base.SyncInfoTypeV1), raw[0], "expected V1 prefix byte from resync write at ccv 4.1")
+}

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -944,7 +944,11 @@ func resyncTestModes() []resyncTestCase {
 // version-byte prefix. regenerateSequences=true is required so the syncInfo update path runs.
 func TestResyncManagerDCPWritesV1SyncInfoAtCcv41(t *testing.T) {
 	docsToCreate := 10
-	db, ctx := setupTestDBForResyncWithDocs(t, docsToCreate, true)
+	opts := testDBForResyncOptions{
+		docsToCreate:                 docsToCreate,
+		updateSyncFuncAfterDocsAdded: true,
+	}
+	db, ctx := setupTestDBForResyncWithDocs(t, opts)
 	defer db.Close(ctx)
 
 	ccv := base.NewClusterCompatVersion(4, 1)

--- a/db/database.go
+++ b/db/database.go
@@ -210,16 +210,17 @@ type DatabaseContextOptions struct {
 	BlipStatsReportingInterval       int64          // interval to report blip stats in milliseconds
 	ChangesRequestPlus               bool           // Sets the default value for request_plus, for non-continuous changes feeds
 	ConfigPrincipals                 *ConfigPrincipals
-	TestPurgeIntervalOverride        *time.Duration    // If set, use this value for db.GetMetadataPurgeInterval - test seam to force specific purge interval for tests
-	TestVersionPruningWindowOverride *time.Duration    // If set, use this value for db.GetVersionPruningWindow - test seam to force specific pruning window for tests
-	LoggingConfig                    *base.DbLogConfig // Per-database log configuration
-	MaxConcurrentChangesBatches      *int              // Maximum number of changes batches to process concurrently per replication
-	MaxConcurrentRevs                *int              // Maximum number of revs to process concurrently per replication
-	NumIndexReplicas                 uint              // Number of replicas for GSI indexes
-	NumIndexPartitions               *uint32           // Number of partitions for GSI indexes, if not set will default to 1
-	ImportVersion                    uint64            // Version included in import DCP checkpoints, incremented when collections added to db
-	DisablePublicAllDocs             bool              // Disable public access to the _all_docs endpoint for this database
-	StoreLegacyRevTreeData           *bool             // Whether to store additional data for legacy rev tree support in delta sync and replication backup revs
+	TestPurgeIntervalOverride        *time.Duration                    // If set, use this value for db.GetMetadataPurgeInterval - test seam to force specific purge interval for tests
+	TestVersionPruningWindowOverride *time.Duration                    // If set, use this value for db.GetVersionPruningWindow - test seam to force specific pruning window for tests
+	LoggingConfig                    *base.DbLogConfig                 // Per-database log configuration
+	MaxConcurrentChangesBatches      *int                              // Maximum number of changes batches to process concurrently per replication
+	MaxConcurrentRevs                *int                              // Maximum number of revs to process concurrently per replication
+	NumIndexReplicas                 uint                              // Number of replicas for GSI indexes
+	NumIndexPartitions               *uint32                           // Number of partitions for GSI indexes, if not set will default to 1
+	ImportVersion                    uint64                            // Version included in import DCP checkpoints, incremented when collections added to db
+	DisablePublicAllDocs             bool                              // Disable public access to the _all_docs endpoint for this database
+	StoreLegacyRevTreeData           *bool                             // Whether to store additional data for legacy rev tree support in delta sync and replication backup revs
+	ClusterCompatVersion             func() *base.ClusterCompatVersion // ClusterCompatVersion returns the current cluster-wide minimum SG version, or nil if not yet known.
 }
 
 type ConfigPrincipals struct {

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -4656,8 +4656,8 @@ func TestSettingSyncInfo(t *testing.T) {
 	collection, _ := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 	ds := collection.GetCollectionDatastore()
 
-	require.NoError(t, base.SetSyncInfoMetaVersion(ctx, ds, "1"))
-	require.NoError(t, base.SetSyncInfoMetadataID(ctx, ds, "someID"))
+	require.NoError(t, base.SetSyncInfoMetaVersion(ctx, ds, "1", nil))
+	require.NoError(t, base.SetSyncInfoMetadataID(ctx, ds, "someID", nil))
 
 	// assert that after above operations meta version is preserved after setting of metadataID
 	var syncInfo base.SyncInfo
@@ -4671,8 +4671,8 @@ func TestSettingSyncInfo(t *testing.T) {
 	// remove sync info to test another permutation
 	require.NoError(t, ds.Delete(ctx, base.SGSyncInfo))
 
-	require.NoError(t, base.SetSyncInfoMetadataID(ctx, ds, "someID"))
-	require.NoError(t, base.SetSyncInfoMetaVersion(ctx, ds, "1"))
+	require.NoError(t, base.SetSyncInfoMetadataID(ctx, ds, "someID", nil))
+	require.NoError(t, base.SetSyncInfoMetaVersion(ctx, ds, "1", nil))
 
 	// assert that after above operations metadataID is preserved after setting of metaVersion
 	syncInfo = base.SyncInfo{}
@@ -4684,7 +4684,7 @@ func TestSettingSyncInfo(t *testing.T) {
 	}, syncInfo)
 
 	// test updating each element in sync info now both elements are defined
-	require.NoError(t, base.SetSyncInfoMetaVersion(ctx, ds, "4"))
+	require.NoError(t, base.SetSyncInfoMetaVersion(ctx, ds, "4", nil))
 	_, err = ds.Get(ctx, base.SGSyncInfo, &syncInfo)
 	require.NoError(t, err)
 	require.Equal(t, base.SyncInfo{
@@ -4692,7 +4692,7 @@ func TestSettingSyncInfo(t *testing.T) {
 		MetadataID:      base.Ptr("someID"),
 	}, syncInfo)
 
-	require.NoError(t, base.SetSyncInfoMetadataID(ctx, ds, "test"))
+	require.NoError(t, base.SetSyncInfoMetadataID(ctx, ds, "test", nil))
 	_, err = ds.Get(ctx, base.SGSyncInfo, &syncInfo)
 	require.NoError(t, err)
 	require.Equal(t, base.SyncInfo{
@@ -4724,15 +4724,15 @@ func TestSetSyncInfoDefaultMetadataID(t *testing.T) {
 	require.NoError(t, ds.Set(ctx, base.SGSyncInfo, 0, nil, oldSyncInfo))
 
 	// InitSyncInfo should detect the mismatch and require resync
-	requiresResync, _, err := base.InitSyncInfo(ctx, ds, db.DatabaseContext.Options.MetadataID)
+	requiresResync, _, err := base.InitSyncInfo(ctx, ds, db.DatabaseContext.Options.MetadataID, nil)
 	require.NoError(t, err)
 	require.True(t, requiresResync)
 
 	// SetSyncInfoMetadataID with the same Options.MetadataID should update the syncInfo document
-	require.NoError(t, base.SetSyncInfoMetadataID(ctx, ds, db.DatabaseContext.Options.MetadataID))
+	require.NoError(t, base.SetSyncInfoMetadataID(ctx, ds, db.DatabaseContext.Options.MetadataID, nil))
 
 	// Subsequent InitSyncInfo should find a match and not require resync
-	requiresResync, _, err = base.InitSyncInfo(ctx, ds, db.DatabaseContext.Options.MetadataID)
+	requiresResync, _, err = base.InitSyncInfo(ctx, ds, db.DatabaseContext.Options.MetadataID, nil)
 	require.NoError(t, err)
 	assert.False(t, requiresResync)
 }
@@ -4791,13 +4791,13 @@ func TestInitSyncInfo(t *testing.T) {
 		t.Run(testcase.name, func(t *testing.T) {
 			ctx := base.TestCtx(t)
 			if testcase.initialMetaID != "" {
-				require.NoError(t, base.SetSyncInfoMetadataID(ctx, ds, testcase.initialMetaID))
+				require.NoError(t, base.SetSyncInfoMetadataID(ctx, ds, testcase.initialMetaID, nil))
 			}
 			if testcase.metaVersion != "" {
-				require.NoError(t, base.SetSyncInfoMetaVersion(ctx, ds, testcase.metaVersion))
+				require.NoError(t, base.SetSyncInfoMetaVersion(ctx, ds, testcase.metaVersion, nil))
 			}
 
-			requireResync, requireMigration, err := base.InitSyncInfo(ctx, ds, testcase.newMetadataID)
+			requireResync, requireMigration, err := base.InitSyncInfo(ctx, ds, testcase.newMetadataID, nil)
 			require.NoError(t, err)
 			if testcase.requireMigration {
 				assert.True(t, requireMigration)
@@ -4827,13 +4827,13 @@ func TestInitSyncInfoRequireMigrationEmptyBucket(t *testing.T) {
 	ds := tb.GetSingleDataStore()
 
 	// test no sync info in bucket and set metadataID, returns requireMigration
-	_, requireMigration, err := base.InitSyncInfo(ctx, ds, "someID")
+	_, requireMigration, err := base.InitSyncInfo(ctx, ds, "someID", nil)
 	require.NoError(t, err)
 	assert.True(t, requireMigration)
 
 	// delete the doc, test no sync info in bucket returns requireMigration
 	require.NoError(t, ds.Delete(ctx, base.SGSyncInfo))
-	_, requireMigration, err = base.InitSyncInfo(ctx, ds, "")
+	_, requireMigration, err = base.InitSyncInfo(ctx, ds, "", nil)
 	require.NoError(t, err)
 	assert.True(t, requireMigration)
 }
@@ -4881,15 +4881,15 @@ func TestInitSyncInfoMetaVersionComparison(t *testing.T) {
 		t.Run(testcase.name, func(t *testing.T) {
 			ctx := base.TestCtx(t)
 			// set sync info with no metaversion
-			require.NoError(t, base.SetSyncInfoMetadataID(ctx, ds, testcase.metadataID))
+			require.NoError(t, base.SetSyncInfoMetadataID(ctx, ds, testcase.metadataID, nil))
 
 			if testcase.metaVersion == "" {
-				_, requireMigration, err := base.InitSyncInfo(ctx, ds, "someID")
+				_, requireMigration, err := base.InitSyncInfo(ctx, ds, "someID", nil)
 				require.NoError(t, err)
 				assert.True(t, requireMigration)
 			} else {
-				require.NoError(t, base.SetSyncInfoMetaVersion(ctx, ds, testcase.metaVersion))
-				_, requireMigration, err := base.InitSyncInfo(ctx, ds, "someID")
+				require.NoError(t, base.SetSyncInfoMetaVersion(ctx, ds, testcase.metaVersion, nil))
+				_, requireMigration, err := base.InitSyncInfo(ctx, ds, "someID", nil)
 				require.NoError(t, err)
 				assert.False(t, requireMigration)
 			}

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -986,9 +986,10 @@ func RequireBackgroundManagerState(t testing.TB, mgr *BackgroundManager, expStat
 
 // AssertSyncInfoMetaVersion will assert that meta version is equal to current product version
 func AssertSyncInfoMetaVersion(t *testing.T, ds base.DataStore) {
-	var syncInfo base.SyncInfo
-	_, err := ds.Get(base.TestCtx(t), base.SGSyncInfo, &syncInfo)
+	rawBody, _, err := ds.GetRaw(base.TestCtx(t), base.SGSyncInfo)
 	require.NoError(t, err)
+	syncInfo, decodeErr := base.DecodeSyncInfo(rawBody)
+	require.NoError(t, decodeErr)
 	assert.Equal(t, "4.0.0", syncInfo.MetaDataVersion)
 }
 

--- a/rest/cluster_compat_test.go
+++ b/rest/cluster_compat_test.go
@@ -1539,3 +1539,53 @@ func TestClusterCompatRefreshIntervalUnclamped(t *testing.T) {
 		assert.Equal(t, d, ccm.refreshInterval(), "refreshInterval should return the configured value verbatim for %s", d)
 	}
 }
+
+// TestSyncInfoUpgradeGate tests syncInfo write gate during a rolling upgrade.
+// With a 4.0 peer present, writes must stay legacy JSON and once all peers reach 4.1+, writes flip to V1.
+func TestSyncInfoUpgradeGate(t *testing.T) {
+	rt := NewRestTesterPersistentConfig(t)
+	defer rt.Close()
+
+	ctx := base.TestCtx(t)
+	bucketName := rt.Bucket().GetName()
+	ccm := rt.ServerContext().ClusterCompat
+	require.NotNil(t, ccm)
+	dbCtx := rt.GetDatabase()
+	ds := rt.GetSingleDataStore()
+
+	const metadataID = "test_md"
+	const fakePeerUID = "fake-4.0-peer"
+
+	// Phase 1: mid-upgrade, a 4.0 peer is still registered. ccv should be 4.0.
+	seedRegistryNode(t, rt, bucketName, fakePeerUID, base.NewClusterCompatVersion(4, 0))
+	ccm.lastRefreshAt = time.Time{} // bypass refresh rate-limit
+	ccm.Refresh(ctx)
+	got := ccm.ClusterCompatVersion()
+	require.NotNil(t, got)
+	require.Equal(t, base.NewClusterCompatVersion(4, 0), *got, "mixed-version min should be 4.0")
+
+	// Resolve the production-wired closure and feed its result to SetSyncInfoMetadataID
+	ccv := dbCtx.Options.ClusterCompatVersion()
+	require.NoError(t, base.SetSyncInfoMetadataID(ctx, ds, metadataID, ccv))
+	raw, _, err := ds.GetRaw(ctx, base.SGSyncInfo)
+	require.NoError(t, err)
+	require.NotEmpty(t, raw)
+	require.Equal(t, byte('{'), raw[0], "during mixed-version cluster, syncInfo write must be legacy JSON")
+
+	// Phase 2: 4.0 peer leaves. Only the local node (>=4.1) remains.
+	rt.ServerContext().BootstrapContext.DeregisterNodeVersion(ctx, bucketName, fakePeerUID)
+	ccm.lastRefreshAt = time.Time{} // bypass refresh rate-limit
+	ccm.Refresh(ctx)
+	got = ccm.ClusterCompatVersion()
+	require.NotNil(t, got)
+	require.True(t, got.AtLeast(4, 1), "after 4.0 peer leaves, ccv should be >= 4.1; got %v", got)
+
+	// Same closure, called again — must resolve to the new value at call time, not the value
+	// captured during phase 1.
+	ccv = dbCtx.Options.ClusterCompatVersion()
+	require.NoError(t, base.SetSyncInfoMetadataID(ctx, ds, metadataID, ccv))
+	raw, _, err = ds.GetRaw(ctx, base.SGSyncInfo)
+	require.NoError(t, err)
+	require.NotEmpty(t, raw)
+	require.Equal(t, byte(base.SyncInfoTypeV1), raw[0], "after upgrade completes, syncInfo write should be V1")
+}

--- a/rest/config_manager.go
+++ b/rest/config_manager.go
@@ -1041,10 +1041,17 @@ func (b *bootstrapContext) computeMetadataID(ctx context.Context, registry *Gate
 	// If _default._default is already associated with a non-default metadataID, use the standard ID
 	bucketName := config.GetBucketName()
 	var syncInfo base.SyncInfo
-	exists, err := b.Connection.GetDocument(ctx, bucketName, base.SGSyncInfo, &syncInfo)
+	rawSyncInfo, exists, err := b.Connection.GetRawDocument(ctx, bucketName, base.SGSyncInfo)
 	if err != nil {
 		base.WarnfCtx(ctx, "Error checking syncInfo metadataID in default collection - using standard metadataID.  Error: %v", err)
 		return standardMetadataID
+	}
+	if exists {
+		syncInfo, err = base.DecodeSyncInfo(rawSyncInfo)
+		if err != nil {
+			base.WarnfCtx(ctx, "Error decoding syncInfo metadataID in default collection - using standard metadataID.  Error: %v", err)
+			return standardMetadataID
+		}
 	}
 
 	if exists && (syncInfo.MetadataID != nil && *syncInfo.MetadataID != defaultMetadataID) {

--- a/rest/config_manager_test.go
+++ b/rest/config_manager_test.go
@@ -148,6 +148,69 @@ func TestComputeMetadataID(t *testing.T) {
 
 }
 
+// TestComputeMetadataIDBinaryFormat covers the syncInfo-V1 binary read path through
+// computeMetadataID, plus the corrupt-doc fallback. Existing TestComputeMetadataID covers
+// the legacy JSON, no-doc, and short-circuit cases
+func TestComputeMetadataIDBinaryFormat(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server - requires bootstrap support")
+	}
+	base.TestRequiresCollections(t)
+
+	config := BootstrapStartupConfigForTest(t)
+	ctx := base.TestCtx(t)
+	sc, err := SetupServerContext(ctx, &config, true)
+	require.NoError(t, err)
+	defer sc.Close(ctx)
+
+	bootstrapContext := sc.BootstrapContext
+
+	tb := base.GetTestBucket(t)
+	defer tb.Close(ctx)
+	bucketName := tb.GetName()
+
+	registry, err := bootstrapContext.getGatewayRegistry(ctx, bucketName)
+	require.NoError(t, err)
+
+	dbName := "dbName"
+	standardMetadataID := dbName
+	defaultDbConfig := makeDbConfig(bucketName, dbName, nil)
+	defaultStore := tb.Bucket.DefaultDataStore(ctx)
+
+	resetSyncInfo := func(t *testing.T) {
+		err := defaultStore.Delete(ctx, base.SGSyncInfo)
+		if err != nil && !base.IsDocNotFoundError(err) {
+			require.NoError(t, err)
+		}
+	}
+
+	t.Run("V1 binary doc with non-default metadataID returns standard ID", func(t *testing.T) {
+		resetSyncInfo(t)
+		payload := append([]byte{byte(base.SyncInfoTypeV1)}, []byte(`{"metadataID":"foo"}`)...)
+		require.NoError(t, defaultStore.SetRaw(ctx, base.SGSyncInfo, 0, nil, payload))
+
+		metadataID := bootstrapContext.computeMetadataID(ctx, registry, &defaultDbConfig)
+		assert.Equal(t, standardMetadataID, metadataID)
+	})
+
+	t.Run("V1 binary doc with default metadataID returns default ID", func(t *testing.T) {
+		resetSyncInfo(t)
+		payload := append([]byte{byte(base.SyncInfoTypeV1)}, []byte(`{"metadataID":"`+defaultMetadataID+`"}`)...)
+		require.NoError(t, defaultStore.SetRaw(ctx, base.SGSyncInfo, 0, nil, payload))
+
+		metadataID := bootstrapContext.computeMetadataID(ctx, registry, &defaultDbConfig)
+		assert.Equal(t, defaultMetadataID, metadataID)
+	})
+
+	t.Run("corrupt doc falls back to standard ID", func(t *testing.T) {
+		resetSyncInfo(t)
+		require.NoError(t, defaultStore.SetRaw(ctx, base.SGSyncInfo, 0, nil, append([]byte{0xff}, []byte(`{"metadataID":"foo"}`)...)))
+
+		metadataID := bootstrapContext.computeMetadataID(ctx, registry, &defaultDbConfig)
+		assert.Equal(t, standardMetadataID, metadataID)
+	})
+}
+
 func TestLongMetadataID(t *testing.T) {
 
 	bootstrapContext := bootstrapContext{}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -834,7 +834,11 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 				}
 
 				// Verify whether the collection is associated with a different database's metadataID - if so, add to set requiring resync
-				resyncRequired, requiresAttachmentMigration, err := base.InitSyncInfo(ctx, dataStore, config.MetadataID)
+				var ccv *base.ClusterCompatVersion
+				if sc.ClusterCompat != nil {
+					ccv = sc.ClusterCompat.ClusterCompatVersion()
+				}
+				resyncRequired, requiresAttachmentMigration, err := base.InitSyncInfo(ctx, dataStore, config.MetadataID, ccv)
 				if err != nil {
 					if options.loadFromBucket {
 						sc._handleInvalidDatabaseConfig(ctx, spec.BucketName, config, db.NewDatabaseError(db.DatabaseInitSyncInfoError))
@@ -858,7 +862,11 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		// No explicitly defined scopes means we'll initialize this as a usable default collection, otherwise it's for metadata only
 		if len(config.Scopes) == 0 {
 			scName := base.DefaultScopeAndCollectionName()
-			resyncRequired, requiresAttachmentMigration, err := base.InitSyncInfo(ctx, ds, config.MetadataID)
+			var ccv *base.ClusterCompatVersion
+			if sc.ClusterCompat != nil {
+				ccv = sc.ClusterCompat.ClusterCompatVersion()
+			}
+			resyncRequired, requiresAttachmentMigration, err := base.InitSyncInfo(ctx, ds, config.MetadataID, ccv)
 			if err != nil {
 				if options.loadFromBucket {
 					sc._handleInvalidDatabaseConfig(ctx, spec.BucketName, config, db.NewDatabaseError(db.DatabaseInitSyncInfoError))
@@ -968,6 +976,16 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 
 	// NewMetadataKeys handles the "_default" -> legacy (unprefixed) key mapping, so we can pass config.MetadataID through directly.
 	contextOptions.MetadataID = config.MetadataID
+
+	// Stored as a closure so callers re-resolve at call time: cluster compat changes as peers
+	// join/leave during a rolling upgrade, and long-lived consumers (e.g. background managers
+	// mid-run) must observe the current value rather than one captured at db construction.
+	contextOptions.ClusterCompatVersion = func() *base.ClusterCompatVersion {
+		if sc.ClusterCompat != nil {
+			return sc.ClusterCompat.ClusterCompatVersion()
+		}
+		return nil
+	}
 
 	contextOptions.BlipStatsReportingInterval = defaultBytesStatsReportingInterval.Milliseconds()
 	contextOptions.ImportVersion = config.ImportVersion


### PR DESCRIPTION
CBG-5366

- Introduces a versioned syncInfo encoding: at cluster compat ≥ 4.1, marshalSyncInfo prepends a SyncInfoTypeV1 discriminator byte; older clusters keep writing bare JSON so a not-yet-upgraded peer can still read the doc. DecodeSyncInfo handles both forms. 
- Plumbs *ClusterCompatVersion through InitSyncInfo / SetSyncInfoMetadataID / SetSyncInfoMetaVersion and their callers (bootstrap, server context, attachment migration, resync DCP) via closure on dbcontext 
- Replaces DataStore.Update/Add in the syncInfo write path with a GetRaw + WriteCas CAS-retry loop. Update/Add route through gocb's RawJSONTranscoder / SGJSONTranscoder, which reject or mis-tag the non-JSON V1 prefix byte; the new path uses syncInfoWriteOpts to pick the datatype tag from the payload (binary for V1, JSON for bare JSON), preserving the older-peer read path. Retry semantics match the existing Update (unbounded loop, retry on IsCasMismatch).
- Adds a WriteCasCallback hook to LeakyDataStore and migrates TestInitSyncInfoErrors to it, since AddCallback no longer fires on the new write path.

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/667/ 
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/671/ (run base package to show above failures are fixed)
