### PR TITLE
CBG-5226: Opt-in use of `_system._mobile` for databases and bootstrap

### DIFF
--- a/base/bootstrap.go
+++ b/base/bootstrap.go
@@ -10,11 +10,13 @@ package base
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"dario.cat/mergo"
@@ -47,6 +49,42 @@ type BootstrapConnection interface {
 	// GetRawDocument retrieves the document with the specified key from the bucket's default collection as raw bytes.
 	// Returns exists=false if key is not found, returns error for any other error.
 	GetRawDocument(ctx context.Context, bucket, docID string) (value []byte, exists bool, err error)
+	// SetMigrationComplete signals that bootstrap-metadata migration to _system._mobile has finished;
+	// subsequent reads stop falling back to _default._default. No-op when useSystemMetadataCollection is false.
+	SetMigrationComplete()
+	// GetMetadataMigrationStatus reads the bucket-level metadata-migration status doc directly from
+	// _system._mobile (never via the dual-collection wrapper). Returns ErrNotFound when the doc has
+	// not yet been stamped on this bucket.
+	GetMetadataMigrationStatus(ctx context.Context, bucket string) (status *MetadataMigrationStatus, cas uint64, err error)
+	// InsertMetadataMigrationStatus stamps the initial status doc in _system._mobile. Returns
+	// ErrAlreadyExists if another SG node won the race.
+	InsertMetadataMigrationStatus(ctx context.Context, bucket string, status *MetadataMigrationStatus) (cas uint64, err error)
+	// UpdateMetadataMigrationStatus runs the callback inside a CAS-safe read-modify-write loop
+	// against _system._mobile. The callback receives the current status (or a fresh seed if absent)
+	// and may mutate it in place. Returns the new CAS once the update lands.
+	UpdateMetadataMigrationStatus(ctx context.Context, bucket string, callback func(*MetadataMigrationStatus) error) (newCAS uint64, err error)
+	// MigrateBootstrapDocs copies the supplied document keys from _default._default into
+	// _system._mobile. Caller assembles the key list (registry, enumerated dbconfig keys, well-known
+	// cbgt cfg keys). Idempotent: already-present primary docs are skipped; fallback-resident docs
+	// are copied and then CAS-deleted from the fallback. Intended for the bucket-level migration
+	// step that fires once every per-DB migration reports complete.
+	MigrateBootstrapDocs(ctx context.Context, bucket string, docIDs []string) error
+	// RefreshBucketBootstrapTarget reads the bucket's metadata-migration status doc and, if the
+	// bootstrap phase has completed (i.e. a peer node moved this bucket's bootstrap docs into
+	// _system._mobile), updates the local per-bucket cache to point at _system._mobile so subsequent
+	// reads/writes route there directly without paying the self-heal fallback cost. No-op when the
+	// status doc is absent or bootstrap.state is anything other than complete. Intended to be called
+	// periodically from the config-polling loop so peer nodes converge on the post-migration cache
+	// state proactively rather than only on a failed read.
+	RefreshBucketBootstrapTarget(ctx context.Context, bucket string) error
+	// SetBucketBootstrapTargetHint resolves and caches where bootstrap docs land for a given bucket.
+	// The decision: (1) registry already in _system._mobile → that collection; (2) registry in
+	// _default._default → that collection (legacy registry stays put); (3) no registry anywhere →
+	// _system._mobile if optInHint or the cluster-wide flag is on, otherwise _default._default.
+	// Once cached the choice is sticky. Callers should invoke this when they have authoritative
+	// information about whether a new DB on this bucket has opted in (e.g., PUT /<db>/ with
+	// use_system_metadata_collection: true) so the very first bootstrap doc lands correctly.
+	SetBucketBootstrapTargetHint(ctx context.Context, bucket string, optInHint bool) error
 	// Close releases any long-lived connections
 	Close()
 }
@@ -64,16 +102,31 @@ type CouchbaseClusterSpec struct {
 
 // CouchbaseCluster is a GoCBv2 implementation of BootstrapConnection
 type CouchbaseCluster struct {
-	server                  string
-	clusterOptions          gocb.ClusterOptions
-	forcePerBucketAuth      bool // Forces perBucketAuth authenticators to be used to connect to the bucket
-	perBucketAuth           map[string]*gocb.Authenticator
-	bucketConnectionMode    BucketConnectionMode    // Whether to cache cluster connections
-	cachedClusterConnection *gocb.Cluster           // Cached cluster connection, should only be used by GetConfigBuckets
-	cachedBucketConnections cachedBucketConnections // Per-bucket cached connections
-	cachedConnectionLock    sync.Mutex              // mutex for access to cachedBucketConnections
-	configPersistence       ConfigPersistence       // ConfigPersistence mode
+	server                      string
+	clusterOptions              gocb.ClusterOptions
+	forcePerBucketAuth          bool // Forces perBucketAuth authenticators to be used to connect to the bucket
+	perBucketAuth               map[string]*gocb.Authenticator
+	bucketConnectionMode        BucketConnectionMode    // Whether to cache cluster connections
+	cachedClusterConnection     *gocb.Cluster           // Cached cluster connection, should only be used by GetConfigBuckets
+	cachedBucketConnections     cachedBucketConnections // Per-bucket cached connections
+	cachedConnectionLock        sync.Mutex              // mutex for access to cachedBucketConnections
+	configPersistence           ConfigPersistence       // ConfigPersistence mode
+	useSystemMetadataCollection bool                    // When true, bootstrap metadata is stored in _system._mobile, with read-fallback to _default._default during migration
+	migrationComplete           atomic.Bool             // When set, fallback reads are skipped even if useSystemMetadataCollection is true
+	// bucketBootstrapTargets caches the resolved bootstrap-doc location for each bucket.
+	// Resolved lazily on first interaction (or eagerly via SetBucketBootstrapTargetHint). Values
+	// are bucketBootstrapTarget; absence of an entry means "fall back to the connection-wide flag."
+	bucketBootstrapTargets sync.Map
 }
+
+// bucketBootstrapTarget records where bootstrap docs (registry, dbconfig, cbgt cfg) live for a
+// particular bucket. Caches the result of probing _sync:registry across both collections.
+type bucketBootstrapTarget int
+
+const (
+	bucketTargetDefault      bucketBootstrapTarget = iota // _default._default — legacy registry or no opt-in
+	bucketTargetSystemMobile                              // _system._mobile primary; _default._default fallback until migration complete
+)
 
 type BucketConnectionMode int
 
@@ -156,9 +209,12 @@ func (c *cachedBucketConnections) _set(bucketName string, bucket *cachedBucket) 
 var _ BootstrapConnection = &CouchbaseCluster{}
 
 // NewCouchbaseCluster creates and opens a Couchbase Server cluster connection.
+// useSystemMetadataCollection controls where bootstrap metadata is read/written: when true,
+// _system._mobile is the source of truth and reads transparently fall back to _default._default
+// for any keys that have not yet been migrated; when false, _default._default is used unconditionally.
 func NewCouchbaseCluster(ctx context.Context, clusterSpec CouchbaseClusterSpec,
 	forcePerBucketAuth bool, perBucketCreds PerBucketCredentialsConfig,
-	useXattrConfig bool, bucketMode BucketConnectionMode) (*CouchbaseCluster, error) {
+	useXattrConfig bool, useSystemMetadataCollection bool, bucketMode BucketConnectionMode) (*CouchbaseCluster, error) {
 	securityConfig, err := GoCBv2SecurityConfig(ctx, Ptr(clusterSpec.TLSSkipVerify), clusterSpec.CACertpath)
 	if err != nil {
 		return nil, err
@@ -193,11 +249,12 @@ func NewCouchbaseCluster(ctx context.Context, clusterSpec CouchbaseClusterSpec,
 	}
 
 	cbCluster := &CouchbaseCluster{
-		server:               clusterSpec.Server,
-		forcePerBucketAuth:   forcePerBucketAuth,
-		perBucketAuth:        perBucketAuth,
-		clusterOptions:       clusterOptions,
-		bucketConnectionMode: bucketMode,
+		server:                      clusterSpec.Server,
+		forcePerBucketAuth:          forcePerBucketAuth,
+		perBucketAuth:               perBucketAuth,
+		clusterOptions:              clusterOptions,
+		bucketConnectionMode:        bucketMode,
+		useSystemMetadataCollection: useSystemMetadataCollection,
 	}
 
 	if bucketMode == CachedClusterConnections {
@@ -294,6 +351,155 @@ func (cc *CouchbaseCluster) GetConfigBuckets(context.Context) ([]string, error) 
 	return bucketList, nil
 }
 
+// metadataCollections returns the primary collection where bootstrap metadata writes go,
+// and an optional fallback collection that reads consult when the primary returns ErrNotFound.
+// Per-bucket target cache (populated by SetBucketBootstrapTargetHint or the probe in getBucket)
+// takes precedence; if a bucket isn't cached yet the connection-wide flag drives the decision.
+//
+// Fallback semantics are symmetric so reads can self-heal across a stale cache:
+//   - target=systemMobile: primary=_system._mobile, fallback=_default._default (legacy docs not
+//     yet migrated by the bucket-level migration step). Skipped once SetMigrationComplete has
+//     been called.
+//   - target=default (or no opt-in indication yet): primary=_default._default,
+//     fallback=_system._mobile. A successful fallback hit indicates a peer has migrated this
+//     bucket's bootstrap docs — the caller is expected to invoke noteBucketFallbackHit so the
+//     cache is corrected before the next op.
+func (cc *CouchbaseCluster) metadataCollections(b *gocb.Bucket) (primary, fallback *gocb.Collection) {
+	cached, hasCachedTarget := cc.bucketBootstrapTargets.Load(b.Name())
+	useSystemMobile := cc.useSystemMetadataCollection
+	if hasCachedTarget {
+		useSystemMobile = cached.(bucketBootstrapTarget) == bucketTargetSystemMobile
+	}
+	if !useSystemMobile {
+		// When this bucket has any opt-in indication — either cached as bucketTargetDefault
+		// (set by SetBucketBootstrapTargetHint after probing a legacy registry) or the
+		// connection-wide flag — wire systemMobile as a self-heal fallback so a peer-migrated
+		// bucket doesn't return not-found from a stale-cached perspective. A bucket with no
+		// cache entry and no connection-wide opt-in skips the fallback entirely so non-opt-in
+		// clusters don't pay an extra _system._mobile probe per op.
+		if hasCachedTarget || cc.useSystemMetadataCollection {
+			return b.DefaultCollection(), b.Scope(SystemScope).Collection(SystemCollectionMobile)
+		}
+		return b.DefaultCollection(), nil
+	}
+	primary = b.Scope(SystemScope).Collection(SystemCollectionMobile)
+	if cc.migrationComplete.Load() {
+		return primary, nil
+	}
+	return primary, b.DefaultCollection()
+}
+
+// noteBucketFallbackHit updates the per-bucket cache to _system._mobile after a successful read
+// or existence check against the fallback collection, when that hit indicates the cache was stale
+// (the cached target was _default._default — i.e. this node had not yet observed that a peer ran
+// the bucket-level migration). A no-op when the cache already says _system._mobile, since the
+// systemMobile→default fallback direction is the legitimate in-progress-migration legacy path.
+func (cc *CouchbaseCluster) noteBucketFallbackHit(bucketName string) {
+	if cached, ok := cc.bucketBootstrapTargets.Load(bucketName); ok && cached.(bucketBootstrapTarget) == bucketTargetSystemMobile {
+		return
+	}
+	cc.bucketBootstrapTargets.Store(bucketName, bucketTargetSystemMobile)
+}
+
+// SetBucketBootstrapTargetHint resolves and caches the bootstrap-doc target for a bucket. See the
+// interface doc for the decision tree. If the registry is found in either collection the location
+// is cached and the hint is irrelevant. If no registry exists yet, optInHint (or the connection-
+// wide flag) determines the cached target. Already-cached targets are not overwritten.
+func (cc *CouchbaseCluster) SetBucketBootstrapTargetHint(ctx context.Context, bucketName string, optInHint bool) error {
+	if cc == nil {
+		return errors.New("nil CouchbaseCluster")
+	}
+	if _, cached := cc.bucketBootstrapTargets.Load(bucketName); cached {
+		return nil
+	}
+	b, teardown, err := cc.getBucket(ctx, bucketName)
+	if err != nil {
+		return err
+	}
+	defer teardown()
+	target, found, err := cc.probeRegistryLocation(b)
+	if err != nil {
+		return err
+	}
+	if !found {
+		if optInHint || cc.useSystemMetadataCollection {
+			target = bucketTargetSystemMobile
+		} else {
+			target = bucketTargetDefault
+		}
+	}
+	cc.bucketBootstrapTargets.LoadOrStore(bucketName, target)
+	return nil
+}
+
+// probeRegistryLocation checks both collections for an existing _sync:registry doc. Returns
+// (target, found): when found, target identifies the collection; when not found, target is
+// undefined and the caller picks based on its own policy (cluster flag or per-DB hint).
+// A "collection not found" probe error on _system._mobile is treated as "not present".
+func (cc *CouchbaseCluster) probeRegistryLocation(b *gocb.Bucket) (target bucketBootstrapTarget, found bool, err error) {
+	systemCol := b.Scope(SystemScope).Collection(SystemCollectionMobile)
+	existsInSystem, sysErr := cc.configPersistence.keyExists(systemCol, SGRegistryKey)
+	if sysErr == nil && existsInSystem {
+		return bucketTargetSystemMobile, true, nil
+	}
+	defaultCol := b.DefaultCollection()
+	existsInDefault, defErr := cc.configPersistence.keyExists(defaultCol, SGRegistryKey)
+	if defErr != nil {
+		return 0, false, defErr
+	}
+	if existsInDefault {
+		return bucketTargetDefault, true, nil
+	}
+	return 0, false, nil
+}
+
+// shouldFallback returns true if a primary read returned a not-found-style error and the cluster
+// has a fallback collection configured (i.e. useSystemMetadataCollection is enabled).
+func (cc *CouchbaseCluster) shouldFallback(err error, fallback *gocb.Collection) bool {
+	return fallback != nil && IsDocNotFoundError(err)
+}
+
+// SetMigrationComplete marks bootstrap-metadata migration as finished; subsequent reads stop
+// falling back to _default._default. Safe to call concurrently with in-flight operations.
+func (cc *CouchbaseCluster) SetMigrationComplete() {
+	cc.migrationComplete.Store(true)
+}
+
+// RefreshBucketBootstrapTarget reads the bucket's metadata-migration status doc; if bootstrap.state
+// is complete it updates the per-bucket cache to _system._mobile via noteBucketFallbackHit. ErrNotFound
+// (no migration ever started here) and any other transient error are returned to the caller for
+// telemetry but never escalate — this is best-effort cache convergence, not a correctness path.
+func (cc *CouchbaseCluster) RefreshBucketBootstrapTarget(ctx context.Context, bucket string) error {
+	if cc == nil {
+		return errors.New("nil CouchbaseCluster")
+	}
+	status, _, err := cc.GetMetadataMigrationStatus(ctx, bucket)
+	if err != nil {
+		return err
+	}
+	if status.Bootstrap.State == MigrationStateComplete {
+		cc.noteBucketFallbackHit(bucket)
+	}
+	return nil
+}
+
+// loadConfigWithFallback resolves which of primary/fallback currently holds docID and returns its
+// value+CAS along with the resolved collection. Callers should pass the returned collection back
+// in subsequent writes so the CAS stays valid. Re-call on CAS mismatch to handle the doc being
+// migrated between collections mid-operation. On a successful fallback hit the bucket's cached
+// bootstrap target is updated (via noteBucketFallbackHit) so subsequent ops route correctly.
+func (cc *CouchbaseCluster) loadConfigWithFallback(ctx context.Context, bucketName string, primary, fallback *gocb.Collection, docID string) (collection *gocb.Collection, value []byte, cas gocb.Cas, err error) {
+	value, cas, err = cc.configPersistence.loadRawConfig(ctx, primary, docID)
+	if cc.shouldFallback(err, fallback) {
+		value, cas, err = cc.configPersistence.loadRawConfig(ctx, fallback, docID)
+		if err == nil {
+			cc.noteBucketFallbackHit(bucketName)
+			return fallback, value, cas, nil
+		}
+	}
+	return primary, value, cas, err
+}
+
 func (cc *CouchbaseCluster) GetMetadataDocument(ctx context.Context, location, docID string, valuePtr any) (cas uint64, err error) {
 	if cc == nil {
 		return 0, errors.New("nil CouchbaseCluster")
@@ -307,7 +513,14 @@ func (cc *CouchbaseCluster) GetMetadataDocument(ctx context.Context, location, d
 
 	defer teardown()
 
-	cas, err = cc.configPersistence.loadConfig(ctx, b.DefaultCollection(), docID, valuePtr)
+	primary, fallback := cc.metadataCollections(b)
+	cas, err = cc.configPersistence.loadConfig(ctx, primary, docID, valuePtr)
+	if cc.shouldFallback(err, fallback) {
+		cas, err = cc.configPersistence.loadConfig(ctx, fallback, docID, valuePtr)
+		if err == nil {
+			cc.noteBucketFallbackHit(location)
+		}
+	}
 	SyncGatewayStats.GlobalStats.ResourceUtilizationStats().NumIdleKvOps.Add(1)
 	return cas, err
 }
@@ -323,10 +536,29 @@ func (cc *CouchbaseCluster) InsertMetadataDocument(ctx context.Context, location
 	}
 	defer teardown()
 
-	return cc.configPersistence.insertConfig(b.DefaultCollection(), key, value)
+	primary, fallback := cc.metadataCollections(b)
+	// If a fallback exists and already holds the doc, surface ErrAlreadyExists rather than
+	// silently creating a duplicate in primary that diverges from the legacy copy. A transient
+	// fallback-read error must be propagated rather than swallowed, otherwise a TOCTOU race could
+	// hide an existing legacy copy and we'd create exactly the divergence we're guarding against.
+	if fallback != nil {
+		exists, existsErr := cc.configPersistence.keyExists(fallback, key)
+		if existsErr != nil {
+			return 0, existsErr
+		}
+		if exists {
+			cc.noteBucketFallbackHit(location)
+			return 0, ErrAlreadyExists
+		}
+	}
+	return cc.configPersistence.insertConfig(primary, key, value)
 }
 
-// WriteMetadataDocument writes a metadata document, and fails on CAS mismatch
+// WriteMetadataDocument writes a metadata document, and fails on CAS mismatch.
+// When useSystemMetadataCollection is enabled and the supplied CAS came from a fallback read
+// (i.e. the document still lives in _default._default), the write is applied against the
+// fallback collection so the CAS stays valid. Migration to the primary collection is left to a
+// future explicit migration step.
 func (cc *CouchbaseCluster) WriteMetadataDocument(ctx context.Context, location, docID string, cas uint64, value any) (newCAS uint64, err error) {
 	if cc == nil {
 		return 0, errors.New("nil CouchbaseCluster")
@@ -346,7 +578,16 @@ func (cc *CouchbaseCluster) WriteMetadataDocument(ctx context.Context, location,
 		return 0, err
 	}
 
-	casOut, err := cc.configPersistence.replaceRawConfig(b.DefaultCollection(), docID, rawDocument, gocb.Cas(cas))
+	primary, fallback := cc.metadataCollections(b)
+	casOut, err := cc.configPersistence.replaceRawConfig(primary, docID, rawDocument, gocb.Cas(cas))
+	if cc.shouldFallback(err, fallback) {
+		// Doc is not in primary. Caller's CAS must be from a previous fallback read; replay the
+		// write against the fallback collection so CAS semantics line up.
+		casOut, err = cc.configPersistence.replaceRawConfig(fallback, docID, rawDocument, gocb.Cas(cas))
+		if err == nil {
+			cc.noteBucketFallbackHit(location)
+		}
+	}
 	return uint64(casOut), err
 }
 
@@ -362,7 +603,14 @@ func (cc *CouchbaseCluster) TouchMetadataDocument(ctx context.Context, location,
 	}
 	defer teardown()
 
-	casOut, err := cc.configPersistence.touchConfigRollback(b.DefaultCollection(), docID, property, value, gocb.Cas(cas))
+	primary, fallback := cc.metadataCollections(b)
+	casOut, err := cc.configPersistence.touchConfigRollback(primary, docID, property, value, gocb.Cas(cas))
+	if cc.shouldFallback(err, fallback) {
+		casOut, err = cc.configPersistence.touchConfigRollback(fallback, docID, property, value, gocb.Cas(cas))
+		if err == nil {
+			cc.noteBucketFallbackHit(location)
+		}
+	}
 	return uint64(casOut), err
 
 }
@@ -378,11 +626,21 @@ func (cc *CouchbaseCluster) DeleteMetadataDocument(ctx context.Context, location
 	}
 	defer teardown()
 
-	_, removeErr := cc.configPersistence.removeRawConfig(b.DefaultCollection(), key, gocb.Cas(cas))
+	primary, fallback := cc.metadataCollections(b)
+	_, removeErr := cc.configPersistence.removeRawConfig(primary, key, gocb.Cas(cas))
+	if cc.shouldFallback(removeErr, fallback) {
+		_, removeErr = cc.configPersistence.removeRawConfig(fallback, key, gocb.Cas(cas))
+		if removeErr == nil {
+			cc.noteBucketFallbackHit(location)
+		}
+	}
 	return removeErr
 }
 
-// UpdateMetadataDocument retries on CAS mismatch
+// UpdateMetadataDocument retries on CAS mismatch.
+// When useSystemMetadataCollection is enabled the read-modify-write loop re-resolves the owning
+// collection (primary or fallback) on every retry, so a doc that migrates between collections
+// concurrently with this Update is picked up on the next iteration instead of returning ErrNotFound.
 func (cc *CouchbaseCluster) UpdateMetadataDocument(ctx context.Context, location, docID string, updateCallback func(bucketConfig []byte, rawBucketConfigCas uint64) (newConfig []byte, err error)) (newCAS uint64, err error) {
 	if cc == nil {
 		return 0, errors.New("nil CouchbaseCluster")
@@ -394,13 +652,14 @@ func (cc *CouchbaseCluster) UpdateMetadataDocument(ctx context.Context, location
 	}
 	defer teardown()
 
-	collection := b.DefaultCollection()
+	primary, fallback := cc.metadataCollections(b)
+
+	collection, bucketValue, cas, err := cc.loadConfigWithFallback(ctx, location, primary, fallback, docID)
+	if err != nil {
+		return 0, err
+	}
 
 	for {
-		bucketValue, cas, err := cc.configPersistence.loadRawConfig(ctx, collection, docID)
-		if err != nil {
-			return 0, err
-		}
 		newConfig, err := updateCallback(bucketValue, uint64(cas))
 		if err != nil {
 			return 0, err
@@ -410,8 +669,11 @@ func (cc *CouchbaseCluster) UpdateMetadataDocument(ctx context.Context, location
 		if newConfig == nil {
 			removeCasOut, err := cc.configPersistence.removeRawConfig(collection, docID, cas)
 			if err != nil {
-				// retry on cas failure
 				if errors.Is(err, gocb.ErrCasMismatch) {
+					collection, bucketValue, cas, err = cc.loadConfigWithFallback(ctx, location, primary, fallback, docID)
+					if err != nil {
+						return 0, err
+					}
 					continue
 				}
 				return 0, err
@@ -422,7 +684,10 @@ func (cc *CouchbaseCluster) UpdateMetadataDocument(ctx context.Context, location
 		replaceCfgCasOut, err := cc.configPersistence.replaceRawConfig(collection, docID, newConfig, cas)
 		if err != nil {
 			if errors.Is(err, gocb.ErrCasMismatch) {
-				// retry on cas failure
+				collection, bucketValue, cas, err = cc.loadConfigWithFallback(ctx, location, primary, fallback, docID)
+				if err != nil {
+					return 0, err
+				}
 				continue
 			}
 			return 0, err
@@ -433,7 +698,9 @@ func (cc *CouchbaseCluster) UpdateMetadataDocument(ctx context.Context, location
 
 }
 
-// KeyExists checks whether a key exists in the default collection for the specified bucket
+// KeyExists checks whether a key exists in the bootstrap metadata collection for the specified bucket.
+// When useSystemMetadataCollection is enabled, both the primary (_system._mobile) and fallback
+// (_default._default) collections are checked, mirroring read semantics of GetMetadataDocument.
 func (cc *CouchbaseCluster) KeyExists(ctx context.Context, location, docID string) (exists bool, err error) {
 	if cc == nil {
 		return false, errors.New("nil CouchbaseCluster")
@@ -447,7 +714,16 @@ func (cc *CouchbaseCluster) KeyExists(ctx context.Context, location, docID strin
 
 	defer teardown()
 
-	return cc.configPersistence.keyExists(b.DefaultCollection(), docID)
+	primary, fallback := cc.metadataCollections(b)
+	exists, err = cc.configPersistence.keyExists(primary, docID)
+	if err != nil || exists || fallback == nil {
+		return exists, err
+	}
+	exists, err = cc.configPersistence.keyExists(fallback, docID)
+	if err == nil && exists {
+		cc.noteBucketFallbackHit(location)
+	}
+	return exists, err
 }
 
 // GetDocument fetches a document from the default collection.  Does not use configPersistence - callers
@@ -504,6 +780,178 @@ func (cc *CouchbaseCluster) GetRawDocument(ctx context.Context, bucketName, docI
 	return value, true, err
 }
 
+// systemMobileCollection returns the _system._mobile collection for the supplied bucket. Used by
+// the metadata-migration status doc path, which must bypass the dual-collection wrapper.
+func (cc *CouchbaseCluster) systemMobileCollection(b *gocb.Bucket) *gocb.Collection {
+	return b.Scope(SystemScope).Collection(SystemCollectionMobile)
+}
+
+// GetMetadataMigrationStatus reads the status doc directly from _system._mobile.
+func (cc *CouchbaseCluster) GetMetadataMigrationStatus(ctx context.Context, bucket string) (*MetadataMigrationStatus, uint64, error) {
+	if cc == nil {
+		return nil, 0, errors.New("nil CouchbaseCluster")
+	}
+	b, teardown, err := cc.getBucket(ctx, bucket)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer teardown()
+
+	res, err := cc.systemMobileCollection(b).Get(MetadataMigrationStatusDocID, &gocb.GetOptions{Transcoder: NewSGJSONTranscoder()})
+	if err != nil {
+		if IsDocNotFoundError(err) {
+			return nil, 0, ErrNotFound
+		}
+		return nil, 0, err
+	}
+	status := &MetadataMigrationStatus{}
+	if err := res.Content(status); err != nil {
+		return nil, 0, err
+	}
+	return status, uint64(res.Cas()), nil
+}
+
+// InsertMetadataMigrationStatus stamps the initial status doc in _system._mobile. Concurrent
+// stamp attempts from peer SG nodes lose the CAS race and receive ErrAlreadyExists.
+func (cc *CouchbaseCluster) InsertMetadataMigrationStatus(ctx context.Context, bucket string, status *MetadataMigrationStatus) (uint64, error) {
+	if cc == nil {
+		return 0, errors.New("nil CouchbaseCluster")
+	}
+	if status == nil {
+		return 0, errors.New("nil MetadataMigrationStatus")
+	}
+	b, teardown, err := cc.getBucket(ctx, bucket)
+	if err != nil {
+		return 0, err
+	}
+	defer teardown()
+
+	res, err := cc.systemMobileCollection(b).Insert(MetadataMigrationStatusDocID, status, &gocb.InsertOptions{Transcoder: NewSGJSONTranscoder()})
+	if err != nil {
+		if errors.Is(err, gocb.ErrDocumentExists) {
+			return 0, ErrAlreadyExists
+		}
+		return 0, err
+	}
+	return uint64(res.Cas()), nil
+}
+
+// UpdateMetadataMigrationStatus runs the callback inside a CAS-safe read-modify-write loop. If the
+// doc is absent the callback receives a freshly seeded status (created via NewMetadataMigrationStatus)
+// and a successful return triggers an Insert; otherwise a Replace is issued with the observed CAS.
+func (cc *CouchbaseCluster) UpdateMetadataMigrationStatus(ctx context.Context, bucket string, callback func(*MetadataMigrationStatus) error) (uint64, error) {
+	if cc == nil {
+		return 0, errors.New("nil CouchbaseCluster")
+	}
+	b, teardown, err := cc.getBucket(ctx, bucket)
+	if err != nil {
+		return 0, err
+	}
+	defer teardown()
+	col := cc.systemMobileCollection(b)
+
+	for {
+		var (
+			status  = &MetadataMigrationStatus{}
+			cas     gocb.Cas
+			isFresh bool
+		)
+		res, getErr := col.Get(MetadataMigrationStatusDocID, &gocb.GetOptions{Transcoder: NewSGJSONTranscoder()})
+		if getErr != nil {
+			if !IsDocNotFoundError(getErr) {
+				return 0, getErr
+			}
+			status = NewMetadataMigrationStatus()
+			isFresh = true
+		} else {
+			if err := res.Content(status); err != nil {
+				return 0, err
+			}
+			cas = res.Cas()
+		}
+		if err := callback(status); err != nil {
+			return 0, err
+		}
+		if isFresh {
+			ins, err := col.Insert(MetadataMigrationStatusDocID, status, &gocb.InsertOptions{Transcoder: NewSGJSONTranscoder()})
+			if err != nil {
+				if errors.Is(err, gocb.ErrDocumentExists) {
+					// peer SG won the race; retry the read-modify-write against the real doc
+					continue
+				}
+				return 0, err
+			}
+			return uint64(ins.Cas()), nil
+		}
+		repl, err := col.Replace(MetadataMigrationStatusDocID, status, &gocb.ReplaceOptions{Cas: cas, Transcoder: NewSGJSONTranscoder()})
+		if err != nil {
+			if errors.Is(err, gocb.ErrCasMismatch) {
+				continue
+			}
+			return 0, err
+		}
+		return uint64(repl.Cas()), nil
+	}
+}
+
+// MigrateBootstrapDocs is the bucket-level copy step. For each supplied docID, reads the raw body
+// from _default._default and CAS-inserts it into _system._mobile; if primary already has the doc
+// the fallback copy is left for the verify-and-delete sweep below. Once every doc is in primary
+// the fallback copy is removed with the originally observed CAS — a CAS mismatch means a write
+// slipped in mid-migration, which we log and skip (the caller is responsible for re-running).
+func (cc *CouchbaseCluster) MigrateBootstrapDocs(ctx context.Context, bucket string, docIDs []string) error {
+	if cc == nil {
+		return errors.New("nil CouchbaseCluster")
+	}
+	b, teardown, err := cc.getBucket(ctx, bucket)
+	if err != nil {
+		return err
+	}
+	defer teardown()
+
+	primary := cc.systemMobileCollection(b)
+	fallback := b.DefaultCollection()
+	raw := &gocb.GetOptions{Transcoder: NewSGRawTranscoder()}
+
+	for _, docID := range docIDs {
+		fallbackRes, err := fallback.Get(docID, raw)
+		if err != nil {
+			if IsDocNotFoundError(err) {
+				continue
+			}
+			return fmt.Errorf("read fallback %q during bootstrap migration: %w", docID, err)
+		}
+		var body []byte
+		if err := fallbackRes.Content(&body); err != nil {
+			return fmt.Errorf("decode fallback %q: %w", docID, err)
+		}
+		fallbackCas := fallbackRes.Cas()
+
+		// Use the JSON transcoder for both sides so the destination preserves JSONType flags
+		// even when the source datatype is masked behind the raw read.
+		_, insertErr := primary.Insert(docID, json.RawMessage(body), &gocb.InsertOptions{Transcoder: gocb.NewRawJSONTranscoder()})
+		if insertErr != nil && !errors.Is(insertErr, gocb.ErrDocumentExists) {
+			return fmt.Errorf("insert primary %q during bootstrap migration: %w", docID, insertErr)
+		}
+
+		if _, err := fallback.Remove(docID, &gocb.RemoveOptions{Cas: fallbackCas}); err != nil {
+			if errors.Is(err, gocb.ErrCasMismatch) {
+				InfofCtx(ctx, KeyConfig, "Bootstrap migration: skipping fallback delete for %q on bucket %q (CAS mismatch — concurrent write), caller should re-run", MD(docID), MD(bucket))
+				continue
+			}
+			if IsDocNotFoundError(err) {
+				continue
+			}
+			return fmt.Errorf("delete fallback %q during bootstrap migration: %w", docID, err)
+		}
+	}
+	// The bootstrap docs now live in _system._mobile on this bucket; any prior cache entry that
+	// pointed at _default._default is stale and would route subsequent reads/writes to a deleted
+	// location. Store (not LoadOrStore) so a pre-migration bucketTargetDefault is overwritten.
+	cc.bucketBootstrapTargets.Store(bucket, bucketTargetSystemMobile)
+	return nil
+}
+
 // Close calls teardown for any cached buckets and removes from cachedBucketConnections
 func (cc *CouchbaseCluster) Close() {
 
@@ -521,7 +969,12 @@ func (cc *CouchbaseCluster) Close() {
 func (cc *CouchbaseCluster) getBucket(ctx context.Context, bucketName string) (b *gocb.Bucket, teardownFn func(), err error) {
 
 	if cc.bucketConnectionMode != CachedClusterConnections {
-		return cc.connectToBucket(ctx, bucketName)
+		b, teardownFn, err = cc.connectToBucket(ctx, bucketName)
+		if err != nil {
+			return nil, nil, err
+		}
+		cc.ensureBucketBootstrapTargetCached(b)
+		return b, teardownFn, nil
 	}
 
 	teardownFn = func() {
@@ -531,6 +984,7 @@ func (cc *CouchbaseCluster) getBucket(ctx context.Context, bucketName string) (b
 	defer cc.cachedBucketConnections.lock.Unlock()
 	bucket := cc.cachedBucketConnections._get(bucketName)
 	if bucket != nil {
+		cc.ensureBucketBootstrapTargetCached(bucket.bucket)
 		return bucket.bucket, teardownFn, nil
 	}
 
@@ -544,8 +998,24 @@ func (cc *CouchbaseCluster) getBucket(ctx context.Context, bucketName string) (b
 		bucketCloseFn: bucketCloseFn,
 		refcount:      1,
 	})
-
+	cc.ensureBucketBootstrapTargetCached(newBucket)
 	return newBucket, teardownFn, nil
+}
+
+// ensureBucketBootstrapTargetCached freezes the bucket's bootstrap target IF an existing
+// _sync:registry is found in either collection — a definitive location we should stick to.
+// When no registry exists yet the decision is left uncached so a subsequent per-DB opt-in (via
+// SetBucketBootstrapTargetHint) can still claim system._mobile; metadataCollections will fall
+// back to the connection-wide flag in the meantime. Best-effort: probe errors are swallowed.
+func (cc *CouchbaseCluster) ensureBucketBootstrapTargetCached(b *gocb.Bucket) {
+	if _, cached := cc.bucketBootstrapTargets.Load(b.Name()); cached {
+		return
+	}
+	target, found, err := cc.probeRegistryLocation(b)
+	if err != nil || !found {
+		return
+	}
+	cc.bucketBootstrapTargets.LoadOrStore(b.Name(), target)
 }
 
 func (cc *CouchbaseCluster) GetClusterConnectionForBucket(ctx context.Context, bucketName string) (connection *gocb.Cluster, teardownFn func(), err error) {

--- a/base/bootstrap_test.go
+++ b/base/bootstrap_test.go
@@ -19,7 +19,6 @@ import (
 
 	"dario.cat/mergo"
 	"github.com/couchbase/gocb/v2"
-	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbaselabs/rosmar"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -345,8 +344,7 @@ func newRosmarBootstrapDualFixture(t *testing.T) bootstrapDualTestFixture {
 }
 
 // newCouchbaseBootstrapDualFixture builds a fixture over the first available test-pool bucket on a
-// real Couchbase Server cluster running in dual-collection mode. Skips when the cluster doesn't
-// expose _system._mobile (CBS < 7.6).
+// real Couchbase Server cluster running in dual-collection mode.
 func newCouchbaseBootstrapDualFixture(t *testing.T) bootstrapDualTestFixture {
 	t.Helper()
 	ctx := TestCtx(t)
@@ -365,10 +363,6 @@ func newCouchbaseBootstrapDualFixture(t *testing.T) bootstrapDualTestFixture {
 
 	bucket, teardown, err := cluster.getBucket(ctx, bucketName)
 	require.NoError(t, err)
-	if !(&GocbV2Bucket{bucket: bucket}).IsSupported(sgbucket.BucketStoreFeatureSystemCollections) {
-		teardown()
-		t.Skip("Test requires system collection support (CBS 7.6+)")
-	}
 	t.Cleanup(teardown)
 
 	primaryCol := bucket.Scope(SystemScope).Collection(SystemCollectionMobile)

--- a/base/bootstrap_test.go
+++ b/base/bootstrap_test.go
@@ -9,6 +9,8 @@
 package base
 
 import (
+	"encoding/json"
+	"errors"
 	"sort"
 	"strings"
 	"sync"
@@ -16,6 +18,8 @@ import (
 	"time"
 
 	"dario.cat/mergo"
+	"github.com/couchbase/gocb/v2"
+	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbaselabs/rosmar"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -51,7 +55,7 @@ func TestBootstrapRefCounting(t *testing.T) {
 
 	var perBucketCredentialsConfig map[string]*CredentialsConfig
 	forcePerBucketAuth := false
-	cluster, err := NewCouchbaseCluster(ctx, TestClusterSpec(t), forcePerBucketAuth, perBucketCredentialsConfig, TestUseXattrs(), CachedClusterConnections)
+	cluster, err := NewCouchbaseCluster(ctx, TestClusterSpec(t), forcePerBucketAuth, perBucketCredentialsConfig, TestUseXattrs(), false, CachedClusterConnections)
 	require.NoError(t, err)
 	defer cluster.Close()
 	require.NotNil(t, cluster)
@@ -138,12 +142,12 @@ func newTestBootstrapConnection(t *testing.T) BootstrapConnection {
 	t.Helper()
 	ctx := TestCtx(t)
 	if UnitTestUrlIsWalrus() {
-		cluster, err := NewRosmarCluster(rosmar.InMemoryURL)
+		cluster, err := NewRosmarCluster(rosmar.InMemoryURL, false)
 		require.NoError(t, err)
 		t.Cleanup(cluster.Close)
 		return cluster
 	}
-	cluster, err := NewCouchbaseCluster(ctx, TestClusterSpec(t), false, nil, TestUseXattrs(), CachedClusterConnections)
+	cluster, err := NewCouchbaseCluster(ctx, TestClusterSpec(t), false, nil, TestUseXattrs(), false, CachedClusterConnections)
 	require.NoError(t, err)
 	t.Cleanup(cluster.Close)
 	return cluster
@@ -243,4 +247,263 @@ func TestTouchMetadataDocument(t *testing.T) {
 	_, err = cluster.TouchMetadataDocument(ctx, bucketName, docID, "name", "db2", originalCAS)
 	require.Error(t, err)
 	require.True(t, IsCasMismatch(err), "expected CasMismatch on stale CAS retry, got %T: %v", err, err)
+}
+
+// bootstrapTestCfg is the value shape used by the dual-collection bootstrap tests.
+type bootstrapTestCfg struct {
+	Foo string `json:"foo"`
+}
+
+// seedLegacyBootstrapDoc writes a bootstrap-config-shaped document directly into the bucket's
+// _default._default collection, mimicking pre-migration state. It honors TestUseXattrs so the
+// on-disk shape matches what configPersistence.loadConfig expects.
+func seedLegacyBootstrapDoc(t *testing.T, bucket *gocb.Bucket, docID string, value bootstrapTestCfg) {
+	t.Helper()
+	if TestUseXattrs() {
+		_, err := bucket.DefaultCollection().MutateIn(docID, []gocb.MutateInSpec{
+			gocb.UpsertSpec(cfgXattrConfigPath, value, UpsertSpecXattr),
+			gocb.ReplaceSpec("", json.RawMessage(cfgXattrBody), nil),
+		}, &gocb.MutateInOptions{StoreSemantic: gocb.StoreSemanticsInsert})
+		require.NoError(t, err)
+		return
+	}
+	_, err := bucket.DefaultCollection().Insert(docID, value, nil)
+	require.NoError(t, err)
+}
+
+// bootstrapDualTestFixture pairs a BootstrapConnection in dual-collection mode with helpers that
+// reach past the cluster API to inspect or seed each underlying collection. Implementations exist
+// for both Rosmar and CouchbaseCluster; newBootstrapDualTestFixture selects based on the test's
+// backing store.
+type bootstrapDualTestFixture struct {
+	Cluster    BootstrapConnection
+	BucketName string
+	// SeedLegacy writes a config-shaped doc directly into the fallback (_default._default)
+	// collection, bypassing the cluster API.
+	SeedLegacy func(t *testing.T, docID string, value bootstrapTestCfg)
+	// PrimaryExists reports whether docID currently exists in the primary (_system._mobile).
+	PrimaryExists func(t *testing.T, docID string) bool
+	// FallbackExists reports whether docID currently exists in _default._default.
+	FallbackExists func(t *testing.T, docID string) bool
+	// CleanupDoc removes docID from both collections. Idempotent.
+	CleanupDoc func(t *testing.T, docID string)
+}
+
+func newBootstrapDualTestFixture(t *testing.T) bootstrapDualTestFixture {
+	t.Helper()
+	if UnitTestUrlIsWalrus() {
+		return newRosmarBootstrapDualFixture(t)
+	}
+	return newCouchbaseBootstrapDualFixture(t)
+}
+
+// newRosmarBootstrapDualFixture builds a fixture over a test-pool Rosmar bucket. The cluster and
+// the seed/inspect helpers all point at the same in-memory bucket via rosmar's process-global
+// bucket registry.
+func newRosmarBootstrapDualFixture(t *testing.T) bootstrapDualTestFixture {
+	t.Helper()
+	ctx := TestCtx(t)
+	tb := GetTestBucket(t)
+	t.Cleanup(func() { tb.Close(ctx) })
+	bucketName := tb.GetName()
+
+	cluster, err := NewRosmarCluster(UnitTestUrl(), true)
+	require.NoError(t, err)
+	t.Cleanup(cluster.Close)
+
+	defaultDS, err := tb.Bucket.NamedDataStore(ctx, DefaultScopeAndCollectionName())
+	require.NoError(t, err)
+	systemDS, err := tb.Bucket.NamedDataStore(ctx, MobileSystemScopeAndCollectionName())
+	require.NoError(t, err)
+
+	return bootstrapDualTestFixture{
+		Cluster:    cluster,
+		BucketName: bucketName,
+		SeedLegacy: func(t *testing.T, docID string, value bootstrapTestCfg) {
+			t.Helper()
+			_, err := defaultDS.WriteCas(TestCtx(t), docID, 0, 0, value, 0)
+			require.NoError(t, err)
+		},
+		PrimaryExists: func(t *testing.T, docID string) bool {
+			t.Helper()
+			ok, err := systemDS.Exists(TestCtx(t), docID)
+			require.NoError(t, err)
+			return ok
+		},
+		FallbackExists: func(t *testing.T, docID string) bool {
+			t.Helper()
+			ok, err := defaultDS.Exists(TestCtx(t), docID)
+			require.NoError(t, err)
+			return ok
+		},
+		CleanupDoc: func(t *testing.T, docID string) {
+			t.Helper()
+			_, _ = systemDS.Remove(TestCtx(t), docID, 0)
+			_, _ = defaultDS.Remove(TestCtx(t), docID, 0)
+		},
+	}
+}
+
+// newCouchbaseBootstrapDualFixture builds a fixture over the first available test-pool bucket on a
+// real Couchbase Server cluster running in dual-collection mode. Skips when the cluster doesn't
+// expose _system._mobile (CBS < 7.6).
+func newCouchbaseBootstrapDualFixture(t *testing.T) bootstrapDualTestFixture {
+	t.Helper()
+	ctx := TestCtx(t)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, int32(GTestBucketPool.numBuckets), GTestBucketPool.stats.TotalBucketInitCount.Load())
+	}, 2*time.Minute, 5*time.Millisecond)
+
+	cluster, err := NewCouchbaseCluster(ctx, TestClusterSpec(t), false, nil, TestUseXattrs(), true, CachedClusterConnections)
+	require.NoError(t, err)
+	t.Cleanup(cluster.Close)
+
+	buckets, err := cluster.GetConfigBuckets(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, buckets)
+	bucketName := buckets[0]
+
+	bucket, teardown, err := cluster.getBucket(ctx, bucketName)
+	require.NoError(t, err)
+	if !(&GocbV2Bucket{bucket: bucket}).IsSupported(sgbucket.BucketStoreFeatureSystemCollections) {
+		teardown()
+		t.Skip("Test requires system collection support (CBS 7.6+)")
+	}
+	t.Cleanup(teardown)
+
+	primaryCol := bucket.Scope(SystemScope).Collection(SystemCollectionMobile)
+	fallbackCol := bucket.DefaultCollection()
+	colExists := func(c *gocb.Collection, docID string) bool {
+		t.Helper()
+		_, err := c.Get(docID, nil)
+		if errors.Is(err, gocb.ErrDocumentNotFound) {
+			return false
+		}
+		require.NoError(t, err)
+		return true
+	}
+
+	return bootstrapDualTestFixture{
+		Cluster:    cluster,
+		BucketName: bucketName,
+		SeedLegacy: func(t *testing.T, docID string, value bootstrapTestCfg) {
+			t.Helper()
+			seedLegacyBootstrapDoc(t, bucket, docID, value)
+		},
+		PrimaryExists:  func(t *testing.T, docID string) bool { return colExists(primaryCol, docID) },
+		FallbackExists: func(t *testing.T, docID string) bool { return colExists(fallbackCol, docID) },
+		CleanupDoc: func(t *testing.T, docID string) {
+			t.Helper()
+			_, _ = primaryCol.Remove(docID, nil)
+			_, _ = fallbackCol.Remove(docID, nil)
+		},
+	}
+}
+
+// TestBootstrapInsertMetadataDocumentWritesPrimary verifies that with no pre-existing legacy copy,
+// InsertMetadataDocument lands in the primary (_system._mobile) collection and not the fallback.
+func TestBootstrapInsertMetadataDocumentWritesPrimary(t *testing.T) {
+	f := newBootstrapDualTestFixture(t)
+	ctx := TestCtx(t)
+	docID := SyncDocPrefix + "metadata-insert-primary"
+	t.Cleanup(func() { f.CleanupDoc(t, docID) })
+
+	_, err := f.Cluster.InsertMetadataDocument(ctx, f.BucketName, docID, bootstrapTestCfg{Foo: "primary"})
+	require.NoError(t, err)
+
+	require.True(t, f.PrimaryExists(t, docID))
+	require.False(t, f.FallbackExists(t, docID))
+
+	var loaded bootstrapTestCfg
+	_, err = f.Cluster.GetMetadataDocument(ctx, f.BucketName, docID, &loaded)
+	require.NoError(t, err)
+	require.Equal(t, "primary", loaded.Foo)
+}
+
+// TestBootstrapWriteMetadataDocumentFallbackCAS verifies WriteMetadataDocument replays against the
+// fallback collection when the supplied CAS came from a fallback read, so callers don't see a
+// spurious not-found just because the doc hasn't migrated to _system._mobile yet.
+func TestBootstrapWriteMetadataDocumentFallbackCAS(t *testing.T) {
+	f := newBootstrapDualTestFixture(t)
+	ctx := TestCtx(t)
+	docID := SyncDocPrefix + "metadata-write-fallback-cas"
+	t.Cleanup(func() { f.CleanupDoc(t, docID) })
+	f.SeedLegacy(t, docID, bootstrapTestCfg{Foo: "legacy"})
+
+	var initial bootstrapTestCfg
+	cas, err := f.Cluster.GetMetadataDocument(ctx, f.BucketName, docID, &initial)
+	require.NoError(t, err)
+	require.Equal(t, "legacy", initial.Foo)
+	require.NotZero(t, cas)
+
+	newCAS, err := f.Cluster.WriteMetadataDocument(ctx, f.BucketName, docID, cas, bootstrapTestCfg{Foo: "updated"})
+	require.NoError(t, err)
+	require.NotEqual(t, cas, newCAS)
+
+	var reloaded bootstrapTestCfg
+	_, err = f.Cluster.GetMetadataDocument(ctx, f.BucketName, docID, &reloaded)
+	require.NoError(t, err)
+	require.Equal(t, "updated", reloaded.Foo)
+
+	require.False(t, f.PrimaryExists(t, docID), "write must not have migrated the doc to primary")
+	require.True(t, f.FallbackExists(t, docID))
+}
+
+// TestBootstrapInsertMetadataDocumentFallbackDuplicate verifies InsertMetadataDocument returns
+// ErrAlreadyExists when the doc already lives in the fallback collection - never silently creating
+// a divergent primary copy.
+func TestBootstrapInsertMetadataDocumentFallbackDuplicate(t *testing.T) {
+	f := newBootstrapDualTestFixture(t)
+	ctx := TestCtx(t)
+	docID := SyncDocPrefix + "metadata-insert-fallback-dup"
+	t.Cleanup(func() { f.CleanupDoc(t, docID) })
+	f.SeedLegacy(t, docID, bootstrapTestCfg{Foo: "legacy"})
+
+	_, err := f.Cluster.InsertMetadataDocument(ctx, f.BucketName, docID, bootstrapTestCfg{Foo: "primary"})
+	require.ErrorIs(t, err, ErrAlreadyExists)
+	require.False(t, f.PrimaryExists(t, docID), "InsertMetadataDocument must not have created a primary copy")
+}
+
+// TestBootstrapTouchMetadataDocumentFallback verifies TouchMetadataDocument retries against the
+// fallback collection when the primary returns ErrNotFound, leaving the doc in place rather than
+// migrating it.
+func TestBootstrapTouchMetadataDocumentFallback(t *testing.T) {
+	f := newBootstrapDualTestFixture(t)
+	ctx := TestCtx(t)
+	docID := SyncDocPrefix + "metadata-touch-fallback"
+	t.Cleanup(func() { f.CleanupDoc(t, docID) })
+	f.SeedLegacy(t, docID, bootstrapTestCfg{Foo: "legacy"})
+
+	var initial bootstrapTestCfg
+	cas, err := f.Cluster.GetMetadataDocument(ctx, f.BucketName, docID, &initial)
+	require.NoError(t, err)
+	require.NotZero(t, cas)
+
+	newCAS, err := f.Cluster.TouchMetadataDocument(ctx, f.BucketName, docID, "version", "v2", cas)
+	require.NoError(t, err)
+	require.NotEqual(t, cas, newCAS, "Touch must bump CAS")
+	require.False(t, f.PrimaryExists(t, docID))
+	require.True(t, f.FallbackExists(t, docID))
+}
+
+// TestBootstrapDeleteMetadataDocumentFallback verifies DeleteMetadataDocument retries against the
+// fallback collection when the primary returns ErrNotFound, removing the legacy doc.
+func TestBootstrapDeleteMetadataDocumentFallback(t *testing.T) {
+	f := newBootstrapDualTestFixture(t)
+	ctx := TestCtx(t)
+	docID := SyncDocPrefix + "metadata-delete-fallback"
+	t.Cleanup(func() { f.CleanupDoc(t, docID) })
+	f.SeedLegacy(t, docID, bootstrapTestCfg{Foo: "legacy"})
+
+	var initial bootstrapTestCfg
+	cas, err := f.Cluster.GetMetadataDocument(ctx, f.BucketName, docID, &initial)
+	require.NoError(t, err)
+	require.NotZero(t, cas)
+
+	require.NoError(t, f.Cluster.DeleteMetadataDocument(ctx, f.BucketName, docID, cas))
+	require.False(t, f.FallbackExists(t, docID))
+
+	var afterDelete bootstrapTestCfg
+	_, err = f.Cluster.GetMetadataDocument(ctx, f.BucketName, docID, &afterDelete)
+	require.True(t, IsDocNotFoundError(err), "expected not-found after delete, got %T: %v", err, err)
 }

--- a/base/bootstrap_test.go
+++ b/base/bootstrap_test.go
@@ -254,11 +254,13 @@ type bootstrapTestCfg struct {
 }
 
 // seedLegacyBootstrapDoc writes a bootstrap-config-shaped document directly into the bucket's
-// _default._default collection, mimicking pre-migration state. It honors TestUseXattrs so the
-// on-disk shape matches what configPersistence.loadConfig expects.
-func seedLegacyBootstrapDoc(t *testing.T, bucket *gocb.Bucket, docID string, value bootstrapTestCfg) {
+// _default._default collection, mimicking pre-migration state. The on-disk shape must match what
+// configPersistence.loadConfig expects, which is controlled by NewCouchbaseCluster's
+// useXattrConfig — a distinct setting from SG's general use_xattrs for application metadata.
+// Callers must pass the same useXattrs value used to construct the cluster under test.
+func seedLegacyBootstrapDoc(t *testing.T, bucket *gocb.Bucket, docID string, value bootstrapTestCfg, useXattrs bool) {
 	t.Helper()
-	if TestUseXattrs() {
+	if useXattrs {
 		_, err := bucket.DefaultCollection().MutateIn(docID, []gocb.MutateInSpec{
 			gocb.UpsertSpec(cfgXattrConfigPath, value, UpsertSpecXattr),
 			gocb.ReplaceSpec("", json.RawMessage(cfgXattrBody), nil),
@@ -288,12 +290,17 @@ type bootstrapDualTestFixture struct {
 	CleanupDoc func(t *testing.T, docID string)
 }
 
-func newBootstrapDualTestFixture(t *testing.T) bootstrapDualTestFixture {
+// newBootstrapDualTestFixture constructs a fixture for dual-collection bootstrap tests. useXattrs
+// selects the bootstrap-config persistence mode on Couchbase Server (NewCouchbaseCluster's
+// useXattrConfig); on Rosmar it's ignored since Rosmar's bootstrap path only supports
+// document-mode persistence — callers that want to exercise useXattrs=true should skip on
+// UnitTestUrlIsWalrus().
+func newBootstrapDualTestFixture(t *testing.T, useXattrs bool) bootstrapDualTestFixture {
 	t.Helper()
 	if UnitTestUrlIsWalrus() {
 		return newRosmarBootstrapDualFixture(t)
 	}
-	return newCouchbaseBootstrapDualFixture(t)
+	return newCouchbaseBootstrapDualFixture(t, useXattrs)
 }
 
 // newRosmarBootstrapDualFixture builds a fixture over a test-pool Rosmar bucket. The cluster and
@@ -344,15 +351,16 @@ func newRosmarBootstrapDualFixture(t *testing.T) bootstrapDualTestFixture {
 }
 
 // newCouchbaseBootstrapDualFixture builds a fixture over the first available test-pool bucket on a
-// real Couchbase Server cluster running in dual-collection mode.
-func newCouchbaseBootstrapDualFixture(t *testing.T) bootstrapDualTestFixture {
+// real Couchbase Server cluster running in dual-collection mode. useXattrs selects the
+// bootstrap-config persistence mode and must match the seed format used by SeedLegacy.
+func newCouchbaseBootstrapDualFixture(t *testing.T, useXattrs bool) bootstrapDualTestFixture {
 	t.Helper()
 	ctx := TestCtx(t)
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		assert.Equal(c, int32(GTestBucketPool.numBuckets), GTestBucketPool.stats.TotalBucketInitCount.Load())
 	}, 2*time.Minute, 5*time.Millisecond)
 
-	cluster, err := NewCouchbaseCluster(ctx, TestClusterSpec(t), false, nil, TestUseXattrs(), true, CachedClusterConnections)
+	cluster, err := NewCouchbaseCluster(ctx, TestClusterSpec(t), false, nil, useXattrs, true, CachedClusterConnections)
 	require.NoError(t, err)
 	t.Cleanup(cluster.Close)
 
@@ -382,7 +390,7 @@ func newCouchbaseBootstrapDualFixture(t *testing.T) bootstrapDualTestFixture {
 		BucketName: bucketName,
 		SeedLegacy: func(t *testing.T, docID string, value bootstrapTestCfg) {
 			t.Helper()
-			seedLegacyBootstrapDoc(t, bucket, docID, value)
+			seedLegacyBootstrapDoc(t, bucket, docID, value, useXattrs)
 		},
 		PrimaryExists:  func(t *testing.T, docID string) bool { return colExists(primaryCol, docID) },
 		FallbackExists: func(t *testing.T, docID string) bool { return colExists(fallbackCol, docID) },
@@ -394,110 +402,140 @@ func newCouchbaseBootstrapDualFixture(t *testing.T) bootstrapDualTestFixture {
 	}
 }
 
+// forEachBootstrapXattrMode runs body once with useXattrs=false and once with useXattrs=true,
+// each as a t.Run subtest. The useXattrs=true subtest is skipped on Rosmar — its bootstrap
+// path doesn't support xattr-mode persistence, so the variant has no meaningful coverage
+// there.
+func forEachBootstrapXattrMode(t *testing.T, body func(t *testing.T, useXattrs bool)) {
+	t.Helper()
+	for _, useXattrs := range []bool{false, true} {
+		name := "bootstrap_xattr=false"
+		if useXattrs {
+			name = "bootstrap_xattr=true"
+		}
+		t.Run(name, func(t *testing.T) {
+			if useXattrs && UnitTestUrlIsWalrus() {
+				t.Skip("Rosmar bootstrap does not support xattr-mode persistence")
+			}
+			body(t, useXattrs)
+		})
+	}
+}
+
 // TestBootstrapInsertMetadataDocumentWritesPrimary verifies that with no pre-existing legacy copy,
 // InsertMetadataDocument lands in the primary (_system._mobile) collection and not the fallback.
 func TestBootstrapInsertMetadataDocumentWritesPrimary(t *testing.T) {
-	f := newBootstrapDualTestFixture(t)
-	ctx := TestCtx(t)
-	docID := SyncDocPrefix + "metadata-insert-primary"
-	t.Cleanup(func() { f.CleanupDoc(t, docID) })
+	forEachBootstrapXattrMode(t, func(t *testing.T, useXattrs bool) {
+		f := newBootstrapDualTestFixture(t, useXattrs)
+		ctx := TestCtx(t)
+		docID := SyncDocPrefix + "metadata-insert-primary"
+		t.Cleanup(func() { f.CleanupDoc(t, docID) })
 
-	_, err := f.Cluster.InsertMetadataDocument(ctx, f.BucketName, docID, bootstrapTestCfg{Foo: "primary"})
-	require.NoError(t, err)
+		_, err := f.Cluster.InsertMetadataDocument(ctx, f.BucketName, docID, bootstrapTestCfg{Foo: "primary"})
+		require.NoError(t, err)
 
-	require.True(t, f.PrimaryExists(t, docID))
-	require.False(t, f.FallbackExists(t, docID))
+		require.True(t, f.PrimaryExists(t, docID))
+		require.False(t, f.FallbackExists(t, docID))
 
-	var loaded bootstrapTestCfg
-	_, err = f.Cluster.GetMetadataDocument(ctx, f.BucketName, docID, &loaded)
-	require.NoError(t, err)
-	require.Equal(t, "primary", loaded.Foo)
+		var loaded bootstrapTestCfg
+		_, err = f.Cluster.GetMetadataDocument(ctx, f.BucketName, docID, &loaded)
+		require.NoError(t, err)
+		require.Equal(t, "primary", loaded.Foo)
+	})
 }
 
 // TestBootstrapWriteMetadataDocumentFallbackCAS verifies WriteMetadataDocument replays against the
 // fallback collection when the supplied CAS came from a fallback read, so callers don't see a
 // spurious not-found just because the doc hasn't migrated to _system._mobile yet.
 func TestBootstrapWriteMetadataDocumentFallbackCAS(t *testing.T) {
-	f := newBootstrapDualTestFixture(t)
-	ctx := TestCtx(t)
-	docID := SyncDocPrefix + "metadata-write-fallback-cas"
-	t.Cleanup(func() { f.CleanupDoc(t, docID) })
-	f.SeedLegacy(t, docID, bootstrapTestCfg{Foo: "legacy"})
+	forEachBootstrapXattrMode(t, func(t *testing.T, useXattrs bool) {
+		f := newBootstrapDualTestFixture(t, useXattrs)
+		ctx := TestCtx(t)
+		docID := SyncDocPrefix + "metadata-write-fallback-cas"
+		t.Cleanup(func() { f.CleanupDoc(t, docID) })
+		f.SeedLegacy(t, docID, bootstrapTestCfg{Foo: "legacy"})
 
-	var initial bootstrapTestCfg
-	cas, err := f.Cluster.GetMetadataDocument(ctx, f.BucketName, docID, &initial)
-	require.NoError(t, err)
-	require.Equal(t, "legacy", initial.Foo)
-	require.NotZero(t, cas)
+		var initial bootstrapTestCfg
+		cas, err := f.Cluster.GetMetadataDocument(ctx, f.BucketName, docID, &initial)
+		require.NoError(t, err)
+		require.Equal(t, "legacy", initial.Foo)
+		require.NotZero(t, cas)
 
-	newCAS, err := f.Cluster.WriteMetadataDocument(ctx, f.BucketName, docID, cas, bootstrapTestCfg{Foo: "updated"})
-	require.NoError(t, err)
-	require.NotEqual(t, cas, newCAS)
+		newCAS, err := f.Cluster.WriteMetadataDocument(ctx, f.BucketName, docID, cas, bootstrapTestCfg{Foo: "updated"})
+		require.NoError(t, err)
+		require.NotEqual(t, cas, newCAS)
 
-	var reloaded bootstrapTestCfg
-	_, err = f.Cluster.GetMetadataDocument(ctx, f.BucketName, docID, &reloaded)
-	require.NoError(t, err)
-	require.Equal(t, "updated", reloaded.Foo)
+		var reloaded bootstrapTestCfg
+		_, err = f.Cluster.GetMetadataDocument(ctx, f.BucketName, docID, &reloaded)
+		require.NoError(t, err)
+		require.Equal(t, "updated", reloaded.Foo)
 
-	require.False(t, f.PrimaryExists(t, docID), "write must not have migrated the doc to primary")
-	require.True(t, f.FallbackExists(t, docID))
+		require.False(t, f.PrimaryExists(t, docID), "write must not have migrated the doc to primary")
+		require.True(t, f.FallbackExists(t, docID))
+	})
 }
 
 // TestBootstrapInsertMetadataDocumentFallbackDuplicate verifies InsertMetadataDocument returns
 // ErrAlreadyExists when the doc already lives in the fallback collection - never silently creating
 // a divergent primary copy.
 func TestBootstrapInsertMetadataDocumentFallbackDuplicate(t *testing.T) {
-	f := newBootstrapDualTestFixture(t)
-	ctx := TestCtx(t)
-	docID := SyncDocPrefix + "metadata-insert-fallback-dup"
-	t.Cleanup(func() { f.CleanupDoc(t, docID) })
-	f.SeedLegacy(t, docID, bootstrapTestCfg{Foo: "legacy"})
+	forEachBootstrapXattrMode(t, func(t *testing.T, useXattrs bool) {
+		f := newBootstrapDualTestFixture(t, useXattrs)
+		ctx := TestCtx(t)
+		docID := SyncDocPrefix + "metadata-insert-fallback-dup"
+		t.Cleanup(func() { f.CleanupDoc(t, docID) })
+		f.SeedLegacy(t, docID, bootstrapTestCfg{Foo: "legacy"})
 
-	_, err := f.Cluster.InsertMetadataDocument(ctx, f.BucketName, docID, bootstrapTestCfg{Foo: "primary"})
-	require.ErrorIs(t, err, ErrAlreadyExists)
-	require.False(t, f.PrimaryExists(t, docID), "InsertMetadataDocument must not have created a primary copy")
+		_, err := f.Cluster.InsertMetadataDocument(ctx, f.BucketName, docID, bootstrapTestCfg{Foo: "primary"})
+		require.ErrorIs(t, err, ErrAlreadyExists)
+		require.False(t, f.PrimaryExists(t, docID), "InsertMetadataDocument must not have created a primary copy")
+	})
 }
 
 // TestBootstrapTouchMetadataDocumentFallback verifies TouchMetadataDocument retries against the
 // fallback collection when the primary returns ErrNotFound, leaving the doc in place rather than
 // migrating it.
 func TestBootstrapTouchMetadataDocumentFallback(t *testing.T) {
-	f := newBootstrapDualTestFixture(t)
-	ctx := TestCtx(t)
-	docID := SyncDocPrefix + "metadata-touch-fallback"
-	t.Cleanup(func() { f.CleanupDoc(t, docID) })
-	f.SeedLegacy(t, docID, bootstrapTestCfg{Foo: "legacy"})
+	forEachBootstrapXattrMode(t, func(t *testing.T, useXattrs bool) {
+		f := newBootstrapDualTestFixture(t, useXattrs)
+		ctx := TestCtx(t)
+		docID := SyncDocPrefix + "metadata-touch-fallback"
+		t.Cleanup(func() { f.CleanupDoc(t, docID) })
+		f.SeedLegacy(t, docID, bootstrapTestCfg{Foo: "legacy"})
 
-	var initial bootstrapTestCfg
-	cas, err := f.Cluster.GetMetadataDocument(ctx, f.BucketName, docID, &initial)
-	require.NoError(t, err)
-	require.NotZero(t, cas)
+		var initial bootstrapTestCfg
+		cas, err := f.Cluster.GetMetadataDocument(ctx, f.BucketName, docID, &initial)
+		require.NoError(t, err)
+		require.NotZero(t, cas)
 
-	newCAS, err := f.Cluster.TouchMetadataDocument(ctx, f.BucketName, docID, "version", "v2", cas)
-	require.NoError(t, err)
-	require.NotEqual(t, cas, newCAS, "Touch must bump CAS")
-	require.False(t, f.PrimaryExists(t, docID))
-	require.True(t, f.FallbackExists(t, docID))
+		newCAS, err := f.Cluster.TouchMetadataDocument(ctx, f.BucketName, docID, "version", "v2", cas)
+		require.NoError(t, err)
+		require.NotEqual(t, cas, newCAS, "Touch must bump CAS")
+		require.False(t, f.PrimaryExists(t, docID))
+		require.True(t, f.FallbackExists(t, docID))
+	})
 }
 
 // TestBootstrapDeleteMetadataDocumentFallback verifies DeleteMetadataDocument retries against the
 // fallback collection when the primary returns ErrNotFound, removing the legacy doc.
 func TestBootstrapDeleteMetadataDocumentFallback(t *testing.T) {
-	f := newBootstrapDualTestFixture(t)
-	ctx := TestCtx(t)
-	docID := SyncDocPrefix + "metadata-delete-fallback"
-	t.Cleanup(func() { f.CleanupDoc(t, docID) })
-	f.SeedLegacy(t, docID, bootstrapTestCfg{Foo: "legacy"})
+	forEachBootstrapXattrMode(t, func(t *testing.T, useXattrs bool) {
+		f := newBootstrapDualTestFixture(t, useXattrs)
+		ctx := TestCtx(t)
+		docID := SyncDocPrefix + "metadata-delete-fallback"
+		t.Cleanup(func() { f.CleanupDoc(t, docID) })
+		f.SeedLegacy(t, docID, bootstrapTestCfg{Foo: "legacy"})
 
-	var initial bootstrapTestCfg
-	cas, err := f.Cluster.GetMetadataDocument(ctx, f.BucketName, docID, &initial)
-	require.NoError(t, err)
-	require.NotZero(t, cas)
+		var initial bootstrapTestCfg
+		cas, err := f.Cluster.GetMetadataDocument(ctx, f.BucketName, docID, &initial)
+		require.NoError(t, err)
+		require.NotZero(t, cas)
 
-	require.NoError(t, f.Cluster.DeleteMetadataDocument(ctx, f.BucketName, docID, cas))
-	require.False(t, f.FallbackExists(t, docID))
+		require.NoError(t, f.Cluster.DeleteMetadataDocument(ctx, f.BucketName, docID, cas))
+		require.False(t, f.FallbackExists(t, docID))
 
-	var afterDelete bootstrapTestCfg
-	_, err = f.Cluster.GetMetadataDocument(ctx, f.BucketName, docID, &afterDelete)
-	require.True(t, IsDocNotFoundError(err), "expected not-found after delete, got %T: %v", err, err)
+		var afterDelete bootstrapTestCfg
+		_, err = f.Cluster.GetMetadataDocument(ctx, f.BucketName, docID, &afterDelete)
+		require.True(t, IsDocNotFoundError(err), "expected not-found after delete, got %T: %v", err, err)
+	})
 }

--- a/base/metadata_migration_status.go
+++ b/base/metadata_migration_status.go
@@ -24,7 +24,14 @@ const MetadataMigrationStatusDocID = "_sync:metadata_migration_status"
 type MigrationState string
 
 const (
-	MigrationStateNotStarted MigrationState = "not_started"
+	// MigrationStatePending means migration has not yet been observed complete on this bucket.
+	// It does NOT imply "no one has tried" — multiple attempts may have run and failed/crashed;
+	// Bootstrap.Attempts and Bootstrap.LastAttemptedAt expose that history. The state machine
+	// for the bucket-level bootstrap block is two-valued: pending → complete.
+	MigrationStatePending MigrationState = "pending"
+	// MigrationStateInProgress is only used by per-DB entries, where a BackgroundManager
+	// heartbeat doc serialises execution to one node at a time, so in_progress meaningfully
+	// indicates a lease-holder. The bucket-level bootstrap block never uses this value.
 	MigrationStateInProgress MigrationState = "in_progress"
 	MigrationStateComplete   MigrationState = "complete"
 )
@@ -48,10 +55,16 @@ type DatabaseMigrationStatus struct {
 	CompletedAt *time.Time     `json:"completed_at,omitempty"`
 }
 
-// BootstrapMigrationStatus is the bucket-global state for bootstrap docs.
+// BootstrapMigrationStatus is the bucket-global state for bootstrap docs. State is two-valued
+// (pending / complete); Attempts and LastAttemptedAt are observability fields, not part of the
+// state machine — they're written by every node that runs the migration loop, regardless of
+// outcome, so operators can tell the difference between "no one has tried yet" and "we've been
+// retrying for an hour."
 type BootstrapMigrationStatus struct {
-	State       MigrationState `json:"state"`
-	CompletedAt *time.Time     `json:"completed_at,omitempty"`
+	State           MigrationState `json:"state"`
+	CompletedAt     *time.Time     `json:"completed_at,omitempty"`
+	LastAttemptedAt *time.Time     `json:"last_attempted_at,omitempty"`
+	Attempts        int            `json:"attempts,omitempty"`
 }
 
 // NewMetadataMigrationStatus returns a freshly-stamped status doc with an empty databases map and
@@ -61,7 +74,7 @@ func NewMetadataMigrationStatus() *MetadataMigrationStatus {
 	return &MetadataMigrationStatus{
 		BucketMigrationID: uuid.NewString(),
 		Databases:         map[string]*DatabaseMigrationStatus{},
-		Bootstrap:         BootstrapMigrationStatus{State: MigrationStateNotStarted},
+		Bootstrap:         BootstrapMigrationStatus{State: MigrationStatePending},
 	}
 }
 

--- a/base/metadata_migration_status.go
+++ b/base/metadata_migration_status.go
@@ -1,0 +1,82 @@
+// Copyright 2026-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package base
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// MetadataMigrationStatusDocID is the document key for the bucket-level metadata-migration status
+// doc. The doc is stored directly in _system._mobile from creation and is never routed through the
+// dual-collection bootstrap wrapper — its location is what tells callers whether migration is
+// running or done in the first place.
+const MetadataMigrationStatusDocID = "_sync:metadata_migration_status"
+
+// MigrationState is the per-database (or bootstrap-scope) state in the metadata-migration lifecycle.
+type MigrationState string
+
+const (
+	MigrationStateNotStarted MigrationState = "not_started"
+	MigrationStateInProgress MigrationState = "in_progress"
+	MigrationStateComplete   MigrationState = "complete"
+)
+
+// MetadataMigrationStatus tracks the per-bucket metadata-migration lifecycle. One doc per bucket,
+// keyed by MetadataMigrationStatusDocID, born in _system._mobile.
+//
+// Databases is keyed by RegistryDatabase.MetadataID so renames don't break tracking. Bootstrap is
+// the bucket-global state covering _sync:registry / _sync:dbconfig:* / cbgt cfg docs; it only
+// transitions to complete once every entry in Databases is complete.
+type MetadataMigrationStatus struct {
+	BucketMigrationID string                              `json:"bucket_migration_id"`
+	Databases         map[string]*DatabaseMigrationStatus `json:"databases"`
+	Bootstrap         BootstrapMigrationStatus            `json:"bootstrap"`
+}
+
+// DatabaseMigrationStatus is the per-database entry in the status doc.
+type DatabaseMigrationStatus struct {
+	State       MigrationState `json:"state"`
+	StartedAt   *time.Time     `json:"started_at,omitempty"`
+	CompletedAt *time.Time     `json:"completed_at,omitempty"`
+}
+
+// BootstrapMigrationStatus is the bucket-global state for bootstrap docs.
+type BootstrapMigrationStatus struct {
+	State       MigrationState `json:"state"`
+	CompletedAt *time.Time     `json:"completed_at,omitempty"`
+}
+
+// NewMetadataMigrationStatus returns a freshly-stamped status doc with an empty databases map and
+// bootstrap.state = not_started. The caller is expected to InsertMetadataMigrationStatus this into
+// the bucket; concurrent stamp attempts from other SG nodes will receive ErrAlreadyExists.
+func NewMetadataMigrationStatus() *MetadataMigrationStatus {
+	return &MetadataMigrationStatus{
+		BucketMigrationID: uuid.NewString(),
+		Databases:         map[string]*DatabaseMigrationStatus{},
+		Bootstrap:         BootstrapMigrationStatus{State: MigrationStateNotStarted},
+	}
+}
+
+// AllDatabasesComplete reports whether every metadataID in expected has a Databases entry in
+// state complete. An entry that is missing, in_progress, or not_started counts as not complete.
+// Callers must pass the live registry-derived set so a DB added mid-migration isn't missed.
+func (s *MetadataMigrationStatus) AllDatabasesComplete(expected []string) bool {
+	if len(expected) == 0 {
+		return false
+	}
+	for _, id := range expected {
+		entry, ok := s.Databases[id]
+		if !ok || entry == nil || entry.State != MigrationStateComplete {
+			return false
+		}
+	}
+	return true
+}

--- a/base/rosmar_cluster.go
+++ b/base/rosmar_cluster.go
@@ -16,6 +16,8 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"sync"
+	"sync/atomic"
 
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbaselabs/rosmar"
@@ -25,14 +27,23 @@ var _ BootstrapConnection = &RosmarCluster{}
 
 // RosmarCluster implements BootstrapConnection and is used for connecting to a rosmar cluster
 type RosmarCluster struct {
-	serverURL       string
-	bucketDirectory string
+	serverURL                   string
+	bucketDirectory             string
+	useSystemMetadataCollection bool        // When true, bootstrap metadata is stored in _system._mobile, with read-fallback to _default._default during migration
+	migrationComplete           atomic.Bool // When set, fallback reads are skipped even if useSystemMetadataCollection is true
+	// bucketBootstrapTargets caches the resolved bootstrap-doc target for each bucket.
+	// Mirrors CouchbaseCluster.bucketBootstrapTargets — see that comment for the decision tree.
+	bucketBootstrapTargets sync.Map
 }
 
-// NewRosmarCluster creates a from a given URL
-func NewRosmarCluster(serverURL string) (*RosmarCluster, error) {
+// NewRosmarCluster creates a from a given URL. useSystemMetadataCollection mirrors
+// NewCouchbaseCluster: when true, bootstrap metadata is read/written against _system._mobile with
+// transparent read-fallback to _default._default; when false, _default._default is used
+// unconditionally.
+func NewRosmarCluster(serverURL string, useSystemMetadataCollection bool) (*RosmarCluster, error) {
 	cluster := &RosmarCluster{
-		serverURL: serverURL,
+		serverURL:                   serverURL,
+		useSystemMetadataCollection: useSystemMetadataCollection,
 	}
 	if serverURL != rosmar.InMemoryURL {
 		u, err := url.Parse(serverURL)
@@ -101,75 +112,318 @@ func (c *RosmarCluster) getDefaultDataStore(ctx context.Context, bucketName stri
 	return rosmarCollection, closeFn, nil
 }
 
-// GetMetadataDocument returns a metadata document from the default collection for the specified bucket.
+// metadataDataStores opens the bucket and returns the primary metadata DataStore plus an optional
+// fallback. The per-bucket target cache (populated by SetBucketBootstrapTargetHint or the lazy
+// probe in this function) determines the choice; absent a cached entry the connection-wide flag
+// drives the decision.
+//
+// Fallback semantics are symmetric so reads can self-heal across a stale cache:
+//   - target=systemMobile: primary=_system._mobile, fallback=_default._default (legacy docs not
+//     yet migrated by the bucket-level migration step). Skipped when SetMigrationComplete has
+//     been called.
+//   - target=default (or no opt-in indication yet): primary=_default._default,
+//     fallback=_system._mobile. A successful fallback hit here indicates a peer has migrated
+//     this bucket's bootstrap docs — the caller is expected to invoke noteBucketFallbackHit so
+//     the cache is corrected before the next op.
+//
+// Both are returned as *rosmar.Collection so callers can use rosmar-specific subdoc primitives
+// (e.g. TouchXattrWithCas).
+func (c *RosmarCluster) metadataDataStores(ctx context.Context, bucketName string) (primary, fallback *rosmar.Collection, closer func(ctx context.Context), err error) {
+	bucket, err := rosmar.OpenBucketIn(c.serverURL, bucketName, rosmar.CreateOrOpen)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	closer = func(ctx context.Context) { bucket.Close(ctx) }
+
+	defaultDS, err := bucket.NamedDataStore(ctx, DefaultScopeAndCollectionName())
+	if err != nil {
+		AssertfCtx(ctx, "Unexpected error getting default collection for bucket %q: %v", bucketName, err)
+		closer(ctx)
+		return nil, nil, nil, err
+	}
+	defaultCol, ok := defaultDS.(*rosmar.Collection)
+	if !ok {
+		AssertfCtx(ctx, "Unexpected type for default collection for bucket %q: %T", bucketName, defaultDS)
+		closer(ctx)
+		return nil, nil, nil, fmt.Errorf("unexpected type for default collection for bucket %q: %T", bucketName, defaultDS)
+	}
+	systemDS, err := bucket.NamedDataStore(ctx, MobileSystemScopeAndCollectionName())
+	if err != nil {
+		closer(ctx)
+		return nil, nil, nil, fmt.Errorf("unable to access %s.%s on bucket %q: %w", SystemScope, SystemCollectionMobile, bucketName, err)
+	}
+	systemCol, ok := systemDS.(*rosmar.Collection)
+	if !ok {
+		AssertfCtx(ctx, "Unexpected type for system collection for bucket %q: %T", bucketName, systemDS)
+		closer(ctx)
+		return nil, nil, nil, fmt.Errorf("unexpected type for system collection for bucket %q: %T", bucketName, systemDS)
+	}
+
+	cached, hasCachedTarget := c.bucketBootstrapTargets.Load(bucketName)
+	useSystemMobile := c.useSystemMetadataCollection
+	if hasCachedTarget {
+		useSystemMobile = cached.(bucketBootstrapTarget) == bucketTargetSystemMobile
+	}
+	if !useSystemMobile {
+		// Reads/writes route to default first. When this bucket has any opt-in indication —
+		// either cached as bucketTargetDefault (set by SetBucketBootstrapTargetHint after probing
+		// a legacy registry) or the connection-wide flag — systemMobile is wired as a self-heal
+		// fallback so a peer-migrated bucket doesn't return not-found from a stale-cached
+		// perspective. A bucket with no cache entry and no connection-wide opt-in skips the
+		// fallback entirely so non-opt-in clusters don't pay an extra _system._mobile probe per op.
+		if hasCachedTarget || c.useSystemMetadataCollection {
+			return defaultCol, systemCol, closer, nil
+		}
+		return defaultCol, nil, closer, nil
+	}
+	// Lazy-cache the target only when a registry is found in one of the collections — that's
+	// the only case where we have authoritative information. With no registry yet the choice
+	// stays uncached so a subsequent SetBucketBootstrapTargetHint(optIn=true) can still claim
+	// _system._mobile.
+	if _, alreadyCached := c.bucketBootstrapTargets.Load(bucketName); !alreadyCached {
+		if target, found := c.probeRegistryLocation(ctx, systemCol, defaultCol); found {
+			c.bucketBootstrapTargets.LoadOrStore(bucketName, target)
+		}
+	}
+	if c.migrationComplete.Load() {
+		return systemCol, nil, closer, nil
+	}
+	return systemCol, defaultCol, closer, nil
+}
+
+// noteBucketFallbackHit updates the per-bucket cache to _system._mobile after a successful read
+// or existence check against the fallback collection, when that hit indicates the cache was stale
+// (the cached target was _default._default — i.e. this node had not yet observed that a peer ran
+// the bucket-level migration). A no-op when the cache already says _system._mobile, since the
+// systemMobile→default fallback direction is the legitimate in-progress-migration legacy path.
+func (c *RosmarCluster) noteBucketFallbackHit(bucketName string) {
+	if cached, ok := c.bucketBootstrapTargets.Load(bucketName); ok && cached.(bucketBootstrapTarget) == bucketTargetSystemMobile {
+		return
+	}
+	c.bucketBootstrapTargets.Store(bucketName, bucketTargetSystemMobile)
+}
+
+// SetBucketBootstrapTargetHint resolves and caches the bootstrap-doc target for a rosmar bucket.
+// Mirrors CouchbaseCluster.SetBucketBootstrapTargetHint.
+func (c *RosmarCluster) SetBucketBootstrapTargetHint(ctx context.Context, bucketName string, optInHint bool) error {
+	if c == nil {
+		return errors.New("nil RosmarCluster")
+	}
+	if _, cached := c.bucketBootstrapTargets.Load(bucketName); cached {
+		return nil
+	}
+	bucket, err := rosmar.OpenBucketIn(c.serverURL, bucketName, rosmar.CreateOrOpen)
+	if err != nil {
+		return err
+	}
+	defer bucket.Close(ctx)
+
+	defaultDS, err := bucket.NamedDataStore(ctx, DefaultScopeAndCollectionName())
+	if err != nil {
+		return err
+	}
+	defaultCol, ok := defaultDS.(*rosmar.Collection)
+	if !ok {
+		return fmt.Errorf("unexpected type for default collection on bucket %q: %T", bucketName, defaultDS)
+	}
+	systemDS, err := bucket.NamedDataStore(ctx, MobileSystemScopeAndCollectionName())
+	if err != nil {
+		return err
+	}
+	systemCol, ok := systemDS.(*rosmar.Collection)
+	if !ok {
+		return fmt.Errorf("unexpected type for system collection on bucket %q: %T", bucketName, systemDS)
+	}
+	target, found := c.probeRegistryLocation(ctx, systemCol, defaultCol)
+	if !found {
+		if optInHint || c.useSystemMetadataCollection {
+			target = bucketTargetSystemMobile
+		} else {
+			target = bucketTargetDefault
+		}
+	}
+	c.bucketBootstrapTargets.LoadOrStore(bucketName, target)
+	return nil
+}
+
+// probeRegistryLocation reports where _sync:registry already lives, or that it doesn't exist yet.
+// Mirrors CouchbaseCluster.probeRegistryLocation.
+func (c *RosmarCluster) probeRegistryLocation(ctx context.Context, systemCol, defaultCol *rosmar.Collection) (target bucketBootstrapTarget, found bool) {
+	if exists, err := systemCol.Exists(ctx, SGRegistryKey); err == nil && exists {
+		return bucketTargetSystemMobile, true
+	}
+	if exists, err := defaultCol.Exists(ctx, SGRegistryKey); err == nil && exists {
+		return bucketTargetDefault, true
+	}
+	return 0, false
+}
+
+// shouldFallback returns true when a primary error indicates not-found and a fallback collection
+// is configured (i.e. useSystemMetadataCollection is enabled and migration is not yet complete).
+func (c *RosmarCluster) shouldFallback(err error, fallback *rosmar.Collection) bool {
+	return fallback != nil && IsDocNotFoundError(err)
+}
+
+// SetMigrationComplete marks bootstrap-metadata migration as finished; subsequent reads stop
+// falling back to _default._default. Safe to call concurrently with in-flight operations.
+func (c *RosmarCluster) SetMigrationComplete() {
+	c.migrationComplete.Store(true)
+}
+
+// RefreshBucketBootstrapTarget reads the bucket's metadata-migration status doc; if bootstrap.state
+// is complete it updates the per-bucket cache to _system._mobile via noteBucketFallbackHit. ErrNotFound
+// (no migration ever started here) and any other transient error are returned to the caller for
+// telemetry but never escalate — this is best-effort cache convergence, not a correctness path.
+func (c *RosmarCluster) RefreshBucketBootstrapTarget(ctx context.Context, bucket string) error {
+	status, _, err := c.GetMetadataMigrationStatus(ctx, bucket)
+	if err != nil {
+		return err
+	}
+	if status.Bootstrap.State == MigrationStateComplete {
+		c.noteBucketFallbackHit(bucket)
+	}
+	return nil
+}
+
+// loadConfigWithFallback resolves which of primary/fallback currently holds docID and returns its
+// value+CAS along with the resolved datastore. Callers should pass the returned datastore back in
+// subsequent writes so the CAS stays valid. Re-call on CAS mismatch to handle the doc being
+// migrated between collections mid-operation. On a successful fallback hit the bucket's cached
+// bootstrap target is updated (via noteBucketFallbackHit) so subsequent ops route correctly.
+func (c *RosmarCluster) loadConfigWithFallback(ctx context.Context, bucketName string, primary, fallback *rosmar.Collection, docID string) (ds *rosmar.Collection, value []byte, cas uint64, err error) {
+	cas, err = primary.Get(ctx, docID, &value)
+	if c.shouldFallback(err, fallback) {
+		cas, err = fallback.Get(ctx, docID, &value)
+		if err == nil {
+			c.noteBucketFallbackHit(bucketName)
+			return fallback, value, cas, nil
+		}
+	}
+	return primary, value, cas, err
+}
+
+// GetMetadataDocument returns a metadata document. When useSystemMetadataCollection is enabled,
+// reads consult _system._mobile first and transparently fall back to _default._default for any
+// pre-migration metadata. Returns the underlying rosmar not-found error when the doc is absent
+// from both collections; callers should use IsDocNotFoundError to test for not-found.
 func (c *RosmarCluster) GetMetadataDocument(ctx context.Context, location, docID string, valuePtr any) (cas uint64, err error) {
-	ds, closer, err := c.getDefaultDataStore(ctx, location)
+	primary, fallback, closer, err := c.metadataDataStores(ctx, location)
 	if err != nil {
 		return 0, err
 	}
 	defer closer(ctx)
 
-	return ds.Get(ctx, docID, valuePtr)
+	cas, err = primary.Get(ctx, docID, valuePtr)
+	if c.shouldFallback(err, fallback) {
+		cas, err = fallback.Get(ctx, docID, valuePtr)
+		if err == nil {
+			c.noteBucketFallbackHit(location)
+		}
+	}
+	return cas, err
 }
 
-// InsertMetadataDocument inserts a metadata document, and fails if it already exists.
+// InsertMetadataDocument inserts a metadata document into the primary collection. When
+// useSystemMetadataCollection is enabled and the doc already lives in the fallback collection,
+// returns ErrAlreadyExists rather than creating a divergent primary copy.
 func (c *RosmarCluster) InsertMetadataDocument(ctx context.Context, location, key string, value any) (newCAS uint64, err error) {
-	ds, closer, err := c.getDefaultDataStore(ctx, location)
+	primary, fallback, closer, err := c.metadataDataStores(ctx, location)
 	if err != nil {
 		return 0, err
 	}
 	defer closer(ctx)
 
-	return ds.WriteCas(ctx, key, 0, 0, value, 0)
+	// Surface a fallback existence-check error rather than silently writing to primary — a
+	// swallowed error here could let a divergent legacy copy survive in fallback.
+	if fallback != nil {
+		exists, existsErr := fallback.Exists(ctx, key)
+		if existsErr != nil {
+			return 0, existsErr
+		}
+		if exists {
+			c.noteBucketFallbackHit(location)
+			return 0, ErrAlreadyExists
+		}
+	}
+	return primary.WriteCas(ctx, key, 0, 0, value, 0)
 }
 
-// WriteMetadataDocument writes a metadata document, and fails on CAS mismatch
+// WriteMetadataDocument writes a metadata document, and fails on CAS mismatch. When the supplied
+// CAS came from a fallback read (i.e. the document still lives in _default._default), the write is
+// replayed against the fallback collection so the CAS stays valid.
 func (c *RosmarCluster) WriteMetadataDocument(ctx context.Context, location, docID string, cas uint64, value any) (newCAS uint64, err error) {
-	ds, closer, err := c.getDefaultDataStore(ctx, location)
+	primary, fallback, closer, err := c.metadataDataStores(ctx, location)
 	if err != nil {
 		return 0, err
 	}
 	defer closer(ctx)
-	return ds.WriteCas(ctx, docID, 0, cas, value, 0)
+
+	newCAS, err = primary.WriteCas(ctx, docID, 0, cas, value, 0)
+	if c.shouldFallback(err, fallback) {
+		newCAS, err = fallback.WriteCas(ctx, docID, 0, cas, value, 0)
+		if err == nil {
+			c.noteBucketFallbackHit(location)
+		}
+	}
+	return newCAS, err
 }
 
-// TouchMetadataDocument sets the specified property in a bootstrap metadata document for a given bucket and key.  Used to
-// trigger CAS update on the document, to block any racing updates. Does not retry on CAS failure.
+// TouchMetadataDocument sets the specified property in the _sync xattr of a bootstrap metadata
+// document via subdoc operation with CAS check. Mirrors CouchbaseCluster's implementation. When
+// useSystemMetadataCollection is enabled and the primary returns ErrNotFound, the operation is
+// retried against the fallback collection so legacy metadata in _default._default can still be
+// touched without migration.
 func (c *RosmarCluster) TouchMetadataDocument(ctx context.Context, location, docID string, property, value string, cas uint64) (newCAS uint64, err error) {
-	ds, closer, err := c.getDefaultDataStore(ctx, location)
+	primary, fallback, closer, err := c.metadataDataStores(ctx, location)
 	if err != nil {
 		return 0, err
 	}
 	defer closer(ctx)
 
-	return ds.TouchXattrWithCas(ctx, docID, cfgXattrKey, property, value, cas)
+	newCAS, err = primary.TouchXattrWithCas(ctx, docID, cfgXattrKey, property, value, cas)
+	if c.shouldFallback(err, fallback) {
+		newCAS, err = fallback.TouchXattrWithCas(ctx, docID, cfgXattrKey, property, value, cas)
+		if err == nil {
+			c.noteBucketFallbackHit(location)
+		}
+	}
+	return newCAS, err
 }
 
-// DeleteMetadataDocument deletes an existing bootstrap metadata document for a given bucket and key.
+// DeleteMetadataDocument deletes an existing bootstrap metadata document.
 func (c *RosmarCluster) DeleteMetadataDocument(ctx context.Context, location, key string, cas uint64) error {
-	ds, closer, err := c.getDefaultDataStore(ctx, location)
+	primary, fallback, closer, err := c.metadataDataStores(ctx, location)
 	if err != nil {
 		return err
 	}
 	defer closer(ctx)
 
-	_, err = ds.Remove(ctx, key, cas)
-	return err
+	_, removeErr := primary.Remove(ctx, key, cas)
+	if c.shouldFallback(removeErr, fallback) {
+		_, removeErr = fallback.Remove(ctx, key, cas)
+		if removeErr == nil {
+			c.noteBucketFallbackHit(location)
+		}
+	}
+	return removeErr
 }
 
-// UpdateMetadataDocument updates a given document and retries on CAS mismatch.
+// UpdateMetadataDocument updates a given document and retries on CAS mismatch. The owning
+// datastore (primary or fallback) is re-resolved on every CAS retry so a doc that migrates between
+// collections concurrently with this Update is picked up on the next iteration rather than vanishing.
 func (c *RosmarCluster) UpdateMetadataDocument(ctx context.Context, location, docID string, updateCallback func(bucketConfig []byte, rawBucketConfigCas uint64) (newConfig []byte, err error)) (newCAS uint64, err error) {
-	ds, closer, err := c.getDefaultDataStore(ctx, location)
+	primary, fallback, closer, err := c.metadataDataStores(ctx, location)
 	if err != nil {
 		return 0, err
 	}
 	defer closer(ctx)
+
+	ds, bucketValue, cas, err := c.loadConfigWithFallback(ctx, location, primary, fallback, docID)
+	if err != nil {
+		return 0, err
+	}
+
 	for {
-		var bucketValue []byte
-		cas, err := ds.Get(ctx, docID, &bucketValue)
-		if err != nil {
-			return 0, err
-		}
 		newConfig, err := updateCallback(bucketValue, cas)
 		if err != nil {
 			return 0, err
@@ -178,8 +432,11 @@ func (c *RosmarCluster) UpdateMetadataDocument(ctx context.Context, location, do
 		if newConfig == nil {
 			removeCasOut, err := ds.Remove(ctx, docID, cas)
 			if err != nil {
-				// retry on cas failure
 				if errors.As(err, &sgbucket.CasMismatchErr{}) {
+					ds, bucketValue, cas, err = c.loadConfigWithFallback(ctx, location, primary, fallback, docID)
+					if err != nil {
+						return 0, err
+					}
 					continue
 				}
 				return 0, err
@@ -190,7 +447,10 @@ func (c *RosmarCluster) UpdateMetadataDocument(ctx context.Context, location, do
 		replaceCfgCasOut, err := ds.WriteCas(ctx, docID, 0, cas, newConfig, 0)
 		if err != nil {
 			if errors.As(err, &sgbucket.CasMismatchErr{}) {
-				// retry on cas failure
+				ds, bucketValue, cas, err = c.loadConfigWithFallback(ctx, location, primary, fallback, docID)
+				if err != nil {
+					return 0, err
+				}
 				continue
 			}
 			return 0, err
@@ -201,15 +461,24 @@ func (c *RosmarCluster) UpdateMetadataDocument(ctx context.Context, location, do
 
 }
 
-// KeyExists checks whether a key exists in the default collection for the specified bucket
+// KeyExists checks whether a key exists for the specified bucket. When useSystemMetadataCollection
+// is enabled, checks primary then fallback, mirroring CouchbaseCluster.KeyExists.
 func (c *RosmarCluster) KeyExists(ctx context.Context, location, docID string) (exists bool, err error) {
-	ds, closer, err := c.getDefaultDataStore(ctx, location)
+	primary, fallback, closer, err := c.metadataDataStores(ctx, location)
 	if err != nil {
 		return false, err
 	}
 	defer closer(ctx)
 
-	return ds.Exists(ctx, docID)
+	exists, err = primary.Exists(ctx, docID)
+	if err != nil || exists || fallback == nil {
+		return exists, err
+	}
+	exists, err = fallback.Exists(ctx, docID)
+	if err == nil && exists {
+		c.noteBucketFallbackHit(location)
+	}
+	return exists, err
 }
 
 // GetDocument fetches a document from the default collection.  Does not use configPersistence - callers
@@ -242,6 +511,165 @@ func (c *RosmarCluster) GetRawDocument(ctx context.Context, bucket, docID string
 		return nil, false, nil
 	}
 	return value, err == nil, err
+}
+
+// systemMobileDataStore opens the bucket and returns the _system._mobile DataStore plus a closer.
+// Used by the metadata-migration status doc path, which always targets _system._mobile directly
+// (independent of useSystemMetadataCollection / migrationComplete).
+func (c *RosmarCluster) systemMobileDataStore(ctx context.Context, bucketName string) (*rosmar.Collection, func(ctx context.Context), error) {
+	bucket, err := rosmar.OpenBucketIn(c.serverURL, bucketName, rosmar.CreateOrOpen)
+	if err != nil {
+		return nil, nil, err
+	}
+	closeFn := func(ctx context.Context) { bucket.Close(ctx) }
+	ds, err := bucket.NamedDataStore(ctx, MobileSystemScopeAndCollectionName())
+	if err != nil {
+		closeFn(ctx)
+		return nil, nil, fmt.Errorf("unable to access %s.%s on bucket %q: %w", SystemScope, SystemCollectionMobile, bucketName, err)
+	}
+	col, ok := ds.(*rosmar.Collection)
+	if !ok {
+		closeFn(ctx)
+		return nil, nil, fmt.Errorf("unexpected type for system collection for bucket %q: %T", bucketName, ds)
+	}
+	return col, closeFn, nil
+}
+
+// GetMetadataMigrationStatus reads the status doc directly from _system._mobile.
+func (c *RosmarCluster) GetMetadataMigrationStatus(ctx context.Context, bucket string) (*MetadataMigrationStatus, uint64, error) {
+	col, closer, err := c.systemMobileDataStore(ctx, bucket)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer closer(ctx)
+
+	status := &MetadataMigrationStatus{}
+	cas, err := col.Get(ctx, MetadataMigrationStatusDocID, status)
+	if err != nil {
+		if IsDocNotFoundError(err) {
+			return nil, 0, ErrNotFound
+		}
+		return nil, 0, err
+	}
+	return status, cas, nil
+}
+
+// InsertMetadataMigrationStatus stamps the initial status doc. Returns ErrAlreadyExists if another
+// node won the race.
+func (c *RosmarCluster) InsertMetadataMigrationStatus(ctx context.Context, bucket string, status *MetadataMigrationStatus) (uint64, error) {
+	if status == nil {
+		return 0, errors.New("nil MetadataMigrationStatus")
+	}
+	col, closer, err := c.systemMobileDataStore(ctx, bucket)
+	if err != nil {
+		return 0, err
+	}
+	defer closer(ctx)
+
+	cas, err := col.WriteCas(ctx, MetadataMigrationStatusDocID, 0, 0, status, 0)
+	if err != nil {
+		if errors.Is(err, sgbucket.ErrKeyExists) {
+			return 0, ErrAlreadyExists
+		}
+		return 0, err
+	}
+	return cas, nil
+}
+
+// UpdateMetadataMigrationStatus runs the callback inside a CAS-safe loop, seeding a fresh status
+// doc when none exists yet.
+func (c *RosmarCluster) UpdateMetadataMigrationStatus(ctx context.Context, bucket string, callback func(*MetadataMigrationStatus) error) (uint64, error) {
+	col, closer, err := c.systemMobileDataStore(ctx, bucket)
+	if err != nil {
+		return 0, err
+	}
+	defer closer(ctx)
+
+	for {
+		var (
+			status = &MetadataMigrationStatus{}
+		)
+		cas, getErr := col.Get(ctx, MetadataMigrationStatusDocID, status)
+		if getErr != nil {
+			if !IsDocNotFoundError(getErr) {
+				return 0, getErr
+			}
+			status = NewMetadataMigrationStatus()
+		}
+		if err := callback(status); err != nil {
+			return 0, err
+		}
+		newCAS, err := col.WriteCas(ctx, MetadataMigrationStatusDocID, 0, cas, status, 0)
+		if err != nil {
+			if errors.As(err, &sgbucket.CasMismatchErr{}) {
+				continue
+			}
+			if errors.Is(err, sgbucket.ErrKeyExists) {
+				// peer SG inserted between our miss and our write — retry against the real doc
+				continue
+			}
+			return 0, err
+		}
+		return newCAS, nil
+	}
+}
+
+// MigrateBootstrapDocs copies the supplied keys from _default._default into _system._mobile and
+// removes the fallback copies. Idempotent; CAS-mismatch on the fallback delete is logged and the
+// caller is expected to retry.
+func (c *RosmarCluster) MigrateBootstrapDocs(ctx context.Context, bucket string, docIDs []string) error {
+	bucketHandle, err := rosmar.OpenBucketIn(c.serverURL, bucket, rosmar.CreateOrOpen)
+	if err != nil {
+		return err
+	}
+	defer bucketHandle.Close(ctx)
+
+	defaultDS, err := bucketHandle.NamedDataStore(ctx, DefaultScopeAndCollectionName())
+	if err != nil {
+		return err
+	}
+	defaultCol, ok := defaultDS.(*rosmar.Collection)
+	if !ok {
+		return fmt.Errorf("unexpected type for default collection on bucket %q: %T", bucket, defaultDS)
+	}
+	systemDS, err := bucketHandle.NamedDataStore(ctx, MobileSystemScopeAndCollectionName())
+	if err != nil {
+		return err
+	}
+	systemCol, ok := systemDS.(*rosmar.Collection)
+	if !ok {
+		return fmt.Errorf("unexpected type for system collection on bucket %q: %T", bucket, systemDS)
+	}
+
+	for _, docID := range docIDs {
+		var body []byte
+		fallbackCas, err := defaultCol.Get(ctx, docID, &body)
+		if err != nil {
+			if IsDocNotFoundError(err) {
+				continue
+			}
+			return fmt.Errorf("read fallback %q during bootstrap migration: %w", docID, err)
+		}
+		_, insertErr := systemCol.WriteCas(ctx, docID, 0, 0, body, 0)
+		if insertErr != nil && !errors.Is(insertErr, sgbucket.ErrKeyExists) {
+			return fmt.Errorf("insert primary %q during bootstrap migration: %w", docID, insertErr)
+		}
+		if _, err := defaultCol.Remove(ctx, docID, fallbackCas); err != nil {
+			if errors.As(err, &sgbucket.CasMismatchErr{}) {
+				InfofCtx(ctx, KeyConfig, "Bootstrap migration: skipping fallback delete for %q on bucket %q (CAS mismatch — concurrent write), caller should re-run", MD(docID), MD(bucket))
+				continue
+			}
+			if IsDocNotFoundError(err) {
+				continue
+			}
+			return fmt.Errorf("delete fallback %q during bootstrap migration: %w", docID, err)
+		}
+	}
+	// The bootstrap docs now live in _system._mobile on this bucket; any prior cache entry that
+	// pointed at _default._default is stale and would route subsequent reads/writes to a deleted
+	// location. Store (not LoadOrStore) so a pre-migration bucketTargetDefault is overwritten.
+	c.bucketBootstrapTargets.Store(bucket, bucketTargetSystemMobile)
+	return nil
 }
 
 // Close calls teardown for any cached buckets and removes from cachedBucketConnections

--- a/db/background_mgr_metadata_migration.go
+++ b/db/background_mgr_metadata_migration.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/google/uuid"
@@ -94,7 +95,56 @@ func (m *MetadataMigrationManager) Run(ctx context.Context, options map[string]a
 	}
 	defer persistClusterStatus()
 
-	base.InfofCtx(ctx, base.KeyAll, "[%s] Metadata Migration TODO: CBG-5228", metadataMigrationLoggingID)
+	metadataID := m.dbContext.Options.MetadataID
+	if metadataID == "" {
+		base.WarnfCtx(ctx, "[%s] No MetadataID set on DatabaseContext, cannot record per-DB status", metadataMigrationLoggingID)
+		return nil
+	}
+
+	if m.dbContext.MetadataMigrationStatusUpdater == nil {
+		base.WarnfCtx(ctx, "[%s] MetadataMigrationStatusUpdater not wired on DatabaseContext, skipping status tracking", metadataMigrationLoggingID)
+		return nil
+	}
+
+	now := time.Now().UTC()
+	if err := m.dbContext.MetadataMigrationStatusUpdater(ctx, func(s *base.MetadataMigrationStatus) error {
+		entry, ok := s.Databases[metadataID]
+		if !ok || entry == nil {
+			entry = &base.DatabaseMigrationStatus{}
+			s.Databases[metadataID] = entry
+		}
+		entry.State = base.MigrationStateInProgress
+		entry.StartedAt = &now
+		entry.CompletedAt = nil
+		return nil
+	}); err != nil {
+		return base.RedactErrorf("[%s] Failed to mark per-DB migration in_progress: %v", metadataMigrationLoggingID, err)
+	}
+
+	// CBG-5228 will implement the actual copy + verify here. For now the manager treats the
+	// in_progress → complete transition as a no-op so the bucket-level all-complete trigger can
+	// be exercised end-to-end without waiting on the data movement implementation.
+	base.InfofCtx(ctx, base.KeyAll, "[%s] Per-DB copy step is stubbed (CBG-5228) — recording complete", metadataMigrationLoggingID)
+
+	completedAt := time.Now().UTC()
+	if err := m.dbContext.MetadataMigrationStatusUpdater(ctx, func(s *base.MetadataMigrationStatus) error {
+		entry, ok := s.Databases[metadataID]
+		if !ok || entry == nil {
+			entry = &base.DatabaseMigrationStatus{StartedAt: &now}
+			s.Databases[metadataID] = entry
+		}
+		entry.State = base.MigrationStateComplete
+		entry.CompletedAt = &completedAt
+		return nil
+	}); err != nil {
+		return base.RedactErrorf("[%s] Failed to mark per-DB migration complete: %v", metadataMigrationLoggingID, err)
+	}
+
+	if m.dbContext.PostMetadataMigrationCompleteFunc != nil {
+		if err := m.dbContext.PostMetadataMigrationCompleteFunc(ctx); err != nil {
+			base.WarnfCtx(ctx, "[%s] Post-completion hook returned an error: %v", metadataMigrationLoggingID, err)
+		}
+	}
 	return nil
 }
 

--- a/db/database.go
+++ b/db/database.go
@@ -152,26 +152,34 @@ type DatabaseContext struct {
 	NoX509HTTPClient             *http.Client                                      // A HTTP Client from gocb to use the management endpoints
 	ServerContextHasStarted      chan struct{}                                     // Closed via PostStartup once the server has fully started
 	ConfigFullyAppliedFunc       func(ctx context.Context) (bool, []string, error) // Returns (applied, missingNodeUIDs, err) for the current db config version
-	ClusterCompatVersionFunc     func() *base.ClusterCompatVersion                 // Resolves the current cluster-wide minimum SG version, or nil if not yet known. Re-resolved at call time since CCV changes during rolling upgrades.
-	UserFunctionTimeout          time.Duration                                     // Default timeout for N1QL & JavaScript queries. (Applies to REST and BLIP requests.)
-	Scopes                       map[string]Scope                                  // A map keyed by scope name containing a set of scopes/collections. Nil if running with only _default._default
-	CollectionByID               map[uint32]*DatabaseCollection                    // A map keyed by collection ID to Collection
-	CollectionNames              map[string]map[string]struct{}                    // Map of scope, collection names
-	MetadataKeys                 *base.MetadataKeys                                // Factory to generate metadata document keys
-	RequireResync                base.ScopeAndCollectionNames                      // Collections requiring resync before database can go online
-	RequireAttachmentMigration   base.ScopeAndCollectionNames                      // Collections that require the attachment migration background task to run against
-	CORS                         *auth.CORSConfig                                  // CORS configuration
-	EnableMou                    bool                                              // Write _mou xattr when performing metadata-only update.  Set based on bucket capability on connect
-	WasInitializedSynchronously  bool                                              // true if the database was initialized synchronously
-	BroadcastSlowMode            atomic.Bool                                       // bool to indicate if a slower ticker value should be used to notify changes feeds of changes
-	DatabaseStartupError         *DatabaseError                                    // Error that occurred during database online processes startup
-	CachedPurgeInterval          atomic.Pointer[time.Duration]                     // If set, the cached value of the purge interval to avoid repeated lookups
-	CachedVersionPruningWindow   atomic.Pointer[time.Duration]                     // If set, the cached value of the version pruning window to avoid repeated lookups
-	CachedCCVStartingCas         *base.VBucketCAS                                  // If set, the cached value of the CCV starting CAS value to avoid repeated lookups
-	CachedCCVEnabled             atomic.Bool                                       // If set, the cached value of the CCV Enabled flag (this is not expected to transition from true->false, but could go false->true)
-	numVBuckets                  uint16                                            // Number of vbuckets in the bucket
-	SameSiteCookieMode           http.SameSite
-	DBStateManager               *DatabaseStateMgr // Manager used to manage the state of processes across nodes
+	// MetadataMigrationStatusUpdater runs a CAS-safe read-modify-write against the bucket-level
+	// _sync:metadata_migration_status doc in _system._mobile. Set by ServerContext when the
+	// db is created under use_system_metadata_collection.
+	MetadataMigrationStatusUpdater func(ctx context.Context, mutator func(*base.MetadataMigrationStatus) error) error
+	// PostMetadataMigrationCompleteFunc fires after this database's per-DB migration reports
+	// complete in the status doc. Triggers the bucket-level all-complete check + bootstrap copy
+	// + SetMigrationComplete on the cluster.
+	PostMetadataMigrationCompleteFunc func(ctx context.Context) error
+	ClusterCompatVersionFunc          func() *base.ClusterCompatVersion // Resolves the current cluster-wide minimum SG version, or nil if not yet known. Re-resolved at call time since CCV changes during rolling upgrades.
+	UserFunctionTimeout               time.Duration                     // Default timeout for N1QL & JavaScript queries. (Applies to REST and BLIP requests.)
+	Scopes                            map[string]Scope                  // A map keyed by scope name containing a set of scopes/collections. Nil if running with only _default._default
+	CollectionByID                    map[uint32]*DatabaseCollection    // A map keyed by collection ID to Collection
+	CollectionNames                   map[string]map[string]struct{}    // Map of scope, collection names
+	MetadataKeys                      *base.MetadataKeys                // Factory to generate metadata document keys
+	RequireResync                     base.ScopeAndCollectionNames      // Collections requiring resync before database can go online
+	RequireAttachmentMigration        base.ScopeAndCollectionNames      // Collections that require the attachment migration background task to run against
+	CORS                              *auth.CORSConfig                  // CORS configuration
+	EnableMou                         bool                              // Write _mou xattr when performing metadata-only update.  Set based on bucket capability on connect
+	WasInitializedSynchronously       bool                              // true if the database was initialized synchronously
+	BroadcastSlowMode                 atomic.Bool                       // bool to indicate if a slower ticker value should be used to notify changes feeds of changes
+	DatabaseStartupError              *DatabaseError                    // Error that occurred during database online processes startup
+	CachedPurgeInterval               atomic.Pointer[time.Duration]     // If set, the cached value of the purge interval to avoid repeated lookups
+	CachedVersionPruningWindow        atomic.Pointer[time.Duration]     // If set, the cached value of the version pruning window to avoid repeated lookups
+	CachedCCVStartingCas              *base.VBucketCAS                  // If set, the cached value of the CCV starting CAS value to avoid repeated lookups
+	CachedCCVEnabled                  atomic.Bool                       // If set, the cached value of the CCV Enabled flag (this is not expected to transition from true->false, but could go false->true)
+	numVBuckets                       uint16                            // Number of vbuckets in the bucket
+	SameSiteCookieMode                http.SameSite
+	DBStateManager                    *DatabaseStateMgr // Manager used to manage the state of processes across nodes
 
 	scopeName string // name of the single scope for the database
 }
@@ -626,10 +634,15 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 
 // shouldRunMetadataMigration checks whether we should start metadata migration on db startup. Will not start the
 // migration unless all of the following is true:
-// - The option to use a system metadata collection is enabled on db context
-// - The cluster compatibility version is at least 4.1
+//   - The option to use a system metadata collection is enabled on db context
+//   - The cluster compatibility version is at least 4.1
+//   - The per-DB MetadataStore wrapper hasn't already been flagged migration-complete (new-DB fast
+//     path applied at construction time when _default._default has no legacy metadata for this DB)
 func (context *DatabaseContext) shouldRunMetadataMigration() bool {
 	if !context.Options.UseSystemMetadataCollection {
+		return false
+	}
+	if ms, ok := context.MetadataStore.(*base.MetadataStore); ok && ms.MigrationComplete() {
 		return false
 	}
 	return context.ClusterCompatVersion().AtLeast(4, 1)
@@ -649,7 +662,9 @@ func (context *DatabaseContext) ClusterCompatVersion() *base.ClusterCompatVersio
 // armMetadataMigrationTask polls until all nodes have applied the db config that enables the
 // system metadata collection, then starts the metadata migration background task. This
 // prevents migration from running while some nodes are still writing metadata to the old location.
-// The first attempt happens immediately so an already-converged cluster starts without delay.
+// The first attempt is the caller's responsibility (done synchronously during StartOnlineProcesses
+// so the goroutine is only spawned when polling is actually needed) — this loop handles the
+// retry cadence for subsequent attempts.
 func (dbCtx *DatabaseContext) armMetadataMigrationTask(ctx context.Context) {
 	if dbCtx.ConfigFullyAppliedFunc == nil {
 		base.WarnfCtx(ctx, "No ConfigFullyAppliedFunc set, cannot arm metadata migration for database %s", base.MD(dbCtx.Name))
@@ -660,9 +675,6 @@ func (dbCtx *DatabaseContext) armMetadataMigrationTask(ctx context.Context) {
 	defer ticker.Stop()
 
 	for {
-		if dbCtx.tryStartMetadataMigration(ctx) {
-			return
-		}
 		select {
 		case <-ctx.Done():
 			base.DebugfCtx(ctx, base.KeyAll, "Context cancelled, stopping metadata migration arm for database %s", base.MD(dbCtx.Name))
@@ -671,6 +683,9 @@ func (dbCtx *DatabaseContext) armMetadataMigrationTask(ctx context.Context) {
 			base.DebugfCtx(ctx, base.KeyAll, "Database closing, stopping metadata migration arm for database %s", base.MD(dbCtx.Name))
 			return
 		case <-ticker.C:
+		}
+		if dbCtx.tryStartMetadataMigration(ctx) {
+			return
 		}
 	}
 }
@@ -2501,7 +2516,13 @@ func (db *DatabaseContext) StartOnlineProcesses(ctx context.Context) (returnedEr
 
 	db.MetadataMigrationManager = NewMetadataMigrationManager(db)
 	if db.shouldRunMetadataMigration() {
-		go db.armMetadataMigrationTask(ctx)
+		// Run the first attempt synchronously: an already-converged cluster starts migration
+		// without spawning a polling goroutine, and tests that observe state immediately after
+		// StartOnlineProcesses returns see a deterministic outcome (either the migration started,
+		// or the polling goroutine is sleeping a full ticker before the next attempt).
+		if db.ConfigFullyAppliedFunc != nil && !db.tryStartMetadataMigration(ctx) {
+			go db.armMetadataMigrationTask(ctx)
+		}
 	}
 
 	if err := base.RequireNoBucketTTL(ctx, db.Bucket); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/couchbasedeps/fast-skiplist v0.0.0-20250722125747-e0dd031fe2ac
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338
 	github.com/couchbaselabs/gocbconnstr v1.0.5
-	github.com/couchbaselabs/rosmar v0.0.0-20260527130952-42bfa64e0a8e
+	github.com/couchbaselabs/rosmar v0.0.0-20260528075904-428892269c04
 	github.com/elastic/gosigar v0.14.4
 	github.com/felixge/fgprof v0.9.5
 	github.com/go-jose/go-jose/v4 v4.1.4

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/couchbaselabs/gocbconnstr v1.0.5 h1:e0JokB5qbcz7rfnxEhNRTKz8q1svoRvDo
 github.com/couchbaselabs/gocbconnstr v1.0.5/go.mod h1:KV3fnIKMi8/AzX0O9zOrO9rofEqrRF1d2rG7qqjxC7o=
 github.com/couchbaselabs/gocbconnstr/v2 v2.0.0 h1:HU9DlAYYWR69jQnLN6cpg0fh0hxW/8d5hnglCXXjW78=
 github.com/couchbaselabs/gocbconnstr/v2 v2.0.0/go.mod h1:o7T431UOfFVHDNvMBUmUxpHnhivwv7BziUao/nMl81E=
-github.com/couchbaselabs/rosmar v0.0.0-20260527130952-42bfa64e0a8e h1:PWozSE26yBKdH+vzKL8Hit9jAOQooflemQr/5G/t8tQ=
-github.com/couchbaselabs/rosmar v0.0.0-20260527130952-42bfa64e0a8e/go.mod h1:ozhv5+nbL11OjaaoGwzNasfcmrG1AFr2DLPpvgNhH3U=
+github.com/couchbaselabs/rosmar v0.0.0-20260528075904-428892269c04 h1:H3UgciGqjYz4bpK5RdvdG1Pf0W8MQD34DZ4//uh5O0A=
+github.com/couchbaselabs/rosmar v0.0.0-20260528075904-428892269c04/go.mod h1:ozhv5+nbL11OjaaoGwzNasfcmrG1AFr2DLPpvgNhH3U=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -81,6 +81,15 @@ func (h *handler) handleCreateDB() error {
 			config.Bucket = &bucket
 		}
 
+		// Resolve the bucket's bootstrap-doc target before any read/write so a new DB with
+		// per-DB use_system_metadata_collection on a blank bucket lands its registry +
+		// dbconfig directly in _system._mobile rather than stamping into _default._default.
+		// Subsequent bootstrap-doc ops on this bucket reuse the cached decision.
+		optInHint := resolveUseSystemMetadataCollection(h.server.Config, config)
+		if err := h.server.BootstrapContext.Connection.SetBucketBootstrapTargetHint(h.ctx(), bucket, optInHint); err != nil {
+			base.WarnfCtx(h.ctx(), "Failed to resolve bootstrap target for bucket %q: %v", base.MD(bucket), err)
+		}
+
 		metadataID, metadataIDError := h.server.BootstrapContext.ComputeMetadataIDForDbConfig(h.ctx(), config)
 		if metadataIDError != nil {
 			base.WarnfCtx(h.ctx(), "Unable to compute metadata ID - using standard metadataID.  Error: %v", metadataIDError)

--- a/rest/main.go
+++ b/rest/main.go
@@ -387,17 +387,18 @@ func CreateBootstrapConnectionFromStartupConfig(ctx context.Context, config *Sta
 }
 
 type bootstrapConnectionOpts struct {
-	server               string
-	username             string
-	password             string
-	x509CertPath         string
-	x509KeyPath          string
-	caCertPath           string
-	bucketConnectionMode base.BucketConnectionMode
-	isServerless         bool
-	bucketCredentials    base.PerBucketCredentialsConfig
-	tlsSkipVerify        *bool
-	useXattrConfig       bool
+	server                      string
+	username                    string
+	password                    string
+	x509CertPath                string
+	x509KeyPath                 string
+	caCertPath                  string
+	bucketConnectionMode        base.BucketConnectionMode
+	isServerless                bool
+	bucketCredentials           base.PerBucketCredentialsConfig
+	tlsSkipVerify               *bool
+	useXattrConfig              bool
+	useSystemMetadataCollection bool
 }
 
 // bootstrapConnectionOptsConfigs returns a bootstrapConnectionOpts struct with values populated from the startup and db configs.
@@ -420,6 +421,7 @@ func setBootstrapConnectionOptsFromStartupConfig(opts *bootstrapConnectionOpts, 
 	opts.bucketCredentials = config.BucketCredentials
 	opts.tlsSkipVerify = config.Bootstrap.ServerTLSSkipVerify
 	opts.useXattrConfig = base.ValDefault(config.Unsupported.UseXattrConfig, false)
+	opts.useSystemMetadataCollection = base.ValDefault(config.Bootstrap.UseSystemMetadataCollection, DefaultUseSystemMetadataCollection)
 }
 
 // setBootstrapConnectionOptsFromDbConfig sets the bootstrapConnectionOpts struct with values from the db config.
@@ -436,7 +438,7 @@ func setBootstrapConnectionOptsFromDbConfig(opts *bootstrapConnectionOpts, dbCon
 
 func createBootstrapConnectionWithOpts(ctx context.Context, opts bootstrapConnectionOpts) (base.BootstrapConnection, error) {
 	if base.ServerIsWalrus(opts.server) {
-		return base.NewRosmarCluster(opts.server)
+		return base.NewRosmarCluster(opts.server, opts.useSystemMetadataCollection)
 	}
 
 	var connStr string
@@ -462,6 +464,7 @@ func createBootstrapConnectionWithOpts(ctx context.Context, opts bootstrapConnec
 		opts.isServerless,
 		opts.bucketCredentials,
 		opts.useXattrConfig,
+		opts.useSystemMetadataCollection,
 		opts.bucketConnectionMode)
 	if err != nil {
 		base.InfofCtx(ctx, base.KeyConfig, "Couldn't create couchbase cluster instance: %v", err)

--- a/rest/metadatamigrationtest/metadata_migration_test.go
+++ b/rest/metadatamigrationtest/metadata_migration_test.go
@@ -93,8 +93,14 @@ func TestMetadataMigrationStartsAfterAllNodesApplyConfig(t *testing.T) {
 	// _default._default for the db's metadataID, flips the MetadataStore wrapper straight to
 	// MigrationComplete, and shouldRunMetadataMigration returns false — which is exactly what
 	// we want for fresh DBs, but defeats this test's premise of verifying the multi-node gate.
+	//
+	// Seed via Incr so the doc matches the on-disk shape of a counter created by the
+	// sequence allocator in real legacy data. SetRaw would write with explicit BinaryType
+	// flag, which the SGJSONTranscoder used by GetCounter can't decode into a *uint64 —
+	// fine on Rosmar (relaxed datatype handling) but a hard failure on Couchbase Server.
 	dbCtxBefore := rtA.GetDatabase()
-	require.NoError(t, tb.Bucket.DefaultDataStore(ctx).SetRaw(ctx, dbCtxBefore.MetadataKeys.SyncSeqKey(), 0, nil, []byte("0")))
+	_, err := tb.Bucket.DefaultDataStore(ctx).Incr(ctx, dbCtxBefore.MetadataKeys.SyncSeqKey(), 1, 0, 0)
+	require.NoError(t, err)
 
 	// Update db config on node A to enable the system metadata collection.
 	dbConfig.UseSystemMobileMetadataCollection = base.Ptr(true)

--- a/rest/metadatamigrationtest/metadata_migration_test.go
+++ b/rest/metadatamigrationtest/metadata_migration_test.go
@@ -88,6 +88,14 @@ func TestMetadataMigrationStartsAfterAllNodesApplyConfig(t *testing.T) {
 	rtA.ServerContext().ForceClusterCompatRefresh(t, ctx)
 	rtB.ServerContext().ForceClusterCompatRefresh(t, ctx)
 
+	// Seed a legacy per-DB metadata key in _default._default so the new-DB fast path doesn't
+	// classify this as a fresh DB. Without this the probe at db construction sees an empty
+	// _default._default for the db's metadataID, flips the MetadataStore wrapper straight to
+	// MigrationComplete, and shouldRunMetadataMigration returns false — which is exactly what
+	// we want for fresh DBs, but defeats this test's premise of verifying the multi-node gate.
+	dbCtxBefore := rtA.GetDatabase()
+	require.NoError(t, tb.Bucket.DefaultDataStore(ctx).SetRaw(ctx, dbCtxBefore.MetadataKeys.SyncSeqKey(), 0, nil, []byte("0")))
+
 	// Update db config on node A to enable the system metadata collection.
 	dbConfig.UseSystemMobileMetadataCollection = base.Ptr(true)
 	resp = rtA.UpsertDbConfig("db", dbConfig)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -797,13 +797,32 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		contextOptions.UseViews = true
 	}
 
-	// For now, we'll continue writing metadata into `_default`.`_default`, for a few reasons:
-	// - we know it is supported in all server versions
-	// - it cannot be dropped by customers, we always know it exists
-	// - it simplifies RBAC in terms of not having to create a metadata collection
-	// Once system scope/collection is well-supported, and we have a migration path, we can consider using those.
-	// contextOptions.MetadataStore = bucket.NamedDataStore(base.ScopeAndCollectionName{base.MobileMetadataScope, base.MobileMetadataCollection})
-	contextOptions.MetadataStore = bucket.DefaultDataStore(ctx)
+	// Database-level metadata (sequence allocator, syncInfo, _sync:user:*, _sync:role:*, etc.)
+	// is targeted at:
+	//   - _default._default when use_system_metadata_collection is disabled at both the cluster
+	//     and per-DB level (legacy behaviour; simplest RBAC, _default cannot be dropped by customers)
+	//   - _system._mobile (with read-fallback to _default._default) when enabled at either level,
+	//     via base.MetadataStore. For a brand-new database with no legacy metadata in
+	//     _default._default the wrapper is immediately marked MigrationComplete so reads go
+	//     straight to the primary collection — no per-DB migration arming.
+	if resolveUseSystemMetadataCollection(sc.Config, &config.DbConfig) {
+		primaryMetadataStore, err := bucket.NamedDataStore(ctx, base.MobileSystemScopeAndCollectionName())
+		if err != nil {
+			if options.loadFromBucket {
+				sc._handleInvalidDatabaseConfig(ctx, spec.BucketName, config, db.NewDatabaseError(db.DatabaseInvalidDatastore))
+			}
+			return nil, fmt.Errorf("use_system_metadata_collection enabled but unable to access %s.%s on bucket %q: %w", base.SystemScope, base.SystemCollectionMobile, base.MD(spec.BucketName), err)
+		}
+		fallbackStore := bucket.DefaultDataStore(ctx)
+		metaStore := base.NewMetadataStore(primaryMetadataStore, fallbackStore)
+		if !probeLegacyPerDBMetadata(ctx, fallbackStore, config.MetadataID) {
+			metaStore.SetMigrationComplete()
+			base.InfofCtx(ctx, base.KeyConfig, "db:%s no legacy metadata in _default._default — marking per-DB MetadataStore wrapper migration-complete (new-database fast path)", base.MD(dbName))
+		}
+		contextOptions.MetadataStore = metaStore
+	} else {
+		contextOptions.MetadataStore = bucket.DefaultDataStore(ctx)
+	}
 	err = validateMetadataStore(ctx, contextOptions.MetadataStore)
 	if err != nil {
 		if options.loadFromBucket {
@@ -901,11 +920,30 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 			return nil, errors.New("Sync Gateway was unable to connect to a query node on the provided Couchbase Server cluster.  Ensure a query node is accessible, or set 'use_views':true in Sync Gateway's database config.")
 		}
 
-		metadataStore, ok := contextOptions.MetadataStore.(base.N1QLStore)
+		// MetadataStore intentionally doesn't implement N1QLStore — principal queries fan out
+		// to both stores via dualMetadataN1QLQuery — so unwrap to the underlying store(s) for
+		// index inventory inspection. Primary is the write target and the policy default;
+		// fallback acts as a tiebreaker when primary is empty so a pre-migration database
+		// that only had the legacy syncDocs index in _default._default keeps that style
+		// during the migration window rather than being silently upgraded to user/role indexes.
+		primaryIndexStore, fallbackIndexStore := contextOptions.MetadataStore, base.DataStore(nil)
+		if dual, isDual := contextOptions.MetadataStore.(*base.MetadataStore); isDual {
+			primaryIndexStore = dual.Primary()
+			fallbackIndexStore = dual.Fallback()
+		}
+		metadataStore, ok := base.AsN1QLStore(primaryIndexStore)
 		if !ok {
-			return nil, errors.New("Bucket %s is not %T and does not support N1QL.")
+			return nil, fmt.Errorf("metadata store of type %T does not support N1QL", primaryIndexStore)
 		}
 		contextOptions.UseLegacySyncDocsIndex = db.ShouldUseLegacySyncDocsIndex(ctx, metadataStore, config.UseXattrs())
+		if !contextOptions.UseLegacySyncDocsIndex && fallbackIndexStore != nil {
+			// Primary returned "use new-style", but that may just mean primary is empty.
+			// Consult the fallback so an existing database whose _default._default still only
+			// carries the legacy syncDocs index doesn't get implicitly upgraded mid-migration.
+			if fallbackN1QL, ok := base.AsN1QLStore(fallbackIndexStore); ok {
+				contextOptions.UseLegacySyncDocsIndex = db.ShouldUseLegacySyncDocsIndex(ctx, fallbackN1QL, config.UseXattrs())
+			}
+		}
 		if sc.DatabaseInitManager == nil {
 			base.AssertfCtx(ctx, "DatabaseInitManager should always be initialized")
 			return nil, errors.New("DatabaseInitManager not initialized")
@@ -1012,6 +1050,22 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 				return false, nil, err
 			}
 			return registry.IsConfigFullyApplied(ctx, configGroupID, dbName, cfgVersion)
+		}
+	}
+
+	// Hook the per-DB metadata-migration manager into the bucket-level status doc and the
+	// all-complete trigger. Closures capture the bucket name and the BootstrapConnection so the
+	// db package doesn't need to depend on the rest package. Wired whenever the DB has effectively
+	// opted in to system-metadata storage — either via the cluster-level startup flag or via the
+	// per-DB UseSystemMobileMetadataCollection config field.
+	if resolveUseSystemMetadataCollection(sc.Config, &config.DbConfig) {
+		bucketName := spec.BucketName
+		dbcontext.MetadataMigrationStatusUpdater = func(ctx context.Context, mutator func(*base.MetadataMigrationStatus) error) error {
+			_, err := sc.BootstrapContext.Connection.UpdateMetadataMigrationStatus(ctx, bucketName, mutator)
+			return err
+		}
+		dbcontext.PostMetadataMigrationCompleteFunc = func(ctx context.Context) error {
+			return sc.maybeCompleteBucketMetadataMigration(ctx, bucketName)
 		}
 	}
 
@@ -1504,14 +1558,7 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 		base.WarnfCtx(ctx, `Deprecation notice: setting database configuration option "disable_public_all_docs" to false is deprecated. In the future, public access to the all_docs API will be disabled by default.`)
 	}
 
-	useMobileCollection := DefaultUseSystemMetadataCollection
-	if config.UseSystemMobileMetadataCollection != nil && *config.UseSystemMobileMetadataCollection {
-		useMobileCollection = true
-	} else {
-		if sc.Config.Bootstrap.UseSystemMetadataCollection != nil {
-			useMobileCollection = *sc.Config.Bootstrap.UseSystemMetadataCollection
-		}
-	}
+	useMobileCollection := resolveUseSystemMetadataCollection(sc.Config, config)
 
 	contextOptions := db.DatabaseContextOptions{
 		CacheOptions:                  &cacheOptions,
@@ -2248,6 +2295,16 @@ func (sc *ServerContext) initializeBootstrapConnection(ctx context.Context) erro
 		return err
 	}
 
+	// Stamp the bucket-level metadata-migration status doc into _system._mobile on every
+	// bucket this SG can see. The doc is the source-of-truth for "is migration running / done"
+	// — by being born in the destination collection it never needs migration itself, and a
+	// missing doc is treated as "no migration ever started" by the rest of the pipeline.
+	if base.ValDefault(sc.Config.Bootstrap.UseSystemMetadataCollection, DefaultUseSystemMetadataCollection) {
+		if err := sc.stampMetadataMigrationStatusDocs(ctx); err != nil {
+			base.WarnfCtx(ctx, "Failed to stamp metadata-migration status docs at bootstrap: %v", err)
+		}
+	}
+
 	if count > 0 {
 		base.InfofCtx(ctx, base.KeyConfig, "Successfully fetched %d database configs for group %q from buckets in cluster", count, sc.Config.Bootstrap.ConfigGroupID)
 	} else {
@@ -2278,6 +2335,7 @@ func (sc *ServerContext) initializeBootstrapConnection(ctx context.Context) erro
 						base.InfofCtx(ctx, base.KeyConfig, "Successfully fetched %d database configs for group %q from buckets in cluster", count, sc.Config.Bootstrap.ConfigGroupID)
 					}
 					sc.ClusterCompat.Refresh(ctx)
+					sc.refreshBucketBootstrapTargets(ctx)
 				}
 			}
 		}()
@@ -2286,6 +2344,244 @@ func (sc *ServerContext) initializeBootstrapConnection(ctx context.Context) erro
 	}
 	base.InfofCtx(ctx, base.KeyAll, "Finished initializing bootstrap connection")
 
+	return nil
+}
+
+// resolveUseSystemMetadataCollection returns the effective use_system_metadata_collection
+// setting for a database, honouring per-DB opt-in even when the cluster-level startup flag is off.
+// Per-DB opt-in supersedes the cluster default; explicit per-DB false is treated as "not opted in"
+// and falls back to the cluster flag.
+func resolveUseSystemMetadataCollection(startup *StartupConfig, db *DbConfig) bool {
+	if db != nil && db.UseSystemMobileMetadataCollection != nil && *db.UseSystemMobileMetadataCollection {
+		return true
+	}
+	if startup == nil {
+		return DefaultUseSystemMetadataCollection
+	}
+	return base.ValDefault(startup.Bootstrap.UseSystemMetadataCollection, DefaultUseSystemMetadataCollection)
+}
+
+// probeLegacyPerDBMetadata reports whether this database has metadata in _default._default that
+// the per-DB MetadataStore wrapper would need to read. Used to short-circuit a brand-new database
+// (or one originally created in dual mode) into MigrationComplete state so the wrapper bypasses
+// fallback from its first read.
+//
+// Probes _sync:seq (or _sync:m_<id>:seq for metadataID-prefixed DBs): the sequence allocator
+// increments this on every doc write across the DB, regardless of which collection holds user
+// data, so its presence is a reliable signal that legacy per-DB metadata exists. Known gap: a DB
+// with only principals (users/roles) defined and no doc writes will fast-path incorrectly. A
+// range-scan-based probe is the proper fix; tracked as follow-up.
+func probeLegacyPerDBMetadata(ctx context.Context, fallback base.DataStore, metadataID string) bool {
+	key := base.NewMetadataKeys(metadataID).SyncSeqKey()
+	exists, err := fallback.Exists(ctx, key)
+	if err != nil {
+		base.WarnfCtx(ctx, "Failed to probe %q in _default._default while resolving new-DB fast path: %v — assuming legacy data present", base.MD(key), err)
+		return true
+	}
+	return exists
+}
+
+// maybeCompleteBucketMetadataMigration is invoked after each per-DB migration reports complete.
+// If every database in the bucket's registry has its status entry == complete and the bootstrap
+// block is still not_started, this node claims the bootstrap migration via CAS (winning peer is
+// the only one that proceeds), copies the bucket-global bootstrap docs into _system._mobile,
+// flips bootstrap.state to complete, and finally calls SetMigrationComplete on the cluster so
+// fallback reads stop. Caller may retry: every step is idempotent and CAS-guarded.
+func (sc *ServerContext) maybeCompleteBucketMetadataMigration(ctx context.Context, bucketName string) error {
+	registry, err := sc.BootstrapContext.getGatewayRegistry(ctx, bucketName)
+	if err != nil {
+		return fmt.Errorf("read registry for bucket %q: %w", bucketName, err)
+	}
+	expected := registryMetadataIDs(registry)
+	if len(expected) == 0 {
+		// No DBs in registry → nothing to migrate
+		return nil
+	}
+
+	// First, read-only check: every DB complete?
+	status, _, err := sc.BootstrapContext.Connection.GetMetadataMigrationStatus(ctx, bucketName)
+	if err != nil {
+		return fmt.Errorf("read status doc for bucket %q: %w", bucketName, err)
+	}
+	if status.Bootstrap.State == base.MigrationStateComplete {
+		return nil
+	}
+	if !status.AllDatabasesComplete(expected) {
+		base.DebugfCtx(ctx, base.KeyConfig, "Bucket %q metadata migration: per-DB completion still pending", base.MD(bucketName))
+		return nil
+	}
+
+	// CAS-claim the bootstrap migration. Only the node that flips not_started → in_progress
+	// inside the mutator proceeds; everyone else returns and lets the claimant finish.
+	claimed := false
+	_, err = sc.BootstrapContext.Connection.UpdateMetadataMigrationStatus(ctx, bucketName, func(s *base.MetadataMigrationStatus) error {
+		if s.Bootstrap.State != base.MigrationStateNotStarted {
+			return nil
+		}
+		if !s.AllDatabasesComplete(expected) {
+			return nil
+		}
+		s.Bootstrap.State = base.MigrationStateInProgress
+		claimed = true
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("claim bootstrap migration on bucket %q: %w", bucketName, err)
+	}
+	if !claimed {
+		return nil
+	}
+
+	base.InfofCtx(ctx, base.KeyConfig, "Bucket %q metadata migration: all per-DB entries complete, starting bootstrap copy", base.MD(bucketName))
+
+	docIDs := bootstrapDocKeysToMigrate(ctx, registry)
+	if err := sc.BootstrapContext.Connection.MigrateBootstrapDocs(ctx, bucketName, docIDs); err != nil {
+		return fmt.Errorf("migrate bootstrap docs on bucket %q: %w", bucketName, err)
+	}
+
+	completedAt := time.Now().UTC()
+	if _, err := sc.BootstrapContext.Connection.UpdateMetadataMigrationStatus(ctx, bucketName, func(s *base.MetadataMigrationStatus) error {
+		s.Bootstrap.State = base.MigrationStateComplete
+		s.Bootstrap.CompletedAt = &completedAt
+		return nil
+	}); err != nil {
+		return fmt.Errorf("record bootstrap-migration completion on bucket %q: %w", bucketName, err)
+	}
+
+	sc.BootstrapContext.Connection.SetMigrationComplete()
+	base.InfofCtx(ctx, base.KeyConfig, "Bucket %q metadata migration: bootstrap copy complete, fallback reads disabled", base.MD(bucketName))
+	return nil
+}
+
+// refreshBucketBootstrapTargets converges this node's per-bucket bootstrap-target cache with the
+// authoritative migration_status doc for every tracked bucket. When a peer node has completed the
+// bucket-level migration (moving _sync:registry, _sync:dbconfig:*, etc. into _system._mobile and
+// deleting the _default._default copies), this node's cache stays at bucketTargetDefault until
+// either a failed read self-heals (see noteBucketFallbackHit) or this routine runs — proactively
+// invoking it on the config-polling cadence shortens the window during which reads pay the extra
+// fallback cost. Errors per bucket are logged at Debug and never escalated; this is best-effort
+// cache convergence, not a correctness path.
+func (sc *ServerContext) refreshBucketBootstrapTargets(ctx context.Context) {
+	if sc.ClusterCompat == nil || sc.BootstrapContext == nil || sc.BootstrapContext.Connection == nil {
+		return
+	}
+	for _, bucket := range sc.ClusterCompat.trackedBucketList() {
+		if err := sc.BootstrapContext.Connection.RefreshBucketBootstrapTarget(ctx, bucket); err != nil {
+			base.DebugfCtx(ctx, base.KeyConfig, "Bucket %q bootstrap-target refresh: %v", base.MD(bucket), err)
+		}
+	}
+}
+
+// registryMetadataIDs flattens the registry into the metadataIDs we expect to find in the status
+// doc. Deleted / invalid registry entries are skipped — they don't participate in migration.
+func registryMetadataIDs(registry *GatewayRegistry) []string {
+	if registry == nil {
+		return nil
+	}
+	var ids []string
+	for _, group := range registry.ConfigGroups {
+		if group == nil {
+			continue
+		}
+		for _, rdb := range group.Databases {
+			if rdb == nil || rdb.IsDeleted() || rdb.IsInvalid() {
+				continue
+			}
+			if rdb.MetadataID != "" {
+				ids = append(ids, rdb.MetadataID)
+			}
+		}
+	}
+	return ids
+}
+
+// bootstrapDocKeysToMigrate enumerates the bucket-global bootstrap docs the bucket-level migration
+// step needs to move from _default._default to _system._mobile. Covers _sync:registry, the
+// dbconfig docs for every (group, db) in the registry, and the default-group cbgt cfg keys.
+// Per-group / per-DB cbgt cfg variants are intentionally not enumerated here — those are tracked
+// as a known stub limitation pending follow-up work.
+func bootstrapDocKeysToMigrate(ctx context.Context, registry *GatewayRegistry) []string {
+	keys := []string{base.SGRegistryKey}
+	if registry != nil {
+		for groupID, group := range registry.ConfigGroups {
+			if group == nil {
+				continue
+			}
+			for dbName, rdb := range group.Databases {
+				if rdb == nil || rdb.IsDeleted() || rdb.IsInvalid() {
+					continue
+				}
+				keys = append(keys, PersistentConfigKey(ctx, groupID, dbName))
+			}
+		}
+	}
+	keys = append(keys,
+		base.CBGTCfgIndexDefs,
+		base.CBGTCfgNodeDefsKnown,
+		base.CBGTCfgNodeDefsWanted,
+		base.CBGTCfgPlanPIndexes,
+		base.SyncDocPrefix+"cfgsgrCluster",
+	)
+	return keys
+}
+
+// stampMetadataMigrationStatusDocs ensures the bucket-level metadata-migration status doc exists
+// in _system._mobile on every bucket visible to this SG. If a doc is found with bootstrap.state
+// already complete (a previous SG instance finished the bucket migration) we immediately invoke
+// SetMigrationComplete on the cluster so this fresh process doesn't pay the fallback-read cost
+// for the lifetime of the connection.
+//
+// Idempotent across SG nodes — concurrent stamp attempts surface ErrAlreadyExists which we treat
+// as success. Caller has verified that the cluster-level use_system_metadata_collection flag is enabled.
+func (sc *ServerContext) stampMetadataMigrationStatusDocs(ctx context.Context) error {
+	buckets, err := sc.BootstrapContext.Connection.GetConfigBuckets(ctx)
+	if err != nil {
+		return fmt.Errorf("list buckets for status-doc stamp: %w", err)
+	}
+	// SetMigrationComplete is connection-scoped, not per-bucket. Until per-bucket migration
+	// state can be tracked on the BootstrapConnection itself, only flip the flag once every
+	// bucket-with-SG-state reports bootstrap.state=complete — otherwise an unfinished bucket
+	// would lose its legacy fallback. Empty buckets (no SG registry presence) are excluded
+	// since they can never drive the migration to completion themselves.
+	sgBucketsSeen := 0
+	sgBucketsComplete := 0
+	for _, bucket := range buckets {
+		_, err := sc.BootstrapContext.Connection.InsertMetadataMigrationStatus(ctx, bucket, base.NewMetadataMigrationStatus())
+		switch {
+		case err == nil:
+			base.InfofCtx(ctx, base.KeyConfig, "Stamped %s on bucket %q", base.MD(base.MetadataMigrationStatusDocID), base.MD(bucket))
+		case errors.Is(err, base.ErrAlreadyExists):
+			base.DebugfCtx(ctx, base.KeyConfig, "%s already present on bucket %q — leaving as-is", base.MD(base.MetadataMigrationStatusDocID), base.MD(bucket))
+		default:
+			base.WarnfCtx(ctx, "Failed to stamp %s on bucket %q: %v", base.MD(base.MetadataMigrationStatusDocID), base.MD(bucket), err)
+			continue
+		}
+
+		// If this bucket has already finished the bootstrap migration in a prior SG lifecycle,
+		// the cluster object on this process still has migrationComplete=false (it's per-process
+		// state, not bucket-persisted). Re-apply that signal so fallback reads stay disabled
+		// from this process's first KV op.
+		// Skip buckets with no SG registry presence — they don't participate in migration
+		// and would otherwise pin the cluster in dual-read mode forever.
+		registry, regErr := sc.BootstrapContext.getGatewayRegistry(ctx, bucket)
+		if regErr != nil || len(registryMetadataIDs(registry)) == 0 {
+			continue
+		}
+		sgBucketsSeen++
+
+		status, _, statusErr := sc.BootstrapContext.Connection.GetMetadataMigrationStatus(ctx, bucket)
+		if statusErr != nil {
+			base.WarnfCtx(ctx, "Failed to read %s on bucket %q after stamp: %v", base.MD(base.MetadataMigrationStatusDocID), base.MD(bucket), statusErr)
+			continue
+		}
+		if status.Bootstrap.State == base.MigrationStateComplete {
+			sgBucketsComplete++
+		}
+	}
+	if sgBucketsSeen > 0 && sgBucketsComplete == sgBucketsSeen {
+		sc.BootstrapContext.Connection.SetMigrationComplete()
+		base.InfofCtx(ctx, base.KeyConfig, "Bucket metadata migration previously completed on all visible buckets — disabling bootstrap fallback reads for this process")
+	}
 	return nil
 }
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -2382,11 +2382,14 @@ func probeLegacyPerDBMetadata(ctx context.Context, fallback base.DataStore, meta
 }
 
 // maybeCompleteBucketMetadataMigration is invoked after each per-DB migration reports complete.
-// If every database in the bucket's registry has its status entry == complete and the bootstrap
-// block is still not_started, this node claims the bootstrap migration via CAS (winning peer is
-// the only one that proceeds), copies the bucket-global bootstrap docs into _system._mobile,
-// flips bootstrap.state to complete, and finally calls SetMigrationComplete on the cluster so
-// fallback reads stop. Caller may retry: every step is idempotent and CAS-guarded.
+// If every database in the bucket's registry has its status entry == complete, this node copies
+// the bucket-global bootstrap docs into _system._mobile, flips bootstrap.state to complete, and
+// calls SetMigrationComplete on the cluster so fallback reads stop.
+//
+// No leader election: MigrateBootstrapDocs is idempotent under concurrent execution (primary
+// Insert tolerates ErrDocumentExists, fallback Remove uses observed-CAS) and the final state
+// transition is CAS-guarded so the first writer wins and later peers no-op. This avoids the
+// crash-wedge problem an in_progress claim without a lease would introduce.
 func (sc *ServerContext) maybeCompleteBucketMetadataMigration(ctx context.Context, bucketName string) error {
 	registry, err := sc.BootstrapContext.getGatewayRegistry(ctx, bucketName)
 	if err != nil {
@@ -2398,7 +2401,6 @@ func (sc *ServerContext) maybeCompleteBucketMetadataMigration(ctx context.Contex
 		return nil
 	}
 
-	// First, read-only check: every DB complete?
 	status, _, err := sc.BootstrapContext.Connection.GetMetadataMigrationStatus(ctx, bucketName)
 	if err != nil {
 		return fmt.Errorf("read status doc for bucket %q: %w", bucketName, err)
@@ -2411,27 +2413,6 @@ func (sc *ServerContext) maybeCompleteBucketMetadataMigration(ctx context.Contex
 		return nil
 	}
 
-	// CAS-claim the bootstrap migration. Only the node that flips not_started → in_progress
-	// inside the mutator proceeds; everyone else returns and lets the claimant finish.
-	claimed := false
-	_, err = sc.BootstrapContext.Connection.UpdateMetadataMigrationStatus(ctx, bucketName, func(s *base.MetadataMigrationStatus) error {
-		if s.Bootstrap.State != base.MigrationStateNotStarted {
-			return nil
-		}
-		if !s.AllDatabasesComplete(expected) {
-			return nil
-		}
-		s.Bootstrap.State = base.MigrationStateInProgress
-		claimed = true
-		return nil
-	})
-	if err != nil {
-		return fmt.Errorf("claim bootstrap migration on bucket %q: %w", bucketName, err)
-	}
-	if !claimed {
-		return nil
-	}
-
 	base.InfofCtx(ctx, base.KeyConfig, "Bucket %q metadata migration: all per-DB entries complete, starting bootstrap copy", base.MD(bucketName))
 
 	docIDs := bootstrapDocKeysToMigrate(ctx, registry)
@@ -2440,16 +2421,26 @@ func (sc *ServerContext) maybeCompleteBucketMetadataMigration(ctx context.Contex
 	}
 
 	completedAt := time.Now().UTC()
+	wonRace := false
 	if _, err := sc.BootstrapContext.Connection.UpdateMetadataMigrationStatus(ctx, bucketName, func(s *base.MetadataMigrationStatus) error {
+		wonRace = false
+		if s.Bootstrap.State == base.MigrationStateComplete {
+			return nil
+		}
 		s.Bootstrap.State = base.MigrationStateComplete
 		s.Bootstrap.CompletedAt = &completedAt
+		wonRace = true
 		return nil
 	}); err != nil {
 		return fmt.Errorf("record bootstrap-migration completion on bucket %q: %w", bucketName, err)
 	}
 
 	sc.BootstrapContext.Connection.SetMigrationComplete()
-	base.InfofCtx(ctx, base.KeyConfig, "Bucket %q metadata migration: bootstrap copy complete, fallback reads disabled", base.MD(bucketName))
+	if wonRace {
+		base.InfofCtx(ctx, base.KeyConfig, "Bucket %q metadata migration: bootstrap copy complete, fallback reads disabled", base.MD(bucketName))
+	} else {
+		base.DebugfCtx(ctx, base.KeyConfig, "Bucket %q metadata migration: peer already recorded completion, fallback reads disabled locally", base.MD(bucketName))
+	}
 	return nil
 }
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -2415,6 +2415,22 @@ func (sc *ServerContext) maybeCompleteBucketMetadataMigration(ctx context.Contex
 
 	base.InfofCtx(ctx, base.KeyConfig, "Bucket %q metadata migration: all per-DB entries complete, starting bootstrap copy", base.MD(bucketName))
 
+	// Record the attempt for observability. Counter is bumped relative to the latest
+	// stored value on each CAS-retry iteration, so concurrent nodes' attempts sum
+	// correctly. Skip the bump if a peer has already recorded completion since the
+	// outer read — the attempt would be redundant work.
+	attemptedAt := time.Now().UTC()
+	if _, err := sc.BootstrapContext.Connection.UpdateMetadataMigrationStatus(ctx, bucketName, func(s *base.MetadataMigrationStatus) error {
+		if s.Bootstrap.State == base.MigrationStateComplete {
+			return nil
+		}
+		s.Bootstrap.LastAttemptedAt = &attemptedAt
+		s.Bootstrap.Attempts++
+		return nil
+	}); err != nil {
+		return fmt.Errorf("record bootstrap-migration attempt on bucket %q: %w", bucketName, err)
+	}
+
 	docIDs := bootstrapDocKeysToMigrate(ctx, registry)
 	if err := sc.BootstrapContext.Connection.MigrateBootstrapDocs(ctx, bucketName, docIDs); err != nil {
 		return fmt.Errorf("migrate bootstrap docs on bucket %q: %w", bucketName, err)


### PR DESCRIPTION
CBG-5226

- Adds support for the dual-collection `MetadataStore` wrapper on `DatabaseContext` in SG based on opt-in configuration - as well as similar fallback read logic in the bootstrap code.
- Adds support for `_system._mobile` storage for all bootstrap metadata (registry, dbconfigs) for:
  - **New deployments** that have opted in at the bootstrap config level (Capella), or have their first database opting in to use the system metadata collection.
  - **Existing deployments** that have had all databases in the bucket fully migrated with the opt-in.
- Uses a migration status tracking doc `_sync:metadata_migration_status` in `_system._mobile` to track per-bucket and per-database migration state. Used to bypass the dual metadata store wrapper post-migration, and also used to determine the last migrated database for bootstrap/registry migration.
- Does not perform `DatabaseContext` migration - Upcoming PR as CBG-5228 - though all writes get routed to the new location after opting in, and reads do fall back to the fallback datastore even without the migration run.

## Diagrams

Logic to determine which collection to use for bootstrap (not gated behind any opt-in - we only have the opt-in for databases). We optimistically write to `_system` if we find this is a new deployment. We write to `_default` if there is an existing deployment, but have a migration job to move bootstrap-level stuff over once the last database has been fully migrated. 

```mermaid
  flowchart TD
      A[First bootstrap-doc op on bucket] --> C[Read _sync:registry]
      C --> D{Where is it?}
      D -- _system._mobile --> E[Target: _system._mobile]
      D -- _default._default --> F[Target: _default._default]
      D -- not found --> G{Cluster flag<br/>OR per-DB opt-in?}
      G -- yes --> E
      G -- no --> F
```

Logic to determine whether db is new and can bypass metadata migration and write directly to `_system`, or if we need to run migrate.

```mermaid
  flowchart TD
      A[Create or update db] --> B{resolveUseSystemMetadataCollection<br/>per-DB wins over cluster flag}
      B -- no --> J[MetadataStore = _default._default<br/>no wrapper]
      B -- yes --> C[Wrap MetadataStore<br/>base.NewMetadataStore]
      C --> D[probeLegacyPerDBMetadata]
      D --> E{_sync:seq<br/>or _sync:m_id:seq<br/>exists in _default._default?}
      E -- found --> F[Arm migration:<br/>not_started entry in<br/>migration_status]
      E -- none --> G[SetMigrationComplete<br/>on wrapper immediately]
      G --> H[shouldRunMetadataMigration<br/>short-circuits — no manager arm]
      F --> I[MetadataMigrationManager<br/>processes entry]
```

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/714/
  - `TestChangeIndexPartitionsStartStopAndRestart` flake
  - `TestMetadataMigrationStartsAfterAllNodesApplyConfig` Fixed w/ last commit