### PR TITLE
CBG-5106: Incorrect history being sent for legacy revision cases in delta sync

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -932,7 +932,7 @@ func (bsc *BlipSyncContext) sendRevAsDelta(ctx context.Context, sender *blip.Sen
 	}
 
 	if redactedRev != nil {
-		localIsLegacyRev := base.IsRevTreeID(redactedRev.RevID)
+		localIsLegacyRev := redactedRev.CV == nil
 		var revTreeHistory []string
 		if !bsc.useHLV() || localIsLegacyRev || remoteIsLegacyRev || bsc.sendRevTreeProperty() {
 			var err error

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -913,7 +913,7 @@ func (bh *blipHandler) handleProposeChanges(rq *blip.Message) error {
 
 // ////// DOCUMENTS:
 
-func (bsc *BlipSyncContext) sendRevAsDelta(ctx context.Context, sender *blip.Sender, docID, revID string, deltaSrcRevID string, seq SequenceID, knownRevs map[string]bool, maxHistory int, handleChangesResponseCollection *DatabaseCollectionWithUser, collectionIdx *int) error {
+func (bsc *BlipSyncContext) sendRevAsDelta(ctx context.Context, sender *blip.Sender, docID, revID string, deltaSrcRevID string, seq SequenceID, knownRevs map[string]bool, maxHistory int, handleChangesResponseCollection *DatabaseCollectionWithUser, collectionIdx *int, remoteIsLegacyRev bool) error {
 	bsc.replicationStats.SendRevDeltaRequestedCount.Add(1)
 
 	revDelta, redactedRev, err := handleChangesResponseCollection.GetDelta(ctx, docID, deltaSrcRevID, revID)
@@ -922,39 +922,35 @@ func (bsc *BlipSyncContext) sendRevAsDelta(ctx context.Context, sender *blip.Sen
 	} else if base.IsFleeceDeltaError(err) {
 		// Something went wrong in the diffing library. We want to know about this!
 		base.WarnfCtx(ctx, "Falling back to full body replication. Error generating delta from %s to %s for key %s - err: %v", deltaSrcRevID, revID, base.UD(docID), err)
-		return bsc.sendRevision(ctx, sender, docID, revID, seq, knownRevs, maxHistory, handleChangesResponseCollection, collectionIdx, false)
+		return bsc.sendRevision(ctx, sender, docID, revID, seq, knownRevs, maxHistory, handleChangesResponseCollection, collectionIdx, remoteIsLegacyRev)
 	} else if err == base.ErrDeltaSourceIsTombstone {
 		base.TracefCtx(ctx, base.KeySync, "Falling back to full body replication. Delta source %s is tombstone. Unable to generate delta to %s for key %s", deltaSrcRevID, revID, base.UD(docID))
-		return bsc.sendRevision(ctx, sender, docID, revID, seq, knownRevs, maxHistory, handleChangesResponseCollection, collectionIdx, false)
+		return bsc.sendRevision(ctx, sender, docID, revID, seq, knownRevs, maxHistory, handleChangesResponseCollection, collectionIdx, remoteIsLegacyRev)
 	} else if err != nil {
 		base.DebugfCtx(ctx, base.KeySync, "Falling back to full body replication. Couldn't get delta from %s to %s for key %s - err: %v", deltaSrcRevID, revID, base.UD(docID), err)
-		return bsc.sendRevision(ctx, sender, docID, revID, seq, knownRevs, maxHistory, handleChangesResponseCollection, collectionIdx, false)
+		return bsc.sendRevision(ctx, sender, docID, revID, seq, knownRevs, maxHistory, handleChangesResponseCollection, collectionIdx, remoteIsLegacyRev)
 	}
 
 	if redactedRev != nil {
-		var history []string
-		var revTreeProperty []string
-		if !bsc.useHLV() || bsc.sendRevTreeProperty() {
+		localIsLegacyRev := base.IsRevTreeID(redactedRev.RevID)
+		var revTreeHistory []string
+		if !bsc.useHLV() || localIsLegacyRev || remoteIsLegacyRev || bsc.sendRevTreeProperty() {
 			var err error
-			history, err = toHistory(redactedRev.History, knownRevs, maxHistory)
+			revTreeHistory, err = toHistory(redactedRev.History, knownRevs, maxHistory)
 			if err != nil {
 				err := base.RedactErrorf("Could not get rev tree history for replacement rev in sendRevAsDelta %s %s: %w, sending a noRev to skip this revision for replication at sequence %s.", base.UD(docID), revID, err, seq)
 				base.WarnfCtx(ctx, "%s", err)
 				return bsc.sendNoRev(sender, docID, revID, collectionIdx, seq, err)
 			}
-		} else {
-			history = append(history, redactedRev.HlvHistory)
 		}
-		if bsc.sendRevTreeProperty() {
-			revTreeProperty = append(revTreeProperty, redactedRev.RevID)
-			history, err := toHistory(redactedRev.History, knownRevs, maxHistory)
-			if err != nil {
-				err := base.RedactErrorf("Could not get rev tree history for replacement rev when sending in sendRevAsDelta %s %s: %w, sending a noRev to skip this document for replication at sequence %s.", base.UD(docID), redactedRev.RevID, err, seq)
-				base.WarnfCtx(ctx, "%s", err)
-				return bsc.sendNoRev(sender, docID, revID, collectionIdx, seq, err)
-			}
-			revTreeProperty = append(revTreeProperty, history...)
-		}
+
+		history, revTreeProperty := bsc.buildRevHistory(revHistoryInput{
+			revTreeHistory:    revTreeHistory,
+			hlvHistory:        redactedRev.HlvHistory,
+			revID:             redactedRev.RevID,
+			localIsLegacyRev:  localIsLegacyRev,
+			remoteIsLegacyRev: remoteIsLegacyRev,
+		})
 
 		properties, err := blipRevMessageProperties(history, redactedRev.Deleted, seq, "", revTreeProperty)
 		if err != nil {
@@ -965,16 +961,16 @@ func (bsc *BlipSyncContext) sendRevAsDelta(ctx context.Context, sender *blip.Sen
 
 	if revDelta == nil {
 		base.DebugfCtx(ctx, base.KeySync, "Falling back to full body replication. Couldn't get delta from %s to %s for key %s", deltaSrcRevID, revID, base.UD(docID))
-		return bsc.sendRevision(ctx, sender, docID, revID, seq, knownRevs, maxHistory, handleChangesResponseCollection, collectionIdx, false)
+		return bsc.sendRevision(ctx, sender, docID, revID, seq, knownRevs, maxHistory, handleChangesResponseCollection, collectionIdx, remoteIsLegacyRev)
 	}
 
 	resendFullRevisionFunc := func() error {
 		base.InfofCtx(ctx, base.KeySync, "Resending revision as full body. Peer couldn't process delta %s from %s to %s for key %s", base.UD(revDelta.DeltaBytes), deltaSrcRevID, revID, base.UD(docID))
-		return bsc.sendRevision(ctx, sender, docID, revID, seq, knownRevs, maxHistory, handleChangesResponseCollection, collectionIdx, false)
+		return bsc.sendRevision(ctx, sender, docID, revID, seq, knownRevs, maxHistory, handleChangesResponseCollection, collectionIdx, remoteIsLegacyRev)
 	}
 
 	base.TracefCtx(ctx, base.KeySync, "docID: %s - delta: %v", base.UD(docID), base.UD(string(revDelta.DeltaBytes)))
-	if err := bsc.sendDelta(ctx, sender, docID, collectionIdx, deltaSrcRevID, revDelta, seq, resendFullRevisionFunc); err != nil {
+	if err := bsc.sendDelta(ctx, sender, docID, collectionIdx, deltaSrcRevID, revDelta, seq, remoteIsLegacyRev, resendFullRevisionFunc); err != nil {
 		return err
 	}
 

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -638,7 +638,7 @@ type revHistoryInput struct {
 //		│  history property:     [revTreeHistory...]          │
 //		│  revTreeHistory prop:  (not sent)                   │
 //		│                                                     │
-//		│  The remote has a HLV version. Append the rev tree  │
+//		│  The remote has a HLV version. Assign the rev tree  │
 //		│  to history so the remote can parse for conflict    │
 //		│  checks.                                            │
 //		└─────────────────────────────────────────────────────┘

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -602,7 +602,7 @@ type revHistoryInput struct {
 // (e.g. "2-abc") but no version vector. After a node upgrades, new writes get both a rev tree ID
 // and a CV (current version). The combination of local/remote legacy status produces four scenarios:
 //
-//		Scenario 1: Pre-HLV protocol (subprotocol < V4), post-HLV protocol (subprotocol >= V4) and both sides have legacy rev
+//		Scenario 1: Pre-HLV protocol (subprotocol < V4) or post-HLV protocol (subprotocol >= V4) and both sides have legacy rev
 //		┌─────────────────────────────────────────────────────┐
 //		│  history property:     [revTreeHistory...]          │
 //		│  revTreeHistory property:  (not sent)               │

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -393,7 +393,7 @@ func (bsc *BlipSyncContext) handleChangesResponse(ctx context.Context, sender *b
 			var err error
 
 			if deltaSrcRevID != "" {
-				err = bsc.sendRevAsDelta(ctx, sender, docID, rev, deltaSrcRevID, seq, knownRevs, maxHistory, handleChangesResponseDbCollection, collectionIdx)
+				err = bsc.sendRevAsDelta(ctx, sender, docID, rev, deltaSrcRevID, seq, knownRevs, maxHistory, handleChangesResponseDbCollection, collectionIdx, legacyRev)
 			} else {
 				err = bsc.sendRevision(ctx, sender, docID, rev, seq, knownRevs, maxHistory, handleChangesResponseDbCollection, collectionIdx, legacyRev)
 			}
@@ -585,21 +585,109 @@ func (bsc *BlipSyncContext) setUseDeltas(clientCanUseDeltas bool) {
 	}
 }
 
-func (bsc *BlipSyncContext) sendDelta(ctx context.Context, sender *blip.Sender, docID string, collectionIdx *int, deltaSrcRevID string, revDelta *RevisionDelta, seq SequenceID, resendFullRevisionFunc func() error) error {
+// revHistoryInput contains the inputs needed to build revision history properties for a BLIP rev message.
+type revHistoryInput struct {
+	revTreeHistory    []string // Pre-computed rev tree ancestor chain (from toHistory or RevisionDelta.RevisionHistory)
+	hlvHistory        string   // HLV history string in CBL format
+	revID             string   // Current document's rev tree ID (e.g. "2-abc")
+	localIsLegacyRev  bool     // True if the local revision predates HLV (no version vector yet)
+	remoteIsLegacyRev bool     // True if the remote peer's version of this doc predates HLV
+}
 
-	var history []string
-	var revTreeProperty []string
-	// CV can now be empty on rev cache items; only use CV when it's available
-	// history being sent here is potentially incorrect pending CBG-5106
-	if bsc.useHLV() && revDelta.ToCV != "" {
-		history = append(history, revDelta.HlvHistory)
+// buildRevHistory constructs the "history" and "revTreeHistory" BLIP message properties for a rev
+// message. These properties tell the peer what version history the document has, so the peer can
+// determine ancestry and detect conflicts.
+//
+// A "legacy" revision is one that predates HLV (Hybrid Logical Vector) — it has a rev tree ID
+// (e.g. "2-abc") but no version vector. After a node upgrades, new writes get both a rev tree ID
+// and a CV (current version). The combination of local/remote legacy status produces four scenarios:
+//
+//		Scenario 1: Pre-HLV protocol (subprotocol < V4), post-HLV protocol (subprotocol >= V4) and both sides have legacy rev
+//		┌─────────────────────────────────────────────────────┐
+//		│  history property:     [revTreeHistory...]          │
+//		│  revTreeHistory property:  (not sent)               │
+//		│                                                     │
+//		│  Both sides only understand rev trees or only have  │
+//	    │  rev trees, so send the rev tree ancestor chain     │
+//		│  in the history property.     					  │
+//		└─────────────────────────────────────────────────────┘
+//
+//		Scenario 2: Local has HLV, remote has HLV (CBL client)
+//		┌─────────────────────────────────────────────────────┐
+//		│  history property:     [hlvHistory]                 │
+//		│  revTreeHistory prop:  (not sent)                   │
+//		│                                                     │
+//		│  Both sides speak HLV. Send only the HLV history.   │
+//		│  CBL clients don't need the rev tree property.      │
+//		└─────────────────────────────────────────────────────┘
+//
+//		Scenario 3: Local has HLV, remote is legacy
+//		┌─────────────────────────────────────────────────────┐
+//		│  history property:     [hlvHistory, revID,          │
+//		│                         revTreeHistory...]          │
+//		│  revTreeHistory prop:  (not sent)                   │
+//		│                                                     │
+//		│  The remote has a legacy rev tree version. Append   │
+//		│  the current revID + rev tree history after the HLV │
+//		│  history so the remote can detect conflicts via its │
+//		│  rev tree.                                          │
+//		└─────────────────────────────────────────────────────┘
+//
+//		Scenario 4: Local legacy, remote has HLV
+//		┌─────────────────────────────────────────────────────┐
+//		│  history property:     [revTreeHistory...]          │
+//		│  revTreeHistory prop:  (not sent)                   │
+//		│                                                     │
+//		│  The remote has a HLV version. Append the rev tree  │
+//		│  to history so the remote can parse for conflict    │
+//		│  checks.                                            │
+//		└─────────────────────────────────────────────────────┘
+//
+//		Scenario 5: Local is HLV-aware, remote is HLV-aware (ISGR peer)
+//		┌─────────────────────────────────────────────────────┐
+//		│  history property:     [hlvHistory]                 │
+//		│  revTreeHistory prop:  [revID, revTreeHistory...]   │
+//		│                                                     │
+//		│  ISGR peers (sendRevTreeProperty) get HLV in the    │
+//		│  history property and rev tree in a separate        │
+//		│  revTreeHistory property to keep both reconciled.   │
+//		└─────────────────────────────────────────────────────┘
+func (bsc *BlipSyncContext) buildRevHistory(input revHistoryInput) (history []string, revTreeHistoryProperty []string) {
+	// Build main history: rev tree for legacy/pre-HLV, HLV for upgraded docs
+	if !bsc.useHLV() || input.localIsLegacyRev {
+		history = input.revTreeHistory // Scenario 1, 4
 	} else {
-		history = revDelta.RevisionHistory
+		if input.hlvHistory != "" {
+			history = append(history, input.hlvHistory) // Scenarios 2, 3, 5
+		}
 	}
-	if bsc.sendRevTreeProperty() {
-		revTreeProperty = append(revTreeProperty, revDelta.ToRevID)
-		revTreeProperty = append(revTreeProperty, revDelta.RevisionHistory...)
+
+	// Append or separate the rev tree for cross-version or ISGR peer scenarios
+	if input.remoteIsLegacyRev && !input.localIsLegacyRev {
+		// Scenario 3: remote needs rev tree appended to history for conflict detection
+		history = append(history, input.revID)
+		history = append(history, input.revTreeHistory...)
+	} else if bsc.sendRevTreeProperty() && !input.localIsLegacyRev {
+		// Scenario 5: ISGR peer gets rev tree in a separate property
+		revTreeHistoryProperty = append(revTreeHistoryProperty, input.revID)
+		revTreeHistoryProperty = append(revTreeHistoryProperty, input.revTreeHistory...)
 	}
+
+	return history, revTreeHistoryProperty
+}
+
+func (bsc *BlipSyncContext) sendDelta(ctx context.Context, sender *blip.Sender, docID string, collectionIdx *int, deltaSrcRevID string, revDelta *RevisionDelta, seq SequenceID, remoteIsLegacyRev bool, resendFullRevisionFunc func() error) error {
+
+	// ToRevID is always a rev tree ID; use ToCV to determine if the doc has been upgraded to HLV
+	localIsLegacyRev := revDelta.ToCV == ""
+
+	history, revTreeProperty := bsc.buildRevHistory(revHistoryInput{
+		revTreeHistory:    revDelta.RevisionHistory,
+		hlvHistory:        revDelta.HlvHistory,
+		revID:             revDelta.ToRevID,
+		localIsLegacyRev:  localIsLegacyRev,
+		remoteIsLegacyRev: remoteIsLegacyRev,
+	})
 	properties, err := blipRevMessageProperties(history, revDelta.ToDeleted, seq, "", revTreeProperty)
 	if err != nil {
 		return err
@@ -755,50 +843,25 @@ func (bsc *BlipSyncContext) sendRevision(ctx context.Context, sender *blip.Sende
 	if replacedRevID != "" {
 		bsc.replicationStats.SendReplacementRevCount.Add(1)
 	}
-	var history []string
-	if !bsc.useHLV() || localIsLegacyRev {
+	// Compute rev tree history when any scenario needs it (see buildRevHistory for scenario docs)
+	var revTreeHistory []string
+	if !bsc.useHLV() || localIsLegacyRev || remoteIsLegacyRev || bsc.sendRevTreeProperty() {
 		var err error
-		history, err = toHistory(docRev.History, knownRevs, maxHistory)
+		revTreeHistory, err = toHistory(docRev.History, knownRevs, maxHistory)
 		if err != nil {
 			err := base.RedactErrorf("Could not get rev tree history for %s %s: %w, sending a noRev to skip this revision for replication at sequence %s.", base.UD(docID), revID, err, seq)
 			base.WarnfCtx(ctx, "%s", err)
 			return bsc.sendNoRev(sender, docID, revID, collectionIdx, seq, err)
 		}
-	} else {
-		if docRev.HlvHistory != "" {
-			history = append(history, docRev.HlvHistory)
-		}
 	}
 
-	var revTreeHistoryProperty []string
-	// If the remote side of the replication has this document but it's a legacy version of the document, we need to send the full rev tree history
-	// after the hlv history so the remote side can identify iof the document is in conflict or not. We should only do
-	// this when the local revision is not a legacy revision as if local revision is also legacy revision we will have built
-	// the full rev tree history above to send in the history property.
-	if remoteIsLegacyRev && !localIsLegacyRev {
-		// append current revID and rest of rev tree after hlv history
-		revTreeHistory, err := toHistory(docRev.History, knownRevs, maxHistory)
-		if err != nil {
-			err := base.RedactErrorf("Could not get rev tree history for %s %s when remote revision is a legacy rev and the local is hlv aware: %w, sending a noRev to skip this revision for replication at sequence %d.", base.UD(docID), revID, err, seq)
-			base.WarnfCtx(ctx, "%v", err)
-			return bsc.sendNoRev(sender, docID, revID, collectionIdx, seq, err)
-		}
-		history = append(history, docRev.RevID)
-		history = append(history, revTreeHistory...)
-	} else if bsc.sendRevTreeProperty() && !localIsLegacyRev {
-		// If we are communicating in > 4 subprotocol versions and the client is another SGW peer, we have a revTree
-		// property we can populate with the rev tree to keep rev tree reconciled on the replication. This property
-		// should only be sent if the local + remote revisions are not a legacy revisions as the rev tree in this case will be
-		// sent in history property.
-		revTreeHistoryProperty = append(revTreeHistoryProperty, docRev.RevID) // we need current rev
-		history, err := toHistory(docRev.History, knownRevs, maxHistory)
-		if err != nil {
-			err := base.RedactErrorf("Could not get rev tree history for %s %s when local and remote revision are hlv aware: %w, sending a noRev to skip this revision for replication at sequence %s.", base.UD(docID), revID, err, seq)
-			base.WarnfCtx(ctx, "%v", err)
-			return bsc.sendNoRev(sender, docID, revID, collectionIdx, seq, err)
-		}
-		revTreeHistoryProperty = append(revTreeHistoryProperty, history...)
-	}
+	history, revTreeHistoryProperty := bsc.buildRevHistory(revHistoryInput{
+		revTreeHistory:    revTreeHistory,
+		hlvHistory:        docRev.HlvHistory,
+		revID:             docRev.RevID,
+		localIsLegacyRev:  localIsLegacyRev,
+		remoteIsLegacyRev: remoteIsLegacyRev,
+	})
 
 	properties, err := blipRevMessageProperties(history, docRev.Deleted, seq, replacedRevID, revTreeHistoryProperty)
 	if err != nil {

--- a/rest/blip_legacy_revid_test.go
+++ b/rest/blip_legacy_revid_test.go
@@ -660,118 +660,76 @@ func TestChangesResponseLegacyRev(t *testing.T) {
 // Setup:
 //   - Create doc rev1 on SGW
 //   - Update doc to create rev2 on SGW
-//   - Client connects with V4 subprotocol, delta sync enabled
-//   - Custom changes handler responds with [rev1ID] as knownRevs (simulating a client that only has a legacy rev revision 1)
-//   - Server computes delta from rev1 → rev2 and sends via sendDelta with remoteIsLegacyRev=true
+//   - Client pre-populated with rev1 as a legacy revtree revision (no HLV)
+//   - Client pulls with delta sync enabled
+//   - Server computes delta from rev1 → rev2 and sends via sendDelta
 //
 // Expected rev message (buildRevHistory scenario 3):
 //
-//	history property: [hlvHistory, rev2RevTreeID, rev1RevTreeID] (hlv history here is empty since doc has only been updated by one hlv aware peer)
+//	history property: [hlvHistory, rev2RevTreeID, rev1RevTreeID] (no hlv pv here since doc has only been updated by one hlv aware peer)
 //	deltaSrc:         rev1RevTreeID
 //	body:             the delta (not full body)
-func TestDeltaSyncSendHistoryWithLegacyClient(t *testing.T) {
+func TestDeltaSyncSendRevTreeHistoryWithClientHavingLegacyRev(t *testing.T) {
 	if !base.IsEnterpriseEdition() {
 		t.Skip("Delta sync requires EE")
 	}
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeySyncMsg, base.KeyChanges)
+
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[RevtreeSubtestName] = true // V4-specific: tests legacy rev in HLV-aware client
 
 	sgUseDeltas := true
-	rt := NewRestTester(t, &RestTesterConfig{
-		GuestEnabled: true,
-		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-			DeltaSync: &DeltaSyncConfig{
-				Enabled: &sgUseDeltas,
-			},
-		}},
-	})
-	defer rt.Close()
+	btcRunner.Run(func(t *testing.T) {
+		rt := NewRestTester(t, &RestTesterConfig{
+			GuestEnabled: true,
+			DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+				DeltaSync: &DeltaSyncConfig{
+					Enabled: &sgUseDeltas,
+				},
+			}},
+		})
+		defer rt.Close()
 
-	bt := NewBlipTesterFromSpecWithRT(rt, &BlipTesterSpec{
-		blipProtocols: []string{db.CBMobileReplicationV4.SubprotocolString()},
-	})
-	defer bt.Close()
+		docID := SafeDocumentName(t, t.Name())
 
-	// Create rev1 and rev2 on SGW
-	docVersion1 := rt.PutDoc("doc1", `{"key": "val1"}`)
-	rev1ID := docVersion1.RevTreeID
-	docVersion2 := rt.UpdateDoc("doc1", docVersion1, `{"key": "val2"}`)
-	rt.WaitForPendingChanges()
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
+			ClientDeltas: true,
+		})
+		defer client.Close()
 
-	receivedChangesRequestWg := sync.WaitGroup{}
-	receivedChangesRequestWg.Add(2) // 1 for doc changes + 1 for empty "caught up" changes
+		// Create rev1 and rev2 on SGW
+		docVersion1 := rt.PutDoc(docID, `{"key": "val1"}`)
+		rev1ID := docVersion1.RevTreeID
+		docVersion2 := rt.UpdateDoc(docID, docVersion1, `{"key": "val2"}`)
+		rt.WaitForPendingChanges()
 
-	revsFinishedWg := sync.WaitGroup{}
-	revsFinishedWg.Add(1) // expect 1 rev/delta message
+		// Pre-populate the client with rev1 as a legacy revtree revision so that when SGW sends changes
+		// for rev2, the client reports rev1ID as its known rev (triggering delta from rev1).
+		btcRunner.AddRevTreeRev(client.id, docID, rev1ID, EmptyDocVersion(), []byte(`{"key": "val1"}`))
 
-	bt.blipContext.HandlerForProfile["rev"] = func(request *blip.Message) {
-		defer revsFinishedWg.Done()
+		btcRunner.StartOneshotPull(client.id)
+		msg := btcRunner.WaitForPullRevMessage(client.id, docID, docVersion2)
 
 		// Should be sent as delta with rev1 as the delta source
-		deltaSrc := request.Properties[db.RevMessageDeltaSrc]
-		assert.Equal(t, rev1ID, deltaSrc, "delta source should be the legacy revID the client reported")
+		assert.Equal(t, rev1ID, msg.Properties[db.RevMessageDeltaSrc], "delta source should be the legacy revID the client reported")
 
 		// The rev property should be the CV (HLV-aware identifier)
-		rev := request.Properties["rev"]
-		assert.Equal(t, docVersion2.CV.String(), rev)
+		assert.Equal(t, docVersion2.CV.String(), msg.Properties[db.RevMessageRev])
 
-		// History should contain: HLV history, then rev2's revTreeID, then rev1's revTreeID
-		// (scenario 3 in buildRevHistory: local HLV-aware, remote legacy)
-		history := request.Properties[db.RevMessageHistory]
+		// History should contain rev2's revTreeID then rev1's revTreeID
+		// (scenario 3 in buildRevHistory: local HLV-aware, remote legacy; no HLV pv since same source)
+		history := msg.Properties[db.RevMessageHistory]
 		require.NotEmpty(t, history, "history must not be empty — rev tree history is required for legacy client conflict detection")
 		historyList := strings.Split(history, ",")
-		// The history should be the rev tree: current revID then parent revID
-		require.Len(t, historyList, 2, "history should rev tree entries only since hlv history is empty for this doc")
-		assert.Equal(t, docVersion2.RevTreeID, historyList[len(historyList)-2], "second to last history entry should be current revTreeID")
-		assert.Equal(t, docVersion1.RevTreeID, historyList[len(historyList)-1], "last history entry should be parent revTreeID")
+		require.Len(t, historyList, 2, "history should have rev tree entries only since hlv history is empty for this doc")
+		assert.Equal(t, docVersion2.RevTreeID, historyList[0], "first history entry should be current revTreeID")
+		assert.Equal(t, docVersion1.RevTreeID, historyList[1], "second history entry should be parent revTreeID")
 
 		// Should NOT have a separate revTreeHistory property (that's only for SGR2 peers)
-		assert.Empty(t, request.Properties[db.RevMessageTreeHistory], "revTreeHistory property should not be set for non-SGR2 clients")
-	}
-
-	bt.blipContext.HandlerForProfile["changes"] = func(request *blip.Message) {
-		defer receivedChangesRequestWg.Done()
-		body, err := request.Body()
-		require.NoError(t, err)
-
-		knownRevs := []any{}
-		if string(body) != "null" {
-			var changesReqs [][]any
-			err = base.JSONUnmarshal(body, &changesReqs)
-			require.NoError(t, err)
-
-			knownRevs = make([]any, len(changesReqs))
-			for i := range changesReqs {
-				// Respond with the legacy revID as the known rev, simulating a client that has rev1
-				// but predates HLV. This triggers remoteIsLegacyRev=true and sets deltaSrc=rev1ID
-				// on the server side.
-				knownRevs[i] = []string{rev1ID}
-			}
-		}
-
-		if !request.NoReply() {
-			response := request.Response()
-			// Enable deltas so the server sends a delta rather than full body
-			response.Properties[db.ChangesResponseDeltas] = "true"
-			emptyResponseValBytes, err := base.JSONMarshal(knownRevs)
-			require.NoError(t, err)
-			response.SetBody(emptyResponseValBytes)
-		}
-	}
-
-	subChangesRequest := bt.newRequest()
-	subChangesRequest.SetProfile("subChanges")
-	subChangesRequest.Properties["continuous"] = "false"
-	sent := bt.sender.Send(subChangesRequest)
-	assert.True(t, sent)
-
-	subChangesResponse := subChangesRequest.Response()
-	assert.Equal(t, subChangesRequest.SerialNumber(), subChangesResponse.SerialNumber())
-
-	base.WaitWithTimeout(t, &receivedChangesRequestWg, time.Second*10)
-	base.WaitWithTimeout(t, &revsFinishedWg, time.Second*10)
+		assert.Empty(t, msg.Properties[db.RevMessageTreeHistory], "revTreeHistory property should not be set for non-SGR2 clients")
+	})
 }
 
-// TestDeltaSyncSendHistoryWithLegacyClientAndHLVHistory verifies that when a delta is sent to a client that has a
+// TestDeltaSyncSendRevTreeHistoryWithHLVHistoryClientHavingLegacyRev verifies that when a delta is sent to a client that has a
 // legacy revision and the document has multi-source HLV history, the history property contains the HLV previous
 // versions followed by the rev tree.
 //
@@ -781,120 +739,155 @@ func TestDeltaSyncSendHistoryWithLegacyClient(t *testing.T) {
 // Setup:
 //   - Create doc rev1 on SGW (gets revTreeID + HLV cv)
 //   - Update doc via HLV agent to simulate a different peer creating rev2 (gets a new HLV cv with rev1's cv as pv)
-//   - Client connects with V4 subprotocol, delta sync enabled
-//   - Custom changes handler responds with [rev1RevTreeID] as knownRevs (legacy client)
+//   - Client pre-populated with rev1 as a legacy revtree revision (no HLV)
+//   - Client pulls with delta sync enabled
 //
 // Expected rev message (buildRevHistory scenario 3):
 //
 //	history property: [pv (rev1's cv), rev2RevTreeID, rev1RevTreeID]
 //	deltaSrc:         rev1RevTreeID
-func TestDeltaSyncSendHistoryWithLegacyClientAndHLVHistory(t *testing.T) {
+func TestDeltaSyncSendRevTreeHistoryWithHLVHistoryClientHavingLegacyRev(t *testing.T) {
 	if !base.IsEnterpriseEdition() {
 		t.Skip("Delta sync requires EE")
 	}
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeySyncMsg, base.KeyChanges)
+
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[RevtreeSubtestName] = true // V4-specific: tests legacy rev in HLV-aware client
 
 	sgUseDeltas := true
-	rt := NewRestTester(t, &RestTesterConfig{
-		GuestEnabled: true,
-		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-			DeltaSync: &DeltaSyncConfig{
-				Enabled: &sgUseDeltas,
-			},
-		}},
-	})
-	defer rt.Close()
+	btcRunner.Run(func(t *testing.T) {
+		rt := NewRestTester(t, &RestTesterConfig{
+			GuestEnabled: true,
+			DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+				DeltaSync: &DeltaSyncConfig{
+					Enabled: &sgUseDeltas,
+				},
+			}},
+		})
+		defer rt.Close()
 
-	bt := NewBlipTesterFromSpecWithRT(rt, &BlipTesterSpec{
-		blipProtocols: []string{db.CBMobileReplicationV4.SubprotocolString()},
-	})
-	defer bt.Close()
+		docID := SafeDocumentName(t, t.Name())
 
-	collection, ctx := rt.GetSingleTestDatabaseCollection()
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
+			ClientDeltas: true,
+		})
+		defer client.Close()
 
-	// Create rev1 on SGW — gets revTreeID + HLV
-	docVersion1 := rt.PutDoc("doc1", `{"key": "val1"}`)
-	rev1ID := docVersion1.RevTreeID
+		collection, ctx := rt.GetSingleTestDatabaseCollection()
 
-	// Update doc via HLV agent to simulate a different peer creating rev2.
-	// This gives the doc a new CV from "peerSource" with rev1's CV as a previous version in the HLV.
-	newDoc, _, err := collection.GetDocWithXattrs(ctx, "doc1", db.DocUnmarshalAll)
-	require.NoError(t, err)
-	agent := db.NewHLVAgent(t, rt.GetSingleDataStore(), "peerSource", base.VvXattrName)
-	_ = agent.UpdateWithHLV(ctx, "doc1", newDoc.Cas, newDoc.HLV)
+		// Create rev1 on SGW — gets revTreeID + HLV
+		docVersion1 := rt.PutDoc(docID, `{"key": "val1"}`)
+		rev1ID := docVersion1.RevTreeID
 
-	// Force import so SGW picks up the HLV agent's update
-	newDoc, err = collection.GetDocument(ctx, "doc1", db.DocUnmarshalAll)
-	require.NoError(t, err)
-	rt.WaitForPendingChanges()
+		// Pre-populate the client with rev1 as a legacy revtree revision so that when SGW sends changes
+		// for the updated doc, the client reports rev1ID as its known rev (triggering delta from rev1).
+		btcRunner.AddRevTreeRev(client.id, docID, rev1ID, EmptyDocVersion(), []byte(`{"key": "val1"}`))
 
-	receivedChangesRequestWg := sync.WaitGroup{}
-	receivedChangesRequestWg.Add(2)
-	revsFinishedWg := sync.WaitGroup{}
-	revsFinishedWg.Add(1)
+		// Update doc via HLV agent to simulate a different peer creating rev2.
+		// This gives the doc a new CV from "peerSource" with rev1's CV as a previous version in the HLV.
+		newDoc, _, err := collection.GetDocWithXattrs(ctx, docID, db.DocUnmarshalAll)
+		require.NoError(t, err)
+		agent := db.NewHLVAgent(t, rt.GetSingleDataStore(), "peerSource", base.VvXattrName)
+		_ = agent.UpdateWithHLV(ctx, docID, newDoc.Cas, newDoc.HLV)
 
-	bt.blipContext.HandlerForProfile["rev"] = func(request *blip.Message) {
-		defer revsFinishedWg.Done()
+		// Force import so SGW picks up the HLV agent's update
+		newDoc, err = collection.GetDocument(ctx, docID, db.DocUnmarshalAll)
+		require.NoError(t, err)
+		rt.WaitForPendingChanges()
+
+		docVersion2 := newDoc.ExtractDocVersion()
+		btcRunner.StartOneshotPull(client.id)
+		msg := btcRunner.WaitForPullRevMessage(client.id, docID, docVersion2)
 
 		// Should be sent as delta with rev1 as the delta source
-		deltaSrc := request.Properties[db.RevMessageDeltaSrc]
-		assert.Equal(t, rev1ID, deltaSrc, "delta source should be the legacy revID the client reported")
+		assert.Equal(t, rev1ID, msg.Properties[db.RevMessageDeltaSrc], "delta source should be the legacy revID the client reported")
 
 		// Rev property should be the new CV from the HLV agent update
-		rev := request.Properties["rev"]
-		assert.Equal(t, newDoc.HLV.GetCurrentVersionString(), rev)
+		assert.Equal(t, docVersion2.CV.String(), msg.Properties[db.RevMessageRev])
 
 		// History should be: [pv (rev1's original cv), rev2RevTreeID, rev1RevTreeID]
 		// - First entry is HLV previous version (rev1's cv becomes pv after the HLV agent update)
 		// - Last two entries are the rev tree (scenario 3: local HLV-aware, remote legacy)
-		history := request.Properties[db.RevMessageHistory]
+		history := msg.Properties[db.RevMessageHistory]
 		require.NotEmpty(t, history, "history must not be empty")
 		historyList := strings.Split(history, ",")
 		require.Len(t, historyList, 3, "history should have HLV pv + 2 rev tree entries")
 		assert.Equal(t, docVersion1.CV.String(), historyList[0], "first history entry should be HLV previous version (rev1's cv)")
-		assert.Equal(t, newDoc.GetRevTreeID(), historyList[1], "second history entry should be current revTreeID")
+		assert.Equal(t, docVersion2.RevTreeID, historyList[1], "second history entry should be current revTreeID")
 		assert.Equal(t, docVersion1.RevTreeID, historyList[2], "third history entry should be parent revTreeID")
 
-		assert.Empty(t, request.Properties[db.RevMessageTreeHistory], "revTreeHistory property should not be set for non-SGR2 clients")
+		assert.Empty(t, msg.Properties[db.RevMessageTreeHistory], "revTreeHistory property should not be set for non-SGR2 clients")
+	})
+}
+
+// TestBothSidesLegacyRevDeltaSync verifies that when a delta is sent to a client that has a legacy revision
+// and the document on SGW is also a legacy revision (no HLV on either side), the history property contains
+// only the parent revTreeID and the rev property is the current revTreeID (not a CV).
+//
+// Setup:
+//   - Create doc rev1 and rev2 on SGW with no HLV (legacy revs)
+//   - Client pre-populated with rev1 as a legacy revtree revision (no HLV)
+//   - Client pulls with delta sync enabled
+//
+// Expected rev message (buildRevHistory scenario 1):
+//
+//	history property: [rev1RevTreeID] (no hlv pv since neither side is HLV-aware)
+//	rev property:     rev2RevTreeID (not a CV, since both sides are legacy)
+//	deltaSrc:         rev1RevTreeID
+func TestBothSidesLegacyRevDeltaSync(t *testing.T) {
+	if !base.IsEnterpriseEdition() {
+		t.Skip("Delta sync requires EE")
 	}
 
-	bt.blipContext.HandlerForProfile["changes"] = func(request *blip.Message) {
-		defer receivedChangesRequestWg.Done()
-		body, err := request.Body()
-		require.NoError(t, err)
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[RevtreeSubtestName] = true // V4-specific: tests legacy rev in HLV-aware client
 
-		knownRevs := []any{}
-		if string(body) != "null" {
-			var changesReqs [][]any
-			err = base.JSONUnmarshal(body, &changesReqs)
-			require.NoError(t, err)
+	sgUseDeltas := true
+	btcRunner.Run(func(t *testing.T) {
+		rt := NewRestTester(t, &RestTesterConfig{
+			GuestEnabled: true,
+			DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+				DeltaSync: &DeltaSyncConfig{
+					Enabled: &sgUseDeltas,
+				},
+			}},
+		})
+		defer rt.Close()
 
-			knownRevs = make([]any, len(changesReqs))
-			for i := range changesReqs {
-				knownRevs[i] = []string{rev1ID}
-			}
-		}
+		docID := SafeDocumentName(t, t.Name())
 
-		if !request.NoReply() {
-			response := request.Response()
-			response.Properties[db.ChangesResponseDeltas] = "true"
-			emptyResponseValBytes, err := base.JSONMarshal(knownRevs)
-			require.NoError(t, err)
-			response.SetBody(emptyResponseValBytes)
-		}
-	}
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
+			ClientDeltas: true,
+		})
+		defer client.Close()
 
-	subChangesRequest := bt.newRequest()
-	subChangesRequest.SetProfile("subChanges")
-	subChangesRequest.Properties["continuous"] = "false"
-	sent := bt.sender.Send(subChangesRequest)
-	assert.True(t, sent)
+		// create rev1, rev 2 on SGW with no HLV (legacy revs)
+		docRev1 := rt.CreateDocNoHLV(docID, db.Body{"test": "doc"})
+		docRev2 := rt.CreateDocNoHLV(docID, db.Body{"test": "update", db.BodyRev: docRev1.GetRevTreeID()})
+		rt.WaitForPendingChanges()
 
-	subChangesResponse := subChangesRequest.Response()
-	assert.Equal(t, subChangesRequest.SerialNumber(), subChangesResponse.SerialNumber())
+		// Pre-populate the client with rev1 as a legacy revtree revision so that when SGW sends changes
+		// for rev2, the client reports rev1ID as its known rev (triggering delta from rev1).
+		btcRunner.AddRevTreeRev(client.id, docID, docRev1.GetRevTreeID(), EmptyDocVersion(), []byte(`{"test": "doc"}`))
 
-	base.WaitWithTimeout(t, &receivedChangesRequestWg, time.Second*10)
-	base.WaitWithTimeout(t, &revsFinishedWg, time.Second*10)
+		btcRunner.StartOneshotPull(client.id)
+		msg := btcRunner.WaitForPullRevMessage(client.id, docID, docRev2.ExtractDocVersion())
+
+		// Should be sent as delta with rev1 as the delta source
+		assert.Equal(t, docRev1.GetRevTreeID(), msg.Properties[db.RevMessageDeltaSrc], "delta source should be the legacy revID the client reported")
+
+		// Rev property should be rev2's rev tree ID since both sides are legacy
+		assert.Equal(t, docRev2.GetRevTreeID(), msg.Properties[db.RevMessageRev])
+
+		// History should contain rev1's revTreeID
+		history := msg.Properties[db.RevMessageHistory]
+		require.NotEmpty(t, history, "history must not be empty — rev tree history is required for legacy client conflict detection")
+		historyList := strings.Split(history, ",")
+		require.Len(t, historyList, 1, "history should have rev tree entries only since hlv history is empty for this doc")
+		assert.Equal(t, docRev1.GetRevTreeID(), historyList[0], "only history entry should be parent revTreeID since both sides are legacy")
+
+		assert.Empty(t, msg.Properties[db.RevMessageTreeHistory], "revTreeHistory property should not be set for non-SGR2 clients")
+	})
 }
 
 // TestChangesResponseWithHLVInHistory:

--- a/rest/blip_legacy_revid_test.go
+++ b/rest/blip_legacy_revid_test.go
@@ -666,7 +666,7 @@ func TestChangesResponseLegacyRev(t *testing.T) {
 //
 // Expected rev message (buildRevHistory scenario 3):
 //
-//	history property: [hlvHistory, rev2RevTreeID, rev1RevTreeID] (hlv history here is empty since doc has only be updated by one hlv aware peer)
+//	history property: [hlvHistory, rev2RevTreeID, rev1RevTreeID] (hlv history here is empty since doc has only been updated by one hlv aware peer)
 //	deltaSrc:         rev1RevTreeID
 //	body:             the delta (not full body)
 func TestDeltaSyncSendHistoryWithLegacyClient(t *testing.T) {
@@ -720,7 +720,7 @@ func TestDeltaSyncSendHistoryWithLegacyClient(t *testing.T) {
 		require.NotEmpty(t, history, "history must not be empty — rev tree history is required for legacy client conflict detection")
 		historyList := strings.Split(history, ",")
 		// The last two entries in history should be the rev tree: current revID then parent revID
-		assert.Equal(t, len(historyList), 2, "history should rev tree entries only since hlv history is empty for this doc")
+		require.Len(t, len(historyList), 2, "history should rev tree entries only since hlv history is empty for this doc")
 		assert.Equal(t, docVersion2.RevTreeID, historyList[len(historyList)-2], "second to last history entry should be current revTreeID")
 		assert.Equal(t, docVersion1.RevTreeID, historyList[len(historyList)-1], "last history entry should be parent revTreeID")
 

--- a/rest/blip_legacy_revid_test.go
+++ b/rest/blip_legacy_revid_test.go
@@ -720,7 +720,7 @@ func TestDeltaSyncSendHistoryWithLegacyClient(t *testing.T) {
 		require.NotEmpty(t, history, "history must not be empty — rev tree history is required for legacy client conflict detection")
 		historyList := strings.Split(history, ",")
 		// The last two entries in history should be the rev tree: current revID then parent revID
-		require.Len(t, len(historyList), 2, "history should rev tree entries only since hlv history is empty for this doc")
+		require.Len(t, historyList, 2, "history should rev tree entries only since hlv history is empty for this doc")
 		assert.Equal(t, docVersion2.RevTreeID, historyList[len(historyList)-2], "second to last history entry should be current revTreeID")
 		assert.Equal(t, docVersion1.RevTreeID, historyList[len(historyList)-1], "last history entry should be parent revTreeID")
 

--- a/rest/blip_legacy_revid_test.go
+++ b/rest/blip_legacy_revid_test.go
@@ -720,7 +720,7 @@ func TestDeltaSyncSendHistoryWithLegacyClient(t *testing.T) {
 		require.NotEmpty(t, history, "history must not be empty — rev tree history is required for legacy client conflict detection")
 		historyList := strings.Split(history, ",")
 		// The last two entries in history should be the rev tree: current revID then parent revID
-		require.GreaterOrEqual(t, len(historyList), 2, "history should contain at least the rev tree entries")
+		assert.Equal(t, len(historyList), 2, "history should rev tree entries only since hlv history is empty for this doc")
 		assert.Equal(t, docVersion2.RevTreeID, historyList[len(historyList)-2], "second to last history entry should be current revTreeID")
 		assert.Equal(t, docVersion1.RevTreeID, historyList[len(historyList)-1], "last history entry should be parent revTreeID")
 
@@ -775,7 +775,7 @@ func TestDeltaSyncSendHistoryWithLegacyClient(t *testing.T) {
 // legacy revision and the document has multi-source HLV history, the history property contains the HLV previous
 // versions followed by the rev tree.
 //
-// This extends the CBG-5106 coverage from TestDeltaSyncSendHistoryWithLegacyClient to the case where HLV history
+// This extends the coverage from TestDeltaSyncSendHistoryWithLegacyClient to the case where HLV history
 // is non-empty (the document was updated by a different peer before SGW created rev2).
 //
 // Setup:

--- a/rest/blip_legacy_revid_test.go
+++ b/rest/blip_legacy_revid_test.go
@@ -654,6 +654,249 @@ func TestChangesResponseLegacyRev(t *testing.T) {
 
 }
 
+// TestDeltaSyncSendHistoryWithLegacyClient verifies that when a delta is sent to a client that has a legacy revision
+// (pre-HLV), the history property on the rev message includes the rev tree so the client can detect conflicts.
+//
+// Setup:
+//   - Create doc rev1 on SGW
+//   - Update doc to create rev2 on SGW
+//   - Client connects with V4 subprotocol, delta sync enabled
+//   - Custom changes handler responds with [rev1ID] as knownRevs (simulating a client that only has a legacy rev revision 1)
+//   - Server computes delta from rev1 → rev2 and sends via sendDelta with remoteIsLegacyRev=true
+//
+// Expected rev message (buildRevHistory scenario 3):
+//
+//	history property: [hlvHistory, rev2RevTreeID, rev1RevTreeID] (hlv history here is empty since doc has only be updated by one hlv aware peer)
+//	deltaSrc:         rev1RevTreeID
+//	body:             the delta (not full body)
+func TestDeltaSyncSendHistoryWithLegacyClient(t *testing.T) {
+	if !base.IsEnterpriseEdition() {
+		t.Skip("Delta sync requires EE")
+	}
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeySyncMsg, base.KeyChanges)
+
+	sgUseDeltas := true
+	rt := NewRestTester(t, &RestTesterConfig{
+		GuestEnabled: true,
+		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+			DeltaSync: &DeltaSyncConfig{
+				Enabled: &sgUseDeltas,
+			},
+		}},
+	})
+	defer rt.Close()
+
+	bt := NewBlipTesterFromSpecWithRT(rt, &BlipTesterSpec{
+		blipProtocols: []string{db.CBMobileReplicationV4.SubprotocolString()},
+	})
+	defer bt.Close()
+
+	// Create rev1 and rev2 on SGW
+	docVersion1 := rt.PutDoc("doc1", `{"key": "val1"}`)
+	rev1ID := docVersion1.RevTreeID
+	docVersion2 := rt.UpdateDoc("doc1", docVersion1, `{"key": "val2"}`)
+	rt.WaitForPendingChanges()
+
+	receivedChangesRequestWg := sync.WaitGroup{}
+	receivedChangesRequestWg.Add(2) // 1 for doc changes + 1 for empty "caught up" changes
+
+	revsFinishedWg := sync.WaitGroup{}
+	revsFinishedWg.Add(1) // expect 1 rev/delta message
+
+	bt.blipContext.HandlerForProfile["rev"] = func(request *blip.Message) {
+		defer revsFinishedWg.Done()
+
+		// Should be sent as delta with rev1 as the delta source
+		deltaSrc := request.Properties[db.RevMessageDeltaSrc]
+		assert.Equal(t, rev1ID, deltaSrc, "delta source should be the legacy revID the client reported")
+
+		// The rev property should be the CV (HLV-aware identifier)
+		rev := request.Properties["rev"]
+		assert.Equal(t, docVersion2.CV.String(), rev)
+
+		// History should contain: HLV history, then rev2's revTreeID, then rev1's revTreeID
+		// (scenario 3 in buildRevHistory: local HLV-aware, remote legacy)
+		history := request.Properties[db.RevMessageHistory]
+		require.NotEmpty(t, history, "history must not be empty — rev tree history is required for legacy client conflict detection")
+		historyList := strings.Split(history, ",")
+		// The last two entries in history should be the rev tree: current revID then parent revID
+		require.GreaterOrEqual(t, len(historyList), 2, "history should contain at least the rev tree entries")
+		assert.Equal(t, docVersion2.RevTreeID, historyList[len(historyList)-2], "second to last history entry should be current revTreeID")
+		assert.Equal(t, docVersion1.RevTreeID, historyList[len(historyList)-1], "last history entry should be parent revTreeID")
+
+		// Should NOT have a separate revTreeHistory property (that's only for SGR2 peers)
+		assert.Empty(t, request.Properties[db.RevMessageTreeHistory], "revTreeHistory property should not be set for non-SGR2 clients")
+	}
+
+	bt.blipContext.HandlerForProfile["changes"] = func(request *blip.Message) {
+		defer receivedChangesRequestWg.Done()
+		body, err := request.Body()
+		require.NoError(t, err)
+
+		knownRevs := []any{}
+		if string(body) != "null" {
+			var changesReqs [][]any
+			err = base.JSONUnmarshal(body, &changesReqs)
+			require.NoError(t, err)
+
+			knownRevs = make([]any, len(changesReqs))
+			for i := range changesReqs {
+				// Respond with the legacy revID as the known rev, simulating a client that has rev1
+				// but predates HLV. This triggers remoteIsLegacyRev=true and sets deltaSrc=rev1ID
+				// on the server side.
+				knownRevs[i] = []string{rev1ID}
+			}
+		}
+
+		if !request.NoReply() {
+			response := request.Response()
+			// Enable deltas so the server sends a delta rather than full body
+			response.Properties[db.ChangesResponseDeltas] = "true"
+			emptyResponseValBytes, err := base.JSONMarshal(knownRevs)
+			require.NoError(t, err)
+			response.SetBody(emptyResponseValBytes)
+		}
+	}
+
+	subChangesRequest := bt.newRequest()
+	subChangesRequest.SetProfile("subChanges")
+	subChangesRequest.Properties["continuous"] = "false"
+	sent := bt.sender.Send(subChangesRequest)
+	assert.True(t, sent)
+
+	subChangesResponse := subChangesRequest.Response()
+	assert.Equal(t, subChangesRequest.SerialNumber(), subChangesResponse.SerialNumber())
+
+	base.WaitWithTimeout(t, &receivedChangesRequestWg, time.Second*10)
+	base.WaitWithTimeout(t, &revsFinishedWg, time.Second*10)
+}
+
+// TestDeltaSyncSendHistoryWithLegacyClientAndHLVHistory verifies that when a delta is sent to a client that has a
+// legacy revision and the document has multi-source HLV history, the history property contains the HLV previous
+// versions followed by the rev tree.
+//
+// This extends the CBG-5106 coverage from TestDeltaSyncSendHistoryWithLegacyClient to the case where HLV history
+// is non-empty (the document was updated by a different peer before SGW created rev2).
+//
+// Setup:
+//   - Create doc rev1 on SGW (gets revTreeID + HLV cv)
+//   - Update doc via HLV agent to simulate a different peer creating rev2 (gets a new HLV cv with rev1's cv as pv)
+//   - Client connects with V4 subprotocol, delta sync enabled
+//   - Custom changes handler responds with [rev1RevTreeID] as knownRevs (legacy client)
+//
+// Expected rev message (buildRevHistory scenario 3):
+//
+//	history property: [pv (rev1's cv), rev2RevTreeID, rev1RevTreeID]
+//	deltaSrc:         rev1RevTreeID
+func TestDeltaSyncSendHistoryWithLegacyClientAndHLVHistory(t *testing.T) {
+	if !base.IsEnterpriseEdition() {
+		t.Skip("Delta sync requires EE")
+	}
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeySyncMsg, base.KeyChanges)
+
+	sgUseDeltas := true
+	rt := NewRestTester(t, &RestTesterConfig{
+		GuestEnabled: true,
+		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+			DeltaSync: &DeltaSyncConfig{
+				Enabled: &sgUseDeltas,
+			},
+		}},
+	})
+	defer rt.Close()
+
+	bt := NewBlipTesterFromSpecWithRT(rt, &BlipTesterSpec{
+		blipProtocols: []string{db.CBMobileReplicationV4.SubprotocolString()},
+	})
+	defer bt.Close()
+
+	collection, ctx := rt.GetSingleTestDatabaseCollection()
+
+	// Create rev1 on SGW — gets revTreeID + HLV
+	docVersion1 := rt.PutDoc("doc1", `{"key": "val1"}`)
+	rev1ID := docVersion1.RevTreeID
+
+	// Update doc via HLV agent to simulate a different peer creating rev2.
+	// This gives the doc a new CV from "peerSource" with rev1's CV as a previous version in the HLV.
+	newDoc, _, err := collection.GetDocWithXattrs(ctx, "doc1", db.DocUnmarshalAll)
+	require.NoError(t, err)
+	agent := db.NewHLVAgent(t, rt.GetSingleDataStore(), "peerSource", base.VvXattrName)
+	_ = agent.UpdateWithHLV(ctx, "doc1", newDoc.Cas, newDoc.HLV)
+
+	// Force import so SGW picks up the HLV agent's update
+	newDoc, err = collection.GetDocument(ctx, "doc1", db.DocUnmarshalAll)
+	require.NoError(t, err)
+	rt.WaitForPendingChanges()
+
+	receivedChangesRequestWg := sync.WaitGroup{}
+	receivedChangesRequestWg.Add(2)
+	revsFinishedWg := sync.WaitGroup{}
+	revsFinishedWg.Add(1)
+
+	bt.blipContext.HandlerForProfile["rev"] = func(request *blip.Message) {
+		defer revsFinishedWg.Done()
+
+		// Should be sent as delta with rev1 as the delta source
+		deltaSrc := request.Properties[db.RevMessageDeltaSrc]
+		assert.Equal(t, rev1ID, deltaSrc, "delta source should be the legacy revID the client reported")
+
+		// Rev property should be the new CV from the HLV agent update
+		rev := request.Properties["rev"]
+		assert.Equal(t, newDoc.HLV.GetCurrentVersionString(), rev)
+
+		// History should be: [pv (rev1's original cv), rev2RevTreeID, rev1RevTreeID]
+		// - First entry is HLV previous version (rev1's cv becomes pv after the HLV agent update)
+		// - Last two entries are the rev tree (scenario 3: local HLV-aware, remote legacy)
+		history := request.Properties[db.RevMessageHistory]
+		require.NotEmpty(t, history, "history must not be empty")
+		historyList := strings.Split(history, ",")
+		require.Len(t, historyList, 3, "history should have HLV pv + 2 rev tree entries")
+		assert.Equal(t, docVersion1.CV.String(), historyList[0], "first history entry should be HLV previous version (rev1's cv)")
+		assert.Equal(t, newDoc.GetRevTreeID(), historyList[1], "second history entry should be current revTreeID")
+		assert.Equal(t, docVersion1.RevTreeID, historyList[2], "third history entry should be parent revTreeID")
+
+		assert.Empty(t, request.Properties[db.RevMessageTreeHistory], "revTreeHistory property should not be set for non-SGR2 clients")
+	}
+
+	bt.blipContext.HandlerForProfile["changes"] = func(request *blip.Message) {
+		defer receivedChangesRequestWg.Done()
+		body, err := request.Body()
+		require.NoError(t, err)
+
+		knownRevs := []any{}
+		if string(body) != "null" {
+			var changesReqs [][]any
+			err = base.JSONUnmarshal(body, &changesReqs)
+			require.NoError(t, err)
+
+			knownRevs = make([]any, len(changesReqs))
+			for i := range changesReqs {
+				knownRevs[i] = []string{rev1ID}
+			}
+		}
+
+		if !request.NoReply() {
+			response := request.Response()
+			response.Properties[db.ChangesResponseDeltas] = "true"
+			emptyResponseValBytes, err := base.JSONMarshal(knownRevs)
+			require.NoError(t, err)
+			response.SetBody(emptyResponseValBytes)
+		}
+	}
+
+	subChangesRequest := bt.newRequest()
+	subChangesRequest.SetProfile("subChanges")
+	subChangesRequest.Properties["continuous"] = "false"
+	sent := bt.sender.Send(subChangesRequest)
+	assert.True(t, sent)
+
+	subChangesResponse := subChangesRequest.Response()
+	assert.Equal(t, subChangesRequest.SerialNumber(), subChangesResponse.SerialNumber())
+
+	base.WaitWithTimeout(t, &receivedChangesRequestWg, time.Second*10)
+	base.WaitWithTimeout(t, &revsFinishedWg, time.Second*10)
+}
+
 // TestChangesResponseWithHLVInHistory:
 //   - Create doc
 //   - Update doc with hlv agent to mock update from a another peer

--- a/rest/blip_legacy_revid_test.go
+++ b/rest/blip_legacy_revid_test.go
@@ -719,7 +719,7 @@ func TestDeltaSyncSendHistoryWithLegacyClient(t *testing.T) {
 		history := request.Properties[db.RevMessageHistory]
 		require.NotEmpty(t, history, "history must not be empty — rev tree history is required for legacy client conflict detection")
 		historyList := strings.Split(history, ",")
-		// The last two entries in history should be the rev tree: current revID then parent revID
+		// The history should be the rev tree: current revID then parent revID
 		require.Len(t, historyList, 2, "history should rev tree entries only since hlv history is empty for this doc")
 		assert.Equal(t, docVersion2.RevTreeID, historyList[len(historyList)-2], "second to last history entry should be current revTreeID")
 		assert.Equal(t, docVersion1.RevTreeID, historyList[len(historyList)-1], "last history entry should be parent revTreeID")

--- a/rest/replicatortest/replicator_test_legacy_rev_test.go
+++ b/rest/replicatortest/replicator_test_legacy_rev_test.go
@@ -1016,8 +1016,6 @@ func TestActiveReplicatorConflictPreUpgradedVersionOneSide(t *testing.T) {
 func TestActiveReplicatorDeltaSyncWhenBothSidesLegacy(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
 
-	t.Skip("pending fix from CBG-5106")
-
 	if !base.IsEnterpriseEdition() {
 		t.Skip("Delta sync only supported in EE")
 	}

--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -600,11 +600,13 @@ func (btr *BlipTesterReplicator) handleChanges(ctx context.Context, btc *BlipTes
 					} else if localHLV.DominatesSource(changesVersion) {
 						base.DebugfCtx(ctx, base.KeySGTest, "Skipping changes for incoming doc %q with rev %s as we already have a newer version %#v", docID, changesVersion, localHLV)
 						knownRevs[i] = nil // Send back null to signal we don't need this change
-					} else {
+						continue
+					} else if localHLV.GetCurrentVersionString() != "" {
 						// HLV clients only need to send the current version
 						knownRevs[i] = []any{localHLV.GetCurrentVersionString()}
+						continue
 					}
-					continue
+					// local doc has only legacy revtree IDs (no HLV) — fall through to revtree path below
 				}
 				allVersions := btcc.getAllRevisions(docID)
 				if len(allVersions) == 0 {
@@ -710,7 +712,7 @@ func (btr *BlipTesterReplicator) handleRev(ctx context.Context, btc *BlipTesterC
 			require.NoError(btc.TB(), err)
 
 			var deltaSrcVersion DocVersion
-			if btc.UseHLV() {
+			if btc.UseHLV() && !base.IsRevTreeID(deltaSrc) {
 				v, err := db.ParseVersion(deltaSrc)
 				require.NoError(btr.TB(), err, "error parsing version %q: %v", deltaSrc, err)
 				deltaSrcVersion = DocVersion{CV: v}


### PR DESCRIPTION
CBG-5106

- Move rev message history builder into a shared function to be called from multiple places in the code
- Fixes scenario where empty history is sent for a SGW rev that has CV but a client rev that is legacy rev. 
- Introduces some lower level tests to assert on this behaviour. 

QE tests now show history being sent correctly for both test cases in the linked ticket:
```
2026-05-28T10:50:40.398+01:00 [DBG] Sync+: c:[65248013] db:upgrade col:_default Sending rev "<ud>nonconflict_3</ud>" 18b3b1dcf40d0000@Qmce34epjCesjaS8myHE+Q as delta. DeltaSrc:2-509dc0903869f6b103fd1266b169e73876b80d27
2026-05-28T10:50:40.398+01:00 [TRC] SyncMsg+: c:[65248013] db:upgrade Sent Req MSG#3~: Body: '<ud>{"updated_by":"delta_sync_history_test"}</ud>' Properties: <ud>map[Content-Type:application/json Profile:rev collection:0 deltaSrc:2-509dc0903869f6b103fd1266b169e73876b80d27 history:3-3a1c6412b5433949e8ed130d996300a7,2-509dc0903869f6b103fd1266b169e73876b80d27 id:nonconflict_3 rev:18b3b1dcf40d0000@Qmce34epjCesjaS8myHE+Q sequence:34]</ud>
...
2026-05-28T10:51:31.840+01:00 [DBG] Sync+: c:[78356265] db:upgrade col:_default Sending rev "<ud>nonconflict_2</ud>" 2-36a2cfe8544956ad3c5b6491cbfc7d94 as delta. DeltaSrc:1-e643a00fb9cad8cf87ee4d2c4e2383f6ecf118c0
2026-05-28T10:51:31.840+01:00 [TRC] SyncMsg+: c:[78356265] db:upgrade Sent Req MSG#3~: Body: '<ud>{"number":2}</ud>' Properties: <ud>map[Content-Type:application/json Profile:rev collection:0 deltaSrc:1-e643a00fb9cad8cf87ee4d2c4e2383f6ecf118c0 history:1-e643a00fb9cad8cf87ee4d2c4e2383f6ecf118c0 id:nonconflict_2 rev:2-36a2cfe8544956ad3c5b6491cbfc7d94 sequence:6]
```

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/710/
- [x] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/713/ (test fix)
