### PR TITLE
CBG-5372 Move single node resync code into its own functions

### DIFF
--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -30,6 +30,7 @@ import (
 // =====================================================================
 
 type ResyncManagerDCP struct {
+	db                           *DatabaseContext
 	docsProcessedLocal           atomic.Int64  // number of documents processed locally on this node since the last start or resume of resync
 	docsChangedLocal             atomic.Int64  // number of documents changed locally on this node since the last start or resume of resync
 	docsErroredLocal             atomic.Int64  // number of documents that failed to resync locally on this node since the last start or resume of resync
@@ -42,7 +43,6 @@ type ResyncManagerDCP struct {
 	docsTargeted                 atomic.Uint64 // number of documents targeted for resync, computed once at the start of a new run
 	ResyncID                     string
 	VBUUIDs                      []uint64
-	useXattrs                    bool
 	ResyncedCollections          base.CollectionNames
 	resyncCollectionInfo
 	lock        sync.RWMutex
@@ -57,10 +57,10 @@ type resyncCollectionInfo struct {
 
 var _ BackgroundManagerProcessI = &ResyncManagerDCP{}
 
-func NewResyncManagerDCP(metadataStore base.DataStore, useXattrs bool, metaKeys *base.MetadataKeys) *BackgroundManager {
+func NewResyncManagerDCP(metadataStore base.DataStore, metaKeys *base.MetadataKeys, db *DatabaseContext) *BackgroundManager {
 	return &BackgroundManager{
 		name:    "resync",
-		Process: &ResyncManagerDCP{useXattrs: useXattrs},
+		Process: &ResyncManagerDCP{db: db},
 		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
 			metadataStore: metadataStore,
 			metaKeys:      metaKeys,
@@ -72,10 +72,6 @@ func NewResyncManagerDCP(metadataStore base.DataStore, useXattrs bool, metaKeys 
 
 // Init processes the options to start a resync process and sets them as struct memebers.
 func (r *ResyncManagerDCP) Init(ctx context.Context, options map[string]any, clusterStatus []byte) error {
-	db, ok := options["database"].(*Database)
-	if !ok {
-		return errors.New("database option is required and must be of type *Database")
-	}
 	resyncCollections, ok := options["collections"].(base.CollectionNames)
 	if !ok {
 		return errors.New("collections option is required and must be of type base.CollectionNames")
@@ -84,12 +80,12 @@ func (r *ResyncManagerDCP) Init(ctx context.Context, options map[string]any, clu
 	var collections DatabaseCollections
 	if len(resyncCollections) > 0 {
 		var err error
-		collections, err = db.collections(resyncCollections)
+		collections, err = r.db.collections(resyncCollections)
 		if err != nil {
 			return err
 		}
 	} else {
-		collections = slices.Collect(maps.Values(db.CollectionByID))
+		collections = slices.Collect(maps.Values(r.db.CollectionByID))
 		r.hasAllCollections = true
 	}
 	// add collection list to manager for use in status call
@@ -116,7 +112,7 @@ func (r *ResyncManagerDCP) Init(ctx context.Context, options map[string]any, clu
 	}
 
 	if statusDoc.ResyncID != "" {
-		err := r.purgeCheckpoints(ctx, db, statusDoc.ResyncID)
+		err := r.purgeCheckpoints(ctx, statusDoc.ResyncID)
 		if err != nil {
 			base.WarnfCtx(ctx, "Failed to delete checkpoints for previous resync ID %q: %v, these will be abandoned and unused", statusDoc.ResyncID, err)
 		}
@@ -152,12 +148,12 @@ func totalResyncDocs(ctx context.Context, collections DatabaseCollections) (uint
 }
 
 // purgeCheckpoints removes checkpoints for a given resync run.
-func (r *ResyncManagerDCP) purgeCheckpoints(ctx context.Context, db *Database, resyncID string) error {
+func (r *ResyncManagerDCP) purgeCheckpoints(ctx context.Context, resyncID string) error {
 	return base.PurgeDCPCheckpoints(
 		ctx,
-		db.MetadataStore,
-		GetResyncDCPCheckpointPrefix(db.DatabaseContext, resyncID, r.Distributed),
-		db.distributedDCPFeedMode(),
+		r.db.MetadataStore,
+		GetResyncDCPCheckpointPrefix(r.db, resyncID, r.Distributed),
+		r.db.distributedDCPFeedMode(),
 	)
 }
 
@@ -170,17 +166,10 @@ func (r *ResyncManagerDCP) SetVBUUIDs(vbuuids []uint64) {
 
 // Run starts a DCP feed to process documents for resync.
 func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, persistClusterStatusCallback updateStatusCallbackFunc, terminator *base.SafeTerminator) (err error) {
-	db, ok := options["database"].(*Database)
-	if !ok {
-		return errors.New("database option is required and must be of type *Database")
-	}
+	db := r.db
 	regenerateSequences, ok := options["regenerateSequences"].(bool)
 	if !ok {
 		return errors.New("regenerateSequences option is required and must be of type bool")
-	}
-	resyncCollections, ok := options["collections"].(base.CollectionNames)
-	if !ok {
-		return errors.New("collections option is required and must be of type CollectionNames")
 	}
 	ctx = context.WithoutCancel(ctx) // drop cancellation from parent context
 	ctx = base.CorrelationIDLogCtx(ctx, r.ResyncID)
@@ -225,8 +214,8 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 		docID := string(event.Key)
 		base.TracefCtx(ctx, base.KeyAll, "Resync: Received DCP event %d for doc %v", event.Opcode, base.UD(docID))
 
-		// Ignore documents without xattrs if possible, to avoid processing unnecessary documents
-		if r.useXattrs && event.DataType&base.MemcachedDataTypeXattr == 0 {
+		// Ignore documents without xattrs to avoid processing unnecessary documents
+		if event.DataType&base.MemcachedDataTypeXattr == 0 {
 			return true
 		}
 		// Don't want to process raw binary docs
@@ -270,7 +259,7 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 	if r.hasAllCollections {
 		base.InfofCtx(ctx, base.KeyAll, "running resync against all collections")
 	} else {
-		base.InfofCtx(ctx, base.KeyAll, "running resync against specified collections: %s", base.MD(resyncCollections))
+		base.InfofCtx(ctx, base.KeyAll, "running resync against specified collections: %s", base.MD(r.ResyncedCollections))
 	}
 
 	base.InfofCtx(ctx, base.KeyAll, "Starting DCP resync")
@@ -292,7 +281,7 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 		sort.Strings(collectionNamesByScope[scopeName])
 		resyncDestKey = base.DestKey(db.Name, scopeName, collectionNamesByScope[scopeName], base.ShardedDCPFeedTypeResync)
 
-		checkPointPrefix := GetResyncDCPCheckpointPrefix(db.DatabaseContext, r.ResyncID, true)
+		checkPointPrefix := GetResyncDCPCheckpointPrefix(db, r.ResyncID, true)
 
 		resyncDestFunc := func(janitorRollback func()) (cbgt.Dest, error) {
 			resyncDest, err := base.NewDCPDest(ctx, callback, db.MetadataStore, db.numVBuckets, true, nil, nil, checkPointPrefix)
@@ -361,9 +350,9 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 		})
 	} else {
 
-		clientOptions := r.getDCPClientOptions(db.DatabaseContext, r.ResyncID, r.ResyncedCollections.ToCollectionNameSet(), callback, false)
+		clientOptions := r.getDCPClientOptions(db, r.ResyncID, r.ResyncedCollections.ToCollectionNameSet(), callback, false)
 		var err error
-		dcpClient, err = base.NewDCPClient(ctx, db.DatabaseContext.Bucket, clientOptions)
+		dcpClient, err = base.NewDCPClient(ctx, db.Bucket, clientOptions)
 		if err != nil {
 			base.WarnfCtx(ctx, "Failed to create resync DCP client! %v", err)
 			return err
@@ -395,13 +384,13 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 			return err
 		}
 
-		if err := r.invalidatePrincipals(ctx, db, regenerateSequences, r.hasAllCollections); err != nil {
+		if err := invalidatePrincipals(ctx, db, regenerateSequences, r.hasAllCollections, r.DocsChanged()); err != nil {
 			return err
 		}
 
 		// If we regenerated sequences, update syncInfo for all collections affected
 		if regenerateSequences {
-			r.updateSyncInfo(ctx, db)
+			updateSyncInfo(ctx, db, r.collectionIDs)
 		}
 	case <-terminator.Done():
 
@@ -417,12 +406,11 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 	return nil
 }
 
-// invalidatePrincipals ensures the principal docs index is ready, updates principal sequences if requested,
-// and invalidates all principals when documents were changed by the resync run.
-func (r *ResyncManagerDCP) invalidatePrincipals(ctx context.Context, db *Database, regenerateSequences bool, resyncAllCollections bool) error {
+// invalidatePrincipals invalidates principal documents after documents have been resynced.
+func invalidatePrincipals(ctx context.Context, db *DatabaseContext, regenerateSequences bool, resyncAllCollections bool, docsChanged int64) error {
 	// If the principal docs sequences are regenerated, or the user doc need to be invalidated after a dynamic channel grant, db.QueryPrincipals is called to find the principal docs.
 	// In the case that a database is created with "start_offline": true, it is possible the index needed to create this is not yet ready, so make sure it is ready for use.
-	if !db.UseViews() && ((regenerateSequences && resyncAllCollections) || r.DocsChanged() > 0) {
+	if !db.UseViews() && ((regenerateSequences && resyncAllCollections) || docsChanged > 0) {
 		err := initializePrincipalDocsIndex(ctx, db)
 		if err != nil {
 			return err
@@ -435,7 +423,7 @@ func (r *ResyncManagerDCP) invalidatePrincipals(ctx context.Context, db *Databas
 		}
 	}
 
-	if r.DocsChanged() > 0 {
+	if docsChanged > 0 {
 		endSeq, err := db.sequences.getSequence(ctx)
 		if err != nil {
 			return err
@@ -453,17 +441,17 @@ func (r *ResyncManagerDCP) invalidatePrincipals(ctx context.Context, db *Databas
 	return nil
 }
 
-// updateSyncInfo updates the syncInfo metadata for all collections that were resynced and removes them from
-// RequireResync.
-func (r *ResyncManagerDCP) updateSyncInfo(ctx context.Context, db *Database) {
-	updatedDsNames := make(map[base.ScopeAndCollectionName]struct{}, len(r.collectionIDs))
-	for _, collectionID := range r.collectionIDs {
+// updateSyncInfo updates the syncInfo metadata for all collections that were resynced and updates the
+// DatabaseContext.RequireResync attribute
+func updateSyncInfo(ctx context.Context, db *DatabaseContext, collectionIDs []uint32) {
+	updatedDsNames := make(map[base.ScopeAndCollectionName]struct{}, len(collectionIDs))
+	for _, collectionID := range collectionIDs {
 		dbc, ok := db.CollectionByID[collectionID]
 		if !ok {
 			base.WarnfCtx(ctx, "Completed resync, but unable to update syncInfo for collection %v (not found)", collectionID)
 			continue
 		}
-		if err := base.SetSyncInfoMetadataID(ctx, dbc.dataStore, db.DatabaseContext.Options.MetadataID, db.ClusterCompatVersion()); err != nil {
+		if err := base.SetSyncInfoMetadataID(ctx, dbc.dataStore, db.Options.MetadataID, db.ClusterCompatVersion()); err != nil {
 			base.WarnfCtx(ctx, "Completed resync, but unable to update syncInfo for collection %v: %v", collectionID, err)
 			continue
 		}
@@ -641,7 +629,7 @@ type ResyncManagerStatusDocDCP struct {
 }
 
 // initializePrincipalDocsIndex creates the metadata indexes required for resync
-func initializePrincipalDocsIndex(ctx context.Context, db *Database) error {
+func initializePrincipalDocsIndex(ctx context.Context, db *DatabaseContext) error {
 	n1qlStore, ok := base.AsN1QLStore(db.MetadataStore)
 	if !ok {
 		return errors.New("Cannot create indexes on non-Couchbase data store.")

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -395,7 +395,7 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 			return err
 		}
 
-		if err := r.invalidatePrincipals(ctx, db, regenerateSequences, resyncCollections); err != nil {
+		if err := r.invalidatePrincipals(ctx, db, regenerateSequences, r.hasAllCollections); err != nil {
 			return err
 		}
 
@@ -419,16 +419,16 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 
 // invalidatePrincipals ensures the principal docs index is ready, updates principal sequences if requested,
 // and invalidates all principals when documents were changed by the resync run.
-func (r *ResyncManagerDCP) invalidatePrincipals(ctx context.Context, db *Database, regenerateSequences bool, resyncCollections base.CollectionNames) error {
+func (r *ResyncManagerDCP) invalidatePrincipals(ctx context.Context, db *Database, regenerateSequences bool, resyncAllCollections bool) error {
 	// If the principal docs sequences are regenerated, or the user doc need to be invalidated after a dynamic channel grant, db.QueryPrincipals is called to find the principal docs.
 	// In the case that a database is created with "start_offline": true, it is possible the index needed to create this is not yet ready, so make sure it is ready for use.
-	if !db.UseViews() && ((regenerateSequences && resyncCollections == nil) || r.DocsChanged() > 0) {
+	if !db.UseViews() && ((regenerateSequences && resyncAllCollections) || r.DocsChanged() > 0) {
 		err := initializePrincipalDocsIndex(ctx, db)
 		if err != nil {
 			return err
 		}
 	}
-	if regenerateSequences && resyncCollections == nil {
+	if regenerateSequences && resyncAllCollections {
 		err := db.updateAllPrincipalsSequences(ctx)
 		if err != nil {
 			return fmt.Errorf("Error updating principal sequences: %w", err)

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -461,9 +461,11 @@ func (r *ResyncManagerDCP) updateSyncInfo(ctx context.Context, db *Database) {
 		dbc, ok := db.CollectionByID[collectionID]
 		if !ok {
 			base.WarnfCtx(ctx, "Completed resync, but unable to update syncInfo for collection %v (not found)", collectionID)
+			continue
 		}
 		if err := base.SetSyncInfoMetadataID(ctx, dbc.dataStore, db.DatabaseContext.Options.MetadataID, db.ClusterCompatVersion()); err != nil {
 			base.WarnfCtx(ctx, "Completed resync, but unable to update syncInfo for collection %v: %v", collectionID, err)
+			continue
 		}
 		updatedDsNames[base.ScopeAndCollectionName{Scope: dbc.ScopeName, Collection: dbc.Name}] = struct{}{}
 	}

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -395,60 +395,13 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 			return err
 		}
 
-		// If the principal docs sequences are regenerated, or the user doc need to be invalidated after a dynamic channel grant, db.QueryPrincipals is called to find the principal docs.
-		// In the case that a database is created with "start_offline": true, it is possible the index needed to create this is not yet ready, so make sure it is ready for use.
-		if !db.UseViews() && ((regenerateSequences && resyncCollections == nil) || r.DocsChanged() > 0) {
-			err := initializePrincipalDocsIndex(ctx, db)
-			if err != nil {
-				return err
-			}
-		}
-		if regenerateSequences && resyncCollections == nil {
-			err := db.updateAllPrincipalsSequences(ctx)
-
-			if err != nil {
-				return fmt.Errorf("Error updating principal sequences: %w", err)
-			}
-		}
-
-		if r.DocsChanged() > 0 {
-			endSeq, err := db.sequences.getSequence(ctx)
-			if err != nil {
-				return err
-			}
-
-			collectionNames := make(base.ScopeAndCollectionNames, 0)
-			for _, databaseCollection := range db.CollectionByID {
-				collectionNames = append(collectionNames, databaseCollection.ScopeAndCollectionName())
-			}
-			err = db.invalidateAllPrincipals(ctx, collectionNames, endSeq)
-			if err != nil {
-				return fmt.Errorf("Could not invalidate principal documents: %w", err)
-			}
-
+		if err := r.invalidatePrincipals(ctx, db, regenerateSequences, resyncCollections); err != nil {
+			return err
 		}
 
 		// If we regenerated sequences, update syncInfo for all collections affected
 		if regenerateSequences {
-			updatedDsNames := make(map[base.ScopeAndCollectionName]struct{}, len(r.collectionIDs))
-			for _, collectionID := range r.collectionIDs {
-				dbc, ok := db.CollectionByID[collectionID]
-				if !ok {
-					base.WarnfCtx(ctx, "Completed resync, but unable to update syncInfo for collection %v (not found)", collectionID)
-				}
-				if err := base.SetSyncInfoMetadataID(ctx, dbc.dataStore, db.DatabaseContext.Options.MetadataID, db.ClusterCompatVersion()); err != nil {
-					base.WarnfCtx(ctx, "Completed resync, but unable to update syncInfo for collection %v: %v", collectionID, err)
-				}
-				updatedDsNames[base.ScopeAndCollectionName{Scope: dbc.ScopeName, Collection: dbc.Name}] = struct{}{}
-			}
-			collectionsRequiringResync := make([]base.ScopeAndCollectionName, 0)
-			for _, dsName := range db.RequireResync {
-				_, ok := updatedDsNames[dsName]
-				if !ok {
-					collectionsRequiringResync = append(collectionsRequiringResync, dsName)
-				}
-			}
-			db.RequireResync = collectionsRequiringResync
+			r.updateSyncInfo(ctx, db)
 		}
 	case <-terminator.Done():
 
@@ -462,6 +415,66 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 	}
 
 	return nil
+}
+
+// invalidatePrincipals ensures the principal docs index is ready, updates principal sequences if requested,
+// and invalidates all principals when documents were changed by the resync run.
+func (r *ResyncManagerDCP) invalidatePrincipals(ctx context.Context, db *Database, regenerateSequences bool, resyncCollections base.CollectionNames) error {
+	// If the principal docs sequences are regenerated, or the user doc need to be invalidated after a dynamic channel grant, db.QueryPrincipals is called to find the principal docs.
+	// In the case that a database is created with "start_offline": true, it is possible the index needed to create this is not yet ready, so make sure it is ready for use.
+	if !db.UseViews() && ((regenerateSequences && resyncCollections == nil) || r.DocsChanged() > 0) {
+		err := initializePrincipalDocsIndex(ctx, db)
+		if err != nil {
+			return err
+		}
+	}
+	if regenerateSequences && resyncCollections == nil {
+		err := db.updateAllPrincipalsSequences(ctx)
+		if err != nil {
+			return fmt.Errorf("Error updating principal sequences: %w", err)
+		}
+	}
+
+	if r.DocsChanged() > 0 {
+		endSeq, err := db.sequences.getSequence(ctx)
+		if err != nil {
+			return err
+		}
+
+		collectionNames := make(base.ScopeAndCollectionNames, 0)
+		for _, databaseCollection := range db.CollectionByID {
+			collectionNames = append(collectionNames, databaseCollection.ScopeAndCollectionName())
+		}
+		err = db.invalidateAllPrincipals(ctx, collectionNames, endSeq)
+		if err != nil {
+			return fmt.Errorf("Could not invalidate principal documents: %w", err)
+		}
+	}
+	return nil
+}
+
+// updateSyncInfo updates the syncInfo metadata for all collections that were resynced and removes them from
+// RequireResync.
+func (r *ResyncManagerDCP) updateSyncInfo(ctx context.Context, db *Database) {
+	updatedDsNames := make(map[base.ScopeAndCollectionName]struct{}, len(r.collectionIDs))
+	for _, collectionID := range r.collectionIDs {
+		dbc, ok := db.CollectionByID[collectionID]
+		if !ok {
+			base.WarnfCtx(ctx, "Completed resync, but unable to update syncInfo for collection %v (not found)", collectionID)
+		}
+		if err := base.SetSyncInfoMetadataID(ctx, dbc.dataStore, db.DatabaseContext.Options.MetadataID, db.ClusterCompatVersion()); err != nil {
+			base.WarnfCtx(ctx, "Completed resync, but unable to update syncInfo for collection %v: %v", collectionID, err)
+		}
+		updatedDsNames[base.ScopeAndCollectionName{Scope: dbc.ScopeName, Collection: dbc.Name}] = struct{}{}
+	}
+	collectionsRequiringResync := make([]base.ScopeAndCollectionName, 0)
+	for _, dsName := range db.RequireResync {
+		_, ok := updatedDsNames[dsName]
+		if !ok {
+			collectionsRequiringResync = append(collectionsRequiringResync, dsName)
+		}
+	}
+	db.RequireResync = collectionsRequiringResync
 }
 
 func (r *ResyncManagerDCP) ResetStatus() {

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -142,7 +142,6 @@ func TestResyncDCPInit(t *testing.T) {
 			}()
 
 			options := make(map[string]any)
-			options["database"] = db
 			options["collections"] = base.NewCollectionNames()
 			if testCase.forceReset {
 				options["reset"] = true
@@ -206,7 +205,6 @@ func TestResyncManagerDCPStopInMidWay(t *testing.T) {
 			defer db.Close(ctx)
 
 			options := map[string]any{
-				"database":            db,
 				"regenerateSequences": false,
 				"collections":         base.NewCollectionNames(),
 			}
@@ -253,7 +251,6 @@ func TestResyncManagerDCPStart(t *testing.T) {
 				collectionName := scopeAndCollectionName.CollectionName()
 
 				options := map[string]any{
-					"database":            db,
 					"regenerateSequences": false,
 					"collections":         base.NewCollectionNames(),
 				}
@@ -293,7 +290,6 @@ func TestResyncManagerDCPStart(t *testing.T) {
 				log.Printf("initialStats: processed[%v] changed[%v]", initialStats.DocsProcessed, initialStats.DocsChanged)
 
 				options := map[string]any{
-					"database":            db,
 					"regenerateSequences": false,
 					"collections":         base.NewCollectionNames(),
 				}
@@ -357,7 +353,6 @@ func TestResyncManagerDCPRunTwice(t *testing.T) {
 			defer db.Close(ctx)
 
 			options := map[string]any{
-				"database":            db,
 				"regenerateSequences": false,
 				"collections":         base.NewCollectionNames(),
 			}
@@ -410,7 +405,6 @@ func TestResyncManagerDCPResumeStoppedProcess(t *testing.T) {
 			defer db.Close(ctx)
 
 			options := map[string]any{
-				"database":            db,
 				"regenerateSequences": false,
 				"collections":         base.NewCollectionNames(),
 			}
@@ -514,7 +508,6 @@ func TestResyncManagerDCPResumeStoppedProcessChangeCollections(t *testing.T) {
 			}
 
 			options := map[string]any{
-				"database":            db,
 				"regenerateSequences": false,
 				"collections":         base.NewCollectionNames(dbCollections[0].dataStore),
 			}
@@ -709,7 +702,6 @@ func runResync(t *testing.T, ctx context.Context, db *Database, collection *Data
 	log.Printf("initialStats: processed[%v] changed[%v]", initialStats.DocsProcessed, initialStats.DocsChanged)
 
 	options := map[string]any{
-		"database":            db,
 		"regenerateSequences": false,
 		"collections":         base.NewCollectionNames(),
 	}
@@ -917,7 +909,6 @@ func TestResyncImportPartitionsPassthrough(t *testing.T) {
 	rs.Distributed = true
 
 	options := map[string]any{
-		"database":            db,
 		"regenerateSequences": false,
 		"collections":         base.NewCollectionNames(),
 	}
@@ -963,7 +954,6 @@ func TestResyncManagerDCPWritesV1SyncInfoAtCcv41(t *testing.T) {
 	dbc, _ := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 
 	options := map[string]any{
-		"database":            db,
 		"regenerateSequences": true,
 		"collections":         base.NewCollectionNames(),
 	}

--- a/db/database.go
+++ b/db/database.go
@@ -616,7 +616,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 		return nil, err
 	}
 
-	dbContext.ResyncManager = NewResyncManagerDCP(metadataStore, dbContext.UseXattrs(), metaKeys)
+	dbContext.ResyncManager = NewResyncManagerDCP(metadataStore, metaKeys, dbContext)
 	dbContext.AsyncIndexInitManager = NewAsyncIndexInitManager(metadataStore, dbContext.MetadataKeys)
 
 	dbContext.DBStateManager = NewDatabaseStateMgr(metadataStore, metaKeys.DatabaseStateKey())
@@ -1751,7 +1751,7 @@ func (db *DatabaseContext) updateCCVSettings(ctx context.Context) error {
 	return nil
 }
 
-func (db *Database) updateAllPrincipalsSequences(ctx context.Context) error {
+func (db *DatabaseContext) updateAllPrincipalsSequences(ctx context.Context) error {
 	users, roles, err := db.AllPrincipalIDs(ctx)
 	if err != nil {
 		return err
@@ -1789,7 +1789,7 @@ func (db *Database) updateAllPrincipalsSequences(ctx context.Context) error {
 	return nil
 }
 
-func (db *Database) regeneratePrincipalSequences(ctx context.Context, authr *auth.Authenticator, princ auth.Principal) error {
+func (db *DatabaseContext) regeneratePrincipalSequences(ctx context.Context, authr *auth.Authenticator, princ auth.Principal) error {
 	nextSeq, err := db.sequences.nextSequence(ctx)
 	if err != nil {
 		return err

--- a/rest/api.go
+++ b/rest/api.go
@@ -378,7 +378,6 @@ func (h *handler) handlePostResync() error {
 	if action == string(db.BackgroundProcessActionStart) {
 		if atomic.CompareAndSwapUint32(&h.db.State, db.DBOffline, db.DBResyncing) {
 			err := h.db.ResyncManager.Start(h.ctx(), map[string]any{
-				"database":            h.db,
 				"regenerateSequences": regenerateSequences,
 				"collections":         resyncPostReqBody.Scope,
 				"reset":               reset,


### PR DESCRIPTION
CBG-5372 Move single node resync code into its own functions

prep to be able to have this code run on its own. This PR does nothing more than move the functions so make the subsequent PR easier to review.
