### PR TITLE
CBG-5379 add resync stats for targeted/error

### DIFF
--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -448,23 +448,6 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 	return nil
 }
 
-func getResyncCollections(db *Database, resyncCollections base.CollectionNames) (collections DatabaseCollections, err error) {
-	if len(resyncCollections) == 0 {
-		return slices.Collect(maps.Values(db.CollectionByID)), nil
-	}
-
-	for scopeName, collectionsName := range resyncCollections {
-		for _, collectionName := range collectionsName {
-			collection, err := db.GetDatabaseCollection(scopeName, collectionName)
-			if err != nil {
-				return nil, base.RedactErrorf("failed to find ID for collection %s.%s", base.MD(scopeName).Redact(), base.MD(collectionName).Redact())
-			}
-			collections = append(collections, collection)
-		}
-	}
-	return collections, nil
-}
-
 func (r *ResyncManagerDCP) ResetStatus() {
 	r.lock.Lock()
 	defer r.lock.Unlock()

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -81,12 +81,17 @@ func (r *ResyncManagerDCP) Init(ctx context.Context, options map[string]any, clu
 		return errors.New("collections option is required and must be of type base.CollectionNames")
 	}
 
-	// Get collectionIds and store in manager for use in DCP client later
-	collections, err := getResyncCollections(db, resyncCollections)
-	if err != nil {
-		return err
+	var collections DatabaseCollections
+	if len(resyncCollections) > 0 {
+		var err error
+		collections, err = db.collections(resyncCollections)
+		if err != nil {
+			return err
+		}
+	} else {
+		collections = slices.Collect(maps.Values(db.CollectionByID))
+		r.hasAllCollections = true
 	}
-	r.hasAllCollections = len(resyncCollections) == 0
 	// add collection list to manager for use in status call
 	r.setCollectionStatus(collections)
 
@@ -443,7 +448,6 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 	return nil
 }
 
-// getResyncCollections returns collections requested for resync. If no collections are specified, it returns all collections.
 func getResyncCollections(db *Database, resyncCollections base.CollectionNames) (collections DatabaseCollections, err error) {
 	if len(resyncCollections) == 0 {
 		return slices.Collect(maps.Values(db.CollectionByID)), nil

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -124,7 +124,7 @@ func (r *ResyncManagerDCP) Init(ctx context.Context, options map[string]any, clu
 
 	docsTargeted, err := totalResyncDocs(ctx, collections)
 	if err != nil {
-		return err
+		base.WarnfCtx(ctx, "Failed to count total documents for resync: %v, continuing to resync", err)
 	}
 	r.docsTargeted.Store(docsTargeted)
 

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -12,6 +12,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -28,12 +30,16 @@ import (
 // =====================================================================
 
 type ResyncManagerDCP struct {
-	docsProcessedLocal           atomic.Int64 // number of documents processed locally on this node since the last start or resume of resync
-	docsChangedLocal             atomic.Int64 // number of documents changed locally on this node since the last start or resume of resync
-	docsProcessedLocalSerialized atomic.Int64 // number of documents processed locally on this node that have been serialized to the status document
-	docsChangedLocalSerialized   atomic.Int64 // number of documents changed locally on this node that have been serialized to the status document
-	docsProcessedCrossNode       atomic.Int64 // number of documents processed across all nodes, as reported by the status document
-	docsChangedCrossNode         atomic.Int64 // number of documents changed across all nodes, as reported by the status document
+	docsProcessedLocal           atomic.Int64  // number of documents processed locally on this node since the last start or resume of resync
+	docsChangedLocal             atomic.Int64  // number of documents changed locally on this node since the last start or resume of resync
+	docsErroredLocal             atomic.Int64  // number of documents that failed to resync locally on this node since the last start or resume of resync
+	docsProcessedLocalSerialized atomic.Int64  // number of documents processed locally on this node that have been serialized to the status document
+	docsChangedLocalSerialized   atomic.Int64  // number of documents changed locally on this node that have been serialized to the status document
+	docsErroredLocalSerialized   atomic.Int64  // number of documents that failed to resync locally on this node that have been serialized to the status document
+	docsProcessedCrossNode       atomic.Int64  // number of documents processed across all nodes, as reported by the status document
+	docsChangedCrossNode         atomic.Int64  // number of documents changed across all nodes, as reported by the status document
+	docsErroredCrossNode         atomic.Int64  // number of documents that failed to resync across all nodes, as reported by the status document
+	docsTargeted                 atomic.Uint64 // number of documents targeted for resync, computed once at the start of a new run
 	ResyncID                     string
 	VBUUIDs                      []uint64
 	useXattrs                    bool
@@ -45,8 +51,8 @@ type ResyncManagerDCP struct {
 
 // resyncCollectionInfo contains information on collections included on resync run, populated in init() and used in Run()
 type resyncCollectionInfo struct {
-	hasAllCollections bool
 	collectionIDs     []uint32
+	hasAllCollections bool
 }
 
 var _ BackgroundManagerProcessI = &ResyncManagerDCP{}
@@ -76,14 +82,13 @@ func (r *ResyncManagerDCP) Init(ctx context.Context, options map[string]any, clu
 	}
 
 	// Get collectionIds and store in manager for use in DCP client later
-	collectionIDs, hasAllCollections, collectionNames, err := getCollectionIdsAndNames(db, resyncCollections)
+	collections, err := getResyncCollections(db, resyncCollections)
 	if err != nil {
 		return err
 	}
-	r.collectionIDs = collectionIDs
-	r.hasAllCollections = hasAllCollections
+	r.hasAllCollections = len(resyncCollections) == 0
 	// add collection list to manager for use in status call
-	r.SetCollectionStatus(collectionNames)
+	r.setCollectionStatus(collections)
 
 	// If the previous run completed, or we couldn't determine, we will start the resync with a new resync ID.
 	// Otherwise, we should resume with the resync ID, and the previous stats specified in the doc.
@@ -100,9 +105,7 @@ func (r *ResyncManagerDCP) Init(ctx context.Context, options map[string]any, clu
 	} else if !base.SlicesEqualIgnoreOrder(r.collectionIDs, statusDoc.CollectionIDs) {
 		resetMsg = "collection IDs have changed"
 	} else {
-		// use the resync ID from the status doc to resume
-		r.ResyncID = statusDoc.ResyncID
-		r.SetStatus(statusDoc.DocsChanged, statusDoc.DocsProcessed)
+		r.initializeFromPreviousStatus(statusDoc)
 		base.InfofCtx(ctx, base.KeyAll, "Resuming resync with ID: %q", r.ResyncID)
 		return nil
 	}
@@ -118,9 +121,29 @@ func (r *ResyncManagerDCP) Init(ctx context.Context, options map[string]any, clu
 	if err != nil {
 		return err
 	}
+
+	docsTargeted, err := totalResyncDocs(ctx, collections)
+	if err != nil {
+		return err
+	}
+	r.docsTargeted.Store(docsTargeted)
+
 	r.ResyncID = newID.String()
 	base.InfofCtx(ctx, base.KeyAll, "Running new resync process with ID: %q - %s", r.ResyncID, resetMsg)
 	return nil
+}
+
+// totalResyncDocs returns an estimate of the number of documents processed for resync.
+func totalResyncDocs(ctx context.Context, collections DatabaseCollections) (uint64, error) {
+	var total uint64
+	for _, collection := range collections {
+		count, err := collection.CountAllDocs(ctx)
+		if err != nil {
+			return 0, base.RedactErrorf("resync: failed to count docs for collection %s.%s", base.MD(collection.ScopeName), base.MD(collection.Name))
+		}
+		total += count
+	}
+	return total, nil
 }
 
 // purgeCheckpoints removes checkpoints for a given resync run.
@@ -221,6 +244,7 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 			db.DbStats.Database().ResyncNumChanged.Add(1)
 			databaseCollection.collectionStats.ResyncNumChanged.Add(1)
 		} else if err != base.ErrUpdateCancel {
+			r.docsErroredLocal.Add(1)
 			base.WarnfCtx(ctx, "Resync: Error updating doc %q: %v", base.UD(docID), err)
 			return false
 		}
@@ -419,28 +443,22 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 	return nil
 }
 
-// getCollectionIdsAndNames returns collection names. If no collections are specified, it returns all collections. The
-// ids for all collections are returned.
-func getCollectionIdsAndNames(db *Database, resyncCollections base.CollectionNames) (collectionIDs []uint32, hasAllCollections bool, collectionNames base.CollectionNames, err error) {
+// getResyncCollections returns collections requested for resync. If no collections are specified, it returns all collections.
+func getResyncCollections(db *Database, resyncCollections base.CollectionNames) (collections DatabaseCollections, err error) {
 	if len(resyncCollections) == 0 {
-		hasAllCollections = true
-		for collectionID := range db.CollectionByID {
-			collectionIDs = append(collectionIDs, collectionID)
-		}
-		return collectionIDs, hasAllCollections, db.collectionNames(), nil
+		return slices.Collect(maps.Values(db.CollectionByID)), nil
 	}
-	hasAllCollections = false
 
 	for scopeName, collectionsName := range resyncCollections {
 		for _, collectionName := range collectionsName {
 			collection, err := db.GetDatabaseCollection(scopeName, collectionName)
 			if err != nil {
-				return nil, hasAllCollections, nil, fmt.Errorf("failed to find ID for collection %s.%s", base.MD(scopeName).Redact(), base.MD(collectionName).Redact())
+				return nil, base.RedactErrorf("failed to find ID for collection %s.%s", base.MD(scopeName).Redact(), base.MD(collectionName).Redact())
 			}
-			collectionIDs = append(collectionIDs, collection.GetCollectionID())
+			collections = append(collections, collection)
 		}
 	}
-	return collectionIDs, hasAllCollections, resyncCollections, nil
+	return collections, nil
 }
 
 func (r *ResyncManagerDCP) ResetStatus() {
@@ -453,20 +471,32 @@ func (r *ResyncManagerDCP) ResetStatus() {
 	r.docsChangedLocalSerialized.Store(0)
 	r.docsChangedLocal.Store(0)
 	r.docsChangedCrossNode.Store(0)
+	r.docsErroredLocalSerialized.Store(0)
+	r.docsErroredLocal.Store(0)
+	r.docsErroredCrossNode.Store(0)
+	r.docsTargeted.Store(0)
 	r.ResyncedCollections = nil
 }
 
-func (r *ResyncManagerDCP) SetStatus(docChanged, docProcessed int64) {
-	r.docsChangedLocal.Store(docChanged)
-	r.docsProcessedLocal.Store(docProcessed)
+// initializeFromPreviousStatus restores the in-memory state of the manager from a previously persisted status
+// document so that a resumed run starts with the correct accumulated counts.
+func (r *ResyncManagerDCP) initializeFromPreviousStatus(statusDoc ResyncManagerStatusDocDCP) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	r.ResyncID = statusDoc.ResyncID
+	r.docsChangedLocal.Store(statusDoc.DocsChanged)
+	r.docsProcessedLocal.Store(statusDoc.DocsProcessed)
+	r.docsErroredLocal.Store(statusDoc.DocsErrored)
+	r.docsTargeted.Store(statusDoc.DocsTargeted)
 }
 
-// SetCollectionStatus sets the active collection names being resynced.
-func (r *ResyncManagerDCP) SetCollectionStatus(collectionNames base.CollectionNames) {
+// setCollectionStatus sets the active collections being resynced.
+func (r *ResyncManagerDCP) setCollectionStatus(collections DatabaseCollections) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
-	r.ResyncedCollections = collectionNames
+	r.ResyncedCollections = collections.getNames()
+	r.collectionIDs = collections.getIDs()
 }
 
 // ResyncManagerResponseDCP is the struct used to serialize the status of the resync process. This matches the output
@@ -480,8 +510,10 @@ type ResyncManagerResponseDCP struct {
 
 // resyncStats is a part of the ResyncManagerResponseDCP struct that only contains the stats fields for efficincy.
 type resyncStats struct {
-	DocsChanged   int64 `json:"docs_changed"`
-	DocsProcessed int64 `json:"docs_processed"`
+	DocsChanged   int64  `json:"docs_changed"`
+	DocsProcessed int64  `json:"docs_processed"`
+	DocsErrored   int64  `json:"docs_errored"`
+	DocsTargeted  uint64 `json:"docs_targeted"`
 }
 
 // SetProcessStatus reports the new status that was serialized to the bucket along with the last status that polled
@@ -508,8 +540,10 @@ func (r *ResyncManagerDCP) SetProcessStatus(ctx context.Context, previousStatus 
 
 	r.docsProcessedCrossNode.Store(newStats.DocsProcessed)
 	r.docsChangedCrossNode.Store(newStats.DocsChanged)
+	r.docsErroredCrossNode.Store(newStats.DocsErrored)
 	r.docsProcessedLocalSerialized.Add(newStats.DocsProcessed - previousStats.DocsProcessed)
 	r.docsChangedLocalSerialized.Add(newStats.DocsChanged - previousStats.DocsChanged)
+	r.docsErroredLocalSerialized.Add(newStats.DocsErrored - previousStats.DocsErrored)
 }
 
 func (r *ResyncManagerDCP) GetProcessStatus(status BackgroundManagerStatus, previousStatus []byte) ([]byte, []byte, error) {
@@ -530,6 +564,8 @@ func (r *ResyncManagerDCP) GetProcessStatus(status BackgroundManagerStatus, prev
 		resyncStats: resyncStats{
 			DocsChanged:   previousStats.DocsChanged + (r.docsChangedLocal.Load() - r.docsChangedLocalSerialized.Load()),
 			DocsProcessed: previousStats.DocsProcessed + (r.docsProcessedLocal.Load() - r.docsProcessedLocalSerialized.Load()),
+			DocsErrored:   previousStats.DocsErrored + (r.docsErroredLocal.Load() - r.docsErroredLocalSerialized.Load()),
+			DocsTargeted:  r.docsTargeted.Load(),
 		},
 		CollectionsProcessing: r.ResyncedCollections,
 	}
@@ -538,6 +574,7 @@ func (r *ResyncManagerDCP) GetProcessStatus(status BackgroundManagerStatus, prev
 	if len(previousStatus) == 0 {
 		response.DocsChanged = r.DocsChanged()
 		response.DocsProcessed = r.DocsProcessed()
+		response.DocsErrored = r.DocsErrored()
 	}
 
 	meta := ResyncManagerMeta{
@@ -567,6 +604,12 @@ func (r *ResyncManagerDCP) DocsChanged() int64 {
 // processed by other nodes.
 func (r *ResyncManagerDCP) DocsProcessed() int64 {
 	return r.docsProcessedCrossNode.Load() + r.docsProcessedLocal.Load() - r.docsProcessedLocalSerialized.Load()
+}
+
+// DocsErrored returns the total number of documents that failed to resync across the entire resync process.
+// This includes docs errored by other nodes.
+func (r *ResyncManagerDCP) DocsErrored() int64 {
+	return r.docsErroredCrossNode.Load() + r.docsErroredLocal.Load() - r.docsErroredLocalSerialized.Load()
 }
 
 type ResyncManagerMeta struct {

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -124,7 +124,7 @@ func (r *ResyncManagerDCP) Init(ctx context.Context, options map[string]any, clu
 
 	docsTargeted, err := totalResyncDocs(ctx, collections)
 	if err != nil {
-		base.WarnfCtx(ctx, "Failed to count total documents for resync: %v, continuing to resync", err)
+		base.WarnfCtx(ctx, "Failed to count total documents for resync: %v, continuing resync", err)
 	}
 	r.docsTargeted.Store(docsTargeted)
 
@@ -139,7 +139,7 @@ func totalResyncDocs(ctx context.Context, collections DatabaseCollections) (uint
 	for _, collection := range collections {
 		count, err := collection.CountAllDocs(ctx)
 		if err != nil {
-			return 0, base.RedactErrorf("resync: failed to count docs for collection %s.%s", base.MD(collection.ScopeName), base.MD(collection.Name))
+			return 0, base.RedactErrorf("failed to count docs for collection %s.%s: %w", base.MD(collection.ScopeName), base.MD(collection.Name), err)
 		}
 		total += count
 	}

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -56,8 +56,7 @@ func TestResyncDCPInit(t *testing.T) {
 					},
 				},
 				ResyncManagerMeta: ResyncManagerMeta{
-					VBUUIDs:      []uint64{1},
-					DocsTargeted: 50,
+					VBUUIDs: []uint64{1},
 				},
 			},
 			forceReset:           false,

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -29,15 +29,17 @@ import (
 
 func TestResyncDCPInit(t *testing.T) {
 	testCases := []struct {
-		title               string
-		initialClusterState ResyncManagerStatusDocDCP
-		forceReset          bool
-		shouldCreateNewRun  bool
+		title                string
+		initialClusterState  ResyncManagerStatusDocDCP
+		forceReset           bool
+		shouldCreateNewRun   bool
+		expectedDocsTargeted uint64
 	}{
 		{
-			title:              "Initialize new run with empty cluster state",
-			forceReset:         false,
-			shouldCreateNewRun: true,
+			title:                "Initialize new run with empty cluster state",
+			forceReset:           false,
+			shouldCreateNewRun:   true,
+			expectedDocsTargeted: 0, // no docs in DB
 		},
 		{
 			title: "Reinitialize existing run",
@@ -50,14 +52,17 @@ func TestResyncDCPInit(t *testing.T) {
 					resyncStats: resyncStats{
 						DocsChanged:   10,
 						DocsProcessed: 20,
+						DocsTargeted:  50,
 					},
 				},
 				ResyncManagerMeta: ResyncManagerMeta{
-					VBUUIDs: []uint64{1},
+					VBUUIDs:      []uint64{1},
+					DocsTargeted: 50,
 				},
 			},
-			forceReset:         false,
-			shouldCreateNewRun: false,
+			forceReset:           false,
+			shouldCreateNewRun:   false,
+			expectedDocsTargeted: 50, // restored from persisted meta
 		},
 		{
 			title: "Restart existing run new Collection",
@@ -77,8 +82,9 @@ func TestResyncDCPInit(t *testing.T) {
 					CollectionIDs: []uint32{123},
 				},
 			},
-			forceReset:         false,
-			shouldCreateNewRun: true,
+			forceReset:           false,
+			shouldCreateNewRun:   true,
+			expectedDocsTargeted: 0, // no docs in DB
 		},
 		{
 			title: "Reinitialize completed run",
@@ -97,8 +103,9 @@ func TestResyncDCPInit(t *testing.T) {
 					VBUUIDs: []uint64{1},
 				},
 			},
-			forceReset:         false,
-			shouldCreateNewRun: true,
+			forceReset:           false,
+			shouldCreateNewRun:   true,
+			expectedDocsTargeted: 0, // no docs in DB
 		},
 		{
 			title: "Force restart existing run",
@@ -117,8 +124,9 @@ func TestResyncDCPInit(t *testing.T) {
 					VBUUIDs: []uint64{1},
 				},
 			},
-			forceReset:         true,
-			shouldCreateNewRun: true,
+			forceReset:           true,
+			shouldCreateNewRun:   true,
+			expectedDocsTargeted: 0, // no docs in DB
 		},
 	}
 
@@ -172,6 +180,7 @@ func TestResyncDCPInit(t *testing.T) {
 				assert.Equal(t, testCase.initialClusterState.DocsChanged, response.DocsChanged)
 				assert.Equal(t, testCase.initialClusterState.DocsProcessed, response.DocsProcessed)
 			}
+			assert.Equal(t, testCase.expectedDocsTargeted, response.DocsTargeted)
 
 			assert.Equal(t, int64(0), db.DbStats.Database().ResyncNumChanged.Value())
 			assert.Equal(t, int64(0), db.DbStats.Database().ResyncNumProcessed.Value())
@@ -256,6 +265,7 @@ func TestResyncManagerDCPStart(t *testing.T) {
 
 				assert.GreaterOrEqual(t, stats.DocsProcessed, int64(docsToCreate)) // may be processing tombstones from previous tests
 				assert.Equal(t, int64(0), stats.DocsChanged)
+				assert.GreaterOrEqual(t, stats.DocsTargeted, uint64(docsToCreate))
 
 				assert.GreaterOrEqual(t, db.DbStats.Database().ResyncNumProcessed.Value(), int64(docsToCreate))
 				assert.Equal(t, db.DbStats.Database().ResyncNumChanged.Value(), int64(0))
@@ -312,6 +322,7 @@ func TestResyncManagerDCPStart(t *testing.T) {
 				// be greater than DocsChanged
 				assert.GreaterOrEqual(t, stats.DocsProcessed, int64(docsToCreate))
 				assert.Equal(t, int64(docsToCreate), stats.DocsChanged)
+				assert.GreaterOrEqual(t, stats.DocsTargeted, uint64(docsToCreate))
 
 				assert.GreaterOrEqual(t, db.DbStats.Database().ResyncNumProcessed.Value(), int64(docsToCreate))
 				assert.Equal(t, db.DbStats.Database().ResyncNumChanged.Value(), int64(docsToCreate))
@@ -421,6 +432,9 @@ func TestResyncManagerDCPResumeStoppedProcess(t *testing.T) {
 
 			require.Less(t, stats.DocsProcessed, int64(docsToCreate), "DocsProcessed is equal to docs created. Consider setting docsToCreate > %d.", docsToCreate)
 			assert.Less(t, stats.DocsChanged, int64(docsToCreate))
+			// DocsTargeted is computed once at run start and should be >= docsToCreate
+			assert.GreaterOrEqual(t, stats.DocsTargeted, uint64(docsToCreate))
+			initialDocsTargeted := stats.DocsTargeted
 
 			assert.Less(t, db.DbStats.Database().ResyncNumProcessed.Value(), int64(docsToCreate))
 			assert.Less(t, db.DbStats.Database().ResyncNumChanged.Value(), int64(docsToCreate))
@@ -433,6 +447,8 @@ func TestResyncManagerDCPResumeStoppedProcess(t *testing.T) {
 
 			assert.GreaterOrEqual(t, stats.DocsProcessed, int64(docsToCreate))
 			assert.Equal(t, int64(docsToCreate), stats.DocsChanged)
+			// DocsTargeted is preserved from the original run start, even after resume
+			assert.Equal(t, initialDocsTargeted, stats.DocsTargeted)
 
 			assert.GreaterOrEqual(t, db.DbStats.Database().ResyncNumProcessed.Value(), int64(docsToCreate))
 			assert.Equal(t, int64(docsToCreate), db.DbStats.Database().ResyncNumChanged.Value())

--- a/db/database.go
+++ b/db/database.go
@@ -2615,3 +2615,18 @@ func (db *DatabaseContext) InitializeOfflineMode() {
 	db.DBStateManager.SetResyncFunc(TempResyncHandler)
 	db.DBStateManager.StartPolling(db.CancelContext)
 }
+
+// colletions returns the DatabaseCollection objects matching the following collection names.
+func (db *DatabaseContext) collections(names base.CollectionNames) (DatabaseCollections, error) {
+	collections := make(DatabaseCollections, 0, len(names))
+	for scopeName, collectionsName := range names {
+		for _, collectionName := range collectionsName {
+			collection, err := db.GetDatabaseCollection(scopeName, collectionName)
+			if err != nil {
+				return nil, base.RedactErrorf("failed to find ID for collection %s.%s", base.MD(scopeName).Redact(), base.MD(collectionName).Redact())
+			}
+			collections = append(collections, collection)
+		}
+	}
+	return collections, nil
+}

--- a/db/database.go
+++ b/db/database.go
@@ -2026,6 +2026,7 @@ func initDatabaseStats(ctx context.Context, dbName string, autoImport bool, opti
 			QueryTypeTombstones,
 			QueryTypeResync,
 			QueryTypeAllDocs,
+			QueryTypeCountDocs,
 			QueryTypeUsers,
 		}
 	}

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -438,3 +438,24 @@ func (c *DatabaseCollection) ScopeAndCollectionName() base.ScopeAndCollectionNam
 func (c *DatabaseCollection) AddCollectionContext(ctx context.Context) context.Context {
 	return base.CollectionLogCtx(ctx, c.ScopeName, c.Name)
 }
+
+// DatabaseCollections is a set of collections
+type DatabaseCollections []*DatabaseCollection
+
+// getIDs returns the collection IDs for each collection
+func (c *DatabaseCollections) getIDs() []uint32 {
+	ids := make([]uint32, 0, len(*c))
+	for _, collection := range *c {
+		ids = append(ids, collection.GetCollectionID())
+	}
+	return ids
+}
+
+// getNames return the names of the collections
+func (c *DatabaseCollections) getNames() base.CollectionNames {
+	names := base.NewCollectionNames()
+	for _, collection := range *c {
+		names.Add(collection.dataStore)
+	}
+	return names
+}

--- a/db/query.go
+++ b/db/query.go
@@ -370,8 +370,7 @@ var QueryCountDocs = SGQuery{
 			"FROM %s AS %s "+
 			"USE INDEX ($idx) "+
 			"WHERE $sync.`sequence` > 0 AND "+ // Required to use IndexAllDocs
-			"META(%s).id NOT LIKE '%s' "+
-			"AND $sync IS NOT MISSING ",
+			"META(%s).id NOT LIKE '%s' ",
 		base.KeyspaceQueryToken, base.KeyspaceQueryAlias,
 		base.KeyspaceQueryAlias, SyncDocWildcard),
 	adhoc: false,
@@ -750,7 +749,7 @@ func (c *DatabaseCollection) QueryAllDocs(ctx context.Context, startKey string, 
 
 	// View Query
 	if c.useViews() {
-		opts := Body{"stale": false, "reduce": false}
+		opts := Body{"stale": true, "reduce": false}
 		if startKey != "" {
 			opts[QueryParamStartKey] = startKey
 		}
@@ -779,30 +778,28 @@ func (c *DatabaseCollection) QueryAllDocs(ctx context.Context, startKey string, 
 	allDocsQueryStatement = fmt.Sprintf("%s ORDER BY META(%s).id",
 		allDocsQueryStatement, base.KeyspaceQueryAlias)
 
-	return N1QLQueryWithStats(ctx, c.dataStore, QueryTypeAllDocs, allDocsQueryStatement, params, base.RequestPlus, QueryAllDocs.adhoc, c.dbStats(), c.slowQueryWarningThreshold())
+	return N1QLQueryWithStats(ctx, c.dataStore, QueryTypeAllDocs, allDocsQueryStatement, params, base.NotBounded, QueryAllDocs.adhoc, c.dbStats(), c.slowQueryWarningThreshold())
 }
 
 // CountAllDocs returns the total number of documents in the collection that contain _sync metadata.
 // When using views, tombstoned documents are excluded.
-func (c *DatabaseCollection) CountAllDocs(ctx context.Context) (docCount uint64, err error) {
-
-	// View Query
+func (c *DatabaseCollection) CountAllDocs(ctx context.Context) (uint64, error) {
 	if c.useViews() {
 		opts := Body{"stale": false, "reduce": true}
-		results, viewErr := c.dbCtx.ViewQueryWithStats(ctx, c.dataStore, DesignDocSyncHousekeeping(), ViewAllDocs, opts)
-		if viewErr != nil {
-			return 0, viewErr
+		results, err := c.dbCtx.ViewQueryWithStats(ctx, c.dataStore, DesignDocSyncHousekeeping(), ViewAllDocs, opts)
+		if err != nil {
+			return 0, err
 		}
 		var row struct {
 			Value float64 `json:"value"`
 		}
-		if results.Next(ctx, &row) {
-			docCount = uint64(row.Value)
+		err = results.One(ctx, &row)
+		if err != nil {
+			return 0, err
 		}
-		return docCount, results.Close(ctx)
+		return uint64(row.Value), nil
 	}
 
-	// N1QL Query
 	countDocsQueryStatement := replaceSyncTokensQuery(QueryCountDocs.statement, c.UseXattrs())
 	countDocsQueryStatement = replaceIndexTokensQuery(countDocsQueryStatement, sgIndexes[IndexAllDocs], c.UseXattrs(), c.numIndexPartitions())
 
@@ -810,21 +807,14 @@ func (c *DatabaseCollection) CountAllDocs(ctx context.Context) (docCount uint64,
 	if err != nil {
 		return 0, err
 	}
-	defer func() {
-		closeErr := results.Close(ctx)
-		if err == nil {
-			err = closeErr
-		}
-	}()
-
 	var row struct {
 		Count uint64 `json:"count"`
 	}
-	if results.Next(ctx, &row) {
-		return row.Count, nil
+	err = results.One(ctx, &row)
+	if err != nil {
+		return 0, err
 	}
-
-	return 0, nil
+	return row.Count, nil
 }
 
 func (c *DatabaseCollection) QueryTombstones(ctx context.Context, olderThan time.Time, limit int) (sgbucket.QueryResultIterator, error) {

--- a/db/query.go
+++ b/db/query.go
@@ -57,6 +57,7 @@ const (
 	QueryTypeAllDocs             = "allDocs"
 	QueryTypeUsers               = "users"
 	QueryTypeUserFunctionPrefix  = "function:" // Prefix applied to named functions from config file
+	QueryTypeCountDocs           = "count"
 )
 
 type SGQuery struct {
@@ -355,6 +356,22 @@ var QueryAllDocs = SGQuery{
 			"AND $sync IS NOT MISSING "+
 			"AND ($sync.flags IS MISSING OR BITTEST($sync.flags,1) = false)",
 		base.KeyspaceQueryAlias,
+		base.KeyspaceQueryToken, base.KeyspaceQueryAlias,
+		base.KeyspaceQueryAlias, SyncDocWildcard),
+	adhoc: false,
+}
+
+// QueryCountDocs finds documents that are tagged with sync metadata, including tombstones. This ignores any metadata
+// documents starting with _sync:
+var QueryCountDocs = SGQuery{
+	name: QueryTypeCountDocs,
+	statement: fmt.Sprintf(
+		"SELECT COUNT(*) as count "+
+			"FROM %s AS %s "+
+			"USE INDEX ($idx) "+
+			"WHERE $sync.`sequence` > 0 AND "+ // Required to use IndexAllDocs
+			"META(%s).id NOT LIKE '%s' "+
+			"AND $sync IS NOT MISSING ",
 		base.KeyspaceQueryToken, base.KeyspaceQueryAlias,
 		base.KeyspaceQueryAlias, SyncDocWildcard),
 	adhoc: false,
@@ -763,6 +780,51 @@ func (c *DatabaseCollection) QueryAllDocs(ctx context.Context, startKey string, 
 		allDocsQueryStatement, base.KeyspaceQueryAlias)
 
 	return N1QLQueryWithStats(ctx, c.dataStore, QueryTypeAllDocs, allDocsQueryStatement, params, base.RequestPlus, QueryAllDocs.adhoc, c.dbStats(), c.slowQueryWarningThreshold())
+}
+
+// CountAllDocs returns the total number of documents in the collection that contain _sync metadata.
+// When using views, tombstoned documents are excluded.
+func (c *DatabaseCollection) CountAllDocs(ctx context.Context) (docCount uint64, err error) {
+
+	// View Query
+	if c.useViews() {
+		opts := Body{"stale": false, "reduce": true}
+		results, viewErr := c.dbCtx.ViewQueryWithStats(ctx, c.dataStore, DesignDocSyncHousekeeping(), ViewAllDocs, opts)
+		if viewErr != nil {
+			return 0, viewErr
+		}
+		var row struct {
+			Value float64 `json:"value"`
+		}
+		if results.Next(ctx, &row) {
+			docCount = uint64(row.Value)
+		}
+		return docCount, results.Close(ctx)
+	}
+
+	// N1QL Query
+	countDocsQueryStatement := replaceSyncTokensQuery(QueryCountDocs.statement, c.UseXattrs())
+	countDocsQueryStatement = replaceIndexTokensQuery(countDocsQueryStatement, sgIndexes[IndexAllDocs], c.UseXattrs(), c.numIndexPartitions())
+
+	results, err := N1QLQueryWithStats(ctx, c.dataStore, QueryTypeCountDocs, countDocsQueryStatement, nil, base.RequestPlus, QueryCountDocs.adhoc, c.dbStats(), c.slowQueryWarningThreshold())
+	if err != nil {
+		return 0, err
+	}
+	defer func() {
+		closeErr := results.Close(ctx)
+		if err == nil {
+			err = closeErr
+		}
+	}()
+
+	var row struct {
+		Count uint64 `json:"count"`
+	}
+	if results.Next(ctx, &row) {
+		return row.Count, nil
+	}
+
+	return 0, nil
 }
 
 func (c *DatabaseCollection) QueryTombstones(ctx context.Context, olderThan time.Time, limit int) (sgbucket.QueryResultIterator, error) {

--- a/db/query.go
+++ b/db/query.go
@@ -749,7 +749,7 @@ func (c *DatabaseCollection) QueryAllDocs(ctx context.Context, startKey string, 
 
 	// View Query
 	if c.useViews() {
-		opts := Body{"stale": true, "reduce": false}
+		opts := Body{"stale": false, "reduce": false}
 		if startKey != "" {
 			opts[QueryParamStartKey] = startKey
 		}
@@ -778,14 +778,14 @@ func (c *DatabaseCollection) QueryAllDocs(ctx context.Context, startKey string, 
 	allDocsQueryStatement = fmt.Sprintf("%s ORDER BY META(%s).id",
 		allDocsQueryStatement, base.KeyspaceQueryAlias)
 
-	return N1QLQueryWithStats(ctx, c.dataStore, QueryTypeAllDocs, allDocsQueryStatement, params, base.NotBounded, QueryAllDocs.adhoc, c.dbStats(), c.slowQueryWarningThreshold())
+	return N1QLQueryWithStats(ctx, c.dataStore, QueryTypeAllDocs, allDocsQueryStatement, params, base.RequestPlus, QueryAllDocs.adhoc, c.dbStats(), c.slowQueryWarningThreshold())
 }
 
 // CountAllDocs returns the total number of documents in the collection that contain _sync metadata.
 // When using views, tombstoned documents are excluded.
 func (c *DatabaseCollection) CountAllDocs(ctx context.Context) (uint64, error) {
 	if c.useViews() {
-		opts := Body{"stale": false, "reduce": true}
+		opts := Body{"reduce": true}
 		results, err := c.dbCtx.ViewQueryWithStats(ctx, c.dataStore, DesignDocSyncHousekeeping(), ViewAllDocs, opts)
 		if err != nil {
 			return 0, err
@@ -803,7 +803,7 @@ func (c *DatabaseCollection) CountAllDocs(ctx context.Context) (uint64, error) {
 	countDocsQueryStatement := replaceSyncTokensQuery(QueryCountDocs.statement, c.UseXattrs())
 	countDocsQueryStatement = replaceIndexTokensQuery(countDocsQueryStatement, sgIndexes[IndexAllDocs], c.UseXattrs(), c.numIndexPartitions())
 
-	results, err := N1QLQueryWithStats(ctx, c.dataStore, QueryTypeCountDocs, countDocsQueryStatement, nil, base.RequestPlus, QueryCountDocs.adhoc, c.dbStats(), c.slowQueryWarningThreshold())
+	results, err := N1QLQueryWithStats(ctx, c.dataStore, QueryTypeCountDocs, countDocsQueryStatement, nil, base.NotBounded, QueryCountDocs.adhoc, c.dbStats(), c.slowQueryWarningThreshold())
 	if err != nil {
 		return 0, err
 	}

--- a/db/query.go
+++ b/db/query.go
@@ -785,7 +785,7 @@ func (c *DatabaseCollection) QueryAllDocs(ctx context.Context, startKey string, 
 // When using views, tombstoned documents are excluded.
 func (c *DatabaseCollection) CountAllDocs(ctx context.Context) (uint64, error) {
 	if c.useViews() {
-		opts := Body{"reduce": true}
+		opts := Body{"stale": false, "reduce": true}
 		results, err := c.dbCtx.ViewQueryWithStats(ctx, c.dataStore, DesignDocSyncHousekeeping(), ViewAllDocs, opts)
 		if err != nil {
 			return 0, err
@@ -803,7 +803,7 @@ func (c *DatabaseCollection) CountAllDocs(ctx context.Context) (uint64, error) {
 	countDocsQueryStatement := replaceSyncTokensQuery(QueryCountDocs.statement, c.UseXattrs())
 	countDocsQueryStatement = replaceIndexTokensQuery(countDocsQueryStatement, sgIndexes[IndexAllDocs], c.UseXattrs(), c.numIndexPartitions())
 
-	results, err := N1QLQueryWithStats(ctx, c.dataStore, QueryTypeCountDocs, countDocsQueryStatement, nil, base.NotBounded, QueryCountDocs.adhoc, c.dbStats(), c.slowQueryWarningThreshold())
+	results, err := N1QLQueryWithStats(ctx, c.dataStore, QueryTypeCountDocs, countDocsQueryStatement, nil, base.RequestPlus, QueryCountDocs.adhoc, c.dbStats(), c.slowQueryWarningThreshold())
 	if err != nil {
 		return 0, err
 	}

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -533,3 +533,45 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 	require.Len(t, entries, 50)
 	checkFlags(entries)
 }
+
+func TestCountAllDocs(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+
+	// Add some docs
+	numDocs := 5
+	var docToDelete *Document
+	for i := range numDocs {
+		_, doc, err := collection.Put(ctx, fmt.Sprintf("doc%d", i), Body{"value": i})
+		require.NoError(t, err)
+		if i == 0 {
+			docToDelete = doc
+		}
+	}
+
+	count, err := collection.CountAllDocs(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(numDocs), count)
+
+	// Delete a doc
+	_, _, err = collection.DeleteDoc(ctx, "doc0", docToDelete.ExtractDocVersion())
+	require.NoError(t, err)
+
+	count, err = collection.CountAllDocs(ctx)
+	require.NoError(t, err)
+	// Views exclude tombstoned documents from the map function; N1QL counts them until purged.
+	if base.TestsDisableGSI() {
+		assert.Equal(t, uint64(numDocs-1), count)
+	} else {
+		assert.Equal(t, uint64(numDocs), count)
+	}
+
+	err = collection.Purge(ctx, "doc0", false)
+	require.NoError(t, err)
+
+	count, err = collection.CountAllDocs(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(numDocs-1), count)
+
+}

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -554,7 +554,16 @@ func TestCountAllDocs(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, uint64(numDocs), count)
 
-	// Delete a doc
+	if !base.TestsDisableGSI() {
+		n1QLStore, ok := base.AsN1QLStore(collection.dataStore)
+		require.True(t, ok, "Unable to get n1QLStore for testBucket")
+		countDocsQueryStatement := replaceSyncTokensQuery(QueryCountDocs.statement, collection.UseXattrs())
+		countDocsQueryStatement = replaceIndexTokensQuery(countDocsQueryStatement, sgIndexes[IndexAllDocs], collection.UseXattrs(), collection.numIndexPartitions())
+		plan, err := n1QLStore.ExplainQuery(ctx, countDocsQueryStatement, nil)
+		require.NoError(t, err, "Error generating explain for count all docs query")
+		require.True(t, IsCovered(plan), "Expected %s to be covering", plan)
+	}
+
 	_, _, err = collection.DeleteDoc(ctx, "doc0", docToDelete.ExtractDocVersion())
 	require.NoError(t, err)
 

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -2009,6 +2009,11 @@ Resync-status:
     docs_processed:
       description: The amount of docs that have been processed so far in the resync operation.
       type: integer
+    docs_targeted:
+      description: The estimated number of documents to be procsesed by the resync operation.
+      type: integer
+    docs_errored:
+      description: The number of documents which have errored running resync.
     collections_processing:
       description: The collections that the resync operation is running on.
       allOf:

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -2014,6 +2014,7 @@ Resync-status:
       type: integer
     docs_errored:
       description: The number of documents which have errored running resync.
+      type: integer
     collections_processing:
       description: The collections that the resync operation is running on.
       allOf:


### PR DESCRIPTION
CBG-5379 add resync stats for targeted/error

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
