### PR TITLE
CBG-5378: Track older SG nodes for ClusterCompatVersion via cbgt-based side-channels

### DIFF
--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -486,6 +486,7 @@ func (c *CbgtContext) StartManager(ctx context.Context, opts ShardedDCPOptions) 
 // extras.
 func preCbgtExtrasVersion() *ComparableBuildVersion {
 	v := &ComparableBuildVersion{major: 3}
+	v.str = v.formatComparableBuildVersion()
 	return v
 }
 

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -13,6 +13,7 @@ package base
 import (
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"maps"
 	"slices"
@@ -21,8 +22,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"errors"
 
 	"github.com/couchbase/cbgt"
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -481,17 +480,68 @@ func (c *CbgtContext) StartManager(ctx context.Context, opts ShardedDCPOptions) 
 	return nil
 }
 
-// getNodeVersion returns the version of the node from its Extras field, or nil if none is stored. Returns an error if
-// the extras could not be parsed.
+// preCbgtExtrasVersion returns a fake 3.0 ComparableBuildVersion. cbgt extras Version stamping
+// shipped in 3.1 (CBG-2213), so a NodeDef whose Extras carries no version is reliably a pre-3.1
+// Sync Gateway node. Used as the stamped value when getNodeVersion can't find a real version in
+// extras.
+func preCbgtExtrasVersion() *ComparableBuildVersion {
+	v := &ComparableBuildVersion{major: 3}
+	return v
+}
+
+// getNodeVersion returns the version of the node from its Extras field. cbgt extras Version
+// stamping was added in 3.1 (CBG-2213); a missing/empty Extras therefore reliably indicates a
+// pre-3.1 peer and is stamped as a fake 3.0 ComparableBuildVersion — never nil. Returns an
+// error if the extras are present but unparseable.
 func getNodeVersion(def *cbgt.NodeDef) (*ComparableBuildVersion, error) {
 	if len(def.Extras) == 0 {
-		return nil, nil
+		return preCbgtExtrasVersion(), nil
 	}
 	var extras nodeExtras
 	if err := JSONUnmarshal([]byte(def.Extras), &extras); err != nil {
 		return nil, fmt.Errorf("parsing node extras: %w", err)
 	}
+	if extras.Version == nil {
+		return preCbgtExtrasVersion(), nil
+	}
 	return extras.Version, nil
+}
+
+// CbgtNodeInfo is a parsed view of a single cbgt.NodeDef entry suitable for callers outside of
+// the cbgt code path (e.g. cluster compat observation). Hostname comes from NodeDef.HostPort.
+// Version is always non-nil: pre-3.1 peers (no Extras) are stamped as a fake 3.0 by getNodeVersion.
+type CbgtNodeInfo struct {
+	UUID     string
+	Hostname string
+	Version  *ComparableBuildVersion
+}
+
+// ListCbgtNodes enumerates cbgt's NODE_DEFS_KNOWN registry and returns a parsed view of each
+// node. Returns a nil slice when there are no nodes. Returns an error only when the underlying
+// cbgt.CfgGetNodeDefs call fails; per-node extras parse failures degrade to the pre-3.1
+// stamp and do not abort the listing.
+func ListCbgtNodes(ctx context.Context, cfg cbgt.Cfg) ([]CbgtNodeInfo, error) {
+	nodes, _, err := cbgt.CfgGetNodeDefs(cfg, cbgt.NODE_DEFS_KNOWN)
+	if err != nil {
+		return nil, err
+	}
+	if nodes == nil || len(nodes.NodeDefs) == 0 {
+		return nil, nil
+	}
+	out := make([]CbgtNodeInfo, 0, len(nodes.NodeDefs))
+	for _, def := range nodes.NodeDefs {
+		version, err := getNodeVersion(def)
+		if err != nil {
+			WarnfCtx(ctx, "Failed to parse extras for cbgt node %s: %v; treating as pre-3.1", MD(def.UUID), err)
+			version = preCbgtExtrasVersion()
+		}
+		out = append(out, CbgtNodeInfo{
+			UUID:     def.UUID,
+			Hostname: def.HostPort,
+			Version:  version,
+		})
+	}
+	return out, nil
 }
 
 // getMinNodeVersion returns the version of the oldest node currently in the cluster.
@@ -509,9 +559,6 @@ func getMinNodeVersion(cfg cbgt.Cfg) (*ComparableBuildVersion, error) {
 		nodeVersion, err := getNodeVersion(node)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get version of node %v: %w", MD(node.HostPort).Redact(), err)
-		}
-		if nodeVersion == nil {
-			nodeVersion = zeroComparableBuildVersion()
 		}
 		if minVersion == nil || nodeVersion.Less(minVersion) {
 			minVersion = nodeVersion

--- a/base/version_cluster_compat.go
+++ b/base/version_cluster_compat.go
@@ -41,6 +41,13 @@ func (v ClusterCompatVersion) GreaterThan(other ClusterCompatVersion) bool {
 	return clusterCompatVersionLess(other, v)
 }
 
+// IsZero reports whether v is the zero value (Major == 0 && Minor == 0), which is how an
+// unset / never-ratcheted version is represented (e.g. a fresh GatewayRegistry before any
+// node has registered).
+func (v ClusterCompatVersion) IsZero() bool {
+	return v.Major == 0 && v.Minor == 0
+}
+
 // MinClusterCompatVersion returns the minimum version from the given versions.
 // Returns the zero value if no versions are provided.
 func MinClusterCompatVersion(versions ...ClusterCompatVersion) ClusterCompatVersion {
@@ -107,6 +114,34 @@ type RegistryNode struct {
 type RegistryFreeze struct {
 	Version  ClusterCompatVersion `json:"version"`
 	FrozenAt time.Time            `json:"frozen_at"`
+}
+
+// PreSGNodeVersionFallback is the cluster compat version stamped onto an observation of a
+// peer found in SGRCluster.Nodes whose SGNode entry doesn't carry a Version field — i.e. a
+// pre-4.1 peer (SGNode.Version was introduced in 4.1). Capping at 4.0 reflects what we know:
+// the peer participates in ISGR but predates the version-stamping field. When the side-channel
+// does carry a parseable version, that observed version is used directly instead.
+//
+// Different from preCbgtExtrasVersion (3.0) because each side-channel started carrying
+// version info in a different release: cbgt extras since 3.1, SGNode.Version since 4.1.
+var PreSGNodeVersionFallback = NewClusterCompatVersion(4, 0)
+
+// RegistryPreCCVAwareNode represents an observation of a pre-CCV-aware Sync Gateway peer by a CCV-
+// aware node. Unlike RegistryNode, these entries are written by an observing peer, not by the
+// pre-CCV-aware peer itself, and are keyed in GatewayRegistry.PreCCVAwareNodes by the pre-CCV-aware peer's
+// UUID (which is therefore not duplicated inside the entry body). Observations of the same
+// peer through multiple side-channels collapse onto a single entry with the lower-versioned
+// reading winning. LastObservedAt plays the same role as RegistryNode.HeartbeatAt: entries
+// older than the configured heartbeat expiry are pruned by RegisterNodeVersion.
+//
+// Version is the pre-CCV-aware peer's cluster compat version (major.minor). The observer parses
+// the side-channel's full build version at observation time and stores only the major.minor —
+// CCV decisions don't need higher precision and storing the build string would imply
+// precision the observation can't guarantee. When the side-channel carried no version,
+// Version is set to PreSGNodeVersionFallback as a conservative fallback at observation time.
+type RegistryPreCCVAwareNode struct {
+	Version        ClusterCompatVersion `json:"version"`
+	LastObservedAt time.Time            `json:"last_observed_at"`
 }
 
 // ParseClusterCompatVersion parses a "major.minor" string into a ClusterCompatVersion.

--- a/base/version_comparable_build.go
+++ b/base/version_comparable_build.go
@@ -84,8 +84,12 @@ func NewComparableBuildVersion(majorStr, minorStr, patchStr, otherStr, buildStr,
 	return v, nil
 }
 
-// Equal returns true if pv is equal to b
+// Equal returns true if pv and b describe the same build (all version components equal).
+// Nil-safe: two nil receivers are equal; a nil and a non-nil are not.
 func (pv *ComparableBuildVersion) Equal(b *ComparableBuildVersion) bool {
+	if pv == nil || b == nil {
+		return pv == b
+	}
 	return pv.epoch == b.epoch &&
 		pv.major == b.major &&
 		pv.minor == b.minor &&
@@ -135,6 +139,33 @@ func (a *ComparableBuildVersion) Less(b *ComparableBuildVersion) bool {
 
 	// versions are equal
 	return false
+}
+
+// ClusterCompatVersion returns the major.minor of this build as a ClusterCompatVersion.
+// Patch / build / edition / epoch are dropped — CCV decisions are major.minor-only.
+// Returns a zero ClusterCompatVersion when pv is nil.
+func (pv *ComparableBuildVersion) ClusterCompatVersion() ClusterCompatVersion {
+	if pv == nil {
+		return ClusterCompatVersion{}
+	}
+	return ClusterCompatVersion{Major: pv.major, Minor: pv.minor}
+}
+
+// AtLeastMinorVersion returns true if pv is at least the given major.minor (ignoring patch,
+// build, edition). Returns false if pv is nil. Epoch is treated as more significant than
+// major — a higher epoch beats any lower-epoch major.minor regardless of the threshold,
+// matching the ordering used by Less.
+func (pv *ComparableBuildVersion) AtLeastMinorVersion(major, minor uint8) bool {
+	if pv == nil {
+		return false
+	}
+	if pv.epoch != 0 {
+		return true
+	}
+	if pv.major != major {
+		return pv.major > major
+	}
+	return pv.minor >= minor
 }
 
 // AtLeastMinorDowngrade returns true there is a major or minor downgrade from a to b.

--- a/db/peer_observation.go
+++ b/db/peer_observation.go
@@ -1,0 +1,101 @@
+// Copyright 2026-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package db
+
+import (
+	"context"
+
+	"github.com/couchbase/sync_gateway/base"
+)
+
+// ObservePreCCVAwarePeers collects observations of pre-CCV-aware Sync Gateway peers visible to
+// this database through the two side-channels that pre-4.1 nodes populate:
+//
+//  1. cbgt.NODE_DEFS_KNOWN — peers running sharded import (EE).
+//  2. SGRCluster.Nodes — peers participating in inter-SG replication (ISGR).
+//
+// Discrimination is by self-published version on the side-channel entry itself: a peer whose
+// version is at least ccvAwareMajor.ccvAwareMinor is treated as CCV-aware and skipped (it
+// self-registers in GatewayRegistry.Nodes via its own RegisterNodeVersion call). Peers below
+// the threshold are emitted as pre-CCV-aware-peer entries. Entries whose UUID is this database's
+// local db.UUID are excluded as defence in depth — the local node's own cbgt/ISGR entries
+// are version-tagged and would already be filtered, but excluding by UUID guards against any
+// transient pre-write window.
+//
+// The cbgt side-channel always yields a non-nil version: pre-3.1 peers (which predate cbgt
+// extras Version stamping, CBG-2213) are stamped as a fake 3.0 by base.getNodeVersion. The
+// SGRCluster side-channel can still carry nil for pre-4.1 peers that wrote SGNode entries
+// without the Version field — those entries are substituted with PreSGNodeVersionFallback at
+// this layer so the downstream registry always carries a concrete ClusterCompatVersion. CCV
+// decisions don't need precision beyond major.minor, so the observed build version is
+// collapsed at write time.
+//
+// Returns a map keyed by pre-CCV-aware peer UUID, deduped across side-channels. When the same
+// peer appears in both cbgt and SGRCluster, the lower-versioned reading wins — observed
+// inputs are upgrade-fan-in, so the more conservative reading is the correct CCV input.
+//
+// Errors from either side-channel enumeration are logged at Warn and the partial result is
+// returned — the caller's CCV cap still functions correctly with whichever observations did
+// succeed.
+func (db *DatabaseContext) ObservePreCCVAwarePeers(ctx context.Context, ccvAwareMajor, ccvAwareMinor uint8) map[string]base.RegistryPreCCVAwareNode {
+	out := make(map[string]base.RegistryPreCCVAwareNode)
+
+	upsert := func(uuid string, version *base.ComparableBuildVersion) {
+		if uuid == db.UUID {
+			return
+		}
+		if version != nil && version.AtLeastMinorVersion(ccvAwareMajor, ccvAwareMinor) {
+			return
+		}
+		var ccv base.ClusterCompatVersion
+		if version != nil {
+			ccv = version.ClusterCompatVersion()
+		} else {
+			ccv = base.PreSGNodeVersionFallback
+		}
+		if existing, ok := out[uuid]; ok {
+			if existing.Version.GreaterThan(ccv) {
+				existing.Version = ccv
+				out[uuid] = existing
+			}
+			return
+		}
+		out[uuid] = base.RegistryPreCCVAwareNode{Version: ccv}
+	}
+
+	if db.ImportListener != nil && db.ImportListener.cbgtContext != nil {
+		cbgtNodes, err := base.ListCbgtNodes(ctx, db.ImportListener.cbgtContext.Cfg)
+		if err != nil {
+			base.WarnfCtx(ctx, "Failed to enumerate cbgt nodes for pre-CCV-aware peer observation on database %s: %v", base.MD(db.Name), err)
+		} else {
+			for _, node := range cbgtNodes {
+				upsert(node.UUID, node.Version)
+			}
+		}
+	}
+
+	if db.SGReplicateMgr != nil {
+		sgrNodes, err := db.SGReplicateMgr.getNodes()
+		if err != nil {
+			base.WarnfCtx(ctx, "Failed to enumerate SGRCluster nodes for pre-CCV-aware peer observation on database %s: %v", base.MD(db.Name), err)
+		} else {
+			for _, node := range sgrNodes {
+				if node == nil {
+					continue
+				}
+				upsert(node.UUID, node.Version)
+			}
+		}
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -81,14 +81,16 @@ func NewSGRCluster() *SGRCluster {
 
 // SGNode represents a single Sync Gateway node in the cluster
 type SGNode struct {
-	UUID string `json:"uuid"` // Node UUID
-	Host string `json:"host"` // Host name
+	UUID    string                       `json:"uuid"`              // Node UUID
+	Host    string                       `json:"host"`              // Host name
+	Version *base.ComparableBuildVersion `json:"version,omitempty"` // Sync Gateway product version of the node. Pre-4.1 nodes omit this field; CCV-aware observers use its presence and value to filter peers when computing the pre-CCV-aware-node cap.
 }
 
 func NewSGNode(uuid string, host string) *SGNode {
 	return &SGNode{
-		UUID: uuid,
-		Host: host,
+		UUID:    uuid,
+		Host:    host,
+		Version: base.ProductVersion,
 	}
 }
 
@@ -991,13 +993,19 @@ func (m *sgReplicateManager) RegisterNode(nodeUUID string) error {
 }
 
 // registerNodeForHost node adds a node to the cluster config, then triggers replication rebalance.
-// Retries on CAS failure, is no-op if node already exists in config.  Split out of RegisterNode to support
-// testing with specified host values.
+// Retries on CAS failure, is no-op if node already exists in config with matching Version.  Split
+// out of RegisterNode to support testing with specified host values. If the entry exists but its
+// Version differs from the local build (or is missing), Version is refreshed in place so CCV-aware
+// observers correctly classify this node as CCV-aware on subsequent registrations.
 func (m *sgReplicateManager) registerNodeForHost(nodeUUID string, host string) error {
 	registerNodeCallback := func(cluster *SGRCluster) (cancel bool, err error) {
-		_, exists := cluster.Nodes[nodeUUID]
+		existing, exists := cluster.Nodes[nodeUUID]
 		if exists {
-			return true, nil
+			if existing.Version.Equal(base.ProductVersion) {
+				return true, nil
+			}
+			existing.Version = base.ProductVersion
+			return false, nil
 		}
 		cluster.Nodes[nodeUUID] = NewSGNode(nodeUUID, host)
 		cluster.RebalanceReplications()

--- a/db/sg_replicate_cfg_test.go
+++ b/db/sg_replicate_cfg_test.go
@@ -141,6 +141,52 @@ func TestReplicateManagerNodes(t *testing.T) {
 	assert.Len(t, replications, 0)
 }
 
+// TestReplicateManagerRegisterNodeRefreshesVersion verifies registerNodeForHost's in-place
+// Version refresh path: if an SGNode already exists in the cluster config without a Version
+// (the state a pre-4.1 peer would have left behind), a CCV-aware re-registration must overwrite
+// it with the local build's ProductVersion so subsequent observers correctly classify this
+// node as CCV-aware. Re-registering with a matching Version remains a no-op.
+func TestReplicateManagerRegisterNodeRefreshesVersion(t *testing.T) {
+
+	ctx := base.TestCtx(t)
+	testBucket := base.GetTestBucket(t)
+	defer testBucket.Close(ctx)
+
+	testCfg, err := base.NewCfgSG(ctx, testBucket.GetSingleDataStore(), "", false)
+	require.NoError(t, err)
+
+	manager, err := NewSGReplicateManager(ctx, &DatabaseContext{Name: "test"}, testCfg)
+	require.NoError(t, err)
+	defer manager.Stop()
+
+	const nodeUUID = "legacy-style-node"
+	// Seed the cluster with a Version-less entry (simulates a pre-4.1 peer that wrote itself
+	// before SGNode.Version existed).
+	err = manager.updateCluster(func(cluster *SGRCluster) (cancel bool, err error) {
+		cluster.Nodes[nodeUUID] = &SGNode{UUID: nodeUUID, Host: "legacy-host"}
+		return false, nil
+	})
+	require.NoError(t, err)
+
+	nodes, err := manager.getNodes()
+	require.NoError(t, err)
+	require.Contains(t, nodes, nodeUUID)
+	require.Nil(t, nodes[nodeUUID].Version, "seeded entry should have no Version")
+
+	// First refresh: Version was nil → must be set to ProductVersion.
+	require.NoError(t, manager.registerNodeForHost(nodeUUID, "legacy-host"))
+	nodes, err = manager.getNodes()
+	require.NoError(t, err)
+	require.NotNil(t, nodes[nodeUUID].Version, "Version must be set after refresh")
+	assert.True(t, nodes[nodeUUID].Version.Equal(base.ProductVersion), "Version must match local build")
+
+	// Second refresh: Version is already current → no-op, must not error.
+	require.NoError(t, manager.registerNodeForHost(nodeUUID, "legacy-host"))
+	nodes, err = manager.getNodes()
+	require.NoError(t, err)
+	assert.True(t, nodes[nodeUUID].Version.Equal(base.ProductVersion), "idempotent re-registration must not perturb Version")
+}
+
 // Test concurrent node operations on SGReplicateManager
 func TestReplicateManagerConcurrentNodeOperations(t *testing.T) {
 

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -3387,6 +3387,22 @@ ClusterCompatVersionState:
       additionalProperties:
         x-additionalPropertiesName: nodeUID
         $ref: '#/ClusterCompatVersion'
+    pre_ccv_aware_nodes:
+      type: object
+      description: |-
+        Pre-CCV-aware Sync Gateway peers observed via side-channels (cbgt NodeDefs for
+        sharded import, SGRCluster.Nodes for ISGR), keyed by pre-CCV-aware peer UUID. Each
+        peer's value is its observed cluster compatibility version (major.minor) — the
+        observer parses the side-channel's full build version and stores major.minor
+        only, since CCV decisions don't depend on higher precision. When the side-channel
+        didn't carry a version, a conservative pre-SGNode-Version fallback (4.0) is
+        substituted at observation time. Peers below the cluster's HWM are reported here
+        for operator visibility but do not roll cluster_compat_version back below HWM —
+        that case represents an unsupported downgrade. Omitted when no pre-CCV-aware peers
+        are currently observed.
+      additionalProperties:
+        x-additionalPropertiesName: nodeUUID
+        $ref: '#/ClusterCompatVersion'
     frozen_cluster_compat_version:
       allOf:
         - $ref: '#/ClusterCompatVersion'
@@ -3491,6 +3507,18 @@ GatewayRegistry:
         cluster compatibility version reported by this Sync Gateway is capped at
         `frozen_cluster_compat_version.version` until the freeze is cleared via
         `POST /_cluster_compat_version/unfreeze`.
+    pre_ccv_aware_nodes:
+      description: |-
+        Map of pre-CCV-aware peer UUID to that peer's pre-CCV-aware-node entry. Records pre-CCV-aware
+        Sync Gateway peers detected via side-channel registries (cbgt `NODE_DEFS_KNOWN` for
+        sharded import, `SGRCluster.Nodes` for inter-SG replication). Unlike `nodes`, entries
+        here are written by an observing CCV-aware peer rather than by the pre-CCV-aware peer
+        itself. Entries age out via the heartbeat-expiry prune on each registry write. Omitted
+        when no pre-CCV-aware peers are currently recorded.
+      type: object
+      additionalProperties:
+        x-additionalPropertiesName: nodeUUID
+        $ref: '#/RegistryPreCCVAwareNode'
 
 RegistryNode:
   type: object
@@ -3504,6 +3532,34 @@ RegistryNode:
       type: string
       format: date-time
       description: Time of the node's last heartbeat write to this registry.
+
+RegistryPreCCVAwareNode:
+  type: object
+  description: |-
+    An observation of a pre-CCV-aware Sync Gateway peer recorded by a CCV-aware peer. Written
+    by the observer (not the pre-CCV-aware peer), keyed in `pre_ccv_aware_nodes` by the pre-CCV-aware peer's
+    UUID. The observer collapses the peer's side-channel build version to major.minor at write
+    time; when the side-channel observation didn't carry a version, a conservative
+    pre-SGNode-Version fallback (4.0) is substituted. Entries below the bucket's
+    `cluster_compat_version_hwm` are reported here for operator visibility but do not pull
+    reported cluster_compat_version back below HWM.
+  properties:
+    version:
+      allOf:
+        - $ref: '#/ClusterCompatVersion'
+      description: |-
+        The pre-CCV-aware peer's cluster compatibility version (major.minor). Reflects either the
+        parsed side-channel build version or the conservative fallback when none was carried.
+    last_observed_at:
+      type: string
+      format: date-time
+      description: |-
+        Time at which the observation was last refreshed by an observer. Entries whose
+        `last_observed_at` is older than the configured heartbeat expiry are pruned on the
+        next registry write.
+  required:
+    - version
+    - last_observed_at
 
 RegistryFrozenClusterCompatVersion:
   type: object

--- a/rest/cluster_compat.go
+++ b/rest/cluster_compat.go
@@ -239,7 +239,7 @@ func (m *clusterCompatManager) RegisterBucket(ctx context.Context, bucket string
 	// at least one database having reached DBOnline (see ratchetEligibleBuckets) — so the
 	// observation is stable when the ratchet actually runs.
 	preCCVAwarePeers := m.sc._observePreCCVAwarePeersForBucket(ctx, bucket)
-	registry, err := m.sc.BootstrapContext.RegisterNodeVersion(ctx, RegisterNodeVersionParams{
+	registry, err := m.sc.BootstrapContext.RegisterNodeVersion(ctx, RegisterNodeVersionOpts{
 		BucketName:       bucket,
 		NodeUID:          m.sc.NodeUID,
 		GroupID:          m.sc.Config.Bootstrap.ConfigGroupID,
@@ -482,7 +482,7 @@ func (m *clusterCompatManager) refreshNodeRegistrations(ctx context.Context) (ma
 	for _, bucket := range buckets {
 		_, ratchet := eligibleBuckets[bucket]
 		preCCVAwarePeers := m.sc.observePreCCVAwarePeersForBucket(ctx, bucket)
-		registry, err := m.sc.BootstrapContext.RegisterNodeVersion(ctx, RegisterNodeVersionParams{
+		registry, err := m.sc.BootstrapContext.RegisterNodeVersion(ctx, RegisterNodeVersionOpts{
 			BucketName:       bucket,
 			NodeUID:          m.sc.NodeUID,
 			GroupID:          m.sc.Config.Bootstrap.ConfigGroupID,

--- a/rest/cluster_compat.go
+++ b/rest/cluster_compat.go
@@ -239,7 +239,16 @@ func (m *clusterCompatManager) RegisterBucket(ctx context.Context, bucket string
 	// at least one database having reached DBOnline (see ratchetEligibleBuckets) — so the
 	// observation is stable when the ratchet actually runs.
 	preCCVAwarePeers := m.sc._observePreCCVAwarePeersForBucket(ctx, bucket)
-	registry, err := m.sc.BootstrapContext.RegisterNodeVersion(ctx, bucket, m.sc.NodeUID, m.sc.Config.Bootstrap.ConfigGroupID, m.sc.BootstrapContext.clusterCompatVersion, m.getAppliedDBVersionsForBucket(bucket), m.heartbeatExpiry(), preCCVAwarePeers, false)
+	registry, err := m.sc.BootstrapContext.RegisterNodeVersion(ctx, RegisterNodeVersionParams{
+		BucketName:       bucket,
+		NodeUID:          m.sc.NodeUID,
+		GroupID:          m.sc.Config.Bootstrap.ConfigGroupID,
+		Version:          m.sc.BootstrapContext.clusterCompatVersion,
+		Databases:        m.getAppliedDBVersionsForBucket(bucket),
+		HeartbeatExpiry:  m.heartbeatExpiry(),
+		PreCCVAwarePeers: preCCVAwarePeers,
+		RatchetHWM:       false,
+	})
 	if err != nil {
 		m.releaseBucket(bucket)
 		return err
@@ -473,7 +482,16 @@ func (m *clusterCompatManager) refreshNodeRegistrations(ctx context.Context) (ma
 	for _, bucket := range buckets {
 		_, ratchet := eligibleBuckets[bucket]
 		preCCVAwarePeers := m.sc.observePreCCVAwarePeersForBucket(ctx, bucket)
-		registry, err := m.sc.BootstrapContext.RegisterNodeVersion(ctx, bucket, m.sc.NodeUID, m.sc.Config.Bootstrap.ConfigGroupID, nodeVersion, m.getAppliedDBVersionsForBucket(bucket), expiry, preCCVAwarePeers, ratchet)
+		registry, err := m.sc.BootstrapContext.RegisterNodeVersion(ctx, RegisterNodeVersionParams{
+			BucketName:       bucket,
+			NodeUID:          m.sc.NodeUID,
+			GroupID:          m.sc.Config.Bootstrap.ConfigGroupID,
+			Version:          nodeVersion,
+			Databases:        m.getAppliedDBVersionsForBucket(bucket),
+			HeartbeatExpiry:  expiry,
+			PreCCVAwarePeers: preCCVAwarePeers,
+			RatchetHWM:       ratchet,
+		})
 		if err != nil {
 			base.WarnfCtx(ctx, "Failed to register node version in bucket %s: %v", base.MD(bucket), err)
 			continue

--- a/rest/cluster_compat.go
+++ b/rest/cluster_compat.go
@@ -72,7 +72,19 @@ type clusterCompatManager struct {
 	// reports a freeze. Stored separately for surfacing via the API and audit; its Version
 	// participates in computeCCV alongside the node versions.
 	cachedFreeze *base.RegistryFreeze
-	// cachedVersion is the reported cluster compat version: computeCCV(cachedNodes, cachedFreeze).
+	// cachedPreCCVAwareNodes is the union of pre-CCV-aware peers observed across tracked bucket
+	// registries from the most recent observation, keyed by pre-CCV-aware peer UUID. Reported
+	// verbatim via the API for operator visibility; only the subset whose Version is at or
+	// above cachedHWM participates in computeCCV (entries below HWM represent an unsupported
+	// downgrade we deliberately don't roll CCV back for).
+	cachedPreCCVAwareNodes map[string]*base.RegistryPreCCVAwareNode
+	// cachedHWM is the aggregated ClusterCompatVersionHWM across tracked bucket registries
+	// (max across buckets). Acts as a floor for pre-CCV-aware-peer contributions to computeCCV: a
+	// pre-CCV-aware peer observed below HWM is an unsupported downgrade the cluster cannot
+	// stop but should not surface as a CCV regression. Nil until at least one bucket has
+	// reported a non-zero HWM.
+	cachedHWM *base.ClusterCompatVersion
+	// cachedVersion is the reported cluster compat version: computeCCV(cachedNodes, cachedFreeze, cachedPreCCVAwareNodes, cachedHWM).
 	// Nil when nothing has been observed yet.
 	cachedVersion *base.ClusterCompatVersion
 	// appliedDBVersions tracks the database config version this node has successfully
@@ -217,11 +229,17 @@ func (m *clusterCompatManager) RegisterBucket(ctx context.Context, bucket string
 	if !m.claimBucket(bucket) {
 		return nil
 	}
+	// Callers of RegisterBucket (currently only _applyConfig) hold _databasesLock for write,
+	// so observePreCCVAwarePeersForBucket's RLock would self-deadlock. Use the lock-free body —
+	// the caller's exclusive ownership of the database set is the necessary guarantee.
+	//
 	// ratchetHWM=false here: HWM is monotonic and cannot be rolled back, so an advance
 	// committed off transient startup state would lock the cluster at a too-high value
 	// forever. The HWM ratchet happens later via the periodic Refresh, gated per-bucket on
-	// at least one database having reached DBOnline (see ratchetEligibleBuckets).
-	registry, err := m.sc.BootstrapContext.RegisterNodeVersion(ctx, bucket, m.sc.NodeUID, m.sc.Config.Bootstrap.ConfigGroupID, m.sc.BootstrapContext.clusterCompatVersion, m.getAppliedDBVersionsForBucket(bucket), m.heartbeatExpiry(), false)
+	// at least one database having reached DBOnline (see ratchetEligibleBuckets) — so the
+	// observation is stable when the ratchet actually runs.
+	preCCVAwarePeers := m.sc._observePreCCVAwarePeersForBucket(ctx, bucket)
+	registry, err := m.sc.BootstrapContext.RegisterNodeVersion(ctx, bucket, m.sc.NodeUID, m.sc.Config.Bootstrap.ConfigGroupID, m.sc.BootstrapContext.clusterCompatVersion, m.getAppliedDBVersionsForBucket(bucket), m.heartbeatExpiry(), preCCVAwarePeers, false)
 	if err != nil {
 		m.releaseBucket(bucket)
 		return err
@@ -229,9 +247,9 @@ func (m *clusterCompatManager) RegisterBucket(ctx context.Context, bucket string
 	// Merge this bucket's registry into the cached view and recompute. A node removed from
 	// this bucket but still present in another tracked bucket would not be evicted here —
 	// that's reconciled by the periodic Refresh, which rebuilds the cache from scratch. Same
-	// for the freeze record: a freeze cleared elsewhere stays reflected here until the next
-	// Refresh recomputes the aggregate.
-	oldVersion, newVersion := m.mergeRegistryIntoCache(registry.Nodes, registry.Frozen)
+	// for the freeze record and pre-CCV-aware-node observations: an entry cleared elsewhere stays
+	// reflected here until the next Refresh recomputes the aggregate.
+	oldVersion, newVersion := m.mergeRegistryIntoCache(registry.Nodes, registry.Frozen, registry.PreCCVAwareNodes, registry.ClusterCompatVersionHWM)
 	base.InfofCtx(ctx, base.KeyConfig, "Registered node %s in bucket %s; cluster compatibility version is %v", m.sc.NodeUID, base.MD(bucket), newVersion)
 	if !clusterCompatVersionEqual(oldVersion, newVersion) {
 		base.InfofCtx(ctx, base.KeyConfig, "Cluster compatibility version changed from %v to %v", oldVersion, newVersion)
@@ -241,7 +259,7 @@ func (m *clusterCompatManager) RegisterBucket(ctx context.Context, bucket string
 
 // ratchetEligibleBuckets returns the set of buckets with at least one DBOnline database.
 // Used by Refresh to gate the HWM ratchet on per-bucket online state: ratcheting requires
-// inputs (e.g. legacy-node detection via ISGR/cbgt) that are only available once the
+// inputs (e.g. pre-CCV-aware-node detection via ISGR/cbgt) that are only available once the
 // database is fully online. Buckets absent from the returned set stay heartbeat-only until
 // the next refresh tick.
 //
@@ -283,10 +301,15 @@ func (m *clusterCompatManager) releaseBucket(bucket string) {
 	delete(m.trackedBuckets, bucket)
 }
 
-// mergeRegistryIntoCache folds the given bucket's node entries and freeze record into the
-// cached cluster view, recomputes the cluster compat version, and returns the previous and
-// new cached versions for caller-side change logging.
-func (m *clusterCompatManager) mergeRegistryIntoCache(nodes map[string]*base.RegistryNode, freeze *base.RegistryFreeze) (oldVersion, newVersion *base.ClusterCompatVersion) {
+// mergeRegistryIntoCache folds the given bucket's node entries, freeze record, pre-CCV-aware-peer
+// observations, and HWM into the cached cluster view, recomputes the cluster compat version,
+// and returns the previous and new cached versions for caller-side change logging. HWM is
+// merged as a max across buckets; a zero-valued hwm (first registration before any ratchet)
+// is ignored. Observed-peer entries for a peer already in the cache are merged with
+// lower-version-wins (with LastObservedAt advanced to whichever observation is newer),
+// matching the cross-bucket aggregation in refreshNodeRegistrations — observed inputs are
+// upgrade-fan-in, so the more conservative reading is the correct CCV input.
+func (m *clusterCompatManager) mergeRegistryIntoCache(nodes map[string]*base.RegistryNode, freeze *base.RegistryFreeze, preCCVAwareNodes map[string]*base.RegistryPreCCVAwareNode, hwm base.ClusterCompatVersion) (oldVersion, newVersion *base.ClusterCompatVersion) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.cachedNodes == nil {
@@ -298,8 +321,28 @@ func (m *clusterCompatManager) mergeRegistryIntoCache(nodes map[string]*base.Reg
 	if freeze != nil {
 		m.cachedFreeze = mergeFreeze(m.cachedFreeze, freeze)
 	}
+	if len(preCCVAwareNodes) > 0 && m.cachedPreCCVAwareNodes == nil {
+		m.cachedPreCCVAwareNodes = make(map[string]*base.RegistryPreCCVAwareNode, len(preCCVAwareNodes))
+	}
+	for key, entry := range preCCVAwareNodes {
+		cp := *entry
+		if existing, ok := m.cachedPreCCVAwareNodes[key]; ok {
+			if existing.Version.GreaterThan(cp.Version) {
+				existing.Version = cp.Version
+			}
+			if cp.LastObservedAt.After(existing.LastObservedAt) {
+				existing.LastObservedAt = cp.LastObservedAt
+			}
+			continue
+		}
+		m.cachedPreCCVAwareNodes[key] = &cp
+	}
+	if !hwm.IsZero() && (m.cachedHWM == nil || hwm.GreaterThan(*m.cachedHWM)) {
+		cp := hwm
+		m.cachedHWM = &cp
+	}
 	oldVersion = m.cachedVersion
-	newVersion = computeCCV(m.cachedNodes, m.cachedFreeze)
+	newVersion = computeCCV(m.cachedNodes, m.cachedFreeze, m.cachedPreCCVAwareNodes, m.cachedHWM)
 	m.cachedVersion = newVersion
 	return oldVersion, newVersion
 }
@@ -335,6 +378,26 @@ func (m *clusterCompatManager) NodeVersions() map[string]base.ClusterCompatVersi
 	return nodes
 }
 
+// PreCCVAwareNodeVersions returns the observed pre-CCV-aware peers, keyed by peer UUID, with each
+// peer's observed major.minor cluster compat version as the value. Entries whose source
+// observation didn't carry a version are reported as PreSGNodeVersionFallback (the
+// conservative fallback applied at observation time). Reports all pre-CCV-aware peers verbatim,
+// including peers below the registry HWM that don't participate in computeCCV (see
+// computeCCV) — those entries are surfaced here for operator visibility. Returns nil when
+// no pre-CCV-aware peers are currently observed.
+func (m *clusterCompatManager) PreCCVAwareNodeVersions() map[string]base.ClusterCompatVersion {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if len(m.cachedPreCCVAwareNodes) == 0 {
+		return nil
+	}
+	out := make(map[string]base.ClusterCompatVersion, len(m.cachedPreCCVAwareNodes))
+	for k, v := range m.cachedPreCCVAwareNodes {
+		out[k] = v.Version
+	}
+	return out
+}
+
 // Refresh re-registers this node in every tracked bucket and recomputes the cluster compat
 // version. Called from the config polling goroutine.
 //
@@ -354,12 +417,12 @@ func (m *clusterCompatManager) Refresh(ctx context.Context) {
 		return
 	}
 
-	nodes, freeze, err := m.refreshNodeRegistrations(ctx)
+	nodes, freeze, preCCVAwareNodes, hwm, err := m.refreshNodeRegistrations(ctx)
 	if err != nil {
 		base.WarnfCtx(ctx, "Failed to refresh cluster compat version: %v", err)
 		return
 	}
-	newVersion := computeCCV(nodes, freeze)
+	newVersion := computeCCV(nodes, freeze, preCCVAwareNodes, hwm)
 
 	// Race window: if a Freeze or Unfreeze completed between refreshNodeRegistrations
 	// returning and the lock acquisition below, this write overwrites their mutation with
@@ -371,6 +434,8 @@ func (m *clusterCompatManager) Refresh(ctx context.Context) {
 	oldVersion := m.cachedVersion
 	m.cachedNodes = nodes
 	m.cachedFreeze = freeze
+	m.cachedPreCCVAwareNodes = preCCVAwareNodes
+	m.cachedHWM = hwm
 	m.cachedVersion = newVersion
 	m.lastRefreshAt = time.Now().UTC()
 	m.mu.Unlock()
@@ -385,10 +450,10 @@ func (m *clusterCompatManager) Refresh(ctx context.Context) {
 // an error if every tracked bucket failed so callers can leave the previously-cached state
 // in place — stale is preferable to flipping the cluster compat version to nil on a transient
 // bucket outage.
-func (m *clusterCompatManager) refreshNodeRegistrations(ctx context.Context) (map[string]base.ClusterCompatVersion, *base.RegistryFreeze, error) {
+func (m *clusterCompatManager) refreshNodeRegistrations(ctx context.Context) (map[string]base.ClusterCompatVersion, *base.RegistryFreeze, map[string]*base.RegistryPreCCVAwareNode, *base.ClusterCompatVersion, error) {
 	buckets := m.trackedBucketList()
 	if len(buckets) == 0 {
-		return nil, nil, nil
+		return nil, nil, nil, nil, nil
 	}
 
 	nodeVersion := m.sc.BootstrapContext.clusterCompatVersion
@@ -401,11 +466,14 @@ func (m *clusterCompatManager) refreshNodeRegistrations(ctx context.Context) (ma
 	// Collect unique node versions across all bucket registries. A node appearing in multiple
 	// bucket registries will have the same version — last-write-wins is fine.
 	nodeMap := make(map[string]base.ClusterCompatVersion)
+	preCCVAwareMap := make(map[string]*base.RegistryPreCCVAwareNode)
 	var aggregateFreeze *base.RegistryFreeze
+	var aggregateHWM *base.ClusterCompatVersion
 	succeeded := 0
 	for _, bucket := range buckets {
 		_, ratchet := eligibleBuckets[bucket]
-		registry, err := m.sc.BootstrapContext.RegisterNodeVersion(ctx, bucket, m.sc.NodeUID, m.sc.Config.Bootstrap.ConfigGroupID, nodeVersion, m.getAppliedDBVersionsForBucket(bucket), expiry, ratchet)
+		preCCVAwarePeers := m.sc.observePreCCVAwarePeersForBucket(ctx, bucket)
+		registry, err := m.sc.BootstrapContext.RegisterNodeVersion(ctx, bucket, m.sc.NodeUID, m.sc.Config.Bootstrap.ConfigGroupID, nodeVersion, m.getAppliedDBVersionsForBucket(bucket), expiry, preCCVAwarePeers, ratchet)
 		if err != nil {
 			base.WarnfCtx(ctx, "Failed to register node version in bucket %s: %v", base.MD(bucket), err)
 			continue
@@ -417,25 +485,117 @@ func (m *clusterCompatManager) refreshNodeRegistrations(ctx context.Context) (ma
 		if registry.Frozen != nil {
 			aggregateFreeze = mergeFreeze(aggregateFreeze, registry.Frozen)
 		}
+		// HWM aggregates as max across tracked buckets: the cluster's effective floor is the
+		// highest version any bucket has committed to. Zero-valued HWMs (buckets that have
+		// never ratcheted) don't participate.
+		if !registry.ClusterCompatVersionHWM.IsZero() {
+			if aggregateHWM == nil || registry.ClusterCompatVersionHWM.GreaterThan(*aggregateHWM) {
+				cp := registry.ClusterCompatVersionHWM
+				aggregateHWM = &cp
+			}
+		}
+		// A pre-CCV-aware peer UUID appearing in multiple bucket registries — keep the lower-
+		// versioned reading, with LastObservedAt advanced to the most recent observation
+		// of either reading.
+		for uuid, entry := range registry.PreCCVAwareNodes {
+			cp := *entry
+			if existing, ok := preCCVAwareMap[uuid]; ok {
+				if existing.Version.GreaterThan(cp.Version) {
+					existing.Version = cp.Version
+				}
+				if cp.LastObservedAt.After(existing.LastObservedAt) {
+					existing.LastObservedAt = cp.LastObservedAt
+				}
+				continue
+			}
+			preCCVAwareMap[uuid] = &cp
+		}
 	}
 	if succeeded == 0 {
-		return nil, nil, fmt.Errorf("no tracked bucket registries could be updated (%d tracked)", len(buckets))
+		return nil, nil, nil, nil, fmt.Errorf("no tracked bucket registries could be updated (%d tracked)", len(buckets))
 	}
-	return nodeMap, aggregateFreeze, nil
+	return nodeMap, aggregateFreeze, preCCVAwareMap, aggregateHWM, nil
+}
+
+// ccvAwareMajorVersion / ccvAwareMinorVersion is the major.minor threshold used to
+// discriminate CCV-aware peers from pre-CCV-aware peers when reading their
+// self-published version from cbgt NodeDef.Extras and SGNode.Version. Any peer with a non-nil
+// version at-or-above this threshold is assumed to self-register via RegisterNodeVersion;
+// anything below (or nil) is treated as pre-CCV-aware and capped at PreSGNodeVersionFallback.
+const (
+	ccvAwareMajorVersion = 4
+	ccvAwareMinorVersion = 1
+)
+
+// observePreCCVAwarePeersForBucket gathers pre-CCV-aware-peer observations across all databases this
+// server context has loaded against the given bucket. Returns nil when nothing to report.
+//
+// Acquires _databasesLock.RLock to snapshot the database set. Callers that already hold a
+// _databasesLock write lock (e.g. _applyConfig) must use _observePreCCVAwarePeersForBucket instead
+// to avoid self-deadlock.
+//
+// Best-effort: enumeration errors from cbgt cfg / SGRCluster cfg on individual databases are
+// logged by the per-database observer and do not abort the sweep. The caller's CCV cap still
+// works correctly off whichever observations did succeed.
+func (sc *ServerContext) observePreCCVAwarePeersForBucket(ctx context.Context, bucket string) map[string]base.RegistryPreCCVAwareNode {
+	sc._databasesLock.RLock()
+	defer sc._databasesLock.RUnlock()
+	return sc._observePreCCVAwarePeersForBucket(ctx, bucket)
+}
+
+// _observePreCCVAwarePeersForBucket is the lock-free body of observePreCCVAwarePeersForBucket.
+// Callers MUST hold _databasesLock (read or write) for the duration of the call.
+// When the same UUID is observed by multiple databases (e.g. two databases on the same
+// bucket both seeing a 3.x peer), entries are merged with the lower-versioned observation
+// winning, matching the per-database merge inside ObservePreCCVAwarePeers.
+func (sc *ServerContext) _observePreCCVAwarePeersForBucket(ctx context.Context, bucket string) map[string]base.RegistryPreCCVAwareNode {
+	databases := make([]*db.DatabaseContext, 0, len(sc._databases))
+	for _, dbCtx := range sc._databases {
+		if dbCtx == nil || dbCtx.Bucket == nil || dbCtx.Bucket.GetName() != bucket {
+			continue
+		}
+		databases = append(databases, dbCtx)
+	}
+	var out map[string]base.RegistryPreCCVAwareNode
+	for _, dbCtx := range databases {
+		for uuid, entry := range dbCtx.ObservePreCCVAwarePeers(ctx, ccvAwareMajorVersion, ccvAwareMinorVersion) {
+			if out == nil {
+				out = make(map[string]base.RegistryPreCCVAwareNode)
+			}
+			if existing, ok := out[uuid]; ok && !existing.Version.GreaterThan(entry.Version) {
+				continue
+			}
+			out[uuid] = entry
+		}
+	}
+	return out
 }
 
 // computeCCV returns the reported cluster compat version: the minimum across the live-node
-// versions and the freeze ceiling (when set). Returns nil when no versions are available.
+// versions, the freeze ceiling (when set), and any observed pre-CCV-aware peers whose Version is at
+// or above hwm. Returns nil when no inputs at all are available.
 //
-// The single combining point for all CCV inputs. Future inputs (e.g. an HWM floor) should
-// participate here rather than as a separate override path.
-func computeCCV(nodes map[string]base.ClusterCompatVersion, freeze *base.RegistryFreeze) *base.ClusterCompatVersion {
-	versions := make([]base.ClusterCompatVersion, 0, len(nodes)+1)
+// hwm acts as a floor specifically for pre-CCV-aware peers: a pre-CCV-aware peer observed below the
+// registry HWM represents an unsupported downgrade — the cluster has already committed to a
+// higher CCV via the monotonic HWM ratchet, so an aged-in pre-CCV-aware peer should not surface as a
+// CCV regression. Observed peers below HWM are still reported via PreCCVAwareNodeVersions for
+// operator visibility; they're only excluded from this min-fold.
+//
+// The single combining point for all CCV inputs. New inputs should participate here rather
+// than as a separate override path.
+func computeCCV(nodes map[string]base.ClusterCompatVersion, freeze *base.RegistryFreeze, preCCVAwareNodes map[string]*base.RegistryPreCCVAwareNode, hwm *base.ClusterCompatVersion) *base.ClusterCompatVersion {
+	versions := make([]base.ClusterCompatVersion, 0, len(nodes)+1+len(preCCVAwareNodes))
 	for _, v := range nodes {
 		versions = append(versions, v)
 	}
 	if freeze != nil {
 		versions = append(versions, freeze.Version)
+	}
+	for _, ln := range preCCVAwareNodes {
+		if hwm != nil && hwm.GreaterThan(ln.Version) {
+			continue
+		}
+		versions = append(versions, ln.Version)
 	}
 	if len(versions) == 0 {
 		return nil
@@ -539,7 +699,7 @@ func (m *clusterCompatManager) Freeze(ctx context.Context) (*base.RegistryFreeze
 	if succeeded > 0 {
 		m.mu.Lock()
 		m.cachedFreeze = aggregate
-		m.cachedVersion = computeCCV(m.cachedNodes, m.cachedFreeze)
+		m.cachedVersion = computeCCV(m.cachedNodes, m.cachedFreeze, m.cachedPreCCVAwareNodes, m.cachedHWM)
 		m.mu.Unlock()
 	}
 
@@ -582,7 +742,7 @@ func (m *clusterCompatManager) Unfreeze(ctx context.Context) (previousFreeze, re
 	if len(buckets) == 0 {
 		m.mu.Lock()
 		m.cachedFreeze = nil
-		m.cachedVersion = computeCCV(m.cachedNodes, nil)
+		m.cachedVersion = computeCCV(m.cachedNodes, nil, m.cachedPreCCVAwareNodes, m.cachedHWM)
 		m.mu.Unlock()
 		return previousFreeze, nil, nil
 	}
@@ -610,7 +770,7 @@ func (m *clusterCompatManager) Unfreeze(ctx context.Context) (previousFreeze, re
 	if clearFailed == 0 || residual != nil {
 		m.mu.Lock()
 		m.cachedFreeze = residual
-		m.cachedVersion = computeCCV(m.cachedNodes, m.cachedFreeze)
+		m.cachedVersion = computeCCV(m.cachedNodes, m.cachedFreeze, m.cachedPreCCVAwareNodes, m.cachedHWM)
 		m.mu.Unlock()
 	}
 	if residual != nil {

--- a/rest/cluster_compat_test.go
+++ b/rest/cluster_compat_test.go
@@ -115,7 +115,7 @@ func TestRegisterNodeVersionCASRetry(t *testing.T) {
 	var eg errgroup.Group
 	for i := 0; i < n; i++ {
 		eg.Go(func() error {
-			_, err := bc.RegisterNodeVersion(ctx, RegisterNodeVersionParams{
+			_, err := bc.RegisterNodeVersion(ctx, RegisterNodeVersionOpts{
 				BucketName:      bucketName,
 				NodeUID:         fmt.Sprintf("node-%d", i),
 				Version:         version,
@@ -148,7 +148,7 @@ func TestDeregisterNodeVersionCASRetry(t *testing.T) {
 	const n = 10
 	version := base.NodeClusterCompatVersion
 	for i := 0; i < n; i++ {
-		_, err := bc.RegisterNodeVersion(ctx, RegisterNodeVersionParams{
+		_, err := bc.RegisterNodeVersion(ctx, RegisterNodeVersionOpts{
 			BucketName:      bucketName,
 			NodeUID:         fmt.Sprintf("node-%d", i),
 			Version:         version,
@@ -292,7 +292,7 @@ func TestClusterCompatPruneSelfNotPruned(t *testing.T) {
 	require.NotNil(t, ccm)
 
 	// Make sure self is registered, then make its heartbeat ancient.
-	_, err := bc.RegisterNodeVersion(ctx, RegisterNodeVersionParams{
+	_, err := bc.RegisterNodeVersion(ctx, RegisterNodeVersionOpts{
 		BucketName:      bucketName,
 		NodeUID:         selfUID,
 		Version:         base.NodeClusterCompatVersion,
@@ -304,7 +304,7 @@ func TestClusterCompatPruneSelfNotPruned(t *testing.T) {
 	setNodeHeartbeatAt(t, rt, bucketName, selfUID, staleTime)
 
 	// Re-register with a non-zero expiry. Self must survive and have a fresh heartbeat.
-	registry, err := bc.RegisterNodeVersion(ctx, RegisterNodeVersionParams{
+	registry, err := bc.RegisterNodeVersion(ctx, RegisterNodeVersionOpts{
 		BucketName:      bucketName,
 		NodeUID:         selfUID,
 		Version:         base.NodeClusterCompatVersion,
@@ -505,7 +505,7 @@ func TestClusterCompatDowngradeHWMRatchets(t *testing.T) {
 	registry.ClusterCompatVersionHWM = preserved
 	require.NoError(t, bc.setGatewayRegistry(ctx, bucketName, registry))
 
-	_, err = bc.RegisterNodeVersion(ctx, RegisterNodeVersionParams{
+	_, err = bc.RegisterNodeVersion(ctx, RegisterNodeVersionOpts{
 		BucketName:      bucketName,
 		NodeUID:         "lower-peer",
 		Version:         base.NewClusterCompatVersion(0, 1),
@@ -544,7 +544,7 @@ func TestClusterCompatDowngradeHWMTracksMinAcrossNodes(t *testing.T) {
 	// Add a higher-version peer. Cluster compat is still min(self, higher) == self, so HWM
 	// must not budge.
 	higher := base.NewClusterCompatVersion(base.NodeClusterCompatVersion.Major+1, 0)
-	_, err = bc.RegisterNodeVersion(ctx, RegisterNodeVersionParams{
+	_, err = bc.RegisterNodeVersion(ctx, RegisterNodeVersionOpts{
 		BucketName:      bucketName,
 		NodeUID:         "higher-peer",
 		Version:         higher,
@@ -1379,7 +1379,7 @@ func TestClusterCompatFreezePreventsHWMAdvance(t *testing.T) {
 	// Simulate a node upgrade by re-registering self at a higher version. Without the
 	// freeze ceiling, RegisterNodeVersion would ratchet HWM up to this higher value.
 	higher := base.NewClusterCompatVersion(2, 0)
-	_, err = bc.RegisterNodeVersion(ctx, RegisterNodeVersionParams{
+	_, err = bc.RegisterNodeVersion(ctx, RegisterNodeVersionOpts{
 		BucketName:      bucketName,
 		NodeUID:         rt.ServerContext().NodeUID,
 		Version:         higher,
@@ -1657,7 +1657,7 @@ func TestRegisterNodeVersion_PreCCVAwarePeerCapsHWM(t *testing.T) {
 
 	const peerUUID = "observed-db-uuid"
 	peers := map[string]base.RegistryPreCCVAwareNode{peerUUID: {Version: base.PreSGNodeVersionFallback}}
-	registry, err = bc.RegisterNodeVersion(ctx, RegisterNodeVersionParams{
+	registry, err = bc.RegisterNodeVersion(ctx, RegisterNodeVersionOpts{
 		BucketName:       bucketName,
 		NodeUID:          selfUID,
 		Version:          base.NodeClusterCompatVersion,
@@ -1697,7 +1697,7 @@ func TestRegisterNodeVersion_PreCCVAwarePeerIdempotentRefresh(t *testing.T) {
 
 	const peerUUID = "same-peer"
 	peers := map[string]base.RegistryPreCCVAwareNode{peerUUID: {Version: base.PreSGNodeVersionFallback}}
-	params := RegisterNodeVersionParams{
+	opts := RegisterNodeVersionOpts{
 		BucketName:       bucketName,
 		NodeUID:          selfUID,
 		Version:          base.NodeClusterCompatVersion,
@@ -1705,7 +1705,7 @@ func TestRegisterNodeVersion_PreCCVAwarePeerIdempotentRefresh(t *testing.T) {
 		PreCCVAwarePeers: peers,
 		RatchetHWM:       true,
 	}
-	registry, err := bc.RegisterNodeVersion(ctx, params)
+	registry, err := bc.RegisterNodeVersion(ctx, opts)
 	require.NoError(t, err)
 	require.Contains(t, registry.PreCCVAwareNodes, peerUUID)
 	firstObserved := registry.PreCCVAwareNodes[peerUUID].LastObservedAt
@@ -1714,7 +1714,7 @@ func TestRegisterNodeVersion_PreCCVAwarePeerIdempotentRefresh(t *testing.T) {
 	// would otherwise produce identical instants.
 	time.Sleep(2 * time.Millisecond)
 
-	registry, err = bc.RegisterNodeVersion(ctx, params)
+	registry, err = bc.RegisterNodeVersion(ctx, opts)
 	require.NoError(t, err)
 	assert.Len(t, registry.PreCCVAwareNodes, 1, "duplicate observation must not create a second entry")
 	assert.True(t, registry.PreCCVAwareNodes[peerUUID].LastObservedAt.After(firstObserved), "LastObservedAt must be refreshed on re-observation")
@@ -1735,7 +1735,7 @@ func TestRegisterNodeVersion_PreCCVAwarePeerExpires(t *testing.T) {
 	// Seed via initial observation, then mutate LastObservedAt into the past.
 	const peerUUID = "aging-peer"
 	peers := map[string]base.RegistryPreCCVAwareNode{peerUUID: {Version: base.PreSGNodeVersionFallback}}
-	_, err := bc.RegisterNodeVersion(ctx, RegisterNodeVersionParams{
+	_, err := bc.RegisterNodeVersion(ctx, RegisterNodeVersionOpts{
 		BucketName:       bucketName,
 		NodeUID:          selfUID,
 		Version:          base.NodeClusterCompatVersion,
@@ -1753,7 +1753,7 @@ func TestRegisterNodeVersion_PreCCVAwarePeerExpires(t *testing.T) {
 
 	// Re-register with no pre-CCV-aware peers and a short expiry. The aged entry should be pruned and
 	// HWM should now advance to self's version.
-	registry, err = bc.RegisterNodeVersion(ctx, RegisterNodeVersionParams{
+	registry, err = bc.RegisterNodeVersion(ctx, RegisterNodeVersionOpts{
 		BucketName:      bucketName,
 		NodeUID:         selfUID,
 		Version:         base.NodeClusterCompatVersion,
@@ -1866,7 +1866,7 @@ func TestFreezeAndPreCCVAwareInteraction(t *testing.T) {
 	// is persisted in the registry and surfaced via PreCCVAwareNodeVersions, but must not drag
 	// reported CCV back below HWM.
 	peers := map[string]base.RegistryPreCCVAwareNode{"frozen-era-peer": {Version: base.PreSGNodeVersionFallback}}
-	_, err = bc.RegisterNodeVersion(ctx, RegisterNodeVersionParams{
+	_, err = bc.RegisterNodeVersion(ctx, RegisterNodeVersionOpts{
 		BucketName:       bucketName,
 		NodeUID:          selfUID,
 		Version:          base.NodeClusterCompatVersion,

--- a/rest/cluster_compat_test.go
+++ b/rest/cluster_compat_test.go
@@ -115,7 +115,7 @@ func TestRegisterNodeVersionCASRetry(t *testing.T) {
 	var eg errgroup.Group
 	for i := 0; i < n; i++ {
 		eg.Go(func() error {
-			_, err := bc.RegisterNodeVersion(ctx, bucketName, fmt.Sprintf("node-%d", i), "", version, nil, time.Hour, true)
+			_, err := bc.RegisterNodeVersion(ctx, bucketName, fmt.Sprintf("node-%d", i), "", version, nil, time.Hour, nil, true)
 			return err
 		})
 	}
@@ -142,7 +142,7 @@ func TestDeregisterNodeVersionCASRetry(t *testing.T) {
 	const n = 10
 	version := base.NodeClusterCompatVersion
 	for i := 0; i < n; i++ {
-		_, err := bc.RegisterNodeVersion(ctx, bucketName, fmt.Sprintf("node-%d", i), "", version, nil, time.Hour, true)
+		_, err := bc.RegisterNodeVersion(ctx, bucketName, fmt.Sprintf("node-%d", i), "", version, nil, time.Hour, nil, true)
 		require.NoError(t, err)
 	}
 
@@ -280,13 +280,13 @@ func TestClusterCompatPruneSelfNotPruned(t *testing.T) {
 	require.NotNil(t, ccm)
 
 	// Make sure self is registered, then make its heartbeat ancient.
-	_, err := bc.RegisterNodeVersion(ctx, bucketName, selfUID, "", base.NodeClusterCompatVersion, nil, time.Hour, true)
+	_, err := bc.RegisterNodeVersion(ctx, bucketName, selfUID, "", base.NodeClusterCompatVersion, nil, time.Hour, nil, true)
 	require.NoError(t, err)
 	staleTime := time.Now().Add(-100 * ccm.heartbeatExpiry())
 	setNodeHeartbeatAt(t, rt, bucketName, selfUID, staleTime)
 
 	// Re-register with a non-zero expiry. Self must survive and have a fresh heartbeat.
-	registry, err := bc.RegisterNodeVersion(ctx, bucketName, selfUID, "", base.NodeClusterCompatVersion, nil, ccm.heartbeatExpiry(), true)
+	registry, err := bc.RegisterNodeVersion(ctx, bucketName, selfUID, "", base.NodeClusterCompatVersion, nil, ccm.heartbeatExpiry(), nil, true)
 	require.NoError(t, err)
 	require.Contains(t, registry.Nodes, selfUID)
 	assert.True(t, registry.Nodes[selfUID].HeartbeatAt.After(staleTime), "self's heartbeat must have been refreshed")
@@ -481,7 +481,7 @@ func TestClusterCompatDowngradeHWMRatchets(t *testing.T) {
 	registry.ClusterCompatVersionHWM = preserved
 	require.NoError(t, bc.setGatewayRegistry(ctx, bucketName, registry))
 
-	_, err = bc.RegisterNodeVersion(ctx, bucketName, "lower-peer", "", base.NewClusterCompatVersion(0, 1), nil, time.Hour, true)
+	_, err = bc.RegisterNodeVersion(ctx, bucketName, "lower-peer", "", base.NewClusterCompatVersion(0, 1), nil, time.Hour, nil, true)
 	require.Error(t, err, "lower-version registration must be rejected when HWM is higher")
 	require.Contains(t, err.Error(), "newer Sync Gateway cluster compat version")
 
@@ -514,7 +514,7 @@ func TestClusterCompatDowngradeHWMTracksMinAcrossNodes(t *testing.T) {
 	// Add a higher-version peer. Cluster compat is still min(self, higher) == self, so HWM
 	// must not budge.
 	higher := base.NewClusterCompatVersion(base.NodeClusterCompatVersion.Major+1, 0)
-	_, err = bc.RegisterNodeVersion(ctx, bucketName, "higher-peer", "", higher, nil, time.Hour, true)
+	_, err = bc.RegisterNodeVersion(ctx, bucketName, "higher-peer", "", higher, nil, time.Hour, nil, true)
 	require.NoError(t, err)
 	registry, err = bc.getGatewayRegistry(ctx, bucketName)
 	require.NoError(t, err)
@@ -1343,7 +1343,7 @@ func TestClusterCompatFreezePreventsHWMAdvance(t *testing.T) {
 	// Simulate a node upgrade by re-registering self at a higher version. Without the
 	// freeze ceiling, RegisterNodeVersion would ratchet HWM up to this higher value.
 	higher := base.NewClusterCompatVersion(2, 0)
-	_, err = bc.RegisterNodeVersion(ctx, bucketName, rt.ServerContext().NodeUID, "", higher, nil, time.Hour, true)
+	_, err = bc.RegisterNodeVersion(ctx, bucketName, rt.ServerContext().NodeUID, "", higher, nil, time.Hour, nil, true)
 	require.NoError(t, err)
 
 	registry, err := bc.getGatewayRegistry(ctx, bucketName)
@@ -1588,4 +1588,269 @@ func TestSyncInfoUpgradeGate(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, raw)
 	require.Equal(t, byte(base.SyncInfoTypeV1), raw[0], "after upgrade completes, syncInfo write should be V1")
+}
+
+// TestRegisterNodeVersion_PreCCVAwarePeerCapsHWM verifies that supplying an pre-CCV-aware-peer observation
+// to RegisterNodeVersion writes the entry into registry.PreCCVAwareNodes, caps the bucket HWM
+// against advancing past PreSGNodeVersionFallback, and surfaces the cap through the
+// manager's reported CCV. HWM is a one-way ratchet, so this test resets it before exercising
+// the cap path — otherwise the auto-create-db that happens during RestTester setup would have
+// already ratcheted HWM to the node version (and the cap, which only prevents further
+// advancement, would have nothing to do).
+func TestRegisterNodeVersion_PreCCVAwarePeerCapsHWM(t *testing.T) {
+	rt := NewRestTesterPersistentConfig(t)
+	defer rt.Close()
+
+	ctx := base.TestCtx(t)
+	bc := rt.ServerContext().BootstrapContext
+	bucketName := rt.Bucket().GetName()
+	selfUID := rt.ServerContext().NodeUID
+
+	// Reset HWM and Nodes so the upcoming RegisterNodeVersion is the first one to ratchet.
+	registry, err := bc.getGatewayRegistry(ctx, bucketName)
+	require.NoError(t, err)
+	registry.ClusterCompatVersionHWM = base.ClusterCompatVersion{}
+	registry.Nodes = nil
+	require.NoError(t, bc.setGatewayRegistry(ctx, bucketName, registry))
+
+	const peerUUID = "observed-db-uuid"
+	peers := map[string]base.RegistryPreCCVAwareNode{peerUUID: {Version: base.PreSGNodeVersionFallback}}
+	registry, err = bc.RegisterNodeVersion(ctx, bucketName, selfUID, "", base.NodeClusterCompatVersion, nil, time.Hour, peers, true)
+	require.NoError(t, err)
+
+	require.Contains(t, registry.PreCCVAwareNodes, peerUUID)
+	assert.False(t, registry.PreCCVAwareNodes[peerUUID].LastObservedAt.IsZero(), "LastObservedAt must be stamped on upsert")
+
+	// HWM must be capped at PreSGNodeVersionFallback (no observed version → conservative fallback).
+	assert.Equal(t, base.PreSGNodeVersionFallback, registry.ClusterCompatVersionHWM, "HWM must be capped at the PreSGNodeVersionFallback fallback when version is unknown")
+
+	// Manager-reported CCV reflects the cap on next refresh.
+	ccm := rt.ServerContext().ClusterCompat
+	require.NotNil(t, ccm)
+	ccm.lastRefreshAt = time.Time{}
+	ccm.Refresh(ctx)
+	got := ccm.ClusterCompatVersion()
+	require.NotNil(t, got)
+	assert.Equal(t, base.PreSGNodeVersionFallback, *got, "reported CCV must reflect the pre-CCV-aware-peer cap")
+}
+
+// TestRegisterNodeVersion_PreCCVAwarePeerIdempotentRefresh verifies that observing the same peer in (idempotent refresh)
+// two consecutive RegisterNodeVersion calls refreshes LastObservedAt rather than producing a
+// duplicate entry.
+func TestRegisterNodeVersion_PreCCVAwarePeerIdempotentRefresh(t *testing.T) {
+	rt := NewRestTesterPersistentConfig(t)
+	defer rt.Close()
+
+	ctx := base.TestCtx(t)
+	bc := rt.ServerContext().BootstrapContext
+	bucketName := rt.Bucket().GetName()
+	selfUID := rt.ServerContext().NodeUID
+
+	const peerUUID = "same-peer"
+	peers := map[string]base.RegistryPreCCVAwareNode{peerUUID: {Version: base.PreSGNodeVersionFallback}}
+	registry, err := bc.RegisterNodeVersion(ctx, bucketName, selfUID, "", base.NodeClusterCompatVersion, nil, time.Hour, peers, true)
+	require.NoError(t, err)
+	require.Contains(t, registry.PreCCVAwareNodes, peerUUID)
+	firstObserved := registry.PreCCVAwareNodes[peerUUID].LastObservedAt
+
+	// Force time to advance a touch — UTC timestamps with monotonic-stripped seconds resolution
+	// would otherwise produce identical instants.
+	time.Sleep(2 * time.Millisecond)
+
+	registry, err = bc.RegisterNodeVersion(ctx, bucketName, selfUID, "", base.NodeClusterCompatVersion, nil, time.Hour, peers, true)
+	require.NoError(t, err)
+	assert.Len(t, registry.PreCCVAwareNodes, 1, "duplicate observation must not create a second entry")
+	assert.True(t, registry.PreCCVAwareNodes[peerUUID].LastObservedAt.After(firstObserved), "LastObservedAt must be refreshed on re-observation")
+}
+
+// TestRegisterNodeVersion_PreCCVAwarePeerExpires verifies that an pre-CCV-aware-peer entry whose LastObservedAt
+// has aged past heartbeatExpiry is pruned on the next RegisterNodeVersion call that does not
+// re-observe it.
+func TestRegisterNodeVersion_PreCCVAwarePeerExpires(t *testing.T) {
+	rt := NewRestTesterPersistentConfig(t)
+	defer rt.Close()
+
+	ctx := base.TestCtx(t)
+	bc := rt.ServerContext().BootstrapContext
+	bucketName := rt.Bucket().GetName()
+	selfUID := rt.ServerContext().NodeUID
+
+	// Seed via initial observation, then mutate LastObservedAt into the past.
+	const peerUUID = "aging-peer"
+	peers := map[string]base.RegistryPreCCVAwareNode{peerUUID: {Version: base.PreSGNodeVersionFallback}}
+	_, err := bc.RegisterNodeVersion(ctx, bucketName, selfUID, "", base.NodeClusterCompatVersion, nil, time.Hour, peers, true)
+	require.NoError(t, err)
+
+	registry, err := bc.getGatewayRegistry(ctx, bucketName)
+	require.NoError(t, err)
+	require.Contains(t, registry.PreCCVAwareNodes, peerUUID)
+	registry.PreCCVAwareNodes[peerUUID].LastObservedAt = time.Now().Add(-2 * time.Hour)
+	require.NoError(t, bc.setGatewayRegistry(ctx, bucketName, registry))
+
+	// Re-register with no pre-CCV-aware peers and a short expiry. The aged entry should be pruned and
+	// HWM should now advance to self's version.
+	registry, err = bc.RegisterNodeVersion(ctx, bucketName, selfUID, "", base.NodeClusterCompatVersion, nil, time.Minute, nil, true)
+	require.NoError(t, err)
+	assert.NotContains(t, registry.PreCCVAwareNodes, peerUUID, "stale pre-CCV-aware-peer entry must be pruned")
+	assert.Equal(t, base.NodeClusterCompatVersion, registry.ClusterCompatVersionHWM, "HWM must advance after pre-CCV-aware-peer entry is pruned")
+}
+
+// TestComputeCCV_WithPreCCVAwareCap is a unit-level test of computeCCV that verifies pre-CCV-aware peers
+// participate in the same min-fold as live nodes and the freeze ceiling, but only when their
+// Version is at or above the HWM floor. Each pre-CCV-aware peer's Version is already a concrete
+// major.minor — the observer parses and substitutes PreSGNodeVersionFallback before
+// persisting, so computeCCV never sees a nil version.
+func TestComputeCCV_WithPreCCVAwareCap(t *testing.T) {
+	highNode := map[string]base.ClusterCompatVersion{
+		"n1": base.NewClusterCompatVersion(4, 1),
+		"n2": base.NewClusterCompatVersion(4, 1),
+	}
+
+	// No pre-CCV-aware peers, no HWM → reported CCV tracks the live-node min (4.1).
+	got := computeCCV(highNode, nil, nil, nil)
+	require.NotNil(t, got)
+	assert.Equal(t, base.NewClusterCompatVersion(4, 1), *got)
+
+	// Observed peer recorded with the fallback (observer's substitute for an absent version)
+	// and no HWM → CCV capped at PreSGNodeVersionFallback (4.0).
+	fallbackPreCCVAware := map[string]*base.RegistryPreCCVAwareNode{
+		"unknown-source-peer": {Version: base.PreSGNodeVersionFallback},
+	}
+	got = computeCCV(highNode, nil, fallbackPreCCVAware, nil)
+	require.NotNil(t, got)
+	assert.Equal(t, base.PreSGNodeVersionFallback, *got)
+
+	// Observed peer recorded as 3.3, no HWM → CCV folds in 3.3, beating the 4.0 fallback.
+	knownPreCCVAware := map[string]*base.RegistryPreCCVAwareNode{
+		"v33-peer": {Version: base.NewClusterCompatVersion(3, 3)},
+	}
+	got = computeCCV(highNode, nil, knownPreCCVAware, nil)
+	require.NotNil(t, got)
+	assert.Equal(t, base.NewClusterCompatVersion(3, 3), *got, "pre-CCV-aware peer version must be used directly")
+
+	// Mix: a 3.3 peer and a fallback-versioned peer, no HWM — min is 3.3.
+	mixed := map[string]*base.RegistryPreCCVAwareNode{
+		"v33-peer":            {Version: base.NewClusterCompatVersion(3, 3)},
+		"unknown-source-peer": {Version: base.PreSGNodeVersionFallback},
+	}
+	got = computeCCV(highNode, nil, mixed, nil)
+	require.NotNil(t, got)
+	assert.Equal(t, base.NewClusterCompatVersion(3, 3), *got)
+
+	// Freeze at the pre-CCV-aware-peer cap is a no-op alongside a fallback-versioned pre-CCV-aware peer — both report 4.0.
+	freeze := &base.RegistryFreeze{Version: base.PreSGNodeVersionFallback, FrozenAt: time.Now()}
+	got = computeCCV(highNode, freeze, fallbackPreCCVAware, nil)
+	require.NotNil(t, got)
+	assert.Equal(t, base.PreSGNodeVersionFallback, *got)
+
+	// HWM floor at 4.1: a pre-CCV-aware peer at 4.0 (or 3.3) is below HWM and must be excluded from
+	// the fold — the cluster has already committed to 4.1 and an aged-in pre-CCV-aware peer
+	// must not surface as a CCV regression.
+	hwm41 := base.NewClusterCompatVersion(4, 1)
+	got = computeCCV(highNode, nil, fallbackPreCCVAware, &hwm41)
+	require.NotNil(t, got)
+	assert.Equal(t, base.NewClusterCompatVersion(4, 1), *got, "pre-CCV-aware peer below HWM must not drag CCV back")
+
+	got = computeCCV(highNode, nil, mixed, &hwm41)
+	require.NotNil(t, got)
+	assert.Equal(t, base.NewClusterCompatVersion(4, 1), *got, "all pre-CCV-aware peers below HWM are filtered, CCV tracks live-node min")
+
+	// HWM floor at 3.3: the 3.3 pre-CCV-aware peer is *at* the floor (not below) so it still
+	// contributes; the 4.0 fallback peer is above the floor so it also contributes. Min is 3.3.
+	hwm33 := base.NewClusterCompatVersion(3, 3)
+	got = computeCCV(highNode, nil, mixed, &hwm33)
+	require.NotNil(t, got)
+	assert.Equal(t, base.NewClusterCompatVersion(3, 3), *got, "pre-CCV-aware peer at HWM floor must still contribute")
+
+	// All inputs empty → nil.
+	got = computeCCV(nil, nil, nil, nil)
+	assert.Nil(t, got)
+}
+
+// TestFreezeAndPreCCVAwareInteraction verifies that once HWM has ratcheted past a version, an
+// aged-in pre-CCV-aware-peer observation below HWM does not drag the reported CCV back down. The
+// freeze stays at its pinned version and the pre-CCV-aware peer is reported via the API for
+// operator visibility but excluded from the CCV min-fold.
+func TestFreezeAndPreCCVAwareInteraction(t *testing.T) {
+	rt := NewRestTesterPersistentConfig(t)
+	defer rt.Close()
+
+	ctx := base.TestCtx(t)
+	bc := rt.ServerContext().BootstrapContext
+	bucketName := rt.Bucket().GetName()
+	selfUID := rt.ServerContext().NodeUID
+
+	ccm := rt.ServerContext().ClusterCompat
+	require.NotNil(t, ccm)
+	ccm.Refresh(ctx)
+
+	// Freeze at the current (self) version. With only self registered (4.1), freeze pins at 4.1.
+	// Refresh above also ratcheted HWM to 4.1, so the floor is now 4.1.
+	frozen, err := ccm.Freeze(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, frozen)
+	require.Equal(t, base.NodeClusterCompatVersion, frozen.Version)
+
+	// Observe a pre-CCV-aware peer at 4.0 — below the 4.1 HWM. The peer is persisted in the registry
+	// and surfaced via PreCCVAwareNodeVersions, but must not drag reported CCV back below HWM.
+	peers := map[string]base.RegistryPreCCVAwareNode{"frozen-era-peer": {Version: base.PreSGNodeVersionFallback}}
+	_, err = bc.RegisterNodeVersion(ctx, bucketName, selfUID, "", base.NodeClusterCompatVersion, nil, time.Hour, peers, true)
+	require.NoError(t, err)
+
+	ccm.lastRefreshAt = time.Time{}
+	ccm.Refresh(ctx)
+
+	got := ccm.ClusterCompatVersion()
+	require.NotNil(t, got)
+	assert.Equal(t, base.NodeClusterCompatVersion, *got, "HWM floor must prevent pre-CCV-aware peer from dragging CCV back")
+
+	// The peer is still visible via the API for operator visibility.
+	observed := ccm.PreCCVAwareNodeVersions()
+	assert.Contains(t, observed, "frozen-era-peer", "pre-CCV-aware peer must remain reported even when excluded from CCV computation")
+	assert.Equal(t, base.PreSGNodeVersionFallback, observed["frozen-era-peer"], "reported observed version must reflect the observation, not the HWM floor")
+}
+
+// TestMergeRegistryIntoCache_PreCCVAwarePeerLowerWins verifies that when the same pre-CCV-aware peer UUID
+// is folded in from two consecutive bucket-registry reads (the shape produced by both the
+// RegisterBucket path and the refreshNodeRegistrations cross-bucket loop), the cache retains
+// the lower-versioned observation regardless of fold order, and LastObservedAt is advanced to
+// the most recent observation. This pins down the lower-version-wins contract for both
+// merge sites in lockstep — they share the algorithm.
+func TestMergeRegistryIntoCache_PreCCVAwarePeerLowerWins(t *testing.T) {
+	const peerUUID = "shared-pre-CCV-aware-peer"
+	earlier := time.Now().Add(-time.Hour).UTC()
+	later := time.Now().UTC()
+	v33 := base.NewClusterCompatVersion(3, 3)
+	v40 := base.PreSGNodeVersionFallback
+
+	// Higher reading observed first, lower reading observed second: lower wins, LastObservedAt
+	// advances to the second (more recent) observation.
+	t.Run("higher-then-lower", func(t *testing.T) {
+		m := &clusterCompatManager{}
+		bucketA := map[string]*base.RegistryPreCCVAwareNode{peerUUID: {Version: v40, LastObservedAt: earlier}}
+		m.mergeRegistryIntoCache(nil, nil, bucketA, base.ClusterCompatVersion{})
+
+		bucketB := map[string]*base.RegistryPreCCVAwareNode{peerUUID: {Version: v33, LastObservedAt: later}}
+		m.mergeRegistryIntoCache(nil, nil, bucketB, base.ClusterCompatVersion{})
+
+		require.Contains(t, m.cachedPreCCVAwareNodes, peerUUID)
+		assert.Equal(t, v33, m.cachedPreCCVAwareNodes[peerUUID].Version, "lower reading must win")
+		assert.Equal(t, later, m.cachedPreCCVAwareNodes[peerUUID].LastObservedAt, "LastObservedAt must advance to the most recent observation")
+	})
+
+	// Lower reading observed first, higher reading observed second: lower still wins (sticky),
+	// and LastObservedAt still advances to the more recent observation even though the higher
+	// reading was discarded.
+	t.Run("lower-then-higher", func(t *testing.T) {
+		m := &clusterCompatManager{}
+		bucketA := map[string]*base.RegistryPreCCVAwareNode{peerUUID: {Version: v33, LastObservedAt: earlier}}
+		m.mergeRegistryIntoCache(nil, nil, bucketA, base.ClusterCompatVersion{})
+
+		bucketB := map[string]*base.RegistryPreCCVAwareNode{peerUUID: {Version: v40, LastObservedAt: later}}
+		m.mergeRegistryIntoCache(nil, nil, bucketB, base.ClusterCompatVersion{})
+
+		require.Contains(t, m.cachedPreCCVAwareNodes, peerUUID)
+		assert.Equal(t, v33, m.cachedPreCCVAwareNodes[peerUUID].Version, "lower reading must remain after a higher second observation")
+		assert.Equal(t, later, m.cachedPreCCVAwareNodes[peerUUID].LastObservedAt, "LastObservedAt must advance even when the higher reading is discarded")
+	})
 }

--- a/rest/cluster_compat_test.go
+++ b/rest/cluster_compat_test.go
@@ -115,7 +115,13 @@ func TestRegisterNodeVersionCASRetry(t *testing.T) {
 	var eg errgroup.Group
 	for i := 0; i < n; i++ {
 		eg.Go(func() error {
-			_, err := bc.RegisterNodeVersion(ctx, bucketName, fmt.Sprintf("node-%d", i), "", version, nil, time.Hour, nil, true)
+			_, err := bc.RegisterNodeVersion(ctx, RegisterNodeVersionParams{
+				BucketName:      bucketName,
+				NodeUID:         fmt.Sprintf("node-%d", i),
+				Version:         version,
+				HeartbeatExpiry: time.Hour,
+				RatchetHWM:      true,
+			})
 			return err
 		})
 	}
@@ -142,7 +148,13 @@ func TestDeregisterNodeVersionCASRetry(t *testing.T) {
 	const n = 10
 	version := base.NodeClusterCompatVersion
 	for i := 0; i < n; i++ {
-		_, err := bc.RegisterNodeVersion(ctx, bucketName, fmt.Sprintf("node-%d", i), "", version, nil, time.Hour, nil, true)
+		_, err := bc.RegisterNodeVersion(ctx, RegisterNodeVersionParams{
+			BucketName:      bucketName,
+			NodeUID:         fmt.Sprintf("node-%d", i),
+			Version:         version,
+			HeartbeatExpiry: time.Hour,
+			RatchetHWM:      true,
+		})
 		require.NoError(t, err)
 	}
 
@@ -280,13 +292,25 @@ func TestClusterCompatPruneSelfNotPruned(t *testing.T) {
 	require.NotNil(t, ccm)
 
 	// Make sure self is registered, then make its heartbeat ancient.
-	_, err := bc.RegisterNodeVersion(ctx, bucketName, selfUID, "", base.NodeClusterCompatVersion, nil, time.Hour, nil, true)
+	_, err := bc.RegisterNodeVersion(ctx, RegisterNodeVersionParams{
+		BucketName:      bucketName,
+		NodeUID:         selfUID,
+		Version:         base.NodeClusterCompatVersion,
+		HeartbeatExpiry: time.Hour,
+		RatchetHWM:      true,
+	})
 	require.NoError(t, err)
 	staleTime := time.Now().Add(-100 * ccm.heartbeatExpiry())
 	setNodeHeartbeatAt(t, rt, bucketName, selfUID, staleTime)
 
 	// Re-register with a non-zero expiry. Self must survive and have a fresh heartbeat.
-	registry, err := bc.RegisterNodeVersion(ctx, bucketName, selfUID, "", base.NodeClusterCompatVersion, nil, ccm.heartbeatExpiry(), nil, true)
+	registry, err := bc.RegisterNodeVersion(ctx, RegisterNodeVersionParams{
+		BucketName:      bucketName,
+		NodeUID:         selfUID,
+		Version:         base.NodeClusterCompatVersion,
+		HeartbeatExpiry: ccm.heartbeatExpiry(),
+		RatchetHWM:      true,
+	})
 	require.NoError(t, err)
 	require.Contains(t, registry.Nodes, selfUID)
 	assert.True(t, registry.Nodes[selfUID].HeartbeatAt.After(staleTime), "self's heartbeat must have been refreshed")
@@ -481,7 +505,13 @@ func TestClusterCompatDowngradeHWMRatchets(t *testing.T) {
 	registry.ClusterCompatVersionHWM = preserved
 	require.NoError(t, bc.setGatewayRegistry(ctx, bucketName, registry))
 
-	_, err = bc.RegisterNodeVersion(ctx, bucketName, "lower-peer", "", base.NewClusterCompatVersion(0, 1), nil, time.Hour, nil, true)
+	_, err = bc.RegisterNodeVersion(ctx, RegisterNodeVersionParams{
+		BucketName:      bucketName,
+		NodeUID:         "lower-peer",
+		Version:         base.NewClusterCompatVersion(0, 1),
+		HeartbeatExpiry: time.Hour,
+		RatchetHWM:      true,
+	})
 	require.Error(t, err, "lower-version registration must be rejected when HWM is higher")
 	require.Contains(t, err.Error(), "newer Sync Gateway cluster compat version")
 
@@ -514,7 +544,13 @@ func TestClusterCompatDowngradeHWMTracksMinAcrossNodes(t *testing.T) {
 	// Add a higher-version peer. Cluster compat is still min(self, higher) == self, so HWM
 	// must not budge.
 	higher := base.NewClusterCompatVersion(base.NodeClusterCompatVersion.Major+1, 0)
-	_, err = bc.RegisterNodeVersion(ctx, bucketName, "higher-peer", "", higher, nil, time.Hour, nil, true)
+	_, err = bc.RegisterNodeVersion(ctx, RegisterNodeVersionParams{
+		BucketName:      bucketName,
+		NodeUID:         "higher-peer",
+		Version:         higher,
+		HeartbeatExpiry: time.Hour,
+		RatchetHWM:      true,
+	})
 	require.NoError(t, err)
 	registry, err = bc.getGatewayRegistry(ctx, bucketName)
 	require.NoError(t, err)
@@ -1343,7 +1379,13 @@ func TestClusterCompatFreezePreventsHWMAdvance(t *testing.T) {
 	// Simulate a node upgrade by re-registering self at a higher version. Without the
 	// freeze ceiling, RegisterNodeVersion would ratchet HWM up to this higher value.
 	higher := base.NewClusterCompatVersion(2, 0)
-	_, err = bc.RegisterNodeVersion(ctx, bucketName, rt.ServerContext().NodeUID, "", higher, nil, time.Hour, nil, true)
+	_, err = bc.RegisterNodeVersion(ctx, RegisterNodeVersionParams{
+		BucketName:      bucketName,
+		NodeUID:         rt.ServerContext().NodeUID,
+		Version:         higher,
+		HeartbeatExpiry: time.Hour,
+		RatchetHWM:      true,
+	})
 	require.NoError(t, err)
 
 	registry, err := bc.getGatewayRegistry(ctx, bucketName)
@@ -1615,7 +1657,14 @@ func TestRegisterNodeVersion_PreCCVAwarePeerCapsHWM(t *testing.T) {
 
 	const peerUUID = "observed-db-uuid"
 	peers := map[string]base.RegistryPreCCVAwareNode{peerUUID: {Version: base.PreSGNodeVersionFallback}}
-	registry, err = bc.RegisterNodeVersion(ctx, bucketName, selfUID, "", base.NodeClusterCompatVersion, nil, time.Hour, peers, true)
+	registry, err = bc.RegisterNodeVersion(ctx, RegisterNodeVersionParams{
+		BucketName:       bucketName,
+		NodeUID:          selfUID,
+		Version:          base.NodeClusterCompatVersion,
+		HeartbeatExpiry:  time.Hour,
+		PreCCVAwarePeers: peers,
+		RatchetHWM:       true,
+	})
 	require.NoError(t, err)
 
 	require.Contains(t, registry.PreCCVAwareNodes, peerUUID)
@@ -1648,7 +1697,15 @@ func TestRegisterNodeVersion_PreCCVAwarePeerIdempotentRefresh(t *testing.T) {
 
 	const peerUUID = "same-peer"
 	peers := map[string]base.RegistryPreCCVAwareNode{peerUUID: {Version: base.PreSGNodeVersionFallback}}
-	registry, err := bc.RegisterNodeVersion(ctx, bucketName, selfUID, "", base.NodeClusterCompatVersion, nil, time.Hour, peers, true)
+	params := RegisterNodeVersionParams{
+		BucketName:       bucketName,
+		NodeUID:          selfUID,
+		Version:          base.NodeClusterCompatVersion,
+		HeartbeatExpiry:  time.Hour,
+		PreCCVAwarePeers: peers,
+		RatchetHWM:       true,
+	}
+	registry, err := bc.RegisterNodeVersion(ctx, params)
 	require.NoError(t, err)
 	require.Contains(t, registry.PreCCVAwareNodes, peerUUID)
 	firstObserved := registry.PreCCVAwareNodes[peerUUID].LastObservedAt
@@ -1657,7 +1714,7 @@ func TestRegisterNodeVersion_PreCCVAwarePeerIdempotentRefresh(t *testing.T) {
 	// would otherwise produce identical instants.
 	time.Sleep(2 * time.Millisecond)
 
-	registry, err = bc.RegisterNodeVersion(ctx, bucketName, selfUID, "", base.NodeClusterCompatVersion, nil, time.Hour, peers, true)
+	registry, err = bc.RegisterNodeVersion(ctx, params)
 	require.NoError(t, err)
 	assert.Len(t, registry.PreCCVAwareNodes, 1, "duplicate observation must not create a second entry")
 	assert.True(t, registry.PreCCVAwareNodes[peerUUID].LastObservedAt.After(firstObserved), "LastObservedAt must be refreshed on re-observation")
@@ -1678,7 +1735,14 @@ func TestRegisterNodeVersion_PreCCVAwarePeerExpires(t *testing.T) {
 	// Seed via initial observation, then mutate LastObservedAt into the past.
 	const peerUUID = "aging-peer"
 	peers := map[string]base.RegistryPreCCVAwareNode{peerUUID: {Version: base.PreSGNodeVersionFallback}}
-	_, err := bc.RegisterNodeVersion(ctx, bucketName, selfUID, "", base.NodeClusterCompatVersion, nil, time.Hour, peers, true)
+	_, err := bc.RegisterNodeVersion(ctx, RegisterNodeVersionParams{
+		BucketName:       bucketName,
+		NodeUID:          selfUID,
+		Version:          base.NodeClusterCompatVersion,
+		HeartbeatExpiry:  time.Hour,
+		PreCCVAwarePeers: peers,
+		RatchetHWM:       true,
+	})
 	require.NoError(t, err)
 
 	registry, err := bc.getGatewayRegistry(ctx, bucketName)
@@ -1689,7 +1753,13 @@ func TestRegisterNodeVersion_PreCCVAwarePeerExpires(t *testing.T) {
 
 	// Re-register with no pre-CCV-aware peers and a short expiry. The aged entry should be pruned and
 	// HWM should now advance to self's version.
-	registry, err = bc.RegisterNodeVersion(ctx, bucketName, selfUID, "", base.NodeClusterCompatVersion, nil, time.Minute, nil, true)
+	registry, err = bc.RegisterNodeVersion(ctx, RegisterNodeVersionParams{
+		BucketName:      bucketName,
+		NodeUID:         selfUID,
+		Version:         base.NodeClusterCompatVersion,
+		HeartbeatExpiry: time.Minute,
+		RatchetHWM:      true,
+	})
 	require.NoError(t, err)
 	assert.NotContains(t, registry.PreCCVAwareNodes, peerUUID, "stale pre-CCV-aware-peer entry must be pruned")
 	assert.Equal(t, base.NodeClusterCompatVersion, registry.ClusterCompatVersionHWM, "HWM must advance after pre-CCV-aware-peer entry is pruned")
@@ -1784,17 +1854,26 @@ func TestFreezeAndPreCCVAwareInteraction(t *testing.T) {
 	require.NotNil(t, ccm)
 	ccm.Refresh(ctx)
 
-	// Freeze at the current (self) version. With only self registered (4.1), freeze pins at 4.1.
-	// Refresh above also ratcheted HWM to 4.1, so the floor is now 4.1.
+	// Freeze at the current (self) version. With only self registered, freeze pins at
+	// base.NodeClusterCompatVersion. Refresh above also ratcheted HWM to that version, so the
+	// floor is now base.NodeClusterCompatVersion.
 	frozen, err := ccm.Freeze(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, frozen)
 	require.Equal(t, base.NodeClusterCompatVersion, frozen.Version)
 
-	// Observe a pre-CCV-aware peer at 4.0 — below the 4.1 HWM. The peer is persisted in the registry
-	// and surfaced via PreCCVAwareNodeVersions, but must not drag reported CCV back below HWM.
+	// Observe a pre-CCV-aware peer at PreSGNodeVersionFallback — below the HWM floor. The peer
+	// is persisted in the registry and surfaced via PreCCVAwareNodeVersions, but must not drag
+	// reported CCV back below HWM.
 	peers := map[string]base.RegistryPreCCVAwareNode{"frozen-era-peer": {Version: base.PreSGNodeVersionFallback}}
-	_, err = bc.RegisterNodeVersion(ctx, bucketName, selfUID, "", base.NodeClusterCompatVersion, nil, time.Hour, peers, true)
+	_, err = bc.RegisterNodeVersion(ctx, RegisterNodeVersionParams{
+		BucketName:       bucketName,
+		NodeUID:          selfUID,
+		Version:          base.NodeClusterCompatVersion,
+		HeartbeatExpiry:  time.Hour,
+		PreCCVAwarePeers: peers,
+		RatchetHWM:       true,
+	})
 	require.NoError(t, err)
 
 	ccm.lastRefreshAt = time.Time{}

--- a/rest/config_manager.go
+++ b/rest/config_manager.go
@@ -701,9 +701,9 @@ func (b *bootstrapContext) setGatewayRegistry(ctx context.Context, bucketName st
 	return nil
 }
 
-// RegisterNodeVersionParams bundles arguments to RegisterNodeVersion. Grouped into a struct
+// RegisterNodeVersionOpts bundles arguments to RegisterNodeVersion. Grouped into a struct
 // so the call sites stay readable as the parameter set grows.
-type RegisterNodeVersionParams struct {
+type RegisterNodeVersionOpts struct {
 	// Databases is the map of database name → config version applied on this node for the
 	// bucket, stamped into registry.Nodes[NodeUID].Databases. Nil-safe.
 	Databases map[string]string
@@ -736,52 +736,52 @@ type RegisterNodeVersionParams struct {
 // write per attempt.
 //
 // The cluster compat downgrade gate is enforced here: if registry.ClusterCompatVersionHWM has
-// a higher major.minor than params.Version, registration is refused with an error and no write
+// a higher major.minor than opts.Version, registration is refused with an error and no write
 // occurs. This is the single point of enforcement for cluster compat — every writer that
 // updates Nodes / ClusterCompatVersionHWM goes through this function, so the gate cannot be
 // bypassed by callers updating those fields. Other registry fields (e.g. ConfigGroups) are
 // written by separate code paths and are unaffected by this gate. registry.SGVersion is
 // intentionally not consulted; it is diagnostic-only.
 //
-// Self (params.NodeUID) is always retained: even if a stale prior entry for this node exists,
+// Self (opts.NodeUID) is always retained: even if a stale prior entry for this node exists,
 // it is not pruned by the prune step — it is overwritten with a fresh heartbeat in the same
 // write. This guarantees the registry never ends up with an empty Nodes map after a successful
 // call.
 //
 // Uses CAS retry on conflict. Returns the registry as written.
-func (b *bootstrapContext) RegisterNodeVersion(ctx context.Context, params RegisterNodeVersionParams) (*GatewayRegistry, error) {
+func (b *bootstrapContext) RegisterNodeVersion(ctx context.Context, opts RegisterNodeVersionOpts) (*GatewayRegistry, error) {
 	for attempt := 1; attempt <= nodeVersionUpdateMaxRetryAttempts; attempt++ {
-		registry, err := b.getGatewayRegistry(ctx, params.BucketName)
+		registry, err := b.getGatewayRegistry(ctx, opts.BucketName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get registry for node registration: %w", err)
 		}
-		if registry.ClusterCompatVersionHWM.GreaterThan(params.Version) {
-			return nil, base.RedactErrorf("Bucket %q has metadata from a newer Sync Gateway cluster compat version %s. This Sync Gateway is %s.", base.MD(params.BucketName), registry.ClusterCompatVersionHWM, params.Version)
+		if registry.ClusterCompatVersionHWM.GreaterThan(opts.Version) {
+			return nil, base.RedactErrorf("Bucket %q has metadata from a newer Sync Gateway cluster compat version %s. This Sync Gateway is %s.", base.MD(opts.BucketName), registry.ClusterCompatVersionHWM, opts.Version)
 		}
 		if registry.Nodes == nil {
 			registry.Nodes = make(map[string]*base.RegistryNode)
 		}
-		pruned := pruneStaleNodes(registry.Nodes, params.NodeUID, params.HeartbeatExpiry)
-		registry.Nodes[params.NodeUID] = &base.RegistryNode{
-			Version:       params.Version,
+		pruned := pruneStaleNodes(registry.Nodes, opts.NodeUID, opts.HeartbeatExpiry)
+		registry.Nodes[opts.NodeUID] = &base.RegistryNode{
+			Version:       opts.Version,
 			HeartbeatAt:   time.Now().UTC(),
-			ConfigGroupID: params.GroupID,
-			Databases:     params.Databases,
+			ConfigGroupID: opts.GroupID,
+			Databases:     opts.Databases,
 		}
 		// Mirror pre-CCV-aware-peer observations into registry.PreCCVAwareNodes, keyed by pre-CCV-aware peer
 		// UUID. Upsert refreshes LastObservedAt to "now" so subsequent prune calls keep them
 		// alive while we keep seeing them; entries we no longer observe age out via
 		// pruneStalePreCCVAwareNodes.
 		now := time.Now().UTC()
-		if len(params.PreCCVAwarePeers) > 0 && registry.PreCCVAwareNodes == nil {
+		if len(opts.PreCCVAwarePeers) > 0 && registry.PreCCVAwareNodes == nil {
 			registry.PreCCVAwareNodes = make(map[string]*base.RegistryPreCCVAwareNode)
 		}
-		for uuid, peer := range params.PreCCVAwarePeers {
+		for uuid, peer := range opts.PreCCVAwarePeers {
 			entry := peer
 			entry.LastObservedAt = now
 			registry.PreCCVAwareNodes[uuid] = &entry
 		}
-		preCCVAwarePruned := pruneStalePreCCVAwareNodes(registry.PreCCVAwareNodes, params.HeartbeatExpiry)
+		preCCVAwarePruned := pruneStalePreCCVAwareNodes(registry.PreCCVAwareNodes, opts.HeartbeatExpiry)
 		// Ratchet ClusterCompatVersionHWM up to the current cluster compat version (min over
 		// all registered nodes and observed pre-CCV-aware peers). Each pre-CCV-aware peer contributes its
 		// observed major.minor when its build version is known, falling back to
@@ -791,12 +791,12 @@ func (b *bootstrapContext) RegisterNodeVersion(ctx context.Context, params Regis
 		// otherwise the downgrade gate above would later block rolling any node back to the
 		// frozen version (the freeze's whole purpose).
 		//
-		// Gated on params.RatchetHWM so startup-window registrations can refresh Nodes /
+		// Gated on opts.RatchetHWM so startup-window registrations can refresh Nodes /
 		// PreCCVAwareNodes without committing HWM off a possibly-incomplete pre-CCV-aware-peer
 		// observation.
 		var hwmBumped bool
 		var previousHWM, ccv base.ClusterCompatVersion
-		if params.RatchetHWM {
+		if opts.RatchetHWM {
 			ccv = minRegistryNodeClusterCompatVersion(registry.Nodes)
 			if preCCVAwareMin, ok := minPreCCVAwareNodeClusterCompatVersion(registry.PreCCVAwareNodes); ok && ccv.GreaterThan(preCCVAwareMin) {
 				ccv = preCCVAwareMin
@@ -810,26 +810,26 @@ func (b *bootstrapContext) RegisterNodeVersion(ctx context.Context, params Regis
 				registry.ClusterCompatVersionHWM = ccv
 			}
 		}
-		err = b.setGatewayRegistry(ctx, params.BucketName, registry)
+		err = b.setGatewayRegistry(ctx, opts.BucketName, registry)
 		if err != nil {
 			if base.IsCasMismatch(err) {
-				base.DebugfCtx(ctx, base.KeyConfig, "CAS mismatch registering node version in bucket %s, retrying (attempt %d/%d)", base.MD(params.BucketName), attempt, nodeVersionUpdateMaxRetryAttempts)
+				base.DebugfCtx(ctx, base.KeyConfig, "CAS mismatch registering node version in bucket %s, retrying (attempt %d/%d)", base.MD(opts.BucketName), attempt, nodeVersionUpdateMaxRetryAttempts)
 				continue
 			}
 			return nil, fmt.Errorf("failed to write registry for node registration: %w", err)
 		}
 		if len(pruned) > 0 {
-			base.InfofCtx(ctx, base.KeyConfig, "Pruned %d stale cluster compat node entries from bucket %s: %v", len(pruned), base.MD(params.BucketName), base.MD(pruned))
+			base.InfofCtx(ctx, base.KeyConfig, "Pruned %d stale cluster compat node entries from bucket %s: %v", len(pruned), base.MD(opts.BucketName), base.MD(pruned))
 		}
 		if len(preCCVAwarePruned) > 0 {
-			base.InfofCtx(ctx, base.KeyConfig, "Pruned %d stale pre-CCV-aware peer observations from bucket %s: %v", len(preCCVAwarePruned), base.MD(params.BucketName), base.MD(preCCVAwarePruned))
+			base.InfofCtx(ctx, base.KeyConfig, "Pruned %d stale pre-CCV-aware peer observations from bucket %s: %v", len(preCCVAwarePruned), base.MD(opts.BucketName), base.MD(preCCVAwarePruned))
 		}
 		if hwmBumped {
-			base.InfofCtx(ctx, base.KeyConfig, "Updated cluster compat version high-water mark in bucket %s from %s to %s", base.MD(params.BucketName), previousHWM, ccv)
+			base.InfofCtx(ctx, base.KeyConfig, "Updated cluster compat version high-water mark in bucket %s from %s to %s", base.MD(opts.BucketName), previousHWM, ccv)
 		}
 		return registry, nil
 	}
-	return nil, base.RedactErrorf("RegisterNodeVersion failed after %d CAS retry attempts for bucket %s", nodeVersionUpdateMaxRetryAttempts, base.MD(params.BucketName))
+	return nil, base.RedactErrorf("RegisterNodeVersion failed after %d CAS retry attempts for bucket %s", nodeVersionUpdateMaxRetryAttempts, base.MD(opts.BucketName))
 }
 
 // DeregisterNodeVersion removes a node's version entry from the given bucket's registry.

--- a/rest/config_manager.go
+++ b/rest/config_manager.go
@@ -701,73 +701,87 @@ func (b *bootstrapContext) setGatewayRegistry(ctx context.Context, bucketName st
 	return nil
 }
 
+// RegisterNodeVersionParams bundles arguments to RegisterNodeVersion. Grouped into a struct
+// so the call sites stay readable as the parameter set grows.
+type RegisterNodeVersionParams struct {
+	// Databases is the map of database name → config version applied on this node for the
+	// bucket, stamped into registry.Nodes[NodeUID].Databases. Nil-safe.
+	Databases map[string]string
+	// PreCCVAwarePeers carries observations of pre-CCV-aware peers (detected via cbgt NodeDefs
+	// or SGRCluster.Nodes) keyed by pre-CCV-aware peer UUID. Each observation is upserted into
+	// registry.PreCCVAwareNodes with LastObservedAt = now; entries not refreshed within
+	// HeartbeatExpiry are pruned in the same write. Passing a nil/empty map is safe — existing
+	// pre-CCV-aware entries simply age out naturally.
+	PreCCVAwarePeers map[string]base.RegistryPreCCVAwareNode
+	BucketName       string
+	NodeUID          string
+	GroupID          string
+	// HeartbeatExpiry must be positive; the validator enforces this for user-supplied configs
+	// and the runtime fallback ensures a sane default (see clusterCompatManager.heartbeatExpiry).
+	// It governs both node and pre-CCV-aware peer entry pruning.
+	HeartbeatExpiry time.Duration
+	Version         base.ClusterCompatVersion
+	// RatchetHWM controls whether this call is allowed to advance ClusterCompatVersionHWM. Pass
+	// false for the first registration during database load (e.g. the RegisterBucket call from
+	// _applyConfig) — HWM is monotonic and a ratchet committed off transient startup state can
+	// never be rolled back. The periodic Refresh passes true only for buckets where at least
+	// one database has reached DBOnline (see clusterCompatManager.ratchetEligibleBuckets), so
+	// the pre-CCV-aware-peer side-channels are guaranteed to be live when the ratchet runs.
+	// Node heartbeat refresh, pre-CCV-aware-peer upsert, and stale pruning happen in either case.
+	RatchetHWM bool
+}
+
 // RegisterNodeVersion registers or updates a node's version and heartbeat in the given bucket's
 // registry, and prunes stale node entries. All mutations are bundled into a single CAS-checked
 // write per attempt.
 //
 // The cluster compat downgrade gate is enforced here: if registry.ClusterCompatVersionHWM has
-// a higher major.minor than version, registration is refused with an error and no write
+// a higher major.minor than params.Version, registration is refused with an error and no write
 // occurs. This is the single point of enforcement for cluster compat — every writer that
 // updates Nodes / ClusterCompatVersionHWM goes through this function, so the gate cannot be
 // bypassed by callers updating those fields. Other registry fields (e.g. ConfigGroups) are
 // written by separate code paths and are unaffected by this gate. registry.SGVersion is
 // intentionally not consulted; it is diagnostic-only.
 //
-// Self (nodeUID) is always retained: even if a stale prior entry for this node exists, it is
-// not pruned by the prune step — it is overwritten with a fresh heartbeat in the same write.
-// This guarantees the registry never ends up with an empty Nodes map after a successful call.
-//
-// heartbeatExpiry must be positive; the validator enforces this for user-supplied configs and
-// the runtime fallback ensures a sane default (see clusterCompatManager.heartbeatExpiry).
-//
-// preCCVAwarePeers carries observations of pre-CCV-aware peers (detected via cbgt NodeDefs or
-// SGRCluster.Nodes) keyed by pre-CCV-aware peer UUID. Each observation is upserted into
-// registry.PreCCVAwareNodes with LastObservedAt = now; entries not refreshed within heartbeatExpiry
-// are pruned in the same write. Passing a nil/empty map is safe — existing legacy entries
-// simply age out naturally.
-//
-// ratchetHWM controls whether this call is allowed to advance ClusterCompatVersionHWM. Pass
-// false for the first registration during database load (e.g. the RegisterBucket call from
-// _applyConfig) — HWM is monotonic and a ratchet committed off transient startup state can
-// never be rolled back. The periodic Refresh passes true only for buckets where at least
-// one database has reached DBOnline (see clusterCompatManager.ratchetEligibleBuckets), so the
-// pre-CCV-aware-peer side-channels are guaranteed to be live when the ratchet runs. Node heartbeat
-// refresh, pre-CCV-aware-peer upsert, and stale pruning happen in either case.
+// Self (params.NodeUID) is always retained: even if a stale prior entry for this node exists,
+// it is not pruned by the prune step — it is overwritten with a fresh heartbeat in the same
+// write. This guarantees the registry never ends up with an empty Nodes map after a successful
+// call.
 //
 // Uses CAS retry on conflict. Returns the registry as written.
-func (b *bootstrapContext) RegisterNodeVersion(ctx context.Context, bucketName, nodeUID, groupID string, version base.ClusterCompatVersion, databases map[string]string, heartbeatExpiry time.Duration, preCCVAwarePeers map[string]base.RegistryPreCCVAwareNode, ratchetHWM bool) (*GatewayRegistry, error) {
+func (b *bootstrapContext) RegisterNodeVersion(ctx context.Context, params RegisterNodeVersionParams) (*GatewayRegistry, error) {
 	for attempt := 1; attempt <= nodeVersionUpdateMaxRetryAttempts; attempt++ {
-		registry, err := b.getGatewayRegistry(ctx, bucketName)
+		registry, err := b.getGatewayRegistry(ctx, params.BucketName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get registry for node registration: %w", err)
 		}
-		if registry.ClusterCompatVersionHWM.GreaterThan(version) {
-			return nil, base.RedactErrorf("Bucket %q has metadata from a newer Sync Gateway cluster compat version %s. This Sync Gateway is %s.", base.MD(bucketName), registry.ClusterCompatVersionHWM, version)
+		if registry.ClusterCompatVersionHWM.GreaterThan(params.Version) {
+			return nil, base.RedactErrorf("Bucket %q has metadata from a newer Sync Gateway cluster compat version %s. This Sync Gateway is %s.", base.MD(params.BucketName), registry.ClusterCompatVersionHWM, params.Version)
 		}
 		if registry.Nodes == nil {
 			registry.Nodes = make(map[string]*base.RegistryNode)
 		}
-		pruned := pruneStaleNodes(registry.Nodes, nodeUID, heartbeatExpiry)
-		registry.Nodes[nodeUID] = &base.RegistryNode{
-			Version:       version,
+		pruned := pruneStaleNodes(registry.Nodes, params.NodeUID, params.HeartbeatExpiry)
+		registry.Nodes[params.NodeUID] = &base.RegistryNode{
+			Version:       params.Version,
 			HeartbeatAt:   time.Now().UTC(),
-			ConfigGroupID: groupID,
-			Databases:     databases,
+			ConfigGroupID: params.GroupID,
+			Databases:     params.Databases,
 		}
 		// Mirror pre-CCV-aware-peer observations into registry.PreCCVAwareNodes, keyed by pre-CCV-aware peer
 		// UUID. Upsert refreshes LastObservedAt to "now" so subsequent prune calls keep them
 		// alive while we keep seeing them; entries we no longer observe age out via
 		// pruneStalePreCCVAwareNodes.
 		now := time.Now().UTC()
-		if len(preCCVAwarePeers) > 0 && registry.PreCCVAwareNodes == nil {
+		if len(params.PreCCVAwarePeers) > 0 && registry.PreCCVAwareNodes == nil {
 			registry.PreCCVAwareNodes = make(map[string]*base.RegistryPreCCVAwareNode)
 		}
-		for uuid, peer := range preCCVAwarePeers {
+		for uuid, peer := range params.PreCCVAwarePeers {
 			entry := peer
 			entry.LastObservedAt = now
 			registry.PreCCVAwareNodes[uuid] = &entry
 		}
-		preCCVAwarePruned := pruneStalePreCCVAwareNodes(registry.PreCCVAwareNodes, heartbeatExpiry)
+		preCCVAwarePruned := pruneStalePreCCVAwareNodes(registry.PreCCVAwareNodes, params.HeartbeatExpiry)
 		// Ratchet ClusterCompatVersionHWM up to the current cluster compat version (min over
 		// all registered nodes and observed pre-CCV-aware peers). Each pre-CCV-aware peer contributes its
 		// observed major.minor when its build version is known, falling back to
@@ -777,11 +791,12 @@ func (b *bootstrapContext) RegisterNodeVersion(ctx context.Context, bucketName, 
 		// otherwise the downgrade gate above would later block rolling any node back to the
 		// frozen version (the freeze's whole purpose).
 		//
-		// Gated on ratchetHWM so startup-window registrations can refresh Nodes / PreCCVAwareNodes
-		// without committing HWM off a possibly-incomplete pre-CCV-aware-peer observation.
+		// Gated on params.RatchetHWM so startup-window registrations can refresh Nodes /
+		// PreCCVAwareNodes without committing HWM off a possibly-incomplete pre-CCV-aware-peer
+		// observation.
 		var hwmBumped bool
 		var previousHWM, ccv base.ClusterCompatVersion
-		if ratchetHWM {
+		if params.RatchetHWM {
 			ccv = minRegistryNodeClusterCompatVersion(registry.Nodes)
 			if preCCVAwareMin, ok := minPreCCVAwareNodeClusterCompatVersion(registry.PreCCVAwareNodes); ok && ccv.GreaterThan(preCCVAwareMin) {
 				ccv = preCCVAwareMin
@@ -795,26 +810,26 @@ func (b *bootstrapContext) RegisterNodeVersion(ctx context.Context, bucketName, 
 				registry.ClusterCompatVersionHWM = ccv
 			}
 		}
-		err = b.setGatewayRegistry(ctx, bucketName, registry)
+		err = b.setGatewayRegistry(ctx, params.BucketName, registry)
 		if err != nil {
 			if base.IsCasMismatch(err) {
-				base.DebugfCtx(ctx, base.KeyConfig, "CAS mismatch registering node version in bucket %s, retrying (attempt %d/%d)", base.MD(bucketName), attempt, nodeVersionUpdateMaxRetryAttempts)
+				base.DebugfCtx(ctx, base.KeyConfig, "CAS mismatch registering node version in bucket %s, retrying (attempt %d/%d)", base.MD(params.BucketName), attempt, nodeVersionUpdateMaxRetryAttempts)
 				continue
 			}
 			return nil, fmt.Errorf("failed to write registry for node registration: %w", err)
 		}
 		if len(pruned) > 0 {
-			base.InfofCtx(ctx, base.KeyConfig, "Pruned %d stale cluster compat node entries from bucket %s: %v", len(pruned), base.MD(bucketName), base.MD(pruned))
+			base.InfofCtx(ctx, base.KeyConfig, "Pruned %d stale cluster compat node entries from bucket %s: %v", len(pruned), base.MD(params.BucketName), base.MD(pruned))
 		}
 		if len(preCCVAwarePruned) > 0 {
-			base.InfofCtx(ctx, base.KeyConfig, "Pruned %d stale pre-CCV-aware peer observations from bucket %s: %v", len(preCCVAwarePruned), base.MD(bucketName), base.MD(preCCVAwarePruned))
+			base.InfofCtx(ctx, base.KeyConfig, "Pruned %d stale pre-CCV-aware peer observations from bucket %s: %v", len(preCCVAwarePruned), base.MD(params.BucketName), base.MD(preCCVAwarePruned))
 		}
 		if hwmBumped {
-			base.InfofCtx(ctx, base.KeyConfig, "Updated cluster compat version high-water mark in bucket %s from %s to %s", base.MD(bucketName), previousHWM, ccv)
+			base.InfofCtx(ctx, base.KeyConfig, "Updated cluster compat version high-water mark in bucket %s from %s to %s", base.MD(params.BucketName), previousHWM, ccv)
 		}
 		return registry, nil
 	}
-	return nil, base.RedactErrorf("RegisterNodeVersion failed after %d CAS retry attempts for bucket %s", nodeVersionUpdateMaxRetryAttempts, base.MD(bucketName))
+	return nil, base.RedactErrorf("RegisterNodeVersion failed after %d CAS retry attempts for bucket %s", nodeVersionUpdateMaxRetryAttempts, base.MD(params.BucketName))
 }
 
 // DeregisterNodeVersion removes a node's version entry from the given bucket's registry.

--- a/rest/config_manager.go
+++ b/rest/config_manager.go
@@ -720,15 +720,22 @@ func (b *bootstrapContext) setGatewayRegistry(ctx context.Context, bucketName st
 // heartbeatExpiry must be positive; the validator enforces this for user-supplied configs and
 // the runtime fallback ensures a sane default (see clusterCompatManager.heartbeatExpiry).
 //
+// preCCVAwarePeers carries observations of pre-CCV-aware peers (detected via cbgt NodeDefs or
+// SGRCluster.Nodes) keyed by pre-CCV-aware peer UUID. Each observation is upserted into
+// registry.PreCCVAwareNodes with LastObservedAt = now; entries not refreshed within heartbeatExpiry
+// are pruned in the same write. Passing a nil/empty map is safe — existing legacy entries
+// simply age out naturally.
+//
 // ratchetHWM controls whether this call is allowed to advance ClusterCompatVersionHWM. Pass
 // false for the first registration during database load (e.g. the RegisterBucket call from
 // _applyConfig) — HWM is monotonic and a ratchet committed off transient startup state can
 // never be rolled back. The periodic Refresh passes true only for buckets where at least
-// one database has reached DBOnline (see clusterCompatManager.ratchetEligibleBuckets).
-// Node heartbeat refresh and stale pruning happen in either case.
+// one database has reached DBOnline (see clusterCompatManager.ratchetEligibleBuckets), so the
+// pre-CCV-aware-peer side-channels are guaranteed to be live when the ratchet runs. Node heartbeat
+// refresh, pre-CCV-aware-peer upsert, and stale pruning happen in either case.
 //
 // Uses CAS retry on conflict. Returns the registry as written.
-func (b *bootstrapContext) RegisterNodeVersion(ctx context.Context, bucketName, nodeUID, groupID string, version base.ClusterCompatVersion, databases map[string]string, heartbeatExpiry time.Duration, ratchetHWM bool) (*GatewayRegistry, error) {
+func (b *bootstrapContext) RegisterNodeVersion(ctx context.Context, bucketName, nodeUID, groupID string, version base.ClusterCompatVersion, databases map[string]string, heartbeatExpiry time.Duration, preCCVAwarePeers map[string]base.RegistryPreCCVAwareNode, ratchetHWM bool) (*GatewayRegistry, error) {
 	for attempt := 1; attempt <= nodeVersionUpdateMaxRetryAttempts; attempt++ {
 		registry, err := b.getGatewayRegistry(ctx, bucketName)
 		if err != nil {
@@ -747,18 +754,38 @@ func (b *bootstrapContext) RegisterNodeVersion(ctx context.Context, bucketName, 
 			ConfigGroupID: groupID,
 			Databases:     databases,
 		}
+		// Mirror pre-CCV-aware-peer observations into registry.PreCCVAwareNodes, keyed by pre-CCV-aware peer
+		// UUID. Upsert refreshes LastObservedAt to "now" so subsequent prune calls keep them
+		// alive while we keep seeing them; entries we no longer observe age out via
+		// pruneStalePreCCVAwareNodes.
+		now := time.Now().UTC()
+		if len(preCCVAwarePeers) > 0 && registry.PreCCVAwareNodes == nil {
+			registry.PreCCVAwareNodes = make(map[string]*base.RegistryPreCCVAwareNode)
+		}
+		for uuid, peer := range preCCVAwarePeers {
+			entry := peer
+			entry.LastObservedAt = now
+			registry.PreCCVAwareNodes[uuid] = &entry
+		}
+		preCCVAwarePruned := pruneStalePreCCVAwareNodes(registry.PreCCVAwareNodes, heartbeatExpiry)
 		// Ratchet ClusterCompatVersionHWM up to the current cluster compat version (min over
-		// all registered nodes). Never decreases — if a lower-version node joins, HWM stays.
-		// While a freeze is in effect, the freeze version is a ceiling on advancement: HWM
-		// must not climb past it, otherwise the downgrade gate above would later block rolling
-		// any node back to the frozen version (the freeze's whole purpose).
+		// all registered nodes and observed pre-CCV-aware peers). Each pre-CCV-aware peer contributes its
+		// observed major.minor when its build version is known, falling back to
+		// PreSGNodeVersionFallback when the side-channel observation didn't carry one. Never
+		// decreases — if a lower-version node joins, HWM stays. While a freeze is in effect,
+		// the freeze version is a ceiling on advancement: HWM must not climb past it,
+		// otherwise the downgrade gate above would later block rolling any node back to the
+		// frozen version (the freeze's whole purpose).
 		//
-		// Gated on ratchetHWM so startup-window registrations can refresh node heartbeat
-		// without committing HWM off transient state.
+		// Gated on ratchetHWM so startup-window registrations can refresh Nodes / PreCCVAwareNodes
+		// without committing HWM off a possibly-incomplete pre-CCV-aware-peer observation.
 		var hwmBumped bool
 		var previousHWM, ccv base.ClusterCompatVersion
 		if ratchetHWM {
 			ccv = minRegistryNodeClusterCompatVersion(registry.Nodes)
+			if preCCVAwareMin, ok := minPreCCVAwareNodeClusterCompatVersion(registry.PreCCVAwareNodes); ok && ccv.GreaterThan(preCCVAwareMin) {
+				ccv = preCCVAwareMin
+			}
 			if registry.Frozen != nil && ccv.GreaterThan(registry.Frozen.Version) {
 				ccv = registry.Frozen.Version
 			}
@@ -778,6 +805,9 @@ func (b *bootstrapContext) RegisterNodeVersion(ctx context.Context, bucketName, 
 		}
 		if len(pruned) > 0 {
 			base.InfofCtx(ctx, base.KeyConfig, "Pruned %d stale cluster compat node entries from bucket %s: %v", len(pruned), base.MD(bucketName), base.MD(pruned))
+		}
+		if len(preCCVAwarePruned) > 0 {
+			base.InfofCtx(ctx, base.KeyConfig, "Pruned %d stale pre-CCV-aware peer observations from bucket %s: %v", len(preCCVAwarePruned), base.MD(bucketName), base.MD(preCCVAwarePruned))
 		}
 		if hwmBumped {
 			base.InfofCtx(ctx, base.KeyConfig, "Updated cluster compat version high-water mark in bucket %s from %s to %s", base.MD(bucketName), previousHWM, ccv)
@@ -824,6 +854,21 @@ func minRegistryNodeClusterCompatVersion(nodes map[string]*base.RegistryNode) ba
 		versions = append(versions, node.Version)
 	}
 	return base.MinClusterCompatVersion(versions...)
+}
+
+// minPreCCVAwareNodeClusterCompatVersion returns the minimum cluster compat version across all
+// observed pre-CCV-aware-peer entries. Each peer's Version is already the parsed major.minor
+// (PreSGNodeVersionFallback when the side-channel observation didn't carry one) — the
+// observer collapses precision at write time. Returns (zero, false) when preCCVAwareNodes is empty.
+func minPreCCVAwareNodeClusterCompatVersion(preCCVAwareNodes map[string]*base.RegistryPreCCVAwareNode) (base.ClusterCompatVersion, bool) {
+	if len(preCCVAwareNodes) == 0 {
+		return base.ClusterCompatVersion{}, false
+	}
+	versions := make([]base.ClusterCompatVersion, 0, len(preCCVAwareNodes))
+	for _, node := range preCCVAwareNodes {
+		versions = append(versions, node.Version)
+	}
+	return base.MinClusterCompatVersion(versions...), true
 }
 
 // SetRegistryFreeze sets the cluster compat version freeze on the given bucket's registry.
@@ -894,6 +939,22 @@ func pruneStaleNodes(nodes map[string]*base.RegistryNode, selfUID string, expiry
 		if node.HeartbeatAt.Before(cutoff) {
 			delete(nodes, uid)
 			pruned = append(pruned, uid)
+		}
+	}
+	return pruned
+}
+
+// pruneStalePreCCVAwareNodes deletes entries from preCCVAwareNodes whose LastObservedAt is older than
+// expiry. Mirrors pruneStaleNodes' semantics; pre-CCV-aware-peer entries have no "self" exemption since
+// the observer is itself in registry.Nodes, not registry.PreCCVAwareNodes. Returns the keys of
+// pruned entries (in non-deterministic order).
+func pruneStalePreCCVAwareNodes(preCCVAwareNodes map[string]*base.RegistryPreCCVAwareNode, expiry time.Duration) []string {
+	cutoff := time.Now().UTC().Add(-expiry)
+	var pruned []string
+	for key, node := range preCCVAwareNodes {
+		if node.LastObservedAt.Before(cutoff) {
+			delete(preCCVAwareNodes, key)
+			pruned = append(pruned, key)
 		}
 	}
 	return pruned

--- a/rest/config_registry.go
+++ b/rest/config_registry.go
@@ -58,6 +58,17 @@ type GatewayRegistry struct {
 	CreatedAt               time.Time                       `json:"created_at"`                              // Time the registry was created
 	Nodes                   map[string]*base.RegistryNode   `json:"nodes,omitempty"`                         // Map of node UID to node version registration
 	Frozen                  *base.RegistryFreeze            `json:"frozen_cluster_compat_version,omitempty"` // Admin-issued cluster compat version freeze
+	// PreCCVAwareNodes records pre-CCV-aware Sync Gateway peers observed by CCV-aware nodes through
+	// side-channel registries (cbgt NodeDefs for sharded import, SGRCluster.Nodes for ISGR),
+	// keyed by pre-CCV-aware peer UUID. Entries whose side-channel observation didn't carry a
+	// version fall back to base.PreSGNodeVersionFallback. Entries cap HWM ratchet
+	// advancement at observation time (preventing the cluster from committing past a
+	// pre-CCV-aware peer that's still present), and the subset whose Version is at or above
+	// ClusterCompatVersionHWM also participates in computeCCV. Entries strictly below HWM
+	// represent an unsupported downgrade — they remain visible for operator audit but do not
+	// drag reported CCV back below HWM. Entries age out via the heartbeat-expiry prune in
+	// RegisterNodeVersion.
+	PreCCVAwareNodes map[string]*base.RegistryPreCCVAwareNode `json:"pre_ccv_aware_nodes,omitempty"`
 }
 
 const GatewayRegistryVersion = "1.0"

--- a/rest/handler_cluster_compat.go
+++ b/rest/handler_cluster_compat.go
@@ -23,7 +23,7 @@ import (
 type ClusterCompatVersionState struct {
 	ClusterCompatVersion       *base.ClusterCompatVersion           `json:"cluster_compat_version,omitempty"`
 	Nodes                      map[string]base.ClusterCompatVersion `json:"nodes,omitempty"`
-	PreCCVAwareNodes              map[string]base.ClusterCompatVersion `json:"pre_ccv_aware_nodes,omitempty"`
+	PreCCVAwareNodes           map[string]base.ClusterCompatVersion `json:"pre_ccv_aware_nodes,omitempty"`
 	FrozenClusterCompatVersion *base.ClusterCompatVersion           `json:"frozen_cluster_compat_version,omitempty"`
 }
 
@@ -134,7 +134,7 @@ func buildClusterCompatVersionState(mgr *clusterCompatManager) ClusterCompatVers
 	state := ClusterCompatVersionState{
 		ClusterCompatVersion: mgr.ClusterCompatVersion(),
 		Nodes:                mgr.NodeVersions(),
-		PreCCVAwareNodes:        mgr.PreCCVAwareNodeVersions(),
+		PreCCVAwareNodes:     mgr.PreCCVAwareNodeVersions(),
 	}
 	if freeze := mgr.getCachedFreeze(); freeze != nil {
 		v := freeze.Version

--- a/rest/handler_cluster_compat.go
+++ b/rest/handler_cluster_compat.go
@@ -17,11 +17,13 @@ import (
 )
 
 // ClusterCompatVersionState is the response payload for /_cluster_compat_version. It
-// describes the cluster-wide cluster compatibility version, the per-node versions
-// registered in the cluster, and (only when set) the frozen value pinning it.
+// describes the cluster-wide cluster compatibility version, the per-node versions registered
+// in the cluster, any pre-CCV-aware peers observed via side-channels, and (only when set)
+// the frozen value pinning it.
 type ClusterCompatVersionState struct {
 	ClusterCompatVersion       *base.ClusterCompatVersion           `json:"cluster_compat_version,omitempty"`
 	Nodes                      map[string]base.ClusterCompatVersion `json:"nodes,omitempty"`
+	PreCCVAwareNodes              map[string]base.ClusterCompatVersion `json:"pre_ccv_aware_nodes,omitempty"`
 	FrozenClusterCompatVersion *base.ClusterCompatVersion           `json:"frozen_cluster_compat_version,omitempty"`
 }
 
@@ -132,6 +134,7 @@ func buildClusterCompatVersionState(mgr *clusterCompatManager) ClusterCompatVers
 	state := ClusterCompatVersionState{
 		ClusterCompatVersion: mgr.ClusterCompatVersion(),
 		Nodes:                mgr.NodeVersions(),
+		PreCCVAwareNodes:        mgr.PreCCVAwareNodeVersions(),
 	}
 	if freeze := mgr.getCachedFreeze(); freeze != nil {
 		v := freeze.Version


### PR DESCRIPTION
CBG-5378

Finds pre-4.1 SG node version information for ClusterCompatVersion via a few side-channels:
- `CBGT NODE_DEFS_KNOWN` for sharded import (EE)
  - Works for SG versions 3.0 onwards.
- ISGR cluster definitions (CE and disabled-import use-cases)
  - Cannot determine version numbers prior to 4.1, but stamped as 4.0 for purposes of CCV)

## Registry changes
- Adds `pre_ccv_aware_nodes` for these side-channel entries. Expiry via the existing heartbeat-expiry prune on each registry write.
- `SGRCluster.SGNode` gains an optional version field for 4.1+ nodes to differentiate pre-4.1 node and ones capable of reporting cluster compat version natively.

## HWM ratchet changes
- `RegisterNodeVersion` previously folded only `registry.Nodes` into the HWM candidate.
It now also includes min(observed_nodes), so HWM cannot advance past a still-present pre-CCV-aware peer.

## REST API changes
- `GET /_cluster_compat_version` response includes `pre_ccv_aware_nodes` for observability of older node version detection

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/683/
