### PR TITLE
fix flake for TestMetadataMigrationStartsAfterAllNodesApplyConfig

### DIFF
--- a/rest/metadatamigrationtest/metadata_migration_test.go
+++ b/rest/metadatamigrationtest/metadata_migration_test.go
@@ -120,12 +120,15 @@ func TestMetadataMigrationStartsAfterAllNodesApplyConfig(t *testing.T) {
 	assert.True(t, applied, "config should be fully applied once node B has applied the new version")
 	assert.Empty(t, missing)
 
-	// The armMetadataMigrationTask goroutine on node A polls every 10s. Once the gate is open it
-	// starts the migration; wait for that to happen.
+	// Either node can win the race to start the background migration job, so check both.
+	dbCtxB := rtB.GetDatabase()
+	require.NotNil(t, dbCtxB.MetadataMigrationManager)
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		state := dbCtxA.MetadataMigrationManager.GetRunState()
-		assert.NotEqual(c, db.BackgroundProcessState(""), state,
-			"migration should have been started after all nodes applied the config")
+		stateA := dbCtxA.MetadataMigrationManager.GetRunState()
+		stateB := dbCtxB.MetadataMigrationManager.GetRunState()
+		started := stateA != db.BackgroundProcessState("") || stateB != db.BackgroundProcessState("")
+		assert.True(c, started,
+			"migration should have been started on at least one node after all nodes applied the config")
 	}, 30*time.Second, 100*time.Millisecond)
 }
 


### PR DESCRIPTION

- Test flake, need to be resilient to either node starting the job as each node can race to start the job

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
