### PR TITLE
CBG-5412 do not mark error in async init manager if stopping

### DIFF
--- a/db/background_mgr_async_index_init.go
+++ b/db/background_mgr_async_index_init.go
@@ -38,12 +38,11 @@ func (a *AsyncIndexInitManager) Run(ctx context.Context, options map[string]any,
 	a.lock.Lock()
 	doneChan := a._doneChan
 	a.lock.Unlock()
-	select {
-	case err := <-doneChan:
-		return err
-	case <-terminator.Done():
+	err := <-doneChan
+	if terminator.IsClosed() {
 		return nil
 	}
+	return err
 }
 
 type CollectionIndexStatus string


### PR DESCRIPTION
CBG-5412 do not mark error in async init manager if stopping

This block could hit terminator.Done() or doneChan. The doneChan should always be closed and it seems more correct to wait on that, because if there are any actions that were occurring we wait for them.

```
select {
	case err := <-doneChan:
		return err
	case <-terminator.Done():
		return nil
	}
```

1. action=stop -> transition state to Stopping
2. close terminator
3. when Run finishes, transition status to Stopped

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/708/
