### PR TITLE
Parametrize resync tests

### DIFF
--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -188,7 +188,6 @@ func TestResyncDCPInit(t *testing.T) {
 }
 
 func TestResyncManagerDCPStopInMidWay(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	for _, testCase := range ResyncTestModes() {
 		t.Run(testCase.Name, func(t *testing.T) {
 			if testCase.Distributed {

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -196,7 +196,7 @@ func TestResyncManagerDCPStopInMidWay(t *testing.T) {
 			docsToCreate := 1000
 			if base.UnitTestUrlIsWalrus() {
 				// rosmar runs too quickly, increase doc count
-				docsToCreate *= 3
+				docsToCreate *= 5
 			}
 			db, ctx := setupTestDBForResyncWithDocs(t, testDBForResyncOptions{
 				docsToCreate:                 docsToCreate,
@@ -234,7 +234,6 @@ func TestResyncManagerDCPStopInMidWay(t *testing.T) {
 }
 
 func TestResyncManagerDCPStart(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	for _, testCase := range ResyncTestModes() {
 		t.Run(testCase.Name, func(t *testing.T) {
 			t.Run("Resync without updating sync function", func(t *testing.T) {

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -401,7 +401,7 @@ func TestResyncManagerDCPResumeStoppedProcess(t *testing.T) {
 			docsToCreate := 5000
 			// rosmar runs too quickly, increase doc count
 			if base.UnitTestUrlIsWalrus() {
-				docsToCreate *= 5
+				docsToCreate *= 2
 			}
 			db, ctx := setupTestDBForResyncWithDocs(t, testDBForResyncOptions{
 				docsToCreate:                 docsToCreate,

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -188,12 +188,13 @@ func TestResyncDCPInit(t *testing.T) {
 }
 
 func TestResyncManagerDCPStopInMidWay(t *testing.T) {
-	for _, testCase := range resyncTestModes() {
-		t.Run(testCase.name, func(t *testing.T) {
-			if testCase.distributed {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+	for _, testCase := range ResyncTestModes() {
+		t.Run(testCase.Name, func(t *testing.T) {
+			if testCase.Distributed {
 				t.Skip("Enable in CBG-5184")
 			}
-			docsToCreate := 1000
+			docsToCreate := 50000
 			if base.UnitTestUrlIsWalrus() {
 				// rosmar runs too quickly, increase doc count
 				docsToCreate *= 5
@@ -201,7 +202,7 @@ func TestResyncManagerDCPStopInMidWay(t *testing.T) {
 			db, ctx := setupTestDBForResyncWithDocs(t, testDBForResyncOptions{
 				docsToCreate:                 docsToCreate,
 				updateSyncFuncAfterDocsAdded: true,
-				distributed:                  testCase.distributed,
+				distributed:                  testCase.Distributed,
 			})
 			defer db.Close(ctx)
 
@@ -214,12 +215,11 @@ func TestResyncManagerDCPStopInMidWay(t *testing.T) {
 			err := db.ResyncManager.Start(ctx, options)
 			require.NoError(t, err)
 			wg := sync.WaitGroup{}
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			defer base.WaitWithTimeout(t, &wg, 30*time.Second)
+			wg.Go(func() {
 				waitForResyncDocsProcessed(t, db, 300)
 				require.NoError(t, db.ResyncManager.Stop(ctx))
-			}()
+			})
 
 			stats := waitForResyncState(t, db, BackgroundProcessStateStopped)
 			assert.Less(t, stats.DocsProcessed, int64(docsToCreate), "DocsProcessed is equal to docs created. Consider setting docsToCreate > %d.", docsToCreate)
@@ -230,22 +230,22 @@ func TestResyncManagerDCPStopInMidWay(t *testing.T) {
 
 			assert.Less(t, db.DbStats.Database().SyncFunctionCount.Value(), int64(docsToCreate))
 			assert.Greater(t, db.DbStats.Database().SyncFunctionCount.Value(), int64(300))
-			wg.Wait()
 		})
 	}
 }
 
 func TestResyncManagerDCPStart(t *testing.T) {
-	for _, testCase := range resyncTestModes() {
-		t.Run(testCase.name, func(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+	for _, testCase := range ResyncTestModes() {
+		t.Run(testCase.Name, func(t *testing.T) {
 			t.Run("Resync without updating sync function", func(t *testing.T) {
-				if testCase.distributed {
+				if testCase.Distributed {
 					t.Skip("Enable in CBG-5184")
 				}
 				docsToCreate := 100
 				db, ctx := setupTestDBForResyncWithDocs(t, testDBForResyncOptions{
 					docsToCreate: docsToCreate,
-					distributed:  testCase.distributed,
+					distributed:  testCase.Distributed,
 				})
 				defer db.Close(ctx)
 
@@ -282,7 +282,7 @@ func TestResyncManagerDCPStart(t *testing.T) {
 				db, ctx := setupTestDBForResyncWithDocs(t, testDBForResyncOptions{
 					docsToCreate:                 docsToCreate,
 					updateSyncFuncAfterDocsAdded: true,
-					distributed:                  testCase.distributed,
+					distributed:                  testCase.Distributed,
 				})
 				defer db.Close(ctx)
 
@@ -300,7 +300,7 @@ func TestResyncManagerDCPStart(t *testing.T) {
 					"collections":         base.NewCollectionNames(),
 				}
 
-				if testCase.distributed {
+				if testCase.Distributed {
 					rs, ok := db.ResyncManager.Process.(*ResyncManagerDCP)
 					require.True(t, ok)
 					rs.Distributed = true
@@ -308,7 +308,7 @@ func TestResyncManagerDCPStart(t *testing.T) {
 				err := db.ResyncManager.Start(ctx, options)
 				require.NoError(t, err)
 
-				if testCase.distributed {
+				if testCase.Distributed {
 					waitForResyncDocsChanged(t, db, int64(docsToCreate))
 					err := db.ResyncManager.Stop(ctx)
 					require.NoError(t, err)
@@ -332,7 +332,7 @@ func TestResyncManagerDCPStart(t *testing.T) {
 				assert.Equal(t, int64(docsToCreate), cs.ResyncNumChanged.Value())
 
 				// This is just a temporary check until MB-70378 is implemented
-				if !testCase.distributed {
+				if !testCase.Distributed {
 					deltaOk := assert.InDelta(t, int64(docsToCreate), db.DbStats.Database().SyncFunctionCount.Value(), 2)
 					assert.True(t, deltaOk, "DCP stream has processed some documents more than once than allowed delta. Try rerunning the test.")
 				}
@@ -342,19 +342,19 @@ func TestResyncManagerDCPStart(t *testing.T) {
 }
 
 func TestResyncManagerDCPRunTwice(t *testing.T) {
-	for _, testCase := range resyncTestModes() {
-		t.Run(testCase.name, func(t *testing.T) {
-			if testCase.distributed {
+	for _, testCase := range ResyncTestModes() {
+		t.Run(testCase.Name, func(t *testing.T) {
+			if testCase.Distributed {
 				t.Skip("Enable in CBG-5184")
 			}
-			docsToCreate := 1000
+			docsToCreate := 5000
 			// rosmar runs too quickly, increase doc count
 			if base.UnitTestUrlIsWalrus() {
-				docsToCreate *= 10
+				docsToCreate *= 5
 			}
 			db, ctx := setupTestDBForResyncWithDocs(t, testDBForResyncOptions{
 				docsToCreate: docsToCreate,
-				distributed:  testCase.distributed,
+				distributed:  testCase.Distributed,
 			})
 			defer db.Close(ctx)
 
@@ -368,16 +368,15 @@ func TestResyncManagerDCPRunTwice(t *testing.T) {
 			require.NoError(t, err)
 
 			wg := sync.WaitGroup{}
-			wg.Add(1)
+			defer base.WaitWithTimeout(t, &wg, 30*time.Second)
 			// Attempt to Start running process
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				waitForResyncDocsProcessed(t, db, 100)
 
 				err := db.ResyncManager.Start(ctx, options)
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "Process already running")
-			}()
+			})
 
 			stats := waitForResyncState(t, db, BackgroundProcessStateCompleted)
 
@@ -390,22 +389,25 @@ func TestResyncManagerDCPRunTwice(t *testing.T) {
 			assert.Equal(t, int64(0), db.DbStats.Database().ResyncNumChanged.Value())
 
 			assert.Equal(t, db.DbStats.Database().SyncFunctionCount.Value(), int64(docsToCreate))
-			wg.Wait()
 		})
 	}
 }
 
 func TestResyncManagerDCPResumeStoppedProcess(t *testing.T) {
-	for _, testCase := range resyncTestModes() {
-		t.Run(testCase.name, func(t *testing.T) {
-			if testCase.distributed {
+	for _, testCase := range ResyncTestModes() {
+		t.Run(testCase.Name, func(t *testing.T) {
+			if testCase.Distributed {
 				t.Skip("Enable in CBG-5184")
 			}
 			docsToCreate := 5000
+			// rosmar runs too quickly, increase doc count
+			if base.UnitTestUrlIsWalrus() {
+				docsToCreate *= 5
+			}
 			db, ctx := setupTestDBForResyncWithDocs(t, testDBForResyncOptions{
 				docsToCreate:                 docsToCreate,
 				updateSyncFuncAfterDocsAdded: true,
-				distributed:                  testCase.distributed,
+				distributed:                  testCase.Distributed,
 			})
 			defer db.Close(ctx)
 
@@ -420,12 +422,11 @@ func TestResyncManagerDCPResumeStoppedProcess(t *testing.T) {
 
 			// Attempt to Stop Process
 			wg := sync.WaitGroup{}
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			defer base.WaitWithTimeout(t, &wg, 30*time.Second)
+			wg.Go(func() {
 				waitForResyncDocsProcessed(t, db, 2000)
 				require.NoError(t, db.ResyncManager.Stop(ctx))
-			}()
+			})
 
 			stats := waitForResyncState(t, db, BackgroundProcessStateStopped)
 
@@ -453,7 +454,6 @@ func TestResyncManagerDCPResumeStoppedProcess(t *testing.T) {
 			assert.Equal(t, int64(docsToCreate), db.DbStats.Database().ResyncNumChanged.Value())
 
 			assert.GreaterOrEqual(t, db.DbStats.Database().SyncFunctionCount.Value(), int64(docsToCreate))
-			wg.Wait()
 		})
 	}
 }
@@ -461,92 +461,106 @@ func TestResyncManagerDCPResumeStoppedProcess(t *testing.T) {
 // TestResyncManagerDCPResumeStoppedProcessChangeCollections starts a resync with a single collection, stops it, and re-runs with an additional collection.
 // Expects the resync process to reset with a new ID, and new checkpoints, and reprocess the full set of documents across both collections.
 func TestResyncManagerDCPResumeStoppedProcessChangeCollections(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug)
 	base.TestRequiresCollections(t)
+	for _, testCase := range ResyncTestModes() {
+		t.Run(testCase.Name, func(t *testing.T) {
 
-	docsPerCollection := int64(1000)
-	const numCollections = 2
-	totalDocCount := docsPerCollection * numCollections
+			docsPerCollection := int64(1000)
+			// rosmar runs too quickly, increase doc count
+			if base.UnitTestUrlIsWalrus() {
+				docsPerCollection *= 5
+			}
+			const numCollections = 2
+			totalDocCount := docsPerCollection * numCollections
 
-	tb := base.GetTestBucket(t)
-	defer tb.Close(base.TestCtx(t))
-	dbOptions := DatabaseContextOptions{}
-	dbOptions.Scopes = GetScopesOptions(t, tb, numCollections)
+			tb := base.GetTestBucket(t)
+			defer tb.Close(base.TestCtx(t))
+			dbOptions := DatabaseContextOptions{}
+			dbOptions.Scopes = GetScopesOptions(t, tb, numCollections)
 
-	db, ctx := SetupTestDBForBucketWithOptions(t, tb, dbOptions)
-	defer db.Close(ctx)
+			db, ctx := SetupTestDBForBucketWithOptions(t, tb, dbOptions)
+			defer db.Close(ctx)
 
-	dbCollections := make([]*DatabaseCollectionWithUser, numCollections)
-	for i, scName := range db.DataStoreNames() {
-		col, err := db.GetDatabaseCollectionWithUser(scName.ScopeName(), scName.CollectionName())
-		require.NoError(t, err)
-		require.NotNil(t, col)
+			rs, ok := db.ResyncManager.Process.(*ResyncManagerDCP)
+			require.True(t, ok)
 
-		// required to avoid missing audit fields in PUT
-		ctx := col.AddCollectionContext(ctx)
+			if testCase.Distributed {
+				rs.Distributed = true
+			} else {
+				require.False(t, rs.Distributed, "Expected this database ResyncManager to be in non distributed mode")
+			}
 
-		_, err = col.UpdateSyncFun(ctx, `function sync(doc){channel("channel.ABC");}`)
-		require.NoError(t, err)
+			dbCollections := make([]*DatabaseCollectionWithUser, numCollections)
+			for i, scName := range db.DataStoreNames() {
+				col, err := db.GetDatabaseCollectionWithUser(scName.ScopeName(), scName.CollectionName())
+				require.NoError(t, err)
+				require.NotNil(t, col)
 
-		// create docs
-		for i := range docsPerCollection {
-			_, _, err := col.Put(ctx, fmt.Sprintf("%s_%d", t.Name(), i), Body{"foo": "bar"})
+				// required to avoid missing audit fields in PUT
+				ctx := col.AddCollectionContext(ctx)
+
+				_, err = col.UpdateSyncFun(ctx, `function sync(doc){channel("channel.ABC");}`)
+				require.NoError(t, err)
+
+				// create docs
+				for i := range docsPerCollection {
+					_, _, err := col.Put(ctx, fmt.Sprintf("%s_%d", t.Name(), i), Body{"foo": "bar"})
+					require.NoError(t, err)
+				}
+
+				changed, err := col.UpdateSyncFun(ctx, `function sync(doc){channel("channel.DEF");}`)
+				require.NoError(t, err)
+				require.True(t, changed)
+
+				dbCollections[i] = col
+			}
+
+			options := map[string]any{
+				"database":            db,
+				"regenerateSequences": false,
+				"collections":         base.NewCollectionNames(dbCollections[0].dataStore),
+			}
+
+			err := db.ResyncManager.Start(ctx, options)
 			require.NoError(t, err)
-		}
 
-		changed, err := col.UpdateSyncFun(ctx, `function sync(doc){channel("channel.DEF");}`)
-		require.NoError(t, err)
-		require.True(t, changed)
+			// Attempt to Stop Process after 1/5 of docs are processed but before it is completed
+			wg := sync.WaitGroup{}
+			defer base.WaitWithTimeout(t, &wg, 30*time.Second)
+			wg.Go(func() {
+				waitForResyncDocsProcessed(t, db, docsPerCollection/5)
+				err = db.ResyncManager.Stop(ctx)
+				require.NoError(t, err)
+			})
 
-		dbCollections[i] = col
+			stats := waitForResyncState(t, db, BackgroundProcessStateStopped)
+
+			require.Less(t, stats.DocsProcessed, docsPerCollection, "DocsProcessed is equal to docs created. Consider setting docsPerCollection > %d.", docsPerCollection)
+			assert.Less(t, stats.DocsChanged, docsPerCollection)
+
+			assert.Less(t, db.DbStats.Database().ResyncNumProcessed.Value(), docsPerCollection)
+			assert.Less(t, db.DbStats.Database().ResyncNumChanged.Value(), docsPerCollection)
+
+			firstDocsChanged := stats.DocsChanged
+
+			require.GreaterOrEqual(t, len(dbCollections), 2)
+			options["collections"] = db.collectionNames()
+
+			// Resume process
+			err = db.ResyncManager.Start(ctx, options)
+			require.NoError(t, err)
+
+			stats = waitForResyncState(t, db, BackgroundProcessStateCompleted)
+
+			assert.GreaterOrEqual(t, stats.DocsProcessed, totalDocCount)
+			assert.Equal(t, totalDocCount, stats.DocsChanged+firstDocsChanged)
+
+			assert.GreaterOrEqual(t, db.DbStats.Database().ResyncNumProcessed.Value(), totalDocCount)
+			assert.Equal(t, totalDocCount, db.DbStats.Database().ResyncNumChanged.Value())
+
+			assert.GreaterOrEqual(t, db.DbStats.Database().SyncFunctionCount.Value(), totalDocCount)
+		})
 	}
-
-	options := map[string]any{
-		"database":            db,
-		"regenerateSequences": false,
-		"collections":         base.NewCollectionNames(dbCollections[0].dataStore),
-	}
-
-	err := db.ResyncManager.Start(ctx, options)
-	require.NoError(t, err)
-
-	// Attempt to Stop Process after 1/5 of docs are processed but before it is completed
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		waitForResyncDocsProcessed(t, db, docsPerCollection/5)
-		err = db.ResyncManager.Stop(ctx)
-		require.NoError(t, err)
-	}()
-
-	stats := waitForResyncState(t, db, BackgroundProcessStateStopped)
-
-	require.Less(t, stats.DocsProcessed, docsPerCollection, "DocsProcessed is equal to docs created. Consider setting docsPerCollection > %d.", docsPerCollection)
-	assert.Less(t, stats.DocsChanged, docsPerCollection)
-
-	assert.Less(t, db.DbStats.Database().ResyncNumProcessed.Value(), docsPerCollection)
-	assert.Less(t, db.DbStats.Database().ResyncNumChanged.Value(), docsPerCollection)
-
-	firstDocsChanged := stats.DocsChanged
-
-	require.GreaterOrEqual(t, len(dbCollections), 2)
-	options["collections"] = db.collectionNames()
-
-	// Resume process
-	err = db.ResyncManager.Start(ctx, options)
-	require.NoError(t, err)
-
-	stats = waitForResyncState(t, db, BackgroundProcessStateCompleted)
-
-	assert.GreaterOrEqual(t, stats.DocsProcessed, totalDocCount)
-	assert.Equal(t, totalDocCount, stats.DocsChanged+firstDocsChanged)
-
-	assert.GreaterOrEqual(t, db.DbStats.Database().ResyncNumProcessed.Value(), totalDocCount)
-	assert.Equal(t, totalDocCount, db.DbStats.Database().ResyncNumChanged.Value())
-
-	assert.GreaterOrEqual(t, db.DbStats.Database().SyncFunctionCount.Value(), totalDocCount)
-	wg.Wait()
 }
 
 // testDBForResyncOptions defines options for setting up a test database for resync tests.
@@ -928,29 +942,6 @@ func TestResyncImportPartitionsPassthrough(t *testing.T) {
 	require.NoError(t, base.JSONUnmarshal(planPIndexesJSON, &planPIndexes))
 	require.Len(t, planPIndexes.PlanPIndexes, int(numPartitions),
 		"expected %d pindexes matching ResyncPartitions", numPartitions)
-}
-
-type resyncTestCase struct {
-	name        string // name of test case
-	distributed bool   // use distributed resync
-}
-
-// resyncTestModes returns the test modes to run resync tests in for a given test run. Distributed resync requires Couchbase Server and EE.
-func resyncTestModes() []resyncTestCase {
-	testCases := []resyncTestCase{
-		{
-			name:        "distributed=false",
-			distributed: false,
-		},
-	}
-	if !base.UnitTestUrlIsWalrus() && base.IsEnterpriseEdition() {
-		testCases = append(testCases, resyncTestCase{
-
-			name:        "distributed=true",
-			distributed: true,
-		})
-	}
-	return testCases
 }
 
 // TestResyncManagerDCPWritesV1SyncInfoAtCcv41 verifies the end-to-end wiring from

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -193,10 +193,10 @@ func TestResyncManagerDCPStopInMidWay(t *testing.T) {
 			if testCase.Distributed {
 				t.Skip("Enable in CBG-5184")
 			}
-			docsToCreate := 50000
+			docsToCreate := 1000
 			if base.UnitTestUrlIsWalrus() {
 				// rosmar runs too quickly, increase doc count
-				docsToCreate *= 5
+				docsToCreate *= 3
 			}
 			db, ctx := setupTestDBForResyncWithDocs(t, testDBForResyncOptions{
 				docsToCreate:                 docsToCreate,
@@ -346,10 +346,10 @@ func TestResyncManagerDCPRunTwice(t *testing.T) {
 			if testCase.Distributed {
 				t.Skip("Enable in CBG-5184")
 			}
-			docsToCreate := 5000
+			docsToCreate := 1000
 			// rosmar runs too quickly, increase doc count
 			if base.UnitTestUrlIsWalrus() {
-				docsToCreate *= 5
+				docsToCreate *= 10
 			}
 			db, ctx := setupTestDBForResyncWithDocs(t, testDBForResyncOptions{
 				docsToCreate: docsToCreate,

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -1191,3 +1191,27 @@ func (db *DatabaseContext) RestartChangeListener(t testing.TB, flushCache bool) 
 func (db *DatabaseContext) FlushChannelCache(t testing.TB) {
 	db.RestartChangeListener(t, true)
 }
+
+type ResyncTestCase struct {
+	Name        string // name of test case
+	Distributed bool   // use distributed resync
+}
+
+// ResyncTestModes returns the test modes to run resync tests in for a given test run. Distributed resync requires Couchbase Server and EE.
+func ResyncTestModes() []ResyncTestCase {
+	testCases := []ResyncTestCase{
+		{
+			Name:        "distributed=false",
+			Distributed: false,
+		},
+	}
+	/* CBG-5184 enable tests
+	if !base.UnitTestUrlIsWalrus() && base.IsEnterpriseEdition() {
+		testCases = append(testCases, ResyncTestCase{
+			Name:        "distributed=true",
+			Distributed: true,
+		})
+	}
+	*/
+	return testCases
+}

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -623,107 +623,178 @@ func TestDBGetConfigCustomLogging(t *testing.T) {
 }
 
 func TestDBOfflineSingleResyncUsingDCPStream(t *testing.T) {
-	syncFn := `
+	for _, testCase := range db.ResyncTestModes() {
+		t.Run(testCase.Name, func(t *testing.T) {
+
+			syncFn := `
 	function(doc) {
 		channel("x")
 	}`
-	rt := rest.NewRestTester(t, &rest.RestTesterConfig{SyncFn: syncFn})
-	defer rt.Close()
+			rt := rest.NewRestTester(t, &rest.RestTesterConfig{SyncFn: syncFn})
+			defer rt.Close()
 
-	// create documents in DB to cause resync to take a few seconds
-	for i := range 1000 {
-		rt.CreateTestDoc(fmt.Sprintf("doc%v", i))
+			// create documents in DB to cause resync to take a few seconds
+			for i := range 1000 {
+				rt.CreateTestDoc(fmt.Sprintf("doc%v", i))
+			}
+			assert.Equal(t, int64(1000), rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
+
+			rt.TakeDbOffline()
+			rt.SetDistributedResync(testCase.Distributed)
+
+			response := rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
+			rest.RequireStatus(t, response, http.StatusOK)
+
+			// Send a second _resync request.  This must return a 400 since the first one is blocked processing
+			rest.RequireStatus(t, rt.SendAdminRequest("POST", "/db/_resync?action=start", ""), 503)
+
+			rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
+			// offline call above resets stats to 0, so sync function count will only include resync run started above
+			assert.Equal(t, int64(1000), rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
+		})
 	}
-	assert.Equal(t, int64(1000), rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
-
-	rt.TakeDbOffline()
-
-	response := rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
-	rest.RequireStatus(t, response, http.StatusOK)
-
-	// Send a second _resync request.  This must return a 400 since the first one is blocked processing
-	rest.RequireStatus(t, rt.SendAdminRequest("POST", "/db/_resync?action=start", ""), 503)
-
-	rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
-	// offline call above resets stats to 0, so sync function count will only include resync run started above
-	assert.Equal(t, int64(1000), rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
 }
 
 func TestDCPResyncCollectionsStatus(t *testing.T) {
 	base.TestRequiresCollections(t)
+	for _, distributedTestCase := range db.ResyncTestModes() {
+		t.Run(distributedTestCase.Name, func(t *testing.T) {
 
-	testCases := []struct {
-		name              string
-		collectionNames   []string
-		expectedResult    map[string][]string
-		specifyCollection bool
-	}{
-		{
-			name:            "collections_specified",
-			collectionNames: []string{"sg_test_0"},
-			expectedResult: map[string][]string{
-				"sg_test_0": {"sg_test_0"},
-			},
-			specifyCollection: true,
-		},
-		{
-			name: "collections_not_specified",
-			expectedResult: map[string][]string{
-				"sg_test_0": {"sg_test_0", "sg_test_1", "sg_test_2"},
-			},
-			collectionNames: nil,
-		},
-	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			rt := rest.NewRestTesterMultipleCollections(t, nil, 3)
-			defer rt.Close()
-			scopeName := "sg_test_0"
-
-			// create documents in DB to cause resync to take a few seconds
-			for i := range 1000 {
-				resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace1}}/"+fmt.Sprint(i), `{"value":1}`)
-				rest.RequireStatus(t, resp, http.StatusCreated)
+			testCases := []struct {
+				name              string
+				collectionNames   []string
+				expectedResult    map[string][]string
+				specifyCollection bool
+			}{
+				{
+					name:            "collections_specified",
+					collectionNames: []string{"sg_test_0"},
+					expectedResult: map[string][]string{
+						"sg_test_0": {"sg_test_0"},
+					},
+					specifyCollection: true,
+				},
+				{
+					name: "collections_not_specified",
+					expectedResult: map[string][]string{
+						"sg_test_0": {"sg_test_0", "sg_test_1", "sg_test_2"},
+					},
+					collectionNames: nil,
+				},
 			}
+			for _, testCase := range testCases {
+				t.Run(testCase.name, func(t *testing.T) {
+					rt := rest.NewRestTesterMultipleCollections(t, nil, 3)
+					defer rt.Close()
+					scopeName := "sg_test_0"
 
-			rt.TakeDbOffline()
+					// create documents in DB to cause resync to take a few seconds
+					for i := range 1000 {
+						resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace1}}/"+fmt.Sprint(i), `{"value":1}`)
+						rest.RequireStatus(t, resp, http.StatusCreated)
+					}
 
-			if !testCase.specifyCollection {
-				resp := rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
-				rest.RequireStatus(t, resp, http.StatusOK)
-			} else {
-				payload := `{"scopes": {"sg_test_0":["sg_test_0"]}}`
-				resp := rt.SendAdminRequest("POST", "/db/_resync?action=start", payload)
-				rest.RequireStatus(t, resp, http.StatusOK)
+					rt.TakeDbOffline()
+					rt.SetDistributedResync(distributedTestCase.Distributed)
+
+					if !testCase.specifyCollection {
+						resp := rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
+						rest.RequireStatus(t, resp, http.StatusOK)
+					} else {
+						payload := `{"scopes": {"sg_test_0":["sg_test_0"]}}`
+						resp := rt.SendAdminRequest("POST", "/db/_resync?action=start", payload)
+						rest.RequireStatus(t, resp, http.StatusOK)
+					}
+					statusResponse := rt.WaitForResyncDCPStatus(db.BackgroundProcessStateRunning)
+					assert.ElementsMatch(t, statusResponse.CollectionsProcessing[scopeName], testCase.expectedResult[scopeName])
+
+					statusResponse = rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
+					assert.ElementsMatch(t, statusResponse.CollectionsProcessing[scopeName], testCase.expectedResult[scopeName])
+				})
 			}
-			statusResponse := rt.WaitForResyncDCPStatus(db.BackgroundProcessStateRunning)
-			assert.ElementsMatch(t, statusResponse.CollectionsProcessing[scopeName], testCase.expectedResult[scopeName])
-
-			statusResponse = rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
-			assert.ElementsMatch(t, statusResponse.CollectionsProcessing[scopeName], testCase.expectedResult[scopeName])
 		})
 	}
 }
 
 func TestResyncUsingDCPStream(t *testing.T) {
-	testCases := []struct {
-		docsCreated int
-	}{
-		{
-			docsCreated: 0,
-		},
-		{
-			docsCreated: 1000,
-		},
-	}
+	for _, distributedTestCase := range db.ResyncTestModes() {
+		t.Run(distributedTestCase.Name, func(t *testing.T) {
 
-	syncFn := `
+			testCases := []struct {
+				docsCreated int
+			}{
+				{
+					docsCreated: 0,
+				},
+				{
+					docsCreated: 1000,
+				},
+			}
+
+			syncFn := `
 	function(doc) {
 		channel("x")
 	}`
 
-	for _, testCase := range testCases {
-		t.Run(fmt.Sprintf("Docs %d", testCase.docsCreated), func(t *testing.T) {
+			for _, testCase := range testCases {
+				t.Run(fmt.Sprintf("Docs %d", testCase.docsCreated), func(t *testing.T) {
+					rt := rest.NewRestTester(t,
+						&rest.RestTesterConfig{
+							SyncFn: syncFn,
+						},
+					)
+					defer rt.Close()
+
+					for i := 0; i < testCase.docsCreated; i++ {
+						rt.CreateTestDoc(fmt.Sprintf("doc%d", i))
+					}
+
+					err := rt.WaitForCondition(func() bool {
+						return int(rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value()) == testCase.docsCreated
+					})
+					assert.NoError(t, err)
+					rt.GetDatabase().DbStats.Database().SyncFunctionCount.Set(0)
+
+					response := rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
+					rest.RequireStatus(t, response, http.StatusServiceUnavailable)
+
+					rt.TakeDbOffline()
+					rt.SetDistributedResync(distributedTestCase.Distributed)
+
+					response = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
+					rest.RequireStatus(t, response, http.StatusOK)
+
+					resyncManagerStatus := rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
+
+					assert.Equal(t, testCase.docsCreated, int(rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value()))
+					if !base.UnitTestUrlIsWalrus() && !base.TestsDisableGSI() {
+						// It is possible for Couchbase Server GSI runs which use DCP purge to two DCP events from a previous
+						// test.
+						// 1. doc1 mutation
+						// 2. doc1 deletion
+						//
+						// In a test, these will not be resynced but docsProcessed is incremented. Relax
+						// the assertion to greater than the number of documents.
+						assert.GreaterOrEqual(t, int(resyncManagerStatus.DocsProcessed), testCase.docsCreated)
+					} else {
+						assert.Equal(t, testCase.docsCreated, int(resyncManagerStatus.DocsProcessed))
+					}
+					assert.Equal(t, 0, int(resyncManagerStatus.DocsChanged))
+				})
+			}
+		})
+	}
+}
+
+func TestResyncUsingDCPStreamReset(t *testing.T) {
+	for _, testCase := range db.ResyncTestModes() {
+		t.Run(testCase.Name, func(t *testing.T) {
+
+			syncFn := `
+	function(doc) {
+		channel("x")
+	}`
+
 			rt := rest.NewRestTester(t,
 				&rest.RestTesterConfig{
 					SyncFn: syncFn,
@@ -731,27 +802,39 @@ func TestResyncUsingDCPStream(t *testing.T) {
 			)
 			defer rt.Close()
 
-			for i := 0; i < testCase.docsCreated; i++ {
+			const numDocs = 1000
+
+			// create some docs
+			for i := range numDocs {
 				rt.CreateTestDoc(fmt.Sprintf("doc%d", i))
 			}
 
-			err := rt.WaitForCondition(func() bool {
-				return int(rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value()) == testCase.docsCreated
-			})
-			assert.NoError(t, err)
-			rt.GetDatabase().DbStats.Database().SyncFunctionCount.Set(0)
-
-			response := rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
-			rest.RequireStatus(t, response, http.StatusServiceUnavailable)
-
 			rt.TakeDbOffline()
+			rt.SetDistributedResync(testCase.Distributed)
 
-			response = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
+			// start a resync run
+			response := rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
 			rest.RequireStatus(t, response, http.StatusOK)
 
-			resyncManagerStatus := rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
+			resyncManagerStatus := rt.WaitForResyncDCPStatus(db.BackgroundProcessStateRunning)
+			resyncID := resyncManagerStatus.ResyncID
 
-			assert.Equal(t, testCase.docsCreated, int(rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value()))
+			// stop resync before it completes, assert it has been aborted
+			response = rt.SendAdminRequest("POST", "/db/_resync?action=stop", "")
+			rest.RequireStatus(t, response, http.StatusOK)
+
+			_ = rt.WaitForResyncDCPStatus(db.BackgroundProcessStateStopped)
+
+			// reset the resync process through the endpoint
+			response = rt.SendAdminRequest("POST", "/db/_resync?reset=true", "")
+			rest.RequireStatus(t, response, http.StatusOK)
+
+			// grab new resync status from rest run, assert the resync if is not the same as the first
+			// run and that the docs processed is equal to number of docs we have created
+			resyncManagerStatus = rt.WaitForResyncDCPStatus(db.BackgroundProcessStateRunning)
+			assert.NotEqual(t, resyncID, resyncManagerStatus.ResyncID)
+
+			resyncManagerStatus = rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
 			if !base.UnitTestUrlIsWalrus() && !base.TestsDisableGSI() {
 				// It is possible for Couchbase Server GSI runs which use DCP purge to two DCP events from a previous
 				// test.
@@ -760,72 +843,12 @@ func TestResyncUsingDCPStream(t *testing.T) {
 				//
 				// In a test, these will not be resynced but docsProcessed is incremented. Relax
 				// the assertion to greater than the number of documents.
-				assert.GreaterOrEqual(t, int(resyncManagerStatus.DocsProcessed), testCase.docsCreated)
+				assert.GreaterOrEqual(t, int(resyncManagerStatus.DocsProcessed), numDocs)
 			} else {
-				assert.Equal(t, testCase.docsCreated, int(resyncManagerStatus.DocsProcessed))
+
+				assert.Equal(t, int64(numDocs), resyncManagerStatus.DocsProcessed)
 			}
-			assert.Equal(t, 0, int(resyncManagerStatus.DocsChanged))
 		})
-	}
-}
-
-func TestResyncUsingDCPStreamReset(t *testing.T) {
-	syncFn := `
-	function(doc) {
-		channel("x")
-	}`
-
-	rt := rest.NewRestTester(t,
-		&rest.RestTesterConfig{
-			SyncFn: syncFn,
-		},
-	)
-	defer rt.Close()
-
-	const numDocs = 1000
-
-	// create some docs
-	for i := range numDocs {
-		rt.CreateTestDoc(fmt.Sprintf("doc%d", i))
-	}
-
-	rt.TakeDbOffline()
-
-	// start a resync run
-	response := rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
-	rest.RequireStatus(t, response, http.StatusOK)
-
-	resyncManagerStatus := rt.WaitForResyncDCPStatus(db.BackgroundProcessStateRunning)
-	resyncID := resyncManagerStatus.ResyncID
-
-	// stop resync before it completes, assert it has been aborted
-	response = rt.SendAdminRequest("POST", "/db/_resync?action=stop", "")
-	rest.RequireStatus(t, response, http.StatusOK)
-
-	_ = rt.WaitForResyncDCPStatus(db.BackgroundProcessStateStopped)
-
-	// reset the resync process through the endpoint
-	response = rt.SendAdminRequest("POST", "/db/_resync?reset=true", "")
-	rest.RequireStatus(t, response, http.StatusOK)
-
-	// grab new resync status from rest run, assert the resync if is not the same as the first
-	// run and that the docs processed is equal to number of docs we have created
-	resyncManagerStatus = rt.WaitForResyncDCPStatus(db.BackgroundProcessStateRunning)
-	assert.NotEqual(t, resyncID, resyncManagerStatus.ResyncID)
-
-	resyncManagerStatus = rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
-	if !base.UnitTestUrlIsWalrus() && !base.TestsDisableGSI() {
-		// It is possible for Couchbase Server GSI runs which use DCP purge to two DCP events from a previous
-		// test.
-		// 1. doc1 mutation
-		// 2. doc1 deletion
-		//
-		// In a test, these will not be resynced but docsProcessed is incremented. Relax
-		// the assertion to greater than the number of documents.
-		assert.GreaterOrEqual(t, int(resyncManagerStatus.DocsProcessed), numDocs)
-	} else {
-
-		assert.Equal(t, int64(numDocs), resyncManagerStatus.DocsProcessed)
 	}
 }
 
@@ -834,119 +857,130 @@ func TestResyncUsingDCPStreamForNamedCollection(t *testing.T) {
 
 	numCollections := 2
 	base.RequireNumTestDataStores(t, numCollections)
+	for _, testCase := range db.ResyncTestModes() {
+		t.Run(testCase.Name, func(t *testing.T) {
 
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyConfig)
+			base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyConfig)
 
-	syncFn := `
+			syncFn := `
 	function(doc) {
 		channel("x")
 	}`
 
-	rt := rest.NewRestTesterMultipleCollections(t,
-		&rest.RestTesterConfig{
-			SyncFn:           syncFn,
-			PersistentConfig: true,
-		},
-		numCollections,
-	)
-	defer rt.Close()
+			rt := rest.NewRestTesterMultipleCollections(t,
+				&rest.RestTesterConfig{
+					SyncFn:           syncFn,
+					PersistentConfig: true,
+				},
+				numCollections,
+			)
+			defer rt.Close()
 
-	rest.RequireStatus(t, rt.CreateDatabase("db", rt.NewDbConfig()), http.StatusCreated)
-	// put a docs in both collections
-	for i := 1; i <= 10; i++ {
-		resp := rt.SendAdminRequest(http.MethodPut, fmt.Sprintf("/{{.keyspace1}}/1000%d", i), `{"type":"test_doc"}`)
-		rest.RequireStatus(t, resp, http.StatusCreated)
+			rest.RequireStatus(t, rt.CreateDatabase("db", rt.NewDbConfig()), http.StatusCreated)
+			// put a docs in both collections
+			for i := 1; i <= 10; i++ {
+				resp := rt.SendAdminRequest(http.MethodPut, fmt.Sprintf("/{{.keyspace1}}/1000%d", i), `{"type":"test_doc"}`)
+				rest.RequireStatus(t, resp, http.StatusCreated)
 
-		resp = rt.SendAdminRequest(http.MethodPut, fmt.Sprintf("/{{.keyspace2}}/1000%d", i), `{"type":"test_doc"}`)
-		rest.RequireStatus(t, resp, http.StatusCreated)
-	}
+				resp = rt.SendAdminRequest(http.MethodPut, fmt.Sprintf("/{{.keyspace2}}/1000%d", i), `{"type":"test_doc"}`)
+				rest.RequireStatus(t, resp, http.StatusCreated)
+			}
 
-	rt.TakeDbOffline()
+			rt.TakeDbOffline()
+			rt.SetDistributedResync(testCase.Distributed)
 
-	rest.RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/{{.keyspace1}}/_config/sync", `function(doc){channel("A")}`), http.StatusOK)
-	rest.RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/{{.keyspace2}}/_config/sync", `function(doc){channel("A")}`), http.StatusOK)
-	dataStore1, err := rt.TestBucket.GetNamedDataStore(0)
-	require.NoError(t, err)
-	// Run resync for single collection // Request body {"scopes": "scopeName": ["collection1Name", "collection2Name"]}}
-	body := fmt.Sprintf(`{
+			rest.RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/{{.keyspace1}}/_config/sync", `function(doc){channel("A")}`), http.StatusOK)
+			rest.RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/{{.keyspace2}}/_config/sync", `function(doc){channel("A")}`), http.StatusOK)
+			dataStore1, err := rt.TestBucket.GetNamedDataStore(0)
+			require.NoError(t, err)
+			// Run resync for single collection // Request body {"scopes": "scopeName": ["collection1Name", "collection2Name"]}}
+			body := fmt.Sprintf(`{
 			"scopes" :{
 				"%s": ["%s"]
 			}
 		}`, dataStore1.ScopeName(), dataStore1.CollectionName())
-	resp := rt.SendAdminRequest("POST", "/db/_resync?action=start", body)
-	rest.RequireStatus(t, resp, http.StatusOK)
-	resyncManagerStatus := rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
+			resp := rt.SendAdminRequest("POST", "/db/_resync?action=start", body)
+			rest.RequireStatus(t, resp, http.StatusOK)
+			resyncManagerStatus := rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
 
-	assert.Equal(t, 10, int(resyncManagerStatus.DocsChanged))
+			assert.Equal(t, 10, int(resyncManagerStatus.DocsChanged))
 
-	rest.RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/{{.keyspace1}}/_config/sync", `function(doc){channel("B")}`), http.StatusOK)
-	rest.RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/{{.keyspace2}}/_config/sync", `function(doc){channel("B")}`), http.StatusOK)
+			rest.RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/{{.keyspace1}}/_config/sync", `function(doc){channel("B")}`), http.StatusOK)
+			rest.RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/{{.keyspace2}}/_config/sync", `function(doc){channel("B")}`), http.StatusOK)
 
-	// Run resync for all collections
-	resp = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
-	rest.RequireStatus(t, resp, http.StatusOK)
-	resyncManagerStatus = rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
+			// Run resync for all collections
+			resp = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
+			rest.RequireStatus(t, resp, http.StatusOK)
+			resyncManagerStatus = rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
 
-	assert.Equal(t, 20, int(resyncManagerStatus.DocsChanged))
+			assert.Equal(t, 20, int(resyncManagerStatus.DocsChanged))
+		})
+	}
 }
 
 func TestResyncErrorScenariosUsingDCPStream(t *testing.T) {
-	syncFn := `
+	for _, testCase := range db.ResyncTestModes() {
+		t.Run(testCase.Name, func(t *testing.T) {
+
+			syncFn := `
 	function(doc) {
 		channel("x")
 	}`
 
-	testBucket := base.GetTestBucket(t)
+			testBucket := base.GetTestBucket(t)
 
-	rt := rest.NewRestTester(t,
-		&rest.RestTesterConfig{
-			SyncFn:           syncFn,
-			CustomTestBucket: testBucket,
-		},
-	)
-	defer rt.Close()
+			rt := rest.NewRestTester(t,
+				&rest.RestTesterConfig{
+					SyncFn:           syncFn,
+					CustomTestBucket: testBucket,
+				},
+			)
+			defer rt.Close()
 
-	numOfDocs := 1000
-	for i := range numOfDocs {
-		rt.CreateTestDoc(fmt.Sprintf("doc%d", i))
+			numOfDocs := 1000
+			for i := range numOfDocs {
+				rt.CreateTestDoc(fmt.Sprintf("doc%d", i))
+			}
+
+			assert.Equal(t, numOfDocs, int(rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value()))
+			rt.GetDatabase().DbStats.Database().SyncFunctionCount.Set(0)
+
+			response := rt.SendAdminRequest("GET", "/db/_resync", "")
+			rest.RequireStatus(t, response, http.StatusOK)
+
+			response = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
+			rest.RequireStatus(t, response, http.StatusServiceUnavailable)
+
+			response = rt.SendAdminRequest("POST", "/db/_resync?action=stop", "")
+			rest.RequireStatus(t, response, http.StatusBadRequest)
+
+			rt.TakeDbOffline()
+			rt.SetDistributedResync(testCase.Distributed)
+
+			response = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
+			rest.RequireStatus(t, response, http.StatusOK)
+
+			// If processor is running, another start request should throw error
+			response = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
+			rest.RequireStatus(t, response, http.StatusServiceUnavailable)
+
+			rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
+
+			assert.Equal(t, numOfDocs, int(rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value()))
+
+			response = rt.SendAdminRequest("POST", "/db/_resync?action=stop", "")
+			rest.RequireStatus(t, response, http.StatusBadRequest)
+
+			response = rt.SendAdminRequest("POST", "/db/_resync?action=invalid", "")
+			rest.RequireStatus(t, response, http.StatusBadRequest)
+
+			// Test empty action, should default to start
+			response = rt.SendAdminRequest("POST", "/db/_resync", "")
+			rest.RequireStatus(t, response, http.StatusOK)
+
+			rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
+		})
 	}
-
-	assert.Equal(t, numOfDocs, int(rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value()))
-	rt.GetDatabase().DbStats.Database().SyncFunctionCount.Set(0)
-
-	response := rt.SendAdminRequest("GET", "/db/_resync", "")
-	rest.RequireStatus(t, response, http.StatusOK)
-
-	response = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
-	rest.RequireStatus(t, response, http.StatusServiceUnavailable)
-
-	response = rt.SendAdminRequest("POST", "/db/_resync?action=stop", "")
-	rest.RequireStatus(t, response, http.StatusBadRequest)
-
-	rt.TakeDbOffline()
-
-	response = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
-	rest.RequireStatus(t, response, http.StatusOK)
-
-	// If processor is running, another start request should throw error
-	response = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
-	rest.RequireStatus(t, response, http.StatusServiceUnavailable)
-
-	rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
-
-	assert.Equal(t, numOfDocs, int(rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value()))
-
-	response = rt.SendAdminRequest("POST", "/db/_resync?action=stop", "")
-	rest.RequireStatus(t, response, http.StatusBadRequest)
-
-	response = rt.SendAdminRequest("POST", "/db/_resync?action=invalid", "")
-	rest.RequireStatus(t, response, http.StatusBadRequest)
-
-	// Test empty action, should default to start
-	response = rt.SendAdminRequest("POST", "/db/_resync", "")
-	rest.RequireStatus(t, response, http.StatusOK)
-
-	rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
 }
 
 // TestCorruptDbConfigHandling:
@@ -1415,47 +1449,53 @@ func TestConfigPollingRemoveDatabase(t *testing.T) {
 }
 
 func TestResyncStopUsingDCPStream(t *testing.T) {
-	syncFn := `
+	for _, testCase := range db.ResyncTestModes() {
+		t.Run(testCase.Name, func(t *testing.T) {
+
+			syncFn := `
 	function(doc) {
 		channel("x")
 	}`
 
-	testBucket := base.GetTestBucket(t)
+			testBucket := base.GetTestBucket(t)
 
-	rt := rest.NewRestTester(t,
-		&rest.RestTesterConfig{
-			SyncFn:           syncFn,
-			CustomTestBucket: testBucket,
-		},
-	)
-	defer rt.Close()
+			rt := rest.NewRestTester(t,
+				&rest.RestTesterConfig{
+					SyncFn:           syncFn,
+					CustomTestBucket: testBucket,
+				},
+			)
+			defer rt.Close()
 
-	numOfDocs := 1000
-	// gsi is slower than views, so update the number of documents for views so stopping the resync will not complete
-	if base.TestsDisableGSI() {
-		numOfDocs = 5000
+			numOfDocs := 1000
+			// gsi is slower than views, so update the number of documents for views so stopping the resync will not complete
+			if base.TestsDisableGSI() {
+				numOfDocs = 5000
+			}
+			for i := range numOfDocs {
+				rt.CreateTestDoc(fmt.Sprintf("doc%d", i))
+			}
+
+			rt.WaitForPendingChanges()
+
+			require.Equal(t, int64(numOfDocs), rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
+
+			rt.TakeDbOffline()
+			rt.SetDistributedResync(testCase.Distributed)
+
+			response := rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
+			rest.RequireStatus(t, response, http.StatusOK)
+			rt.WaitForResyncDCPStatus(db.BackgroundProcessStateRunning)
+
+			response = rt.SendAdminRequest("POST", "/db/_resync?action=stop", "")
+			rest.RequireStatus(t, response, http.StatusOK)
+
+			rt.WaitForResyncDCPStatus(db.BackgroundProcessStateStopped)
+
+			// make sure resync stopped before it completed
+			require.Less(t, int(rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value()), numOfDocs*2)
+		})
 	}
-	for i := range numOfDocs {
-		rt.CreateTestDoc(fmt.Sprintf("doc%d", i))
-	}
-
-	rt.WaitForPendingChanges()
-
-	require.Equal(t, int64(numOfDocs), rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
-
-	rt.TakeDbOffline()
-
-	response := rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
-	rest.RequireStatus(t, response, http.StatusOK)
-	rt.WaitForResyncDCPStatus(db.BackgroundProcessStateRunning)
-
-	response = rt.SendAdminRequest("POST", "/db/_resync?action=stop", "")
-	rest.RequireStatus(t, response, http.StatusOK)
-
-	rt.WaitForResyncDCPStatus(db.BackgroundProcessStateStopped)
-
-	// make sure resync stopped before it completed
-	require.Less(t, int(rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value()), numOfDocs*2)
 }
 
 // Single threaded bring DB online

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -645,7 +645,7 @@ func TestDBOfflineSingleResyncUsingDCPStream(t *testing.T) {
 			response := rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
 			rest.RequireStatus(t, response, http.StatusOK)
 
-			// Send a second _resync request.  This must return a 400 since the first one is blocked processing
+			// Send a second _resync request. This must return a 503 since the first one is still processing.
 			rest.RequireStatus(t, rt.SendAdminRequest("POST", "/db/_resync?action=start", ""), 503)
 
 			rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
@@ -829,7 +829,7 @@ func TestResyncUsingDCPStreamReset(t *testing.T) {
 			response = rt.SendAdminRequest("POST", "/db/_resync?reset=true", "")
 			rest.RequireStatus(t, response, http.StatusOK)
 
-			// grab new resync status from rest run, assert the resync if is not the same as the first
+			// grab new resync status from rest run, assert the resync id is not the same as the first
 			// run and that the docs processed is equal to number of docs we have created
 			resyncManagerStatus = rt.WaitForResyncDCPStatus(db.BackgroundProcessStateRunning)
 			assert.NotEqual(t, resyncID, resyncManagerStatus.ResyncID)

--- a/rest/adminapitest/collections_admin_api_test.go
+++ b/rest/adminapitest/collections_admin_api_test.go
@@ -171,151 +171,167 @@ func TestRequireResync(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server, until creating a db through the REST API allows the views/walrus/collections combination")
 	}
-	base.TestRequiresCollections(t)
-	base.RequireNumTestDataStores(t, 2)
-	rtConfig := &rest.RestTesterConfig{
-		PersistentConfig: true,
+	for _, testCase := range db.ResyncTestModes() {
+		t.Run(testCase.Name, func(t *testing.T) {
+
+			base.TestRequiresCollections(t)
+			base.RequireNumTestDataStores(t, 2)
+			rtConfig := &rest.RestTesterConfig{
+				PersistentConfig: true,
+			}
+
+			rt := rest.NewRestTesterMultipleCollections(t, rtConfig, 2)
+			defer rt.Close()
+
+			_ = rt.Bucket()
+
+			db1Name := "db1"
+			db2Name := "db2"
+
+			// Set up scopes configs
+			scopesConfig := rest.GetCollectionsConfig(t, rt.TestBucket, 2)
+
+			dataStoreNames := rest.GetDataStoreNamesFromScopesConfig(scopesConfig)
+			scope := dataStoreNames[0].ScopeName()
+			collection1 := dataStoreNames[0].CollectionName()
+			collection2 := dataStoreNames[1].CollectionName()
+			scopeAndCollection1Name := base.ScopeAndCollectionName{Scope: scope, Collection: collection1}
+
+			scopesConfigC1Only := rest.GetCollectionsConfig(t, rt.TestBucket, 2)
+			delete(scopesConfigC1Only[scope].Collections, collection2)
+
+			scopesConfigC2Only := rest.GetCollectionsConfig(t, rt.TestBucket, 2)
+			delete(scopesConfigC2Only[scope].Collections, collection1)
+
+			// Create a db1 with two collections
+			dbConfig := rt.NewDbConfig()
+			dbConfig.Scopes = scopesConfig
+
+			resp := rt.CreateDatabase(db1Name, dbConfig)
+			rest.RequireStatus(t, resp, http.StatusCreated)
+			rt.SetDistributedResync(testCase.Distributed)
+
+			// Write documents to collection 1 and 2
+			ks_db1_c1 := db1Name + "." + scope + "." + collection1
+			ks_db1_c2 := db1Name + "." + scope + "." + collection2
+			ks_db2_c1 := db2Name + "." + scope + "." + collection1
+
+			resp = rt.SendAdminRequest("PUT", "/"+ks_db1_c1+"/testDoc1", `{"foo":"bar"}`)
+			rest.RequireStatus(t, resp, http.StatusCreated)
+			resp = rt.SendAdminRequest("PUT", "/"+ks_db1_c2+"/testDoc2", `{"foo":"bar"}`)
+			rest.RequireStatus(t, resp, http.StatusCreated)
+
+			// Update db1 to remove collection1
+			dbConfig.Scopes = scopesConfigC2Only
+			resp = rt.ReplaceDbConfig(db1Name, dbConfig)
+			rest.RequireStatus(t, resp, http.StatusCreated)
+			rt.SetDistributedResync(testCase.Distributed)
+
+			// Validate that doc can still be retrieved from collection 2
+			resp = rt.SendAdminRequest("GET", "/"+ks_db1_c2+"/testDoc2", "")
+			rest.RequireStatus(t, resp, http.StatusOK)
+
+			// Create db2 targeting collection 1
+			db2Config := rt.NewDbConfig()
+			db2Config.Scopes = scopesConfigC1Only
+
+			resp = rt.CreateDatabase(db2Name, db2Config)
+			rest.RequireStatus(t, resp, http.StatusCreated)
+			for _, database := range rt.ServerContext().AllDatabases() {
+				rs, ok := database.ResyncManager.Process.(*db.ResyncManagerDCP)
+				require.True(rt.TB(), ok)
+				if testCase.Distributed {
+					rs.Distributed = true
+				} else {
+					require.False(rt.TB(), rs.Distributed, "Expected this database ResyncManager to be in non distributed mode")
+				}
+			}
+
+			dbConfigCas1 := getDBConfigCas(rt, db2Name)
+
+			// Get status, verify offline
+			dbRootResponse := rt.GetDatabaseRoot(db2Name)
+			require.Equal(t, db.RunStateString[db.DBOffline], dbRootResponse.State)
+			require.Equal(t, []string{scopeAndCollection1Name.String()}, dbRootResponse.RequireResync)
+
+			// Call _online, verify it doesn't override offline when resync is still required.
+			onlineResponse := rt.SendAdminRequest("POST", "/"+db2Name+"/_online", "")
+			rest.RequireStatus(t, onlineResponse, http.StatusOK)
+
+			// The status will transition from: offline -> starting -> offline, so wait for requireResync: true and offline state.
+			//
+			// - /db/_online transitions state to Starting
+			// - Database written to bucket with a new cas value
+			// - requiresResync is set to true
+			// - Database transitions back to Offline
+			needsResync := []string{scope + "." + collection1}
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				assert.NotEqual(c, dbConfigCas1, getDBConfigCas(rt, db2Name))
+				assert.False(c, rt.ServerContext().DatabaseInitManager.HasActiveInitialization(db2Name))
+				dbRootResponse := rt.GetDatabaseRoot(db2Name)
+				assert.Equal(c, needsResync, dbRootResponse.RequireResync)
+				assert.Equal(c, db.RunStateString[db.DBOffline], dbRootResponse.State)
+			}, 10*time.Second, 50*time.Millisecond)
+
+			allDBsSummary := rt.GetAllDBsVerbose()
+			require.Equal(t, []rest.DbSummary{
+				rest.DbSummary{
+					DBName: db1Name,
+					Bucket: rt.Bucket().GetName(),
+					State:  db.RunStateString[db.DBOnline],
+				},
+				rest.DbSummary{
+					DBName:        db2Name,
+					Bucket:        rt.Bucket().GetName(),
+					State:         db.RunStateString[db.DBOffline],
+					RequireResync: true,
+				},
+			}, allDBsSummary)
+
+			// Run resync for collection
+			resyncCollections := base.NewCollectionNames(scopeAndCollection1Name)
+			resyncPayload, marshalErr := base.JSONMarshal(resyncCollections)
+			require.NoError(t, marshalErr)
+
+			rt.WaitForDatabaseState(db2Name, db.RunStateString[db.DBOffline])
+
+			resp = rt.SendAdminRequest("POST", "/"+db2Name+"/_resync?action=start&regenerate_sequences=true", string(resyncPayload))
+			rest.RequireStatus(t, resp, http.StatusOK)
+			db2, err := rt.ServerContext().GetDatabase(rt.Context(), db2Name)
+			require.NoError(t, err)
+			db.RequireBackgroundManagerState(t, db2.ResyncManager, db.BackgroundProcessStateCompleted)
+
+			allDBsSummary = rt.GetAllDBsVerbose()
+			require.Equal(t, []rest.DbSummary{
+				rest.DbSummary{
+					DBName:        db1Name,
+					Bucket:        rt.Bucket().GetName(),
+					State:         db.RunStateString[db.DBOnline],
+					RequireResync: false,
+				},
+				rest.DbSummary{
+					DBName:        db2Name,
+					Bucket:        rt.Bucket().GetName(),
+					State:         db.RunStateString[db.DBOffline],
+					RequireResync: false,
+				},
+			}, allDBsSummary)
+
+			dbRootResponse = rt.GetDatabaseRoot(db2Name)
+			assert.Nil(t, dbRootResponse.RequireResync)
+
+			// Attempt online again, should now succeed
+			onlineResponse = rt.SendAdminRequest("POST", "/"+db2Name+"/_online", "")
+			rest.RequireStatus(t, onlineResponse, http.StatusOK)
+			rt.WaitForDatabaseState(db2Name, db.RunStateString[db.DBOnline])
+
+			dbRootResponse = rt.GetDatabaseRoot(db2Name)
+			assert.Nil(t, dbRootResponse.RequireResync)
+
+			resp = rt.SendAdminRequest("GET", "/"+ks_db2_c1+"/testDoc1", "")
+			rest.RequireStatus(t, resp, http.StatusOK)
+		})
 	}
-
-	rt := rest.NewRestTesterMultipleCollections(t, rtConfig, 2)
-	defer rt.Close()
-
-	_ = rt.Bucket()
-
-	db1Name := "db1"
-	db2Name := "db2"
-
-	// Set up scopes configs
-	scopesConfig := rest.GetCollectionsConfig(t, rt.TestBucket, 2)
-
-	dataStoreNames := rest.GetDataStoreNamesFromScopesConfig(scopesConfig)
-	scope := dataStoreNames[0].ScopeName()
-	collection1 := dataStoreNames[0].CollectionName()
-	collection2 := dataStoreNames[1].CollectionName()
-	scopeAndCollection1Name := base.ScopeAndCollectionName{Scope: scope, Collection: collection1}
-
-	scopesConfigC1Only := rest.GetCollectionsConfig(t, rt.TestBucket, 2)
-	delete(scopesConfigC1Only[scope].Collections, collection2)
-
-	scopesConfigC2Only := rest.GetCollectionsConfig(t, rt.TestBucket, 2)
-	delete(scopesConfigC2Only[scope].Collections, collection1)
-
-	// Create a db1 with two collections
-	dbConfig := rt.NewDbConfig()
-	dbConfig.Scopes = scopesConfig
-
-	resp := rt.CreateDatabase(db1Name, dbConfig)
-	rest.RequireStatus(t, resp, http.StatusCreated)
-
-	// Write documents to collection 1 and 2
-	ks_db1_c1 := db1Name + "." + scope + "." + collection1
-	ks_db1_c2 := db1Name + "." + scope + "." + collection2
-	ks_db2_c1 := db2Name + "." + scope + "." + collection1
-
-	resp = rt.SendAdminRequest("PUT", "/"+ks_db1_c1+"/testDoc1", `{"foo":"bar"}`)
-	rest.RequireStatus(t, resp, http.StatusCreated)
-	resp = rt.SendAdminRequest("PUT", "/"+ks_db1_c2+"/testDoc2", `{"foo":"bar"}`)
-	rest.RequireStatus(t, resp, http.StatusCreated)
-
-	// Update db1 to remove collection1
-	dbConfig.Scopes = scopesConfigC2Only
-	resp = rt.ReplaceDbConfig(db1Name, dbConfig)
-	rest.RequireStatus(t, resp, http.StatusCreated)
-
-	// Validate that doc can still be retrieved from collection 2
-	resp = rt.SendAdminRequest("GET", "/"+ks_db1_c2+"/testDoc2", "")
-	rest.RequireStatus(t, resp, http.StatusOK)
-
-	// Create db2 targeting collection 1
-	db2Config := rt.NewDbConfig()
-	db2Config.Scopes = scopesConfigC1Only
-
-	resp = rt.CreateDatabase(db2Name, db2Config)
-	rest.RequireStatus(t, resp, http.StatusCreated)
-
-	dbConfigCas1 := getDBConfigCas(rt, db2Name)
-
-	// Get status, verify offline
-	dbRootResponse := rt.GetDatabaseRoot(db2Name)
-	require.Equal(t, db.RunStateString[db.DBOffline], dbRootResponse.State)
-	require.Equal(t, []string{scopeAndCollection1Name.String()}, dbRootResponse.RequireResync)
-
-	// Call _online, verify it doesn't override offline when resync is still required.
-	onlineResponse := rt.SendAdminRequest("POST", "/"+db2Name+"/_online", "")
-	rest.RequireStatus(t, onlineResponse, http.StatusOK)
-
-	// The status will transition from: offline -> starting -> offline, so wait for requireResync: true and offline state.
-	//
-	// - /db/_online transitions state to Starting
-	// - Database written to bucket with a new cas value
-	// - requiresResync is set to true
-	// - Database transitions back to Offline
-	needsResync := []string{scope + "." + collection1}
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.NotEqual(c, dbConfigCas1, getDBConfigCas(rt, db2Name))
-		assert.False(c, rt.ServerContext().DatabaseInitManager.HasActiveInitialization(db2Name))
-		dbRootResponse := rt.GetDatabaseRoot(db2Name)
-		assert.Equal(c, needsResync, dbRootResponse.RequireResync)
-		assert.Equal(c, db.RunStateString[db.DBOffline], dbRootResponse.State)
-	}, 10*time.Second, 50*time.Millisecond)
-
-	allDBsSummary := rt.GetAllDBsVerbose()
-	require.Equal(t, []rest.DbSummary{
-		rest.DbSummary{
-			DBName: db1Name,
-			Bucket: rt.Bucket().GetName(),
-			State:  db.RunStateString[db.DBOnline],
-		},
-		rest.DbSummary{
-			DBName:        db2Name,
-			Bucket:        rt.Bucket().GetName(),
-			State:         db.RunStateString[db.DBOffline],
-			RequireResync: true,
-		},
-	}, allDBsSummary)
-
-	// Run resync for collection
-	resyncCollections := base.NewCollectionNames(scopeAndCollection1Name)
-	resyncPayload, marshalErr := base.JSONMarshal(resyncCollections)
-	require.NoError(t, marshalErr)
-
-	rt.WaitForDatabaseState(db2Name, db.RunStateString[db.DBOffline])
-
-	resp = rt.SendAdminRequest("POST", "/"+db2Name+"/_resync?action=start&regenerate_sequences=true", string(resyncPayload))
-	rest.RequireStatus(t, resp, http.StatusOK)
-	db2, err := rt.ServerContext().GetDatabase(rt.Context(), db2Name)
-	require.NoError(t, err)
-	db.RequireBackgroundManagerState(t, db2.ResyncManager, db.BackgroundProcessStateCompleted)
-
-	allDBsSummary = rt.GetAllDBsVerbose()
-	require.Equal(t, []rest.DbSummary{
-		rest.DbSummary{
-			DBName:        db1Name,
-			Bucket:        rt.Bucket().GetName(),
-			State:         db.RunStateString[db.DBOnline],
-			RequireResync: false,
-		},
-		rest.DbSummary{
-			DBName:        db2Name,
-			Bucket:        rt.Bucket().GetName(),
-			State:         db.RunStateString[db.DBOffline],
-			RequireResync: false,
-		},
-	}, allDBsSummary)
-
-	dbRootResponse = rt.GetDatabaseRoot(db2Name)
-	assert.Nil(t, dbRootResponse.RequireResync)
-
-	// Attempt online again, should now succeed
-	onlineResponse = rt.SendAdminRequest("POST", "/"+db2Name+"/_online", "")
-	rest.RequireStatus(t, onlineResponse, http.StatusOK)
-	rt.WaitForDatabaseState(db2Name, db.RunStateString[db.DBOnline])
-
-	dbRootResponse = rt.GetDatabaseRoot(db2Name)
-	assert.Nil(t, dbRootResponse.RequireResync)
-
-	resp = rt.SendAdminRequest("GET", "/"+ks_db2_c1+"/testDoc1", "")
-	rest.RequireStatus(t, resp, http.StatusOK)
 }
 
 // getDBConfigCas looks at the db config in the bucket and returns the cas value for a database

--- a/rest/sync_fn_test.go
+++ b/rest/sync_fn_test.go
@@ -397,257 +397,182 @@ func TestSyncFnTimeout(t *testing.T) {
 	defer rt.Close()
 
 	syncFnFinishedWG := sync.WaitGroup{}
-	syncFnFinishedWG.Add(1)
-	go func() {
+	defer base.WaitWithTimeout(t, &syncFnFinishedWG, time.Second*15)
+	syncFnFinishedWG.Go(func() {
 		response := rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc", `{"foo": "bar"}`)
 		AssertHTTPErrorReason(t, response, 500, "JS sync function timed out")
-		syncFnFinishedWG.Done()
-	}()
-	base.WaitWithTimeout(t, &syncFnFinishedWG, time.Second*15)
-}
-
-func TestResyncErrorScenariosUsingDCPStream(t *testing.T) {
-	syncFn := `
-	function(doc) {
-		channel("x")
-	}`
-
-	rt := NewRestTester(t,
-		&RestTesterConfig{
-			SyncFn: syncFn,
-		},
-	)
-	defer rt.Close()
-
-	for i := range 1000 {
-		rt.CreateTestDoc(fmt.Sprintf("doc%d", i))
-	}
-
-	response := rt.SendAdminRequest("GET", "/db/_resync", "")
-	RequireStatus(t, response, http.StatusOK)
-
-	response = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
-	RequireStatus(t, response, http.StatusServiceUnavailable)
-
-	response = rt.SendAdminRequest("POST", "/db/_resync?action=stop", "")
-	RequireStatus(t, response, http.StatusBadRequest)
-
-	rt.TakeDbOffline()
-
-	response = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
-	RequireStatus(t, response, http.StatusOK)
-
-	rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
-
-	response = rt.SendAdminRequest("POST", "/db/_resync?action=stop", "")
-	RequireStatus(t, response, http.StatusBadRequest)
-
-	response = rt.SendAdminRequest("POST", "/db/_resync?action=invalid", "")
-	RequireStatus(t, response, http.StatusBadRequest)
-
-	// Test empty action, should default to start
-	response = rt.SendAdminRequest("POST", "/db/_resync", "")
-	RequireStatus(t, response, http.StatusOK)
-
-	rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
-}
-
-func TestResyncStopUsingDCPStream(t *testing.T) {
-	syncFn := `
-	function(doc) {
-		channel("x")
-	}`
-
-	rt := NewRestTester(t,
-		&RestTesterConfig{
-			SyncFn: syncFn,
-			DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-				QueryPaginationLimit: base.Ptr(10),
-			}},
-		},
-	)
-	defer rt.Close()
-
-	for i := range 1000 {
-		rt.CreateTestDoc(fmt.Sprintf("doc%d", i))
-	}
-
-	err := rt.WaitForCondition(func() bool {
-		return int(rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value()) == 1000
 	})
-	assert.NoError(t, err)
-
-	rt.TakeDbOffline()
-
-	response := rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
-	RequireStatus(t, response, http.StatusOK)
-
-	rt.WaitForResyncDCPStatus(db.BackgroundProcessStateRunning)
-	response = rt.SendAdminRequest("POST", "/db/_resync?action=stop", "")
-	RequireStatus(t, response, http.StatusOK)
-
-	rt.WaitForResyncDCPStatus(db.BackgroundProcessStateStopped)
-
-	syncFnCount := int(rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
-	assert.Less(t, syncFnCount, 2000, "Expected syncFnCount < 2000 but syncFnCount=%d", syncFnCount)
 }
 
 func TestResyncRegenerateSequences(t *testing.T) {
-	ctx := base.TestCtx(t)
-	syncFn := `
+	for _, testCase := range db.ResyncTestModes() {
+		t.Run(testCase.Name, func(t *testing.T) {
+
+			ctx := base.TestCtx(t)
+			syncFn := `
 	function(doc) {
 		if (doc.userdoc){
 			channel("channel_1")
 		}
 	}`
 
-	rt := NewRestTester(t,
-		&RestTesterConfig{
-			SyncFn: syncFn,
-		},
-	)
-	defer rt.Close()
+			rt := NewRestTester(t,
+				&RestTesterConfig{
+					SyncFn: syncFn,
+				},
+			)
+			defer rt.Close()
 
-	var response *TestResponse
-	var docSeqArr []uint64
-	var body db.Body
-	var rawDocResponse RawDocResponse
+			var response *TestResponse
+			var docSeqArr []uint64
+			var body db.Body
+			var rawDocResponse RawDocResponse
 
-	for i := range 10 {
-		docID := fmt.Sprintf("doc%d", i)
-		rt.CreateTestDoc(docID)
+			for i := range 10 {
+				docID := fmt.Sprintf("doc%d", i)
+				rt.CreateTestDoc(docID)
 
-		response = rt.SendAdminRequest("GET", "/{{.keyspace}}/_raw/"+docID, "")
-		require.Equal(t, http.StatusOK, response.Code)
+				response = rt.SendAdminRequest("GET", "/{{.keyspace}}/_raw/"+docID, "")
+				require.Equal(t, http.StatusOK, response.Code)
 
-		err := json.Unmarshal(response.BodyBytes(), &rawDocResponse)
-		require.NoError(t, err)
+				err := json.Unmarshal(response.BodyBytes(), &rawDocResponse)
+				require.NoError(t, err)
 
-		docSeqArr = append(docSeqArr, rawDocResponse.Xattrs.Sync.Sequence)
-	}
-
-	ds := rt.GetSingleDataStore()
-	response = rt.SendAdminRequest("PUT", "/{{.db}}/_role/role1", GetRolePayload(t, "role1", ds, []string{"channel_1"}))
-	RequireStatus(t, response, http.StatusCreated)
-
-	response = rt.SendAdminRequest("PUT", "/{{.db}}/_user/user1", GetUserPayload(t, "user1", "letmein", "", ds, []string{"channel_1"}, []string{"role1"}))
-	RequireStatus(t, response, http.StatusCreated)
-
-	_, err := rt.MetadataStore().Get(ctx, rt.GetDatabase().MetadataKeys.RoleKey("role1"), &body)
-	assert.NoError(t, err)
-	role1SeqBefore := body["sequence"].(float64)
-
-	_, err = rt.MetadataStore().Get(ctx, rt.GetDatabase().MetadataKeys.UserKey("user1"), &body)
-	assert.NoError(t, err)
-	user1SeqBefore := body["sequence"].(float64)
-
-	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/userdoc", `{"userdoc": true}`)
-	RequireStatus(t, response, http.StatusCreated)
-
-	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/userdoc2", `{"userdoc": true}`)
-	RequireStatus(t, response, http.StatusCreated)
-
-	// Let everything catch up before opening changes feed
-	rt.WaitForPendingChanges()
-
-	changesRespContains := func(changesResp ChangesResults, docid string) bool {
-		for _, resp := range changesResp.Results {
-			if resp.ID == docid {
-				return true
+				docSeqArr = append(docSeqArr, rawDocResponse.Xattrs.Sync.Sequence)
 			}
-		}
-		return false
+
+			ds := rt.GetSingleDataStore()
+			response = rt.SendAdminRequest("PUT", "/{{.db}}/_role/role1", GetRolePayload(t, "role1", ds, []string{"channel_1"}))
+			RequireStatus(t, response, http.StatusCreated)
+
+			response = rt.SendAdminRequest("PUT", "/{{.db}}/_user/user1", GetUserPayload(t, "user1", "letmein", "", ds, []string{"channel_1"}, []string{"role1"}))
+			RequireStatus(t, response, http.StatusCreated)
+
+			_, err := rt.MetadataStore().Get(ctx, rt.GetDatabase().MetadataKeys.RoleKey("role1"), &body)
+			assert.NoError(t, err)
+			role1SeqBefore := body["sequence"].(float64)
+
+			_, err = rt.MetadataStore().Get(ctx, rt.GetDatabase().MetadataKeys.UserKey("user1"), &body)
+			assert.NoError(t, err)
+			user1SeqBefore := body["sequence"].(float64)
+
+			response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/userdoc", `{"userdoc": true}`)
+			RequireStatus(t, response, http.StatusCreated)
+
+			response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/userdoc2", `{"userdoc": true}`)
+			RequireStatus(t, response, http.StatusCreated)
+
+			// Let everything catch up before opening changes feed
+			rt.WaitForPendingChanges()
+
+			changesRespContains := func(changesResp ChangesResults, docid string) bool {
+				for _, resp := range changesResp.Results {
+					if resp.ID == docid {
+						return true
+					}
+				}
+				return false
+			}
+
+			changesResp := rt.GetChanges("/{{.keyspace}}/_changes", "user1")
+			assert.Len(t, changesResp.Results, 3)
+			assert.True(t, changesRespContains(changesResp, "userdoc"))
+			assert.True(t, changesRespContains(changesResp, "userdoc2"))
+
+			response = rt.SendAdminRequest("GET", "/db/_resync", "")
+			RequireStatus(t, response, http.StatusOK)
+
+			response = rt.SendAdminRequest("POST", "/db/_offline", "")
+			RequireStatus(t, response, http.StatusOK)
+			rt.SetDistributedResync(testCase.Distributed)
+
+			response = rt.SendAdminRequest("POST", "/db/_resync?action=start&regenerate_sequences=true", "")
+			RequireStatus(t, response, http.StatusOK)
+
+			resyncStatus := rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
+
+			_, err = rt.MetadataStore().Get(ctx, rt.GetDatabase().MetadataKeys.RoleKey("role1"), &body)
+			assert.NoError(t, err)
+			role1SeqAfter := body["sequence"].(float64)
+
+			_, err = rt.MetadataStore().Get(ctx, rt.GetDatabase().MetadataKeys.UserKey("user1"), &body)
+			assert.NoError(t, err)
+			user1SeqAfter := body["sequence"].(float64)
+
+			assert.True(t, role1SeqAfter > role1SeqBefore)
+			assert.True(t, user1SeqAfter > user1SeqBefore)
+
+			collection, ctx := rt.GetSingleTestDatabaseCollection()
+			for i := range 10 {
+				docID := fmt.Sprintf("doc%d", i)
+
+				doc, err := collection.GetDocument(ctx, docID, db.DocUnmarshalAll)
+				assert.NoError(t, err)
+
+				assert.True(t, doc.Sequence > docSeqArr[i])
+			}
+
+			assert.Equal(t, int64(12), resyncStatus.DocsChanged)
+			if !base.UnitTestUrlIsWalrus() && !base.TestsDisableGSI() {
+				// It is possible for Couchbase Server GSI runs which use DCP purge to two DCP events from a previous
+				// test.
+				// 1. doc1 mutation
+				// 2. doc1 deletion
+				//
+				// In a test, these will not be resynced but docsProcessed is incremented. Relax
+				// the assertion to greater than the number of documents.
+				assert.GreaterOrEqual(t, resyncStatus.DocsProcessed, int64(12))
+			} else {
+				assert.Equal(t, int64(12), resyncStatus.DocsProcessed)
+			}
+
+			rt.TakeDbOnline()
+
+			changesResp = rt.GetChanges("/{{.keyspace}}/_changes", "user1")
+			assert.Len(t, changesResp.Results, 3)
+			assert.True(t, changesRespContains(changesResp, "userdoc"))
+			assert.True(t, changesRespContains(changesResp, "userdoc2"))
+		})
 	}
-
-	changesResp := rt.GetChanges("/{{.keyspace}}/_changes", "user1")
-	assert.Len(t, changesResp.Results, 3)
-	assert.True(t, changesRespContains(changesResp, "userdoc"))
-	assert.True(t, changesRespContains(changesResp, "userdoc2"))
-
-	response = rt.SendAdminRequest("GET", "/db/_resync", "")
-	RequireStatus(t, response, http.StatusOK)
-
-	response = rt.SendAdminRequest("POST", "/db/_offline", "")
-	RequireStatus(t, response, http.StatusOK)
-
-	response = rt.SendAdminRequest("POST", "/db/_resync?action=start&regenerate_sequences=true", "")
-	RequireStatus(t, response, http.StatusOK)
-
-	resyncStatus := rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
-
-	_, err = rt.MetadataStore().Get(ctx, rt.GetDatabase().MetadataKeys.RoleKey("role1"), &body)
-	assert.NoError(t, err)
-	role1SeqAfter := body["sequence"].(float64)
-
-	_, err = rt.MetadataStore().Get(ctx, rt.GetDatabase().MetadataKeys.UserKey("user1"), &body)
-	assert.NoError(t, err)
-	user1SeqAfter := body["sequence"].(float64)
-
-	assert.True(t, role1SeqAfter > role1SeqBefore)
-	assert.True(t, user1SeqAfter > user1SeqBefore)
-
-	collection, ctx := rt.GetSingleTestDatabaseCollection()
-	for i := range 10 {
-		docID := fmt.Sprintf("doc%d", i)
-
-		doc, err := collection.GetDocument(ctx, docID, db.DocUnmarshalAll)
-		assert.NoError(t, err)
-
-		assert.True(t, doc.Sequence > docSeqArr[i])
-	}
-
-	assert.Equal(t, int64(12), resyncStatus.DocsChanged)
-	if !base.UnitTestUrlIsWalrus() && !base.TestsDisableGSI() {
-		// It is possible for Couchbase Server GSI runs which use DCP purge to two DCP events from a previous
-		// test.
-		// 1. doc1 mutation
-		// 2. doc1 deletion
-		//
-		// In a test, these will not be resynced but docsProcessed is incremented. Relax
-		// the assertion to greater than the number of documents.
-		assert.GreaterOrEqual(t, resyncStatus.DocsProcessed, int64(12))
-	} else {
-		assert.Equal(t, int64(12), resyncStatus.DocsProcessed)
-	}
-
-	rt.TakeDbOnline()
-
-	changesResp = rt.GetChanges("/{{.keyspace}}/_changes", "user1")
-	assert.Len(t, changesResp.Results, 3)
-	assert.True(t, changesRespContains(changesResp, "userdoc"))
-	assert.True(t, changesRespContains(changesResp, "userdoc2"))
 }
 
 // CBG-2150: Tests that resync status is cluster aware
 func TestResyncPersistence(t *testing.T) {
-	tb := base.GetTestBucket(t)
-	noCloseTB := tb.NoCloseClone()
+	for _, testCase := range db.ResyncTestModes() {
+		t.Run(testCase.Name, func(t *testing.T) {
 
-	rt1 := NewRestTester(t, &RestTesterConfig{
-		CustomTestBucket: noCloseTB,
-	})
+			tb := base.GetTestBucket(t)
+			noCloseTB := tb.NoCloseClone()
 
-	rt2 := NewRestTester(t, &RestTesterConfig{
-		CustomTestBucket: tb,
-	})
+			rt1 := NewRestTester(t, &RestTesterConfig{
+				CustomTestBucket: noCloseTB,
+			})
 
-	defer rt2.Close()
-	defer rt1.Close()
+			rt2 := NewRestTester(t, &RestTesterConfig{
+				CustomTestBucket: tb,
+			})
 
-	// Create a document to process through resync
-	rt1.CreateTestDoc("doc1")
+			defer rt2.Close()
+			defer rt1.Close()
 
-	// Start resync
-	rt1.TakeDbOffline()
+			// Create a document to process through resync
+			rt1.CreateTestDoc("doc1")
 
-	resp := rt1.SendAdminRequest("POST", "/{{.db}}/_resync?action=start", "")
-	RequireStatus(t, resp, http.StatusOK)
+			// Start resync
+			rt1.TakeDbOffline()
+			rt1.SetDistributedResync(testCase.Distributed)
+			rt2.SetDistributedResync(testCase.Distributed)
 
-	// Wait for resync to complete
-	rt1Status := rt1.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
+			resp := rt1.SendAdminRequest("POST", "/{{.db}}/_resync?action=start", "")
+			RequireStatus(t, resp, http.StatusOK)
 
-	rt2Status := rt2.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
-	require.Equal(t, rt1Status, rt2Status)
+			// Wait for resync to complete
+			rt1Status := rt1.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
+
+			rt2Status := rt2.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
+			require.Equal(t, rt1Status, rt2Status)
+		})
+	}
 }
 
 func TestExpiryUpdateSyncFunction(t *testing.T) {

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -540,6 +540,18 @@ func (rt *RestTester) WaitForDBInitializationCompleted(dbName string) {
 	}, 30*time.Second, 100*time.Millisecond, "Database initialization did not complete within expected time")
 }
 
+// SetDistributedResync forces the ResyncManager into a single node or distributed resync mode. This should only be called before
+// resync is run for the first time and needs to be called each time a DatabaseContext is reinitialized.
+func (rt *RestTester) SetDistributedResync(useDistributed bool) {
+	rs, ok := rt.GetDatabase().ResyncManager.Process.(*db.ResyncManagerDCP)
+	require.True(rt.TB(), ok)
+	if useDistributed {
+		rs.Distributed = true
+	} else {
+		require.False(rt.TB(), rs.Distributed, "Expected this database ResyncManager to be in non distributed mode")
+	}
+}
+
 type RawDocResponse struct {
 	Xattrs RawDocXattrs `json:"_xattrs"`
 }


### PR DESCRIPTION
Support distributed resync tests. These are expected to be temporary until distributed resync is enabled for all EE builds. Do not enable running any of the tests as part of this PR.

- After running the tests a large number of times, increase some of the docCount numbers so the tests do not flake.
- Have waitgroups run in defers so that failing tests do not contaminate future tests.
- Removed `TestResyncErrorScenariosUsingDCPStream` and `TestResyncStopUsingDCPStream` from rest package since the exact test is in rest/adminapitest. This was a mistake from the initial migration of these tests into this package. 