### PR TITLE
CBG-5228: implement background metadata migration task

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -323,12 +323,13 @@ func GetBucket(ctx context.Context, spec BucketSpec) (bucket Bucket, err error) 
 
 // GetCounter returns a uint64 result for the given counter key.
 // If the given key is not found in the bucket, this function returns a result of zero.
-func GetCounter(ctx context.Context, datastore DataStore, k string) (result uint64, err error) {
-	_, err = datastore.Get(ctx, k, &result)
-	if IsDocNotFoundError(err) {
-		return 0, nil
-	}
-	return result, err
+//
+// Implemented via Incr(amt=0, def=0): on a hit the counter is returned unchanged, on a
+// miss the doc is created at 0. This routes through MetadataStore.Incr's pill-self-heal
+// when the wrapper is in use, so a metadata-migration pill body on the fallback seq
+// counter no longer crashes callers with a JSON-into-uint64 unmarshal error.
+func GetCounter(ctx context.Context, datastore DataStore, k string) (uint64, error) {
+	return datastore.Incr(ctx, k, 0, 0, 0)
 }
 
 func IsCasMismatch(err error) bool {

--- a/base/bucket.go
+++ b/base/bucket.go
@@ -322,7 +322,7 @@ func GetBucket(ctx context.Context, spec BucketSpec) (bucket Bucket, err error) 
 }
 
 // GetCounter returns a uint64 result for the given counter key.
-// If the given key is not found in the bucket, this function returns a result of zero.
+// If the given key is not found in the bucket, the counter is created at zero and zero is returned.
 //
 // Implemented via Incr(amt=0, def=0): on a hit the counter is returned unchanged, on a
 // miss the doc is created at 0. This routes through MetadataStore.Incr's pill-self-heal

--- a/base/constants_syncdocs.go
+++ b/base/constants_syncdocs.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 
 	sgbucket "github.com/couchbase/sg-bucket"
 )
@@ -243,6 +244,17 @@ func (m *MetadataKeys) HeartbeaterPrefix(groupID string) string {
 	return m.heartbeaterPrefix
 }
 
+// IsLegacyHeartbeaterKey reports whether key is a heartbeater timeout document written under
+// this MetadataKeys' heartbeater namespace. CouchbaseHeartbeater writes a single doc shape —
+// `<heartbeaterPrefix>heartbeat_timeout:<nodeUUID>` (see heartbeat.go heartbeatTimeoutDocID).
+//
+// Matching the literal `heartbeat_timeout:` suffix matters because the default-mode
+// heartbeaterPrefix is bare `_sync:`, which would otherwise classify every unrecognised
+// `_sync:` key as a heartbeater and risk deletion during metadata migration.
+func (m *MetadataKeys) IsLegacyHeartbeaterKey(key string) bool {
+	return strings.HasPrefix(key, m.heartbeaterPrefix+"heartbeat_timeout:")
+}
+
 // SGCfgPrefix returns a document prefix to use for cfg documents (cbgt)
 //
 //	format: _sync:{m_$}:cfg[groupID:]   (collections)
@@ -433,6 +445,21 @@ func CollectionSyncFunctionKeyWithGroupID(groupID string, scopeName, collectionN
 		return fmt.Sprintf("%s:%s.%s:%s", CollectionSyncFunctionKeyWithoutGroupID, scopeName, collectionName, groupID)
 	}
 	return fmt.Sprintf("%s:%s.%s", CollectionSyncFunctionKeyWithoutGroupID, scopeName, collectionName)
+}
+
+// SyncSeqMigrationPill is the body written to the fallback sequence counter document during
+// metadata migration. Replacing the numeric counter with this JSON payload causes the next
+// MetadataStore.Incr for that key to take the self-heal branch: read the pill, bootstrap the
+// primary counter at LastSeq, and remove the fallback doc.
+//
+// SGMetadataMigrationPill is the discriminator that distinguishes a deliberately-placed pill
+// from arbitrary JSON that might otherwise be unmarshalled into this struct with zero
+// values. The JSON key is namespaced so a stray body with a generic `migration: true` field
+// cannot be misidentified as a pill.
+type SyncSeqMigrationPill struct {
+	PilledAt                string `json:"pilled_at"`
+	LastSeq                 uint64 `json:"last_seq"`
+	SGMetadataMigrationPill bool   `json:"sg_metadata_migration_pill"`
 }
 
 // SyncInfo documents are stored in collections to identify the metadataID associated with sync metadata in that collection

--- a/base/constants_syncdocs.go
+++ b/base/constants_syncdocs.go
@@ -244,7 +244,7 @@ func (m *MetadataKeys) HeartbeaterPrefix(groupID string) string {
 	return m.heartbeaterPrefix
 }
 
-// IsLegacyHeartbeaterKey reports whether key is a heartbeater timeout document written under
+// IsHeartbeaterKey reports whether key is a heartbeater timeout document written under
 // this MetadataKeys' heartbeater namespace. CouchbaseHeartbeater writes
 // `<heartbeaterPrefix>heartbeat_timeout:<nodeUUID>` (see heartbeat.go heartbeatTimeoutDocID),
 // where heartbeaterPrefix is the value returned by HeartbeaterPrefix(groupID) — i.e. it
@@ -256,7 +256,7 @@ func (m *MetadataKeys) HeartbeaterPrefix(groupID string) string {
 // Matching the literal `heartbeat_timeout:` token matters because the default-mode
 // heartbeaterPrefix is bare `_sync:`, which would otherwise classify every unrecognised
 // `_sync:` key as a heartbeater and risk deletion during metadata migration.
-func (m *MetadataKeys) IsLegacyHeartbeaterKey(key string) bool {
+func (m *MetadataKeys) IsHeartbeaterKey(key string) bool {
 	if !strings.HasPrefix(key, m.heartbeaterPrefix) {
 		return false
 	}
@@ -272,6 +272,29 @@ func (m *MetadataKeys) IsLegacyHeartbeaterKey(key string) bool {
 	if i := strings.IndexByte(rest, ':'); i > 0 {
 		return strings.HasPrefix(rest[i+1:], "heartbeat_timeout:")
 	}
+	return false
+}
+
+func IsHeartbeaterKey(key string) bool {
+	if !strings.HasPrefix(key, "_sync:") {
+		return false
+	}
+
+	parts := strings.Split(key, ":")
+	if len(parts) >= 2 && parts[1] == "heartbeat_timeout" {
+		// no group id or metadata id
+		return true
+	} else if len(parts) >= 3 && parts[2] == "heartbeat_timeout" {
+		// group id
+		return true
+	} else if len(parts) >= 4 && parts[3] == "heartbeat_timeout" {
+		// metadata id - m_:hb:
+		return true
+	} else if len(parts) >= 5 && parts[4] == "heartbeat_timeout" {
+		// metadata id + group id
+		return true
+	}
+
 	return false
 }
 

--- a/base/constants_syncdocs.go
+++ b/base/constants_syncdocs.go
@@ -245,14 +245,34 @@ func (m *MetadataKeys) HeartbeaterPrefix(groupID string) string {
 }
 
 // IsLegacyHeartbeaterKey reports whether key is a heartbeater timeout document written under
-// this MetadataKeys' heartbeater namespace. CouchbaseHeartbeater writes a single doc shape —
-// `<heartbeaterPrefix>heartbeat_timeout:<nodeUUID>` (see heartbeat.go heartbeatTimeoutDocID).
+// this MetadataKeys' heartbeater namespace. CouchbaseHeartbeater writes
+// `<heartbeaterPrefix>heartbeat_timeout:<nodeUUID>` (see heartbeat.go heartbeatTimeoutDocID),
+// where heartbeaterPrefix is the value returned by HeartbeaterPrefix(groupID) — i.e. it
+// already includes the configured groupID when one is set. The full on-disk shape is
+// therefore `<m.heartbeaterPrefix>(<groupID>:)?heartbeat_timeout:<nodeUUID>`, where the
+// inner groupID segment is present only for EE-with-import deployments configured with a
+// non-empty groupID.
 //
-// Matching the literal `heartbeat_timeout:` suffix matters because the default-mode
+// Matching the literal `heartbeat_timeout:` token matters because the default-mode
 // heartbeaterPrefix is bare `_sync:`, which would otherwise classify every unrecognised
 // `_sync:` key as a heartbeater and risk deletion during metadata migration.
 func (m *MetadataKeys) IsLegacyHeartbeaterKey(key string) bool {
-	return strings.HasPrefix(key, m.heartbeaterPrefix+"heartbeat_timeout:")
+	if !strings.HasPrefix(key, m.heartbeaterPrefix) {
+		return false
+	}
+	rest := key[len(m.heartbeaterPrefix):]
+	// No groupID: matches immediately after the heartbeater prefix.
+	if strings.HasPrefix(rest, "heartbeat_timeout:") {
+		return true
+	}
+	// With groupID: one extra colon-terminated segment between the prefix and the
+	// `heartbeat_timeout:` token. The groupID itself cannot contain `:` (config-key
+	// shape — see DefaultGroupID constant), so taking everything up to the first `:`
+	// as the candidate groupID is safe.
+	if i := strings.IndexByte(rest, ':'); i > 0 {
+		return strings.HasPrefix(rest[i+1:], "heartbeat_timeout:")
+	}
+	return false
 }
 
 // SGCfgPrefix returns a document prefix to use for cfg documents (cbgt)

--- a/base/constants_syncdocs_test.go
+++ b/base/constants_syncdocs_test.go
@@ -647,3 +647,36 @@ func TestDecodeSyncInfo(t *testing.T) {
 		})
 	}
 }
+
+func TestIsHeartbeaterKey(t *testing.T) {
+	tests := []struct {
+		key  string
+		want bool
+	}{
+		{
+			"not_heartbeat_timeout",
+			false,
+		},
+		{
+			"_sync:heartbeat_timeout:nodeuid",
+			true,
+		},
+		{
+			"_sync:group_id:heartbeat_timeout:nodeuid",
+			true,
+		},
+		{
+			"_sync:m_id:hb:heartbeat_timeout:nodeuid",
+			true,
+		},
+		{
+			"_sync:m_id:hb:group_id:heartbeat_timeout:nodeuid",
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			assert.Equalf(t, tt.want, IsHeartbeaterKey(tt.key), "IsHeartbeaterKey(%v)", tt.key)
+		})
+	}
+}

--- a/base/dual_metadata_store.go
+++ b/base/dual_metadata_store.go
@@ -13,7 +13,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"strconv"
 	"sync/atomic"
 
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -311,14 +310,16 @@ func (ms *MetadataStore) Incr(ctx context.Context, k string, amt, def uint64, ex
 			return 0, fmt.Errorf("MetadataStore.Incr: unrecognised fallback body for counter %s during migration", UD(k))
 		}
 
-		// 2. insert primary at pill.LastSeq. AddRaw returns (added=false, err=nil) on
-		// duplicate (both gocb and rosmar paths swallow the duplicate explicitly) so a
-		// sibling node that already finished the move is benign; we still proceed to step
-		// 3 to clean up our fallback view. IsCasMismatch is defensive for backends /
-		// wrappers that may surface a CAS error instead.
-		counterBytes := []byte(strconv.FormatUint(pill.LastSeq, 10))
-		if _, addErr := ms.primary.AddRaw(ctx, k, 0, counterBytes); addErr != nil && !IsCasMismatch(addErr) {
-			return 0, addErr
+		// 2. seed primary at pill.LastSeq via Incr(amt=0, def=pill.LastSeq). Using Incr
+		// rather than AddRaw matters on Couchbase Server: AddRaw writes the doc with
+		// the Binary datatype flag, which SGJSONTranscoder (used by GetCounter on
+		// later reads) refuses to decode — causing the sequence allocator to fail
+		// post-migration with "you must encode raw JSON data in a byte array or
+		// string". Incr creates counters with the proper datatype. Race-tolerant:
+		// if a sibling already promoted the counter, Incr(0, def, 0) returns the
+		// existing value without overwriting.
+		if _, seedErr := ms.primary.Incr(ctx, k, 0, pill.LastSeq, 0); seedErr != nil {
+			return 0, seedErr
 		}
 		// 3. delete fallback pill
 		if delErr := ms.fallback.Delete(ctx, k); delErr != nil && !IsDocNotFoundError(delErr) {

--- a/base/dual_metadata_store.go
+++ b/base/dual_metadata_store.go
@@ -11,6 +11,9 @@ package base
 import (
 	"context"
 	"errors"
+	"fmt"
+	"math"
+	"strconv"
 	"sync/atomic"
 
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -251,8 +254,81 @@ func (ms *MetadataStore) Update(ctx context.Context, k string, exp uint32, callb
 	return casOut, err
 }
 
+// Incr runs an Incr op on Primary (with some fallback handling and required migration steps).
+//
+// The outer loop only ever re-enters when another SG node moves the counter to primary
+// between our fallback.Incr and our pill-read GetRaw - exactly one extra iteration in practice.
 func (ms *MetadataStore) Incr(ctx context.Context, k string, amt, def uint64, exp uint32) (casOut uint64, err error) {
-	return ms.primary.Incr(ctx, k, amt, def, exp)
+	const maxAttempts = 2
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if ms.migrationComplete.Load() {
+			return ms.primary.Incr(ctx, k, amt, def, exp)
+		}
+
+		// Happy-path (already migrated incr - don't allow creation of doc via MaxUint64 def)
+		result, primaryErr := ms.primary.Incr(ctx, k, amt, math.MaxUint64, exp)
+		if primaryErr == nil {
+			return result, nil
+		}
+		if !IsDocNotFoundError(primaryErr) {
+			return 0, primaryErr
+		}
+
+		// Primary missing - try fallback with the "don't-create" sentinel def.
+		result, fbIncrErr := ms.fallback.Incr(ctx, k, amt, math.MaxUint64, exp)
+		if fbIncrErr == nil {
+			// Legacy unmigrated counter - pass through. The migration manager (or a later
+			// wrapper call after the pill is written) will move it to primary.
+			return result, nil
+		}
+
+		// Brand-new counter, create on primary at the caller's default.
+		if IsDocNotFoundError(fbIncrErr) {
+			return ms.primary.Incr(ctx, k, amt, def, exp)
+		}
+		// any other errors bubble up
+		if !IsCounterNonNumeric(fbIncrErr) {
+			return 0, fbIncrErr
+		}
+
+		// Fallback returned DELTA_BADVAL - we're mid-migration of the seq - the doc has
+		// been poison pilled but not yet moved. We'll attempt to move it here in case the
+		// migration process failed part way through.
+
+		// 1. read pill counter value
+		raw, _, fbErr := ms.fallback.GetRaw(ctx, k)
+		if IsDocNotFoundError(fbErr) {
+			// Sibling node finished the move between our fallback.Incr (which saw the
+			// pill and returned non-numeric) and this GetRaw. Loop back to the top -
+			// primary now holds the counter so the happy-path branch wins on retry.
+			continue
+		}
+		if fbErr != nil {
+			return 0, fbErr
+		}
+		var pill SyncSeqMigrationPill
+		if jsonErr := JSONUnmarshal(raw, &pill); jsonErr != nil || !pill.SGMetadataMigrationPill {
+			return 0, fmt.Errorf("MetadataStore.Incr: unrecognised fallback body for counter %s during migration", UD(k))
+		}
+
+		// 2. insert primary at pill.LastSeq. AddRaw returns (added=false, err=nil) on
+		// duplicate (both gocb and rosmar paths swallow the duplicate explicitly) so a
+		// sibling node that already finished the move is benign; we still proceed to step
+		// 3 to clean up our fallback view. IsCasMismatch is defensive for backends /
+		// wrappers that may surface a CAS error instead.
+		counterBytes := []byte(strconv.FormatUint(pill.LastSeq, 10))
+		if _, addErr := ms.primary.AddRaw(ctx, k, 0, counterBytes); addErr != nil && !IsCasMismatch(addErr) {
+			return 0, addErr
+		}
+		// 3. delete fallback pill
+		if delErr := ms.fallback.Delete(ctx, k); delErr != nil && !IsDocNotFoundError(delErr) {
+			WarnfCtx(ctx, "MetadataStore.Incr: failed to clear migrated fallback counter %s: %v", UD(k), delErr)
+		}
+
+		// 4. retry the caller's Incr on the now migrated primary
+		return ms.primary.Incr(ctx, k, amt, def, exp)
+	}
+	return 0, fmt.Errorf("MetadataStore.Incr: gave up after %d self-heal attempts for counter %s", maxAttempts, UD(k))
 }
 
 // ---- XattrStore – read operations (primary with fallback) ----

--- a/base/dual_metadata_store_test.go
+++ b/base/dual_metadata_store_test.go
@@ -80,6 +80,15 @@ func TestMetadataStoreIncrSelfHealsPill(t *testing.T) {
 
 	_, _, err = ms.Fallback().GetRaw(ctx, key)
 	assert.True(t, IsDocNotFoundError(err), "expected pill to be removed after self-heal, got %v", err)
+
+	// Regression check: the seeded counter must be readable via GetCounter, which goes
+	// through SGJSONTranscoder. If the seed wrote with the Binary datatype flag instead
+	// of as a counter, this fails on Couchbase Server with "you must encode raw JSON
+	// data in a byte array or string" — exactly the failure mode the migration manager
+	// hit before switching from AddRaw to Incr for the post-pill seed.
+	counterValue, err := GetCounter(ctx, ms.Primary(), key)
+	require.NoError(t, err, "post-self-heal counter must be readable via GetCounter")
+	assert.Equal(t, uint64(50), counterValue)
 }
 
 // TestPrimaryAddRawDuplicateContract pins the AddRaw-on-duplicate contract that the

--- a/base/dual_metadata_store_test.go
+++ b/base/dual_metadata_store_test.go
@@ -153,8 +153,6 @@ func TestPrimaryAddRawDuplicateContract(t *testing.T) {
 }
 
 // TestMetadataStoreIncrAfterMigrationCompleteBypassesFallback verifies that once
-
-// TestMetadataStoreIncrAfterMigrationCompleteBypassesFallback verifies that once
 // SetMigrationComplete has been called the wrapper short-circuits to primary, even if a
 // fallback doc still exists (it should be invisible).
 func TestMetadataStoreIncrAfterMigrationCompleteBypassesFallback(t *testing.T) {

--- a/base/dual_metadata_store_test.go
+++ b/base/dual_metadata_store_test.go
@@ -1,0 +1,188 @@
+// Copyright 2026-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package base
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestMetadataStore returns a MetadataStore backed by two distinct DataStores in the
+// supplied TestBucket: the default collection as fallback (matching legacy SG layout) and a
+// named collection as primary. Both are supported by Rosmar so these tests run by default.
+func newTestMetadataStore(t *testing.T, bucket *TestBucket) *MetadataStore {
+	t.Helper()
+	primary, err := bucket.GetNamedDataStore(0)
+	require.NoError(t, err)
+	fallback := bucket.DefaultDataStore(TestCtx(t))
+	return NewMetadataStore(primary, fallback)
+}
+
+// TestMetadataStoreIncrLegacyFallbackPassthrough verifies that when primary is empty and
+// fallback holds a legacy numeric counter (no migration pill), the wrapper passes Incrs
+// through to the fallback rather than migrating. Migration only happens once the migration
+// manager writes the poison pill.
+func TestMetadataStoreIncrLegacyFallbackPassthrough(t *testing.T) {
+	ctx := TestCtx(t)
+	bucket := GetTestBucket(t)
+	defer bucket.Close(ctx)
+
+	ms := newTestMetadataStore(t, bucket)
+	const key = "_sync:m_testIncr:seq"
+
+	_, err := ms.Fallback().Incr(ctx, key, 10, 10, 0)
+	require.NoError(t, err)
+
+	result, err := ms.Incr(ctx, key, 5, 0, 0)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(15), result, "expected legacy fallback Incr to flow through")
+
+	fbVal, err := GetCounter(ctx, ms.Fallback(), key)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(15), fbVal, "wrapper must not move legacy counters without a pill")
+
+	primaryExists, err := ms.Primary().Exists(ctx, key)
+	require.NoError(t, err)
+	assert.False(t, primaryExists, "primary should remain untouched in the legacy passthrough case")
+}
+
+// TestMetadataStoreIncrSelfHealsPill verifies the wrapper recognises a
+// SyncSeqMigrationPill body on the fallback, extracts LastSeq, bootstraps primary, and
+// clears the pill.
+func TestMetadataStoreIncrSelfHealsPill(t *testing.T) {
+	ctx := TestCtx(t)
+	bucket := GetTestBucket(t)
+	defer bucket.Close(ctx)
+
+	ms := newTestMetadataStore(t, bucket)
+	const key = "_sync:m_testPill:seq"
+
+	pill := SyncSeqMigrationPill{LastSeq: 42, SGMetadataMigrationPill: true, PilledAt: "2026-05-27T00:00:00Z"}
+	payload, err := JSONMarshal(&pill)
+	require.NoError(t, err)
+	_, err = ms.Fallback().AddRaw(ctx, key, 0, payload)
+	require.NoError(t, err)
+
+	// Wrapper Incr: bootstrap primary at LastSeq=42, then add the requested amount.
+	result, err := ms.Incr(ctx, key, 8, 0, 0)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(50), result, "expected primary counter to be seeded from pill.LastSeq")
+
+	_, _, err = ms.Fallback().GetRaw(ctx, key)
+	assert.True(t, IsDocNotFoundError(err), "expected pill to be removed after self-heal, got %v", err)
+}
+
+// TestPrimaryAddRawDuplicateContract pins the AddRaw-on-duplicate contract that the
+// wrapper's Incr self-heal branch relies on: returning (added=false, err=nil) rather than
+// surfacing a duplicate-key error. Both the gocb path (collection_gocb.go) and the
+// rosmar path (rosmar.Collection.add) honour this today. A future backend regression that
+// starts surfacing sgbucket.ErrKeyExists or similar would break the wrapper's race
+// tolerance, so we lock the contract here.
+func TestPrimaryAddRawDuplicateContract(t *testing.T) {
+	ctx := TestCtx(t)
+	bucket := GetTestBucket(t)
+	defer bucket.Close(ctx)
+
+	ms := newTestMetadataStore(t, bucket)
+	const key = "_sync:m_testAddRawDup:seq"
+
+	added, err := ms.Primary().AddRaw(ctx, key, 0, []byte("42"))
+	require.NoError(t, err)
+	require.True(t, added, "first AddRaw should succeed")
+
+	added, err = ms.Primary().AddRaw(ctx, key, 0, []byte("99"))
+	require.NoError(t, err, "duplicate AddRaw must not surface an error — wrapper's self-heal relies on this")
+	require.False(t, added, "duplicate AddRaw must return added=false")
+}
+
+// TestMetadataStoreIncrAfterMigrationCompleteBypassesFallback verifies that once
+
+// TestMetadataStoreIncrAfterMigrationCompleteBypassesFallback verifies that once
+// SetMigrationComplete has been called the wrapper short-circuits to primary, even if a
+// fallback doc still exists (it should be invisible).
+func TestMetadataStoreIncrAfterMigrationCompleteBypassesFallback(t *testing.T) {
+	ctx := TestCtx(t)
+	bucket := GetTestBucket(t)
+	defer bucket.Close(ctx)
+
+	ms := newTestMetadataStore(t, bucket)
+	const key = "_sync:m_testComplete:seq"
+
+	// Stale fallback value present.
+	_, err := ms.Fallback().Incr(ctx, key, 99, 99, 0)
+	require.NoError(t, err)
+
+	ms.SetMigrationComplete()
+
+	// Wrapper should not consult fallback now; primary doc gets created at the supplied
+	// default value (1) and incremented by amt (0), returning the default value.
+	result, err := ms.Incr(ctx, key, 0, 1, 0)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), result, "expected primary auto-create at def, fallback should be invisible")
+}
+
+// TestMetadataStoreIncrUnknownFallbackBodyErrors confirms that a non-pill, non-numeric
+// fallback body produces an explicit error rather than silently treating the doc as zero
+// (which would lose sequences).
+func TestMetadataStoreIncrUnknownFallbackBodyErrors(t *testing.T) {
+	ctx := TestCtx(t)
+	bucket := GetTestBucket(t)
+	defer bucket.Close(ctx)
+
+	ms := newTestMetadataStore(t, bucket)
+	const key = "_sync:m_testGarbage:seq"
+
+	garbage := []byte(`{"unrecognised":"shape"}`)
+	_, err := ms.Fallback().AddRaw(ctx, key, 0, garbage)
+	require.NoError(t, err)
+
+	_, err = ms.Incr(ctx, key, 1, 1, 0)
+	require.Error(t, err, "expected an explicit error when the fallback body is neither a counter nor a pill")
+}
+
+// TestMetadataStoreIncrEmptyFallbackCreatesOnPrimary covers the new-database path: the
+// fallback has nothing for the key, so Incr should fall through to primary's auto-create.
+func TestMetadataStoreIncrEmptyFallbackCreatesOnPrimary(t *testing.T) {
+	ctx := TestCtx(t)
+	bucket := GetTestBucket(t)
+	defer bucket.Close(ctx)
+
+	ms := newTestMetadataStore(t, bucket)
+	const key = "_sync:m_testNewDB:seq"
+
+	result, err := ms.Incr(ctx, key, 0, 100, 0)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(100), result)
+
+	primaryExists, getErr := ms.Primary().Exists(ctx, key)
+	require.NoError(t, getErr)
+	assert.True(t, primaryExists, "expected primary to hold the new counter")
+}
+
+// TestIsCounterNonNumeric verifies the predicate recognises both the gocb
+// StatusBadDelta (DELTA_BADVAL) shape and the rosmar json.UnmarshalTypeError shape so the
+// wrapper's self-heal branch trips uniformly across backends.
+func TestIsCounterNonNumeric(t *testing.T) {
+	assert.False(t, IsCounterNonNumeric(nil))
+
+	// Rosmar surfaces a *json.UnmarshalTypeError when Incr decodes a JSON-object body
+	// into a uint64. Manufacture the same error here so the predicate is exercised
+	// without needing a live backend.
+	var dest uint64
+	rosmarShape := json.Unmarshal([]byte(`{"last_seq":42}`), &dest)
+	require.Error(t, rosmarShape)
+	assert.True(t, IsCounterNonNumeric(rosmarShape))
+
+	// Sanity: an unrelated error should NOT be classified as non-numeric.
+	assert.False(t, IsCounterNonNumeric(errors.New("unrelated")))
+}

--- a/base/dual_metadata_store_test.go
+++ b/base/dual_metadata_store_test.go
@@ -91,6 +91,44 @@ func TestMetadataStoreIncrSelfHealsPill(t *testing.T) {
 	assert.Equal(t, uint64(50), counterValue)
 }
 
+// TestGetCounterHealsSeqMigrationPill is the regression for the crash-restart wedge
+// where a pill on the fallback seq counter outlives the wrapper's Incr self-heal. At
+// DB startup sequenceAllocator.lastSequence -> base.GetCounter is the first read of
+// the seq counter; before GetCounter routed through Incr, a fallback pill body
+// returned an UnmarshalTypeError into *uint64 and the database failed to start.
+// Routing through Incr(0,0,0) lets the wrapper self-heal transparently.
+func TestGetCounterHealsSeqMigrationPill(t *testing.T) {
+	ctx := TestCtx(t)
+	bucket := GetTestBucket(t)
+	defer bucket.Close(ctx)
+
+	ms := newTestMetadataStore(t, bucket)
+	const key = "_sync:m_testGetCounterPill:seq"
+
+	pill := SyncSeqMigrationPill{LastSeq: 100, SGMetadataMigrationPill: true, PilledAt: "2026-05-27T00:00:00Z"}
+	payload, err := JSONMarshal(&pill)
+	require.NoError(t, err)
+	_, err = ms.Fallback().AddRaw(ctx, key, 0, payload)
+	require.NoError(t, err)
+
+	value, err := GetCounter(ctx, ms, key)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(100), value, "GetCounter must return pill.LastSeq via wrapper.Incr self-heal")
+
+	_, _, err = ms.Fallback().GetRaw(ctx, key)
+	assert.True(t, IsDocNotFoundError(err), "fallback pill must be cleared after self-heal, got %v", err)
+
+	primaryValue, err := GetCounter(ctx, ms.Primary(), key)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(100), primaryValue, "primary must hold the seeded counter")
+
+	// Idempotence: second invocation should return the same value with no further side
+	// effects (no second pill required, no error on the already-migrated counter).
+	again, err := GetCounter(ctx, ms, key)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(100), again)
+}
+
 // TestPrimaryAddRawDuplicateContract pins the AddRaw-on-duplicate contract that the
 // wrapper's Incr self-heal branch relies on: returning (added=false, err=nil) rather than
 // surfacing a duplicate-key error. Both the gocb path (collection_gocb.go) and the

--- a/base/error.go
+++ b/base/error.go
@@ -220,6 +220,27 @@ func CouchHTTPErrorName(status int) string {
 	return fmt.Sprintf("%d", status)
 }
 
+// IsCounterNonNumeric returns true if err indicates a counter Incr/Decr was attempted
+// against a document whose body isn't a numeric counter. Two shapes are recognised:
+//
+//   - gocb / Couchbase Server: memcached StatusBadDelta (DELTA_BADVAL).
+//   - Rosmar (until updated): a json.UnmarshalTypeError surfaced when the SDK tries to
+//     decode the body as a uint64.
+//
+// The migration manager's poison pill replaces the seq counter with a JSON pill body,
+// which trips this predicate on the wrapper's fallback.Incr and routes execution into the
+// self-heal branch.
+func IsCounterNonNumeric(err error) bool {
+	if err == nil {
+		return false
+	}
+	if isKVError(pkgerrors.Cause(err), memd.StatusBadDelta) {
+		return true
+	}
+	var jsonTypeErr *json.UnmarshalTypeError
+	return errors.As(err, &jsonTypeErr)
+}
+
 // IsDocNotFoundError returns true if an error is a doc-not-found error
 func IsDocNotFoundError(err error) bool {
 	if err == nil {

--- a/base/stats.go
+++ b/base/stats.go
@@ -903,19 +903,12 @@ type SharedBucketImportStats struct {
 	ImportFeedProcessedCount *SgwIntStat `json:"import_feed_processed_count"`
 }
 
-// Per-DB metadata migration state values exported via MigrationStats.State.
-// These mirror the cluster-status values in base/metadata_migration_status.go but
-// scoped to a single DB's view of progress.
-const (
-	MigrationStatsStateIdle       int64 = 0
-	MigrationStatsStateInProgress int64 = 1
-	MigrationStatsStateComplete   int64 = 2
-)
-
-// MigrationStats are per-DB Prometheus-backed counters and a state gauge for the
-// metadata-migration background task. Only initialized for databases that have
-// opted into the system metadata collection — for all other databases this
-// section is absent from the per-DB stats payload.
+// MigrationStats are per-DB Prometheus-backed counters for the metadata-migration
+// background task. Only initialized for databases that have opted into the system
+// metadata collection — for all other databases this section is absent from the
+// per-DB stats payload. Lifecycle state (running/stopped/error) is owned by the
+// BackgroundManager and surfaced via the _metadata_migration REST endpoint, not
+// here.
 type MigrationStats struct {
 	// Cumulative count of fallback keys observed by range scans across all passes.
 	DocsScannedTotal *SgwIntStat `json:"docs_scanned_total"`
@@ -931,8 +924,6 @@ type MigrationStats struct {
 	SeqPoisonPillApplied *SgwIntStat `json:"seq_poison_pill_applied"`
 	// Cumulative count of MigrateMetadata pass invocations.
 	Passes *SgwIntStat `json:"passes"`
-	// Current per-DB migration state (0=idle, 1=in_progress, 2=complete).
-	State *SgwIntStat `json:"state"`
 }
 
 type SgwStatWrapper interface {
@@ -2572,10 +2563,6 @@ func (d *DbStats) InitMigrationStats() error {
 	if err != nil {
 		return err
 	}
-	resUtil.State, err = NewIntStat(SubsystemMetadataMigration, "state", StatUnitNoUnits, MetadataMigrationStateDesc, StatAddedVersion4dot1dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.GaugeValue, MigrationStatsStateIdle)
-	if err != nil {
-		return err
-	}
 	d.MigrationStats = resUtil
 	return nil
 }
@@ -2588,7 +2575,6 @@ func (d *DbStats) unregisterMigrationStats() {
 	prometheus.Unregister(d.MigrationStats.Errors)
 	prometheus.Unregister(d.MigrationStats.SeqPoisonPillApplied)
 	prometheus.Unregister(d.MigrationStats.Passes)
-	prometheus.Unregister(d.MigrationStats.State)
 }
 
 func (d *DbStats) MetadataMigration() *MigrationStats {

--- a/base/stats.go
+++ b/base/stats.go
@@ -44,6 +44,7 @@ const (
 	SubsystemReplicationPush    = "replication_push"
 	SubsystemSecurity           = "security"
 	SubsystemSharedBucketImport = "shared_bucket_import"
+	SubsystemMetadataMigration  = "metadata_migration"
 
 	DatabaseLabelKey    = "database"
 	ReplicationLabelKey = "replication"
@@ -434,6 +435,7 @@ type DbStats struct {
 	DbReplicatorStats       map[string]*DbReplicatorStats `json:"replications,omitempty"`
 	SecurityStats           *SecurityStats                `json:"security,omitempty"`
 	SharedBucketImportStats *SharedBucketImportStats      `json:"shared_bucket_import,omitempty"`
+	MigrationStats          *MigrationStats               `json:"metadata_migration,omitempty"`
 	CollectionStats         map[string]*CollectionStats   `json:"per_collection,omitempty"`
 	dbReplicatorStatsMutex  sync.Mutex
 }
@@ -901,6 +903,38 @@ type SharedBucketImportStats struct {
 	ImportFeedProcessedCount *SgwIntStat `json:"import_feed_processed_count"`
 }
 
+// Per-DB metadata migration state values exported via MigrationStats.State.
+// These mirror the cluster-status values in base/metadata_migration_status.go but
+// scoped to a single DB's view of progress.
+const (
+	MigrationStatsStateIdle       int64 = 0
+	MigrationStatsStateInProgress int64 = 1
+	MigrationStatsStateComplete   int64 = 2
+)
+
+// MigrationStats are per-DB Prometheus-backed counters and a state gauge for the
+// metadata-migration background task. Only initialized for databases that have
+// opted into the system metadata collection — for all other databases this
+// section is absent from the per-DB stats payload.
+type MigrationStats struct {
+	// Cumulative count of fallback keys observed by range scans across all passes.
+	DocsScannedTotal *SgwIntStat `json:"docs_scanned_total"`
+	// Cumulative count of fallback docs successfully moved to primary (or deleted, for transient docs).
+	DocsMigrated *SgwIntStat `json:"docs_migrated"`
+	// Number of out-of-scope keys observed on the most recent pass (sibling-DB or bucket-level docs).
+	DocsOutOfScope *SgwIntStat `json:"docs_out_of_scope"`
+	// Number of unknown-prefix keys observed on the most recent pass.
+	DocsUnknownPrefix *SgwIntStat `json:"docs_unknown_prefix"`
+	// Cumulative per-doc error count.
+	Errors *SgwIntStat `json:"errors"`
+	// Cumulative count of seq-counter poison-pill applications. Typically 0 or 1 per migration run.
+	SeqPoisonPillApplied *SgwIntStat `json:"seq_poison_pill_applied"`
+	// Cumulative count of MigrateMetadata pass invocations.
+	Passes *SgwIntStat `json:"passes"`
+	// Current per-DB migration state (0=idle, 1=in_progress, 2=complete).
+	State *SgwIntStat `json:"state"`
+}
+
 type SgwStatWrapper interface {
 	FormatString() string
 	Name() string
@@ -1295,7 +1329,7 @@ type QueryStat struct {
 	QueryTime       *SgwIntStat
 }
 
-func (s *SgwStats) NewDBStats(name string, deltaSyncEnabled bool, importEnabled bool, viewsEnabled bool, queryNames []string, collections []string) (*DbStats, error) {
+func (s *SgwStats) NewDBStats(name string, deltaSyncEnabled bool, importEnabled bool, viewsEnabled bool, metadataMigrationEnabled bool, queryNames []string, collections []string) (*DbStats, error) {
 	s.dbStatsMapMutex.Lock()
 	defer s.dbStatsMapMutex.Unlock()
 	dbStats := &DbStats{
@@ -1339,6 +1373,13 @@ func (s *SgwStats) NewDBStats(name string, deltaSyncEnabled bool, importEnabled 
 
 	if importEnabled {
 		err = dbStats.InitSharedBucketImportStats()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if metadataMigrationEnabled {
+		err = dbStats.InitMigrationStats()
 		if err != nil {
 			return nil, err
 		}
@@ -1390,6 +1431,10 @@ func (s *SgwStats) ClearDBStats(name string) {
 
 	if s.DbStats[name].SharedBucketImportStats != nil {
 		s.DbStats[name].unregisterSharedBucketImportStats()
+	}
+
+	if s.DbStats[name].MigrationStats != nil {
+		s.DbStats[name].unregisterMigrationStats()
 	}
 
 	s.DbStats[name].unregisterQueryStats()
@@ -2484,6 +2529,70 @@ func (d *DbStats) unregisterSharedBucketImportStats() {
 
 func (d *DbStats) SharedBucketImport() *SharedBucketImportStats {
 	return d.SharedBucketImportStats
+}
+
+// InitMigrationStats wires up the per-DB metadata migration stat section. Callers
+// should only invoke this for databases that have opted into the system metadata
+// collection — for all others MigrationStats stays nil so the section is omitted
+// from the per-DB stats payload entirely.
+func (d *DbStats) InitMigrationStats() error {
+	if d.MigrationStats != nil {
+		return nil
+	}
+	labelKeys := []string{DatabaseLabelKey}
+	labelVals := []string{d.dbName}
+
+	resUtil := &MigrationStats{}
+	var err error
+	resUtil.DocsScannedTotal, err = NewIntStat(SubsystemMetadataMigration, "docs_scanned_total", StatUnitNoUnits, MetadataMigrationDocsScannedDesc, StatAddedVersion4dot1dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
+	resUtil.DocsMigrated, err = NewIntStat(SubsystemMetadataMigration, "docs_migrated", StatUnitNoUnits, MetadataMigrationDocsMigratedDesc, StatAddedVersion4dot1dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
+	resUtil.DocsOutOfScope, err = NewIntStat(SubsystemMetadataMigration, "docs_out_of_scope", StatUnitNoUnits, MetadataMigrationDocsOutOfScopeDesc, StatAddedVersion4dot1dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.GaugeValue, 0)
+	if err != nil {
+		return err
+	}
+	resUtil.DocsUnknownPrefix, err = NewIntStat(SubsystemMetadataMigration, "docs_unknown_prefix", StatUnitNoUnits, MetadataMigrationDocsUnknownPrefixDesc, StatAddedVersion4dot1dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.GaugeValue, 0)
+	if err != nil {
+		return err
+	}
+	resUtil.Errors, err = NewIntStat(SubsystemMetadataMigration, "errors", StatUnitNoUnits, MetadataMigrationErrorsDesc, StatAddedVersion4dot1dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
+	resUtil.SeqPoisonPillApplied, err = NewIntStat(SubsystemMetadataMigration, "seq_poison_pill_applied", StatUnitNoUnits, MetadataMigrationSeqPoisonPillAppliedDesc, StatAddedVersion4dot1dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
+	resUtil.Passes, err = NewIntStat(SubsystemMetadataMigration, "passes", StatUnitNoUnits, MetadataMigrationPassesDesc, StatAddedVersion4dot1dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
+	resUtil.State, err = NewIntStat(SubsystemMetadataMigration, "state", StatUnitNoUnits, MetadataMigrationStateDesc, StatAddedVersion4dot1dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.GaugeValue, MigrationStatsStateIdle)
+	if err != nil {
+		return err
+	}
+	d.MigrationStats = resUtil
+	return nil
+}
+
+func (d *DbStats) unregisterMigrationStats() {
+	prometheus.Unregister(d.MigrationStats.DocsScannedTotal)
+	prometheus.Unregister(d.MigrationStats.DocsMigrated)
+	prometheus.Unregister(d.MigrationStats.DocsOutOfScope)
+	prometheus.Unregister(d.MigrationStats.DocsUnknownPrefix)
+	prometheus.Unregister(d.MigrationStats.Errors)
+	prometheus.Unregister(d.MigrationStats.SeqPoisonPillApplied)
+	prometheus.Unregister(d.MigrationStats.Passes)
+	prometheus.Unregister(d.MigrationStats.State)
+}
+
+func (d *DbStats) MetadataMigration() *MigrationStats {
+	return d.MigrationStats
 }
 
 func (d *DbStats) InitQueryStats(useViews bool, queryNames ...string) error {

--- a/base/stats_descriptions.go
+++ b/base/stats_descriptions.go
@@ -422,8 +422,6 @@ const (
 	MetadataMigrationSeqPoisonPillAppliedDesc = "The total number of times this node applied the seq-counter poison pill to initiate fallback→primary sequence handoff. Typically 0 or 1 per migration run."
 
 	MetadataMigrationPassesDesc = "The total number of MigrateMetadata range-scan passes executed for this database."
-
-	MetadataMigrationStateDesc = "The current per-DB metadata migration state: 0 = idle/not started, 1 = in_progress, 2 = complete."
 )
 
 // DB Replicators stats descriptions (ISGR Specific)

--- a/base/stats_descriptions.go
+++ b/base/stats_descriptions.go
@@ -406,6 +406,26 @@ const (
 	ImportFeedProcessedCountDesc = "The total number of documents processed by import feed."
 )
 
+// Metadata Migration stats descriptions (per-DB, only populated when the database
+// has opted into the system metadata collection).
+const (
+	MetadataMigrationDocsScannedDesc = "The total number of fallback keys observed by metadata migration range scans across all passes."
+
+	MetadataMigrationDocsMigratedDesc = "The total number of metadata docs successfully moved from the fallback collection to the primary collection (or deleted, for transient docs)."
+
+	MetadataMigrationDocsOutOfScopeDesc = "The number of fallback keys classified as out-of-scope on the most recent pass (sibling-DB or bucket-level docs not owned by this database)."
+
+	MetadataMigrationDocsUnknownPrefixDesc = "The number of fallback keys with an unrecognised prefix observed on the most recent pass — these are left in place and cause an additional pass."
+
+	MetadataMigrationErrorsDesc = "The total number of per-doc errors observed during metadata migration moves or deletes across all passes."
+
+	MetadataMigrationSeqPoisonPillAppliedDesc = "The total number of times this node applied the seq-counter poison pill to initiate fallback→primary sequence handoff. Typically 0 or 1 per migration run."
+
+	MetadataMigrationPassesDesc = "The total number of MigrateMetadata range-scan passes executed for this database."
+
+	MetadataMigrationStateDesc = "The current per-DB metadata migration state: 0 = idle/not started, 1 = in_progress, 2 = complete."
+)
+
 // DB Replicators stats descriptions (ISGR Specific)
 const (
 	SGRDocsCheckedSentDesc = "The total number of documents checked for changes since replication started. This represents the number " +

--- a/base/util.go
+++ b/base/util.go
@@ -612,6 +612,13 @@ func CreateMaxDoublingSleeperFunc(maxNumAttempts, initialTimeToSleepMs int, maxS
 
 }
 
+// CreateIndefiniteSleeperFunc waits a fixed interval before retrying - without any upper bound on number of attempts.
+func CreateIndefiniteSleeperFunc(timeToSleepMs int) RetrySleeper {
+	return func(_ int) (bool, int) {
+		return true, timeToSleepMs
+	}
+}
+
 // CreateIndefiniteMaxDoublingSleeperFunc is similar to CreateMaxDoublingSleeperFunc, with the exception that there is no number of maximum retries.
 func CreateIndefiniteMaxDoublingSleeperFunc(initialTimeToSleepMs int, maxSleepPerRetryMs int) RetrySleeper {
 	timeToSleepMs := initialTimeToSleepMs

--- a/db/background_mgr_metadata_migration.go
+++ b/db/background_mgr_metadata_migration.go
@@ -12,6 +12,7 @@ package db
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -21,11 +22,13 @@ import (
 )
 
 type MetadataMigrationManager struct {
-	docsProcessed atomic.Int64
-	docsFailed    atomic.Int64
-	MigrationID   string
-	dbContext     *DatabaseContext
-	lock          sync.RWMutex
+	docsProcessed  atomic.Int64 // cumulative successful moves/deletes across all passes
+	docsFailed     atomic.Int64 // cumulative per-doc errors across all passes
+	docsOutOfScope atomic.Int64 // last-pass snapshot - same static set is re-scanned each pass
+	passes         atomic.Int64 // number of MigrateMetadata invocations attempted
+	MigrationID    string
+	dbContext      *DatabaseContext
+	lock           sync.RWMutex
 }
 
 const MetadataMigrationManagerName = "metadata_migration"
@@ -47,9 +50,12 @@ func NewMetadataMigrationManager(dbContext *DatabaseContext) *BackgroundManager 
 
 type MigrationManagerResponse struct {
 	BackgroundManagerStatus
-	DocsProcessed int64  `json:"docs_processed"`
-	DocsFailed    int64  `json:"docs_failed"`
-	MigrationID   string `json:"migration_id"`
+	DocsProcessed  int64  `json:"docs_processed"`    // cumulative successful moves/deletes
+	DocsFailed     int64  `json:"docs_failed"`       // cumulative per-doc errors
+	DocsAttempted  int64  `json:"docs_attempted"`    // docs_processed + docs_failed
+	DocsOutOfScope int64  `json:"docs_out_of_scope"` // last-pass snapshot
+	Passes         int64  `json:"passes"`            // number of MigrateMetadata invocations
+	MigrationID    string `json:"migration_id"`
 }
 
 type MigrationManagerStatusDoc struct {
@@ -77,8 +83,10 @@ func (m *MetadataMigrationManager) Init(ctx context.Context, options map[string]
 		}
 		m.docsProcessed.Store(status.DocsProcessed)
 		m.docsFailed.Store(status.DocsFailed)
+		m.docsOutOfScope.Store(status.DocsOutOfScope)
+		m.passes.Store(status.Passes)
 		m.MigrationID = status.MigrationID
-		base.InfofCtx(ctx, base.KeyAll, "Metadata Migration: Resuming migration run with migration ID: %s, docs processed: %d, docs failed: %d", m.MigrationID, status.DocsProcessed, status.DocsFailed)
+		base.InfofCtx(ctx, base.KeyAll, "Metadata Migration: Resuming migration run with migration ID: %s, docs processed: %d, docs failed: %d, passes: %d", m.MigrationID, status.DocsProcessed, status.DocsFailed, status.Passes)
 		return nil
 	}
 	return newRunInit()
@@ -121,10 +129,84 @@ func (m *MetadataMigrationManager) Run(ctx context.Context, options map[string]a
 		return base.RedactErrorf("[%s] Failed to mark per-DB migration in_progress: %v", metadataMigrationLoggingID, err)
 	}
 
-	// CBG-5228 will implement the actual copy + verify here. For now the manager treats the
-	// in_progress → complete transition as a no-op so the bucket-level all-complete trigger can
-	// be exercised end-to-end without waiting on the data movement implementation.
-	base.InfofCtx(ctx, base.KeyAll, "[%s] Per-DB copy step is stubbed (CBG-5228) — recording complete", metadataMigrationLoggingID)
+	// If the MetadataStore is not a dual-collection wrapper there is nothing to copy —
+	// fall through to the per-DB complete write so the bucket-level all-complete trigger
+	// can still fire and the entry doesn't wedge in in_progress.
+	if ms, ok := m.dbContext.MetadataStore.(*base.MetadataStore); ok {
+		// Bridge the terminator into context cancellation so long-running ops inside
+		// migrateSeqCounter (retry loop) and MigrateMetadata (range scan iteration) can
+		// observe stop requests without us having to thread *SafeTerminator through every
+		// function signature.
+		runCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
+		go func() {
+			select {
+			case <-terminator.Done():
+				cancel()
+			case <-runCtx.Done():
+			}
+		}()
+
+		// One-shot setup: poison-pill the fallback seq counter and nudge the wrapper to
+		// promote it to primary. Runs once per migration attempt — it has no per-doc-write
+		// race to recover from, so it does not belong inside the pass loop below.
+		seqStats := &MigrationStats{}
+		if err := migrateSeqCounter(runCtx, ms, base.NewMetadataKeys(metadataID).SyncSeqKey(), seqStats); err != nil {
+			return fmt.Errorf("[%s] seq counter migration: %w", metadataMigrationLoggingID, err)
+		}
+		if applied := seqStats.SeqPoisonPillApplied.Load(); applied > 0 {
+			base.InfofCtx(ctx, base.KeyAll, "[%s] seq counter pilled and promoted to primary", metadataMigrationLoggingID)
+		}
+
+		// The migration loop runs until either:
+		// - there are no in-scope remaining docs
+		// - we hit the max retries limit and give up
+		//
+		// Each pass scans the fallback DataStore, and remaining are in-scope docs we didn't move on this pass
+		const maxPasses = 16
+		for pass := 0; ; pass++ {
+			if terminator.IsClosed() {
+				// Mid-run stop: leave the per-DB entry in in_progress so the next manager
+				// invocation resumes from where we left off.
+				base.InfofCtx(ctx, base.KeyAll, "[%s] terminated mid-run after %d pass(es)", metadataMigrationLoggingID, pass)
+				return nil
+			}
+
+			stats := &MigrationStats{}
+			remaining, err := MigrateMetadata(runCtx, ms, metadataID, stats)
+			m.passes.Add(1)
+			m.docsProcessed.Add(stats.DocsMigrated.Load())
+			m.docsFailed.Add(stats.Errors.Load())
+			// Out-of-scope reflects what is left on the fallback, not work done - record
+			// the latest pass's view rather than accumulating across re-scans.
+			m.docsOutOfScope.Store(stats.DocsOutOfScope.Load())
+			base.InfofCtx(ctx, base.KeyAll,
+				"[%s] pass %d: migrated=%d failed=%d out_of_scope=%d remaining=%d (cumulative: processed=%d failed=%d)",
+				metadataMigrationLoggingID, pass+1,
+				stats.DocsMigrated.Load(), stats.Errors.Load(), stats.DocsOutOfScope.Load(), remaining,
+				m.docsProcessed.Load(), m.docsFailed.Load())
+			persistClusterStatus()
+			if err != nil {
+				return err
+			}
+
+			if remaining == 0 {
+				// finished successfully
+				break
+			}
+
+			if pass+1 >= maxPasses {
+				base.WarnfCtx(ctx, "[%s] gave up after %d passes with %d in-scope docs remaining", metadataMigrationLoggingID, maxPasses, remaining)
+				return fmt.Errorf("%s still not clear of metadata after %d passes: %d unknown-prefix doc(s) remain", ms.Fallback().GetName(), maxPasses, remaining)
+			}
+		}
+
+		ms.SetMigrationComplete()
+		base.InfofCtx(ctx, base.KeyAll, "[%s] Metadata migration complete after %d pass(es): %d migrated, %d failed, %d out of scope",
+			metadataMigrationLoggingID, m.passes.Load(), m.docsProcessed.Load(), m.docsFailed.Load(), m.docsOutOfScope.Load())
+	} else {
+		base.InfofCtx(ctx, base.KeyAll, "[%s] MetadataStore not running in primary/fallback mode - nothing to migrate", metadataMigrationLoggingID)
+	}
 
 	completedAt := time.Now().UTC()
 	if err := m.dbContext.MetadataMigrationStatusUpdater(ctx, func(s *base.MetadataMigrationStatus) error {
@@ -153,6 +235,8 @@ func (m *MetadataMigrationManager) ResetStatus() {
 	defer m.lock.Unlock()
 	m.docsProcessed.Store(0)
 	m.docsFailed.Store(0)
+	m.docsOutOfScope.Store(0)
+	m.passes.Store(0)
 	m.MigrationID = ""
 }
 
@@ -163,10 +247,15 @@ func (m *MetadataMigrationManager) SetProcessStatus(ctx context.Context, previou
 func (m *MetadataMigrationManager) GetProcessStatus(status BackgroundManagerStatus, previousStatus []byte) (statusOut []byte, meta []byte, err error) {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
+	processed := m.docsProcessed.Load()
+	failed := m.docsFailed.Load()
 	resp := MigrationManagerResponse{
 		BackgroundManagerStatus: status,
-		DocsProcessed:           m.docsProcessed.Load(),
-		DocsFailed:              m.docsFailed.Load(),
+		DocsProcessed:           processed,
+		DocsFailed:              failed,
+		DocsAttempted:           processed + failed,
+		DocsOutOfScope:          m.docsOutOfScope.Load(),
+		Passes:                  m.passes.Load(),
 		MigrationID:             m.MigrationID,
 	}
 	statusOut, err = base.JSONMarshal(resp)

--- a/db/background_mgr_metadata_migration.go
+++ b/db/background_mgr_metadata_migration.go
@@ -114,6 +114,18 @@ func (m *MetadataMigrationManager) Run(ctx context.Context, options map[string]a
 		return nil
 	}
 
+	// promStats is nil for databases that haven't opted into the system metadata
+	// collection (NewDBStats does not initialize the MigrationStats section in that
+	// case) and for test contexts that construct a manager without a full DbStats —
+	// every update site below must nil-guard before touching it.
+	var promStats *base.MigrationStats
+	if m.dbContext.DbStats != nil {
+		promStats = m.dbContext.DbStats.MetadataMigration()
+	}
+	if promStats != nil {
+		promStats.State.Set(base.MigrationStatsStateInProgress)
+	}
+
 	now := time.Now().UTC()
 	if err := m.dbContext.MetadataMigrationStatusUpdater(ctx, func(s *base.MetadataMigrationStatus) error {
 		entry, ok := s.Databases[metadataID]
@@ -154,8 +166,12 @@ func (m *MetadataMigrationManager) Run(ctx context.Context, options map[string]a
 		if err := migrateSeqCounter(runCtx, ms, base.NewMetadataKeys(metadataID).SyncSeqKey(), seqStats); err != nil {
 			return fmt.Errorf("[%s] seq counter migration: %w", metadataMigrationLoggingID, err)
 		}
-		if applied := seqStats.SeqPoisonPillApplied.Load(); applied > 0 {
+		applied := seqStats.SeqPoisonPillApplied.Load()
+		if applied > 0 {
 			base.InfofCtx(ctx, base.KeyAll, "[%s] seq counter pilled and promoted to primary", metadataMigrationLoggingID)
+		}
+		if promStats != nil && applied > 0 {
+			promStats.SeqPoisonPillApplied.Add(applied)
 		}
 
 		// The migration loop runs until either:
@@ -180,6 +196,17 @@ func (m *MetadataMigrationManager) Run(ctx context.Context, options map[string]a
 			// Out-of-scope reflects what is left on the fallback, not work done - record
 			// the latest pass's view rather than accumulating across re-scans.
 			m.docsOutOfScope.Store(stats.DocsOutOfScope.Load())
+			if promStats != nil {
+				promStats.Passes.Add(1)
+				promStats.DocsScannedTotal.Add(stats.DocsScannedTotal.Load())
+				promStats.DocsMigrated.Add(stats.DocsMigrated.Load())
+				promStats.Errors.Add(stats.Errors.Load())
+				// Out-of-scope / unknown-prefix counters are last-pass snapshots, not
+				// cumulative — pass-over-pass they re-scan the same static fallback set,
+				// so Set() rather than Add() matches the gauge semantics on these stats.
+				promStats.DocsOutOfScope.Set(stats.DocsOutOfScope.Load())
+				promStats.DocsUnknownPrefix.Set(int64(remaining))
+			}
 			base.InfofCtx(ctx, base.KeyAll,
 				"[%s] pass %d: migrated=%d failed=%d out_of_scope=%d remaining=%d (cumulative: processed=%d failed=%d)",
 				metadataMigrationLoggingID, pass+1,
@@ -220,6 +247,10 @@ func (m *MetadataMigrationManager) Run(ctx context.Context, options map[string]a
 		return nil
 	}); err != nil {
 		return base.RedactErrorf("[%s] Failed to mark per-DB migration complete: %v", metadataMigrationLoggingID, err)
+	}
+
+	if promStats != nil {
+		promStats.State.Set(base.MigrationStatsStateComplete)
 	}
 
 	if m.dbContext.PostMetadataMigrationCompleteFunc != nil {

--- a/db/background_mgr_metadata_migration.go
+++ b/db/background_mgr_metadata_migration.go
@@ -12,6 +12,7 @@ package db
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -34,6 +35,11 @@ type MetadataMigrationManager struct {
 const MetadataMigrationManagerName = "metadata_migration"
 
 var _ BackgroundManagerProcessI = &MetadataMigrationManager{}
+
+// errMetadataMigrationTerminated is the cancellation cause propagated to the run context when
+// the BackgroundManager terminator fires, so ops blocked on ctx (seq-counter retry loop, range
+// scan iteration) can distinguish an operator stop from a parent-context cancellation.
+var errMetadataMigrationTerminated = errors.New("metadata migration terminated by stop request")
 
 func NewMetadataMigrationManager(dbContext *DatabaseContext) *BackgroundManager {
 	return &BackgroundManager{
@@ -77,8 +83,15 @@ func (m *MetadataMigrationManager) Init(ctx context.Context, options map[string]
 	if clusterStatus != nil {
 		var status MigrationManagerStatusDoc
 		err := base.JSONUnmarshal(clusterStatus, &status)
-		// If the previous run completed, or there was an error during unmarshalling the status start again
-		if status.State == BackgroundProcessStateCompleted || err != nil {
+
+		reset, _ := options["reset"].(bool)
+		if reset {
+			base.InfofCtx(ctx, base.KeyAll, "Metadata Migration: Resetting migration process. Will not resume any partially completed process")
+		}
+
+		// If the previous run completed, there was an error during unmarshalling the status, or
+		// the caller requested a reset, start again with a fresh migration ID and zeroed counters.
+		if status.State == BackgroundProcessStateCompleted || err != nil || reset {
 			return newRunInit()
 		}
 		m.docsProcessed.Store(status.DocsProcessed)
@@ -146,12 +159,12 @@ func (m *MetadataMigrationManager) Run(ctx context.Context, options map[string]a
 		// migrateSeqCounter (retry loop) and MigrateMetadata (range scan iteration) can
 		// observe stop requests without us having to thread *SafeTerminator through every
 		// function signature.
-		runCtx, cancel := context.WithCancel(ctx)
-		defer cancel()
+		runCtx, cancel := context.WithCancelCause(ctx)
+		defer cancel(nil)
 		go func() {
 			select {
 			case <-terminator.Done():
-				cancel()
+				cancel(errMetadataMigrationTerminated)
 			case <-runCtx.Done():
 			}
 		}()
@@ -214,14 +227,22 @@ func (m *MetadataMigrationManager) Run(ctx context.Context, options map[string]a
 				return err
 			}
 
-			if remaining == 0 {
-				// finished successfully
+			// Completion gates on a pass that is clean of BOTH unknown-prefix docs (remaining)
+			// AND per-doc move/delete errors. A failed in-scope move increments stats.Errors and
+			// leaves the doc on the fallback, but does not count toward remaining — so breaking on
+			// remaining == 0 alone could call SetMigrationComplete() with an un-migrated doc still
+			// on the fallback, which the wrapper would then permanently ignore (data loss). Errors
+			// are typically transient (CAS races), so a non-clean pass simply forces a retry; only
+			// a persistent failure reaches the maxPasses give-up below, which never completes.
+			passErrors := stats.Errors.Load()
+			if remaining == 0 && passErrors == 0 {
+				// finished successfully — fallback verified clear of in-scope metadata
 				break
 			}
 
 			if pass+1 >= maxPasses {
-				base.WarnfCtx(ctx, "[%s] gave up after %d passes with %d in-scope docs remaining", metadataMigrationLoggingID, maxPasses, remaining)
-				return fmt.Errorf("%s still not clear of metadata after %d passes: %d unknown-prefix doc(s) remain", ms.Fallback().GetName(), maxPasses, remaining)
+				base.WarnfCtx(ctx, "[%s] gave up after %d passes with %d unknown-prefix doc(s) and %d per-doc error(s) on the last pass", metadataMigrationLoggingID, maxPasses, remaining, passErrors)
+				return fmt.Errorf("%s still not clear of metadata after %d passes: %d unknown-prefix doc(s), %d per-doc error(s) remain", ms.Fallback().GetName(), maxPasses, remaining, passErrors)
 			}
 		}
 

--- a/db/background_mgr_metadata_migration.go
+++ b/db/background_mgr_metadata_migration.go
@@ -122,9 +122,6 @@ func (m *MetadataMigrationManager) Run(ctx context.Context, options map[string]a
 	if m.dbContext.DbStats != nil {
 		promStats = m.dbContext.DbStats.MetadataMigration()
 	}
-	if promStats != nil {
-		promStats.State.Set(base.MigrationStatsStateInProgress)
-	}
 
 	now := time.Now().UTC()
 	if err := m.dbContext.MetadataMigrationStatusUpdater(ctx, func(s *base.MetadataMigrationStatus) error {
@@ -247,10 +244,6 @@ func (m *MetadataMigrationManager) Run(ctx context.Context, options map[string]a
 		return nil
 	}); err != nil {
 		return base.RedactErrorf("[%s] Failed to mark per-DB migration complete: %v", metadataMigrationLoggingID, err)
-	}
-
-	if promStats != nil {
-		promStats.State.Set(base.MigrationStatsStateComplete)
 	}
 
 	if m.dbContext.PostMetadataMigrationCompleteFunc != nil {

--- a/db/background_mgr_metadata_migration_test.go
+++ b/db/background_mgr_metadata_migration_test.go
@@ -129,6 +129,128 @@ func TestTryStartMetadataMigrationAlreadyRunning(t *testing.T) {
 	assert.NoError(t, err, "heartbeat lock doc should still exist - attempt must not have taken it")
 }
 
+// inMemoryMigrationStatusUpdater returns a MetadataMigrationStatusUpdater backed by a
+// throwaway in-memory MetadataMigrationStatus. The production wiring CAS-writes the
+// shared bucket-level status doc; these tests don't care about that contract, they just
+// need a non-nil updater so the manager's per-DB in_progress → complete writes succeed
+// and we can exercise the migration logic.
+func inMemoryMigrationStatusUpdater() func(context.Context, func(*base.MetadataMigrationStatus) error) error {
+	status := &base.MetadataMigrationStatus{Databases: map[string]*base.DatabaseMigrationStatus{}}
+	return func(_ context.Context, mutator func(*base.MetadataMigrationStatus) error) error {
+		return mutator(status)
+	}
+}
+
+// TestMetadataMigrationManagerMovesUsersAndRoles is the end-to-end check for the wired-up
+// background task: it seeds user and role docs onto the fallback collection, starts the
+// MetadataMigrationManager, waits for it to reach Completed, and verifies the docs were
+// actually relocated to the primary collection and removed from the fallback. It also
+// asserts the manager's externally-visible counters (DocsProcessed / DocsFailed) match
+// the seeded population and that SetMigrationComplete was flipped on a clean run.
+func TestMetadataMigrationManagerMovesUsersAndRoles(t *testing.T) {
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
+
+	primary, err := bucket.GetNamedDataStore(0)
+	require.NoError(t, err)
+	fallback := bucket.DefaultDataStore(ctx)
+	if _, ok := base.AsRangeScanStore(fallback); !ok {
+		t.Skipf("metadata migration requires KV range scan support on the fallback datastore")
+	}
+	ms := base.NewMetadataStore(primary, fallback)
+
+	const metadataID = "test-mgr-move-userrole"
+	metaKeys := base.NewMetadataKeys(metadataID)
+	seeded := map[string][]byte{
+		metaKeys.UserKey("alice"):   []byte(`{"name":"alice"}`),
+		metaKeys.UserKey("bob"):     []byte(`{"name":"bob"}`),
+		metaKeys.RoleKey("admins"):  []byte(`{"name":"admins"}`),
+		metaKeys.RoleKey("readers"): []byte(`{"name":"readers"}`),
+	}
+	for k, v := range seeded {
+		_, err := ms.Fallback().AddRaw(ctx, k, 0, v)
+		require.NoError(t, err, "seed fallback %s", k)
+	}
+
+	dbCtx := &DatabaseContext{
+		Name:                           "test",
+		terminator:                     make(chan bool),
+		MetadataStore:                  ms,
+		MetadataKeys:                   metaKeys,
+		Options:                        DatabaseContextOptions{MetadataID: metadataID},
+		MetadataMigrationStatusUpdater: inMemoryMigrationStatusUpdater(),
+	}
+	dbCtx.MetadataMigrationManager = NewMetadataMigrationManager(dbCtx)
+
+	require.NoError(t, dbCtx.MetadataMigrationManager.Start(ctx, nil))
+	RequireBackgroundManagerState(t, dbCtx.MetadataMigrationManager, BackgroundProcessStateCompleted)
+
+	rawStatus, err := dbCtx.MetadataMigrationManager.GetStatus(ctx)
+	require.NoError(t, err)
+	var resp MigrationManagerResponse
+	require.NoError(t, base.JSONUnmarshal(rawStatus, &resp))
+	assert.Equal(t, int64(len(seeded)), resp.DocsProcessed, "manager DocsProcessed should equal seeded user+role count")
+	assert.Zero(t, resp.DocsFailed)
+
+	for k, want := range seeded {
+		got, _, getErr := ms.Primary().GetRaw(ctx, k)
+		require.NoError(t, getErr, "primary should hold %s", k)
+		assert.Equal(t, want, got)
+
+		_, _, getErr = ms.Fallback().GetRaw(ctx, k)
+		assert.True(t, base.IsDocNotFoundError(getErr), "fallback should no longer hold %s", k)
+	}
+	assert.True(t, ms.MigrationComplete(), "clean run must flip MigrationComplete so future reads skip the fallback")
+}
+
+// TestMetadataMigrationManagerErrorsOnUnclearableUnknownPrefix forces the bounded-pass
+// give-up branch: an in-scope unknown-prefix doc is reported as "remaining" every pass
+// (the dispatcher classifies it as DocsUnknownPrefix and leaves it on the fallback), so
+// the orchestrator must hit maxPasses and surface a non-nil error rather than silently
+// completing. SetMigrationComplete must NOT be flipped, otherwise the dual-store wrapper
+// would start ignoring the fallback while there is still real data on it.
+func TestMetadataMigrationManagerErrorsOnUnclearableUnknownPrefix(t *testing.T) {
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
+
+	primary, err := bucket.GetNamedDataStore(0)
+	require.NoError(t, err)
+	fallback := bucket.DefaultDataStore(ctx)
+	if _, ok := base.AsRangeScanStore(fallback); !ok {
+		t.Skipf("metadata migration requires KV range scan support on the fallback datastore")
+	}
+	ms := base.NewMetadataStore(primary, fallback)
+
+	const metadataID = "test-mgr-unknown-prefix"
+	// `_sync:m_<id>:wat` is in-scope (starts with our standard-form prefix) but matches
+	// no known family, so handleMigrationKey hits the default branch and counts it as
+	// DocsUnknownPrefix every pass without removing it.
+	stuckKey := base.SyncDocPrefix + base.MetadataIdPrefix + metadataID + ":wat"
+	_, err = ms.Fallback().AddRaw(ctx, stuckKey, 0, []byte(`{"body":"stuck"}`))
+	require.NoError(t, err, "seed in-scope unknown-prefix fallback doc")
+
+	dbCtx := &DatabaseContext{
+		Name:                           "test",
+		terminator:                     make(chan bool),
+		MetadataStore:                  ms,
+		MetadataKeys:                   base.NewMetadataKeys(metadataID),
+		Options:                        DatabaseContextOptions{MetadataID: metadataID},
+		MetadataMigrationStatusUpdater: inMemoryMigrationStatusUpdater(),
+	}
+	dbCtx.MetadataMigrationManager = NewMetadataMigrationManager(dbCtx)
+
+	require.NoError(t, dbCtx.MetadataMigrationManager.Start(ctx, nil))
+	// The manager surfaces the bounded-pass failure via the Errored terminal state.
+	RequireBackgroundManagerState(t, dbCtx.MetadataMigrationManager, BackgroundProcessStateError)
+
+	assert.False(t, ms.MigrationComplete(), "MigrationComplete must not be flipped when the migration gave up with work outstanding")
+
+	_, _, err = ms.Fallback().GetRaw(ctx, stuckKey)
+	assert.NoError(t, err, "stuck unknown-prefix doc should still be on the fallback")
+}
+
 // TestTryStartMetadataMigrationConfigNotApplied verifies that while the cluster has not yet
 // converged on the config, tryStartMetadataMigration reports done=false so the arm loop keeps
 // polling, and does not start the migration.

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -102,7 +102,7 @@ func TestLateSequenceHandling(t *testing.T) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 
 	cache := newSingleChannelCache(collection, channels.NewID("Test1", collectionID), 0, dbstats.CacheStats)
@@ -174,7 +174,7 @@ func TestLateSequenceHandlingWithMultipleListeners(t *testing.T) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 
 	cache := newSingleChannelCache(collection, channels.NewID("Test1", collectionID), 0, dbstats.CacheStats)

--- a/db/channel_cache_single_test.go
+++ b/db/channel_cache_single_test.go
@@ -36,7 +36,7 @@ func TestDuplicateDocID(t *testing.T) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 
 	cache := newSingleChannelCache(collection, channels.NewID("Test1", collection.GetCollectionID()), 0, dbstats.Cache())
@@ -89,7 +89,7 @@ func TestLateArrivingSequence(t *testing.T) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 
 	collection := GetSingleDatabaseCollection(t, db.DatabaseContext)
@@ -130,7 +130,7 @@ func TestLateSequenceAsFirst(t *testing.T) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 
 	collection := GetSingleDatabaseCollection(t, db.DatabaseContext)
@@ -171,7 +171,7 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 
 	collection := GetSingleDatabaseCollection(t, db.DatabaseContext)
@@ -254,7 +254,7 @@ func TestPrependChanges(t *testing.T) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 
 	collection := GetSingleDatabaseCollection(t, db.DatabaseContext)
@@ -279,7 +279,7 @@ func TestPrependChanges(t *testing.T) {
 	// 2. Test prepend to populated cache, with overlap and duplicates
 	stats, err = base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err = stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err = stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	cache = newSingleChannelCache(collection, channels.NewID("PrependPopulatedCache", collection.GetCollectionID()), 0, dbstats.Cache())
 	cache.validFrom = 13
@@ -337,7 +337,7 @@ func TestPrependChanges(t *testing.T) {
 	// 3. Test prepend that exceeds cache capacity
 	stats, err = base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err = stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err = stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	cache = newSingleChannelCache(collection, channels.NewID("PrependToFillCache", collection.GetCollectionID()), 0, dbstats.Cache())
 	cache.options.ChannelCacheMaxLength = 5
@@ -378,7 +378,7 @@ func TestPrependChanges(t *testing.T) {
 	// 4. Test prepend where all docids are already present in cache.  Cache entries shouldn't change, but validFrom is updated
 	stats, err = base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err = stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err = stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	cache = newSingleChannelCache(collection, channels.NewID("PrependDuplicatesOnly", collection.GetCollectionID()), 0, dbstats.Cache())
 	cache.validFrom = 13
@@ -412,7 +412,7 @@ func TestPrependChanges(t *testing.T) {
 	// 5. Test prepend for an already full cache
 	stats, err = base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err = stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err = stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	cache = newSingleChannelCache(collection, channels.NewID("PrependFullCache", collection.GetCollectionID()), 0, dbstats.Cache())
 	cache.options.ChannelCacheMaxLength = 5
@@ -462,7 +462,7 @@ func TestChannelCacheRemove(t *testing.T) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 
 	collection := GetSingleDatabaseCollection(t, db.DatabaseContext)
@@ -510,7 +510,7 @@ func TestChannelCacheStats(t *testing.T) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 
 	collection := GetSingleDatabaseCollection(t, db.DatabaseContext)
@@ -589,7 +589,7 @@ func TestChannelCacheStatsOnPrune(t *testing.T) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 
 	collection := GetSingleDatabaseCollection(t, db.DatabaseContext)
@@ -628,7 +628,7 @@ func TestChannelCacheStatsOnPrepend(t *testing.T) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 
 	collection := GetSingleDatabaseCollection(t, db.DatabaseContext)
@@ -726,7 +726,7 @@ func BenchmarkChannelCacheUniqueDocs_Ordered(b *testing.B) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(b, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(b, err)
 
 	collection := GetSingleDatabaseCollection(b, db.DatabaseContext)
@@ -756,7 +756,7 @@ func BenchmarkChannelCacheRepeatedDocs5(b *testing.B) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(b, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(b, err)
 
 	collection := GetSingleDatabaseCollection(b, db.DatabaseContext)
@@ -780,7 +780,7 @@ func BenchmarkChannelCacheRepeatedDocs20(b *testing.B) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(b, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(b, err)
 
 	collection := GetSingleDatabaseCollection(b, db.DatabaseContext)
@@ -804,7 +804,7 @@ func BenchmarkChannelCacheRepeatedDocs50(b *testing.B) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(b, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(b, err)
 
 	collection := GetSingleDatabaseCollection(b, db.DatabaseContext)
@@ -828,7 +828,7 @@ func BenchmarkChannelCacheRepeatedDocs80(b *testing.B) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(b, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(b, err)
 
 	collection := GetSingleDatabaseCollection(b, db.DatabaseContext)
@@ -852,7 +852,7 @@ func BenchmarkChannelCacheRepeatedDocs95(b *testing.B) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(b, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(b, err)
 
 	collection := GetSingleDatabaseCollection(b, db.DatabaseContext)
@@ -876,7 +876,7 @@ func BenchmarkChannelCacheUniqueDocs_Unordered(b *testing.B) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(b, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(b, err)
 
 	collection := GetSingleDatabaseCollection(b, db.DatabaseContext)

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -131,7 +131,7 @@ func TestChannelCacheSimpleCompact(t *testing.T) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	testStats := dbstats.Cache()
 	activeChannelStat := &base.SgwIntStat{}
@@ -173,7 +173,7 @@ func TestChannelCacheCompactInactiveChannels(t *testing.T) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	testStats := dbstats.Cache()
 	activeChannelStat := &base.SgwIntStat{}
@@ -233,7 +233,7 @@ func TestChannelCacheCompactNRU(t *testing.T) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	testStats := dbstats.Cache()
 	activeChannelStat := &base.SgwIntStat{}
@@ -330,7 +330,7 @@ func TestChannelCacheHighLoadCacheHit(t *testing.T) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	testStats := dbstats.Cache()
 	queryHandler := &testQueryHandler{}
@@ -405,7 +405,7 @@ func TestChannelCacheHighLoadCacheMiss(t *testing.T) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	testStats := dbstats.Cache()
 	queryHandler := &testQueryHandler{}
@@ -475,7 +475,7 @@ func TestChannelCacheBypass(t *testing.T) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	testStats := dbstats.Cache()
 	queryHandler := &testQueryHandler{}
@@ -581,7 +581,7 @@ func TestChannelCacheBackgroundTaskWithIllegalTimeInterval(t *testing.T) {
 	options.ChannelCacheAge = 0
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	testStats := dbstats.Cache()
 

--- a/db/database.go
+++ b/db/database.go
@@ -2081,6 +2081,7 @@ func initDatabaseStats(ctx context.Context, dbName string, autoImport bool, opti
 	enabledDeltaSync := options.DeltaSyncOptions.Enabled
 	enabledImport := autoImport || options.EnableXattr
 	enabledViews := options.UseViews
+	enabledMetadataMigration := options.UseSystemMetadataCollection
 
 	var queryNames []string
 	if enabledViews {
@@ -2136,7 +2137,7 @@ func initDatabaseStats(ctx context.Context, dbName string, autoImport bool, opti
 		}
 	}
 
-	return base.SyncGatewayStats.NewDBStats(dbName, enabledDeltaSync, enabledImport, enabledViews, queryNames, collections)
+	return base.SyncGatewayStats.NewDBStats(dbName, enabledDeltaSync, enabledImport, enabledViews, enabledMetadataMigration, queryNames, collections)
 }
 
 func (context *DatabaseContext) AllowConflicts() bool {

--- a/db/metadata_migration.go
+++ b/db/metadata_migration.go
@@ -136,6 +136,23 @@ func migrateSeqCounter(ctx context.Context, ms *base.MetadataStore, seqKey strin
 		return incrErr
 	}
 
+	// The wrapper's Incr self-heal branch deletes the fallback pill once it seeds
+	// primary — but if primary already held the counter (a prior partial migration
+	// got that far before stopping), the wrapper takes the happy path on primary and
+	// never touches fallback. Without this idempotent cleanup, the pill survives as
+	// `_sync:[m_<id>:]seq` and the next range-scan pass classifies it as
+	// unknown-prefix, wedging the migration. Re-reading and gating on the pill
+	// discriminator avoids deleting a legitimate counter that another process raced
+	// in between the pill phase and here.
+	if raw, _, getErr := ms.Fallback().GetRaw(ctx, seqKey); getErr == nil {
+		var existing base.SyncSeqMigrationPill
+		if jsonErr := base.JSONUnmarshal(raw, &existing); jsonErr == nil && existing.SGMetadataMigrationPill {
+			if delErr := ms.Fallback().Delete(ctx, seqKey); delErr != nil && !base.IsDocNotFoundError(delErr) {
+				base.WarnfCtx(ctx, "migrateSeqCounter: failed to clean up stale fallback pill for %s: %v", base.UD(seqKey), delErr)
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -144,19 +161,31 @@ func migrateSeqCounter(ctx context.Context, ms *base.MetadataStore, seqKey strin
 // MetadataKeys prefix accessors so namespacing (the `m_<id>:` infix) is part of the prefix
 // match for namespaced metadataIDs. For the legacy `_default` metadataID, where each
 // inverted-form prefix (e.g. `_sync:user:`) overlaps with sibling DBs' inverted-form keys
-// (`_sync:user:m_<other>:…`), an additional `+ base.MetadataIdPrefix` HasPrefix check
-// excludes those sibling keys — for namespaced metadataIDs the additional check is a
-// no-op because the prefix already contains `m_<id>:`.
+// (`_sync:user:m_<other>:…`), isOurs additionally excludes the *full* sibling shape
+// (`prefix + m_<X>:`, requiring a `:` after the namespace) — this keeps a legacy default
+// user literally named `m_alice` correctly classified as ours.
 //
 // Anything that doesn't match a known family is split between out-of-scope (sibling-DB
-// standard form, bucket-level bootstrap docs) and genuinely unknown.
+// standard form, bucket-level bootstrap docs, `_sync:syncdata*` and `_sync:syncInfo`
+// which the design plan keeps in the source collection) and genuinely unknown.
 func handleMigrationKey(ctx context.Context, ms *base.MetadataStore, keys *base.MetadataKeys, metadataID, key string, stats *MigrationStats) {
-	// isOurs matches a prefix and, where the prefix doesn't already encode our DB's
-	// metadataID, defensively excludes sibling-DB inverted-form keys via the trailing
-	// `m_` guard. For namespaced metadataIDs the guard is a no-op (the
-	// keys.XxxKeyPrefix() already encodes the unique namespace).
+	// isOurs matches a prefix and excludes sibling-DB inverted-form keys. For namespaced
+	// metadataIDs the keys.XxxKeyPrefix() already encodes the unique `m_<id>:` segment
+	// so isSiblingInverted is structurally a no-op there. For the legacy default DB
+	// the discriminator is "starts with prefix+m_ AND has another colon" — that
+	// distinguishes `_sync:user:m_otherDB:alice` (sibling) from `_sync:user:m_alice`
+	// (our user whose username happens to start with `m_`).
 	isOurs := func(prefix string) bool {
-		return strings.HasPrefix(key, prefix) && !strings.HasPrefix(key, prefix+base.MetadataIdPrefix)
+		if !strings.HasPrefix(key, prefix) {
+			return false
+		}
+		rest := key[len(prefix):]
+		if !strings.HasPrefix(rest, base.MetadataIdPrefix) {
+			return true
+		}
+		// starts with `m_` — sibling shape only if there's another `:` separating the
+		// metadataID from the rest of the key.
+		return !strings.Contains(rest[len(base.MetadataIdPrefix):], ":")
 	}
 	// thisMetadataID is `_sync:m_<id>:` for namespaced metadataIDs — used to exclude OUR
 	// standard-form keys from the sibling-DB out-of-scope check. Empty for default mode
@@ -180,8 +209,18 @@ func handleMigrationKey(ctx context.Context, ms *base.MetadataStore, keys *base.
 		isOurs(keys.BackgroundProcessStatusPrefix("")),
 		isOurs(keys.ResyncHeartbeaterPrefix()),
 		isOurs(keys.ResyncCfgPrefix()):
-		// move to primary (fetch, insert and delete)
-		moveFallbackDoc(ctx, ms, key, stats)
+		// JSON-bodied metadata. moveFallbackDoc(binary=false) preserves the JSON
+		// datatype flag so strict readers (auth, RawJSONTranscoder) can decode the
+		// migrated doc on primary.
+		moveFallbackDoc(ctx, ms, key, false, stats)
+
+	case
+		isOurs(keys.UnusedSeqPrefix()),
+		isOurs(keys.UnusedSeqRangePrefix()):
+		// Binary-bodied metadata (8/16-byte little-endian uint64 payload written by
+		// sequenceAllocator.releaseSequence / releaseSequenceRange). Must preserve
+		// the Binary datatype flag — change_listener.go relies on these docs.
+		moveFallbackDoc(ctx, ms, key, true, stats)
 
 	// Sibling DBs' standard form `_sync:m_<other>:…`, but NOT our own metadata ID
 	case
@@ -189,8 +228,19 @@ func handleMigrationKey(ctx context.Context, ms *base.MetadataStore, keys *base.
 			(thisMetadataID == "" || !strings.HasPrefix(key, thisMetadataID)):
 		stats.DocsOutOfScope.Add(1)
 
-	// Sibling DBs' inverted-form keys (per the migration design doc's `m_` convention)
-	// and bucket-level bootstrap docs.
+	case key == keys.SyncSeqKey():
+		// migrateSeqCounter handles the seq counter via the pill + self-heal +
+		// fallback-cleanup dance before the range-scan loop ever runs. If the range
+		// scan still sees it here (rare: migrateSeqCounter cleanup raced an
+		// in-progress write, or this is a re-run after a partial prior migration),
+		// treat it as out-of-scope rather than unknown — the seq counter has its own
+		// dedicated handling and the range scan is not the right path to move it.
+		stats.DocsOutOfScope.Add(1)
+
+	// Sibling DBs' inverted-form keys (per the migration design doc's `m_` convention),
+	// bucket-level bootstrap docs, and per-collection metadata (`_sync:syncdata*`,
+	// `_sync:syncInfo`) which the design plan keeps in the source collection — these
+	// are *not* part of the per-DB metadata migration.
 	case
 		strings.HasPrefix(key, base.SyncDocPrefix+"user:"+base.MetadataIdPrefix),
 		strings.HasPrefix(key, base.SyncDocPrefix+"role:"+base.MetadataIdPrefix),
@@ -199,7 +249,10 @@ func handleMigrationKey(ctx context.Context, ms *base.MetadataStore, keys *base.
 		strings.HasPrefix(key, base.SyncDocPrefix+base.DCPCheckpointPrefix+base.MetadataIdPrefix),
 		key == base.SGRegistryKey,
 		strings.HasPrefix(key, base.PersistentConfigPrefixWithoutGroupID),
-		key == base.SGSyncInfo:
+		key == base.SGSyncInfo,
+		key == base.SyncFunctionKeyWithoutGroupID,
+		strings.HasPrefix(key, base.SyncFunctionKeyWithoutGroupID+":"),
+		strings.HasPrefix(key, base.CollectionSyncFunctionKeyWithoutGroupID+":"):
 		// ignore - either other DBs or bucket-level docs that require their own migration logic
 		stats.DocsOutOfScope.Add(1)
 
@@ -220,6 +273,15 @@ func handleMigrationKey(ctx context.Context, ms *base.MetadataStore, keys *base.
 // moveFallbackDoc moves a single doc from the fallback collection to the primary
 // collection and removes the fallback copy. Idempotent and safe to re-run.
 //
+// `binary` selects the datatype flag for the primary write: false routes through
+// `MetadataStore.Add` (SGJSONTranscoder, which writes []byte as JSON datatype 0x02);
+// true routes through `MetadataStore.AddRaw` (SGRawTranscoder, which writes []byte as
+// Binary datatype 0x03). Most SG metadata is JSON — only the `unusedSeq` / `unusedSeqs`
+// families are binary (8-/16-byte little-endian uint64 payloads written via AddRaw by
+// sequenceAllocator). Picking the wrong datatype here is silent at write time but
+// surfaces later: strict readers like the auth path's RawJSONTranscoder reject a
+// Binary-tagged user/role/session doc with "binary datatype is not supported".
+//
 // The range scan that drives the migration runs with IDsOnly=true, so we never receive
 // bodies on the scan path. The per-key fetch here is a single subdoc LookupIn that
 // carries the body and the document's expiry (`$document.exptime`) together, so the
@@ -230,9 +292,9 @@ func handleMigrationKey(ctx context.Context, ms *base.MetadataStore, keys *base.
 // Authenticator.Update() during an in-flight migration is "read-through fallback, write
 // to primary" (see base/dual_metadata_store.go Update), so a primary copy that beat us
 // here is fresher than ours and must not be overwritten — we just drop the stale
-// fallback shadow. AddRaw returns (added=false, err=nil) on duplicate; the
+// fallback shadow. Add/AddRaw both return (added=false, err=nil) on duplicate; the
 // IsCasMismatch check is defensive for backends that surface a CAS error instead.
-func moveFallbackDoc(ctx context.Context, ms *base.MetadataStore, key string, stats *MigrationStats) {
+func moveFallbackDoc(ctx context.Context, ms *base.MetadataStore, key string, binary bool, stats *MigrationStats) {
 	raw, expiry, err := fetchFallbackBodyAndExpiry(ctx, ms, key)
 	if base.IsDocNotFoundError(err) {
 		return
@@ -242,7 +304,17 @@ func moveFallbackDoc(ctx context.Context, ms *base.MetadataStore, key string, st
 		stats.Errors.Add(1)
 		return
 	}
-	if _, addErr := ms.Primary().AddRaw(ctx, key, expiry, raw); addErr != nil && !base.IsCasMismatch(addErr) {
+	var addErr error
+	if binary {
+		_, addErr = ms.Primary().AddRaw(ctx, key, expiry, raw)
+	} else {
+		// `Add` with a `[]byte` value writes via SGJSONTranscoder, which routes
+		// `[]byte` through gocb.NewRawJSONTranscoder().Encode — i.e. raw bytes,
+		// JSON datatype flag (0x02). Matches what the auth code path produces on a
+		// fresh write and avoids the strict-transcoder rejection on read.
+		_, addErr = ms.Primary().Add(ctx, key, expiry, raw)
+	}
+	if addErr != nil && !base.IsCasMismatch(addErr) {
 		base.WarnfCtx(ctx, "metadata migration: primary add failed for %s: %v", base.UD(key), addErr)
 		stats.Errors.Add(1)
 		return

--- a/db/metadata_migration.go
+++ b/db/metadata_migration.go
@@ -196,6 +196,7 @@ func handleMigrationKey(ctx context.Context, ms *base.MetadataStore, keys *base.
 	}
 
 	switch {
+	// matching sync docs for this database
 	case
 		isOurs(keys.UserKeyPrefix()),
 		isOurs(keys.RoleKeyPrefix()),
@@ -214,6 +215,7 @@ func handleMigrationKey(ctx context.Context, ms *base.MetadataStore, keys *base.
 		// migrated doc on primary.
 		moveFallbackDoc(ctx, ms, key, false, stats)
 
+	// matching binary sync docs for this database
 	case
 		isOurs(keys.UnusedSeqPrefix()),
 		isOurs(keys.UnusedSeqRangePrefix()):
@@ -222,47 +224,46 @@ func handleMigrationKey(ctx context.Context, ms *base.MetadataStore, keys *base.
 		// the Binary datatype flag — change_listener.go relies on these docs.
 		moveFallbackDoc(ctx, ms, key, true, stats)
 
-	// Sibling DBs' standard form `_sync:m_<other>:…`, but NOT our own metadata ID
+	// heartbeater - don't migrate just cleanup
+	case
+		keys.IsHeartbeaterKey(key):
+		deleteFallbackDoc(ctx, ms, key, stats)
+
+	// never migrate using range scan
+	case key == keys.SyncSeqKey(),
+		key == base.SyncDocPrefix+"seq",
+		key == base.SGRegistryKey,
+		key == base.SGSyncInfo,
+		strings.HasPrefix(key, base.PersistentConfigPrefixWithoutGroupID):
+		stats.DocsOutOfScope.Add(1)
+
+	// non-matching sync docs (metadata prefix before sync doc type - formatInvertedMetadataKey)
 	case
 		strings.HasPrefix(key, base.SyncDocMetadataPrefix) &&
-			(thisMetadataID == "" || !strings.HasPrefix(key, thisMetadataID)):
+			(thisMetadataID == "" || !strings.HasPrefix(key, thisMetadataID)),
+		// inverted but default ("") metadata prefix
+		strings.HasPrefix(key, base.SyncDocPrefix+base.MetaKeyDCPCheckpoint.String()),
+		strings.HasPrefix(key, base.SyncDocPrefix+base.MetaKeyUserPrefix.String()),
+		strings.HasPrefix(key, base.SyncDocPrefix+base.MetaKeyRolePrefix.String()),
+		strings.HasPrefix(key, base.SyncDocPrefix+base.MetaKeyUserEmailPrefix.String()),
+		strings.HasPrefix(key, base.SyncDocPrefix+base.MetaKeySessionPrefix.String()):
 		stats.DocsOutOfScope.Add(1)
 
-	case key == keys.SyncSeqKey():
-		// migrateSeqCounter handles the seq counter via the pill + self-heal +
-		// fallback-cleanup dance before the range-scan loop ever runs. If the range
-		// scan still sees it here (rare: migrateSeqCounter cleanup raced an
-		// in-progress write, or this is a re-run after a partial prior migration),
-		// treat it as out-of-scope rather than unknown — the seq counter has its own
-		// dedicated handling and the range scan is not the right path to move it.
-		stats.DocsOutOfScope.Add(1)
-
-	// Sibling DBs' inverted-form keys (per the migration design doc's `m_` convention),
-	// bucket-level bootstrap docs, and per-collection metadata (`_sync:syncdata*`,
-	// `_sync:syncInfo`) which the design plan keeps in the source collection — these
-	// are *not* part of the per-DB metadata migration.
+	// non-matching sync docs (from other databases - metadata _after_ sync doc type - formatMetadataKey)
 	case
-		strings.HasPrefix(key, base.SyncDocPrefix+"user:"+base.MetadataIdPrefix),
-		strings.HasPrefix(key, base.SyncDocPrefix+"role:"+base.MetadataIdPrefix),
-		strings.HasPrefix(key, base.SyncDocPrefix+"useremail:"+base.MetadataIdPrefix),
-		strings.HasPrefix(key, base.SyncDocPrefix+"session:"+base.MetadataIdPrefix),
-		strings.HasPrefix(key, base.SyncDocPrefix+base.DCPCheckpointPrefix+base.MetadataIdPrefix),
-		key == base.SGRegistryKey,
-		strings.HasPrefix(key, base.PersistentConfigPrefixWithoutGroupID),
-		key == base.SGSyncInfo,
-		key == base.SyncFunctionKeyWithoutGroupID,
-		strings.HasPrefix(key, base.SyncFunctionKeyWithoutGroupID+":"),
-		strings.HasPrefix(key, base.CollectionSyncFunctionKeyWithoutGroupID+":"):
-		// ignore - either other DBs or bucket-level docs that require their own migration logic
+		strings.HasPrefix(key, base.SyncDocPrefix+base.MetaKeySeq.String()),
+		strings.HasPrefix(key, base.SyncDocPrefix+base.MetaKeyUnusedSeq.String()),
+		strings.HasPrefix(key, base.SyncDocPrefix+base.MetaKeyUnusedSeqRange.String()),
+		strings.HasPrefix(key, base.SyncDocPrefix+base.MetaKeySGRStatus.String()),
+		strings.HasPrefix(key, base.SyncDocPrefix+base.MetaKeyHeartbeaterPrefix.String()),
+		strings.HasPrefix(key, base.SyncDocPrefix+base.MetaKeySGCfg.String()),
+		strings.HasPrefix(key, base.SyncDocPrefix+base.MetaKeyBackgroundProcessHeartbeatPrefix.String()),
+		strings.HasPrefix(key, base.SyncDocPrefix+base.MetaKeyBackgroundProcessStatusPrefix.String()),
+		strings.HasPrefix(key, base.SyncDocPrefix+base.MetaKeyResyncHeartBeaterPrefix.String()),
+		strings.HasPrefix(key, base.SyncDocPrefix+base.MetaKeyResyncCfgPrefix.String()),
+		strings.HasPrefix(key, base.SyncDocPrefix+base.MetaKeyDatabaseState.String()),
+		base.IsHeartbeaterKey(key):
 		stats.DocsOutOfScope.Add(1)
-
-	case
-		// Heartbeater keys are matched on their full shape rather than just the
-		// heartbeater prefix — in default mode that prefix is bare `_sync:` and a
-		// HasPrefix would swallow every unrecognised in-scope key.
-		keys.IsLegacyHeartbeaterKey(key):
-		// delete from fallback (don't move)
-		deleteFallbackDoc(ctx, ms, key, stats)
 
 	default:
 		base.WarnfCtx(ctx, "metadata migration: unrecognised prefix, leaving on fallback: %s", base.UD(key))

--- a/db/metadata_migration.go
+++ b/db/metadata_migration.go
@@ -1,0 +1,284 @@
+// Copyright 2026-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	sgbucket "github.com/couchbase/sg-bucket"
+	"github.com/couchbase/sync_gateway/base"
+)
+
+// MigrationStats are aggregate counters populated during a single MigrateMetadata
+// invocation. Wiring to Prometheus is the caller's responsibility.
+type MigrationStats struct {
+	DocsScannedTotal     atomic.Int64
+	DocsMigrated         atomic.Int64
+	DocsOutOfScope       atomic.Int64
+	DocsUnknownPrefix    atomic.Int64
+	Errors               atomic.Int64
+	SeqPoisonPillApplied atomic.Int64
+}
+
+// MigrateMetadata runs a single range-scan pass over the fallback collection and dispatches
+// each `_sync:`-rooted key via handleMigrationKey: move to primary, delete, treat as
+// out-of-scope, or count as unknown-prefix. The seq counter is handled separately by
+// migrateSeqCounter, which the orchestrator calls once before entering the pass loop —
+// MigrateMetadata is per-pass and does not re-pill the seq doc on each iteration.
+//
+// Returns the number of in-scope fallback keys still classified as remaining after the run
+// (DocsUnknownPrefix from this pass). The orchestrator drives this in a loop until remaining
+// reaches zero — a doc written underneath an in-flight scan can be missed on this pass but
+// will surface on the next one.
+func MigrateMetadata(ctx context.Context, ms *base.MetadataStore, metadataID string, stats *MigrationStats) (remaining int, err error) {
+	if ms == nil {
+		return 0, errors.New("MigrateMetadata: nil MetadataStore")
+	}
+	if stats == nil {
+		stats = &MigrationStats{}
+	}
+	keys := base.NewMetadataKeys(metadataID)
+
+	// Range-scan fallback for `_sync:` keys and dispatch each via handleMigrationKey,
+	// which owns both the per-prefix action and the in-scope/out-of-scope decision for
+	// this DB.
+	rss, ok := base.AsRangeScanStore(ms.Fallback())
+	if !ok {
+		return 0, errors.New("metadata migration: fallback datastore does not support range scan")
+	}
+	iter, err := rss.Scan(ctx, sgbucket.NewRangeScanForPrefix(base.SyncDocPrefix), sgbucket.ScanOptions{IDsOnly: true})
+	if err != nil {
+		return 0, fmt.Errorf("metadata migration scan: %w", err)
+	}
+	defer func() {
+		if closeErr := iter.Close(ctx); closeErr != nil {
+			base.WarnfCtx(ctx, "metadata migration scan close: %v", closeErr)
+		}
+	}()
+
+	for item := iter.Next(ctx); item != nil; item = iter.Next(ctx) {
+		// Honour context cancellation between keys so a manager-initiated stop
+		// (terminator bridged to ctx cancel) doesn't have to wait for the scan to drain.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return int(stats.DocsUnknownPrefix.Load()), ctxErr
+		}
+		stats.DocsScannedTotal.Add(1)
+		handleMigrationKey(ctx, ms, keys, metadataID, item.ID, stats)
+	}
+
+	// In-scope leftovers tell the orchestrator whether to schedule another pass. Out-of-
+	// scope keys belong to sibling DBs / bucket-level docs and aren't this pass's concern.
+	return int(stats.DocsUnknownPrefix.Load()), nil
+}
+
+// migrateSeqCounter is the one-shot per-DB setup step that brings the fallback sequence
+// counter forward to primary. It poison-pills the fallback doc (or detects an existing pill
+// from a prior crashed run) and triggers the wrapper's Incr self-heal, which initializes
+// the primary at LastSeq and deletes the fallback pill. Idempotent and safe to re-run —
+// but the orchestrator only calls this once per migration attempt, before entering the
+// range-scan pass loop. The pass loop only exists to catch docs written under an in-flight
+// scan; the seq counter doesn't have that problem, since once the pill is in place any
+// node's Incr can complete the handoff.
+func migrateSeqCounter(ctx context.Context, ms *base.MetadataStore, seqKey string, stats *MigrationStats) error {
+	err, _ := base.RetryLoopCas(ctx, "migrateSeqCounter", func() (shouldRetry bool, err error, value uint64) {
+		// Honour ctx cancellation so a manager-initiated stop (terminator bridged to
+		// ctx cancel) doesn't keep the unbounded sleeper spinning on transient errors.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return false, ctxErr, 0
+		}
+		raw, cas, err := ms.Fallback().GetRaw(ctx, seqKey)
+		if base.IsDocNotFoundError(err) {
+			return false, nil, 0
+		}
+		if err != nil {
+			return true, err, 0
+		}
+		var existing base.SyncSeqMigrationPill
+		if jsonErr := base.JSONUnmarshal(raw, &existing); jsonErr != nil || !existing.SGMetadataMigrationPill {
+			var legacy uint64
+			if err := base.JSONUnmarshal(raw, &legacy); err != nil {
+				return false, err, 0
+			}
+			pill := base.SyncSeqMigrationPill{
+				PilledAt:                time.Now().UTC().Format(time.RFC3339Nano),
+				LastSeq:                 legacy,
+				SGMetadataMigrationPill: true,
+			}
+			payload, mErr := base.JSONMarshal(&pill)
+			if mErr != nil {
+				return false, mErr, 0
+			}
+			if _, wErr := ms.Fallback().WriteCas(ctx, seqKey, 0, cas, payload, 0); wErr != nil {
+				return true, wErr, 0
+			}
+			stats.SeqPoisonPillApplied.Add(1)
+		}
+		return false, nil, 0
+	}, base.CreateIndefiniteSleeperFunc(10))
+	if err != nil {
+		return err
+	}
+
+	// Touch the seq doc to force migration after the poison pill has been written.
+	// Other nodes can opportunistically do this step for us, in case we crash on this exact line, or are too slow.
+	if _, incrErr := ms.Incr(ctx, seqKey, 0, 0, 0); incrErr != nil {
+		return incrErr
+	}
+
+	return nil
+}
+
+// handleMigrationKey is the per-key dispatcher. It owns both the in-scope/out-of-scope
+// decision and the per-family policy. The switch cases use the database's own
+// MetadataKeys prefix accessors so namespacing (the `m_<id>:` infix) is part of the prefix
+// match for namespaced metadataIDs. For the legacy `_default` metadataID, where each
+// inverted-form prefix (e.g. `_sync:user:`) overlaps with sibling DBs' inverted-form keys
+// (`_sync:user:m_<other>:…`), an additional `+ base.MetadataIdPrefix` HasPrefix check
+// excludes those sibling keys — for namespaced metadataIDs the additional check is a
+// no-op because the prefix already contains `m_<id>:`.
+//
+// Anything that doesn't match a known family is split between out-of-scope (sibling-DB
+// standard form, bucket-level bootstrap docs) and genuinely unknown.
+func handleMigrationKey(ctx context.Context, ms *base.MetadataStore, keys *base.MetadataKeys, metadataID, key string, stats *MigrationStats) {
+	// isOurs matches a prefix and, where the prefix doesn't already encode our DB's
+	// metadataID, defensively excludes sibling-DB inverted-form keys via the trailing
+	// `m_` guard. For namespaced metadataIDs the guard is a no-op (the
+	// keys.XxxKeyPrefix() already encodes the unique namespace).
+	isOurs := func(prefix string) bool {
+		return strings.HasPrefix(key, prefix) && !strings.HasPrefix(key, prefix+base.MetadataIdPrefix)
+	}
+	// thisMetadataID is `_sync:m_<id>:` for namespaced metadataIDs — used to exclude OUR
+	// standard-form keys from the sibling-DB out-of-scope check. Empty for default mode
+	// (default DB has no `_sync:m_*` keys, so any `_sync:m_…` is necessarily a sibling).
+	var thisMetadataID string
+	if metadataID != "" && metadataID != base.DefaultMetadataID {
+		thisMetadataID = base.SyncDocMetadataPrefix + metadataID + ":"
+	}
+
+	switch {
+	case
+		isOurs(keys.UserKeyPrefix()),
+		isOurs(keys.RoleKeyPrefix()),
+		isOurs(keys.UserEmailKey("")),
+		isOurs(keys.SessionKey("")),
+		key == keys.DatabaseStateKey(),
+		isOurs(keys.ReplicationStatusKey("")),
+		isOurs(keys.SGCfgPrefix("")),
+		isOurs(keys.DCPCheckpointPrefix("")),
+		isOurs(keys.BackgroundProcessHeartbeatPrefix("")),
+		isOurs(keys.BackgroundProcessStatusPrefix("")),
+		isOurs(keys.ResyncHeartbeaterPrefix()),
+		isOurs(keys.ResyncCfgPrefix()):
+		// move to primary (fetch, insert and delete)
+		moveFallbackDoc(ctx, ms, key, stats)
+
+	// Sibling DBs' standard form `_sync:m_<other>:…`, but NOT our own metadata ID
+	case
+		strings.HasPrefix(key, base.SyncDocMetadataPrefix) &&
+			(thisMetadataID == "" || !strings.HasPrefix(key, thisMetadataID)):
+		stats.DocsOutOfScope.Add(1)
+
+	// Sibling DBs' inverted-form keys (per the migration design doc's `m_` convention)
+	// and bucket-level bootstrap docs.
+	case
+		strings.HasPrefix(key, base.SyncDocPrefix+"user:"+base.MetadataIdPrefix),
+		strings.HasPrefix(key, base.SyncDocPrefix+"role:"+base.MetadataIdPrefix),
+		strings.HasPrefix(key, base.SyncDocPrefix+"useremail:"+base.MetadataIdPrefix),
+		strings.HasPrefix(key, base.SyncDocPrefix+"session:"+base.MetadataIdPrefix),
+		strings.HasPrefix(key, base.SyncDocPrefix+base.DCPCheckpointPrefix+base.MetadataIdPrefix),
+		key == base.SGRegistryKey,
+		strings.HasPrefix(key, base.PersistentConfigPrefixWithoutGroupID),
+		key == base.SGSyncInfo:
+		// ignore - either other DBs or bucket-level docs that require their own migration logic
+		stats.DocsOutOfScope.Add(1)
+
+	case
+		// Heartbeater keys are matched on their full shape rather than just the
+		// heartbeater prefix — in default mode that prefix is bare `_sync:` and a
+		// HasPrefix would swallow every unrecognised in-scope key.
+		keys.IsLegacyHeartbeaterKey(key):
+		// delete from fallback (don't move)
+		deleteFallbackDoc(ctx, ms, key, stats)
+
+	default:
+		base.WarnfCtx(ctx, "metadata migration: unrecognised prefix, leaving on fallback: %s", base.UD(key))
+		stats.DocsUnknownPrefix.Add(1)
+	}
+}
+
+// moveFallbackDoc moves a single doc from the fallback collection to the primary
+// collection and removes the fallback copy. Idempotent and safe to re-run.
+//
+// The range scan that drives the migration runs with IDsOnly=true, so we never receive
+// bodies on the scan path. The per-key fetch here is a single subdoc LookupIn that
+// carries the body and the document's expiry (`$document.exptime`) together, so the
+// move preserves TTL (critical for session docs, which have a Couchbase expiry set at
+// creation by auth.Authenticator.CreateSession).
+//
+// The "already exists on primary" outcome is benign and treated as success: a normal
+// Authenticator.Update() during an in-flight migration is "read-through fallback, write
+// to primary" (see base/dual_metadata_store.go Update), so a primary copy that beat us
+// here is fresher than ours and must not be overwritten — we just drop the stale
+// fallback shadow. AddRaw returns (added=false, err=nil) on duplicate; the
+// IsCasMismatch check is defensive for backends that surface a CAS error instead.
+func moveFallbackDoc(ctx context.Context, ms *base.MetadataStore, key string, stats *MigrationStats) {
+	raw, expiry, err := fetchFallbackBodyAndExpiry(ctx, ms, key)
+	if base.IsDocNotFoundError(err) {
+		return
+	}
+	if err != nil {
+		base.WarnfCtx(ctx, "metadata migration: fallback fetch failed for %s: %v", base.UD(key), err)
+		stats.Errors.Add(1)
+		return
+	}
+	if _, addErr := ms.Primary().AddRaw(ctx, key, expiry, raw); addErr != nil && !base.IsCasMismatch(addErr) {
+		base.WarnfCtx(ctx, "metadata migration: primary add failed for %s: %v", base.UD(key), addErr)
+		stats.Errors.Add(1)
+		return
+	}
+	if delErr := ms.Fallback().Delete(ctx, key); delErr != nil && !base.IsDocNotFoundError(delErr) {
+		base.WarnfCtx(ctx, "metadata migration: fallback delete failed for %s: %v", base.UD(key), delErr)
+		stats.Errors.Add(1)
+		return
+	}
+	stats.DocsMigrated.Add(1)
+}
+
+// deleteFallbackDoc just removes the fallback doc
+// This is used in cases like transient heartbeat documents where it does not make sense to move.
+func deleteFallbackDoc(ctx context.Context, ms *base.MetadataStore, key string, stats *MigrationStats) {
+	if delErr := ms.Fallback().Delete(ctx, key); delErr != nil && !base.IsDocNotFoundError(delErr) {
+		base.WarnfCtx(ctx, "metadata migration: fallback delete failed for %s: %v", base.UD(key), delErr)
+		stats.Errors.Add(1)
+		return
+	}
+	stats.DocsMigrated.Add(1)
+}
+
+// fetchFallbackBodyAndExpiry reads a fallback doc's body and expiry in a single
+// subdoc LookupIn round trip (one body fetch op + one `$document.exptime` xattr op,
+// dispatched together by gocb's GetWithXattrs). Supported by both Couchbase Server and
+// Rosmar, so there is no backend-specific path here.
+func fetchFallbackBodyAndExpiry(ctx context.Context, ms *base.MetadataStore, key string) (body []byte, expiry uint32, err error) {
+	body, xattrs, _, err := ms.Fallback().GetWithXattrs(ctx, key, []string{base.VirtualExpiry})
+	if err != nil {
+		return nil, 0, err
+	}
+	if rawExp, ok := xattrs[base.VirtualExpiry]; ok && len(rawExp) > 0 {
+		if jsonErr := base.JSONUnmarshal(rawExp, &expiry); jsonErr != nil {
+			return nil, 0, fmt.Errorf("parse %s for %s: %w", base.VirtualExpiry, base.UD(key), jsonErr)
+		}
+	}
+	return body, expiry, nil
+}

--- a/db/metadata_migration_test.go
+++ b/db/metadata_migration_test.go
@@ -363,6 +363,38 @@ func TestMigrateMetadataDefaultModeUnknownPreservedHeartbeatDeleted(t *testing.T
 	assert.True(t, base.IsDocNotFoundError(getErr), "heartbeat doc should be removed from fallback")
 }
 
+// TestMigrateMetadataNamespacedHeartbeatWithGroupIDDeletedViaShapeMatch pins the fix
+// for EE-with-import heartbeater key matching: when a non-empty groupID is configured,
+// `HeartbeaterPrefix` returns `_sync:m_<id>:hb:<groupID>:`, so the heartbeater writes
+// `<heartbeaterPrefix>heartbeat_timeout:<nodeUUID>` — i.e. the on-disk key has an extra
+// `<groupID>:` colon-segment between the namespace and the literal `heartbeat_timeout:`
+// token. The original `IsLegacyHeartbeaterKey` only matched the no-groupID form, so the
+// with-groupID heartbeat key fell into DocsUnknownPrefix and wedged the migration on
+// every real EE bucket.
+func TestMigrateMetadataNamespacedHeartbeatWithGroupIDDeletedViaShapeMatch(t *testing.T) {
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
+
+	const metadataID = "testHbShapeGroup"
+	const groupID = "groupA"
+	keys := base.NewMetadataKeys(metadataID)
+	heartbeatKey := keys.HeartbeaterPrefix(groupID) + "heartbeat_timeout:nodeA"
+
+	ms := newMigrationTestStore(t, bucket)
+	seedFallback(ctx, t, ms, heartbeatKey, []byte("nodeA"))
+
+	stats := &MigrationStats{}
+	remaining, err := MigrateMetadata(ctx, ms, metadataID, stats)
+	require.NoError(t, err)
+	assert.Equal(t, 0, remaining, "groupID-suffixed heartbeat must not surface as unknown-prefix")
+	assert.Equal(t, int64(1), stats.DocsMigrated.Load(), "groupID-suffixed heartbeat doc should be deleted via the shape match")
+	assert.Zero(t, stats.DocsUnknownPrefix.Load())
+
+	_, _, getErr := ms.Fallback().GetRaw(ctx, heartbeatKey)
+	assert.True(t, base.IsDocNotFoundError(getErr), "groupID-suffixed heartbeat doc should be removed from fallback")
+}
+
 // TestMigrateMetadataNamespacedHeartbeatDeletedViaShapeMatch verifies the same shape-based
 // heartbeater match works for namespaced metadataIDs, where the heartbeater prefix is
 // `_sync:m_<id>:hb:` and the doc shape is `<prefix>heartbeat_timeout:<nodeUUID>`.
@@ -442,4 +474,118 @@ func TestHandleMigrationKeyScoping(t *testing.T) {
 			assert.Zero(t, s.DocsOutOfScope.Load(), "%q is in-scope (default mode owns `_sync:…`) so should not be out-of-scope", k)
 		}
 	})
+
+	// LegacySiblingInvertedFormOutOfScope pins the sibling-side of the corner-case fix:
+	// the inverted-form keys for a real sibling DB (with a trailing `:` after the
+	// metadataID) must still be classified out-of-scope when the local DB is in legacy
+	// default mode. The ours-side counterpart — a legacy default user literally named
+	// `m_alice` — is covered end-to-end by TestMigrateMetadataLegacyDefaultUserWithMPrefixUsername
+	// below (the dispatcher would call moveFallbackDoc on a real bucket for those).
+	t.Run("LegacySiblingInvertedFormOutOfScope", func(t *testing.T) {
+		for _, k := range []string{
+			"_sync:user:m_otherDB:alice",
+			"_sync:role:m_otherDB:admins",
+			"_sync:useremail:m_otherDB:alice@example.com",
+			"_sync:session:m_otherDB:tok1",
+		} {
+			s := classify(base.DefaultMetadataID, k)
+			assert.Equal(t, int64(1), s.DocsOutOfScope.Load(), "%q is a sibling-DB inverted-form key — must remain out-of-scope", k)
+		}
+	})
+
+	// SyncFunctionDocsOutOfScope pins the design-plan decision that the per-collection
+	// sync-function docs (`_sync:syncdata*`) stay in the source collection — they're
+	// classified out-of-scope rather than left as unknown-prefix (which would block the
+	// migration on every real DB, since every DB writes at least one syncdata doc).
+	t.Run("SyncFunctionDocsOutOfScope", func(t *testing.T) {
+		for _, k := range []string{
+			"_sync:syncdata",
+			"_sync:syncdata:groupA",
+			"_sync:syncdata_collection:scope1.coll1",
+			"_sync:syncdata_collection:scope1.coll1:groupA",
+		} {
+			s := classify("myDB", k)
+			assert.Equal(t, int64(1), s.DocsOutOfScope.Load(), "%q is per-collection sync-function doc — design plan keeps it in source collection", k)
+		}
+	})
+}
+
+// TestMigrateMetadataUnusedSeqMoves verifies the per-DB unused-sequence docs migrate
+// alongside the rest of the per-DB metadata. The bug this pins: prior to classification
+// these tripped DocsUnknownPrefix on every pass, sending the migration into the
+// bounded-pass give-up branch because both the singleton and range forms exist in the
+// wild whenever the sequence allocator has released anything (import races, write
+// conflicts).
+func TestMigrateMetadataUnusedSeqMoves(t *testing.T) {
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
+
+	const metadataID = "testUnusedSeq"
+	keys := base.NewMetadataKeys(metadataID)
+	ms := newMigrationTestStore(t, bucket)
+
+	// Both forms are written as binary docs (8-/16-byte little-endian uint64 payloads).
+	// AddRaw mirrors what sequenceAllocator.releaseSequence/releaseSequenceRange do in
+	// production — datatype matters for the round-trip assertions below.
+	singletonKey := keys.UnusedSeqKey(42)
+	singletonBody := make([]byte, 8)
+	binaryLE := func(v uint64) []byte {
+		b := make([]byte, 8)
+		for i := 0; i < 8; i++ {
+			b[i] = byte(v >> (8 * i))
+		}
+		return b
+	}
+	copy(singletonBody, binaryLE(42))
+	_, err := ms.Fallback().AddRaw(ctx, singletonKey, 0, singletonBody)
+	require.NoError(t, err, "seed fallback unusedSeq")
+
+	rangeKey := keys.UnusedSeqRangeKey(10, 20)
+	rangeBody := append(binaryLE(10), binaryLE(20)...)
+	_, err = ms.Fallback().AddRaw(ctx, rangeKey, 0, rangeBody)
+	require.NoError(t, err, "seed fallback unusedSeqs range")
+
+	stats := &MigrationStats{}
+	remaining, err := MigrateMetadata(ctx, ms, metadataID, stats)
+	require.NoError(t, err)
+	assert.Equal(t, 0, remaining, "unused-seq docs must clear in a single pass")
+	assert.Equal(t, int64(2), stats.DocsMigrated.Load())
+	assert.Zero(t, stats.DocsUnknownPrefix.Load(), "unused-seq docs must not be classified as unknown")
+
+	for _, k := range []string{singletonKey, rangeKey} {
+		_, _, getErr := ms.Primary().GetRaw(ctx, k)
+		require.NoError(t, getErr, "primary should hold %s", k)
+		_, _, getErr = ms.Fallback().GetRaw(ctx, k)
+		assert.True(t, base.IsDocNotFoundError(getErr), "fallback should no longer hold %s", k)
+	}
+}
+
+// TestMigrateMetadataLegacyDefaultUserWithMPrefixUsername is the end-to-end counterpart
+// to the classification subtest above: a default-mode DB whose user is literally named
+// `m_alice` must actually migrate end-to-end. Before the isOurs fix this user's doc
+// fell into the unknown-prefix branch and was left on fallback forever.
+func TestMigrateMetadataLegacyDefaultUserWithMPrefixUsername(t *testing.T) {
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
+
+	keys := base.NewMetadataKeys(base.DefaultMetadataID)
+	ms := newMigrationTestStore(t, bucket)
+
+	mUserKey := keys.UserKey("m_alice")
+	body := []byte(`{"name":"m_alice","legacy":true}`)
+	seedFallback(ctx, t, ms, mUserKey, body)
+
+	stats := &MigrationStats{}
+	remaining, err := MigrateMetadata(ctx, ms, base.DefaultMetadataID, stats)
+	require.NoError(t, err)
+	assert.Equal(t, 0, remaining)
+	assert.Equal(t, int64(1), stats.DocsMigrated.Load(), "m_alice user in default mode must be migrated, not skipped as a sibling-DB shape")
+
+	got, _, getErr := ms.Primary().GetRaw(ctx, mUserKey)
+	require.NoError(t, getErr)
+	assert.Equal(t, body, got)
+	_, _, getErr = ms.Fallback().GetRaw(ctx, mUserKey)
+	assert.True(t, base.IsDocNotFoundError(getErr))
 }

--- a/db/metadata_migration_test.go
+++ b/db/metadata_migration_test.go
@@ -246,7 +246,14 @@ func TestMigrateMetadataMovesUserEmailAndSession(t *testing.T) {
 	assert.Equal(t, sessionBody, gotSession)
 	primarySessionExpiry, err := ms.Primary().GetExpiry(ctx, sessionKey)
 	require.NoError(t, err)
-	assert.Equal(t, seededSessionExpiry, primarySessionExpiry, "session expiry must round-trip through migration unchanged")
+	// Allow a small drift on the absolute epoch — gocb's InsertOptions take a
+	// time.Duration, so absolute expiries are round-tripped through
+	// time.Until(...) on read and re-derived from "now" on write. A few seconds
+	// of wall-time elapse between the fallback read and the primary write means
+	// primary lands marginally before fallback. The point of this assertion is
+	// "TTL preserved", not "epoch byte-equal" — anything within ~10s is fine
+	// for session TTLs measured in hours.
+	assert.InDelta(t, seededSessionExpiry, primarySessionExpiry, 10, "session expiry must round-trip through migration approximately unchanged")
 	_, _, err = ms.Fallback().GetRaw(ctx, sessionKey)
 	assert.True(t, base.IsDocNotFoundError(err), "fallback session shadow should be gone")
 }

--- a/db/metadata_migration_test.go
+++ b/db/metadata_migration_test.go
@@ -1,0 +1,438 @@
+// Copyright 2026-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newMigrationTestStore(t *testing.T, bucket *base.TestBucket) *base.MetadataStore {
+	t.Helper()
+	ctx := base.TestCtx(t)
+	primary, err := bucket.GetNamedDataStore(0)
+	require.NoError(t, err)
+	fallback := bucket.DefaultDataStore(ctx)
+	if _, ok := base.AsRangeScanStore(fallback); !ok {
+		t.Skipf("metadata migration requires KV range scan support on the fallback datastore")
+	}
+	return base.NewMetadataStore(primary, fallback)
+}
+
+func seedFallback(ctx context.Context, t *testing.T, ms *base.MetadataStore, key string, body []byte) {
+	t.Helper()
+	_, err := ms.Fallback().AddRaw(ctx, key, 0, body)
+	require.NoError(t, err, "seed fallback %s", key)
+}
+
+// TestMigrateMetadataEmptyFallback verifies the new-DB fast path: empty fallback yields a
+// zero remaining count and no errors.
+func TestMigrateMetadataEmptyFallback(t *testing.T) {
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
+
+	ms := newMigrationTestStore(t, bucket)
+	stats := &MigrationStats{}
+
+	remaining, err := MigrateMetadata(ctx, ms, "testEmpty", stats)
+	require.NoError(t, err)
+	assert.Equal(t, 0, remaining)
+	assert.Zero(t, stats.DocsScannedTotal.Load())
+}
+
+// TestMigrateSeqCounterPromotesFallbackToPrimary verifies the one-shot seq counter setup
+// step: pill the fallback doc, nudge the wrapper, end with the counter on primary and the
+// fallback key gone. Called directly because the orchestrator hoists this out of the
+// per-pass MigrateMetadata loop — it is a per-DB setup, not per-pass work.
+func TestMigrateSeqCounterPromotesFallbackToPrimary(t *testing.T) {
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
+
+	const metadataID = "testSeq"
+	keys := base.NewMetadataKeys(metadataID)
+	seqKey := keys.SyncSeqKey()
+
+	ms := newMigrationTestStore(t, bucket)
+	_, err := ms.Fallback().Incr(ctx, seqKey, 42, 42, 0)
+	require.NoError(t, err)
+
+	stats := &MigrationStats{}
+	require.NoError(t, migrateSeqCounter(ctx, ms, seqKey, stats))
+	assert.Equal(t, int64(1), stats.SeqPoisonPillApplied.Load())
+
+	_, _, err = ms.Fallback().GetRaw(ctx, seqKey)
+	assert.True(t, base.IsDocNotFoundError(err), "expected fallback seq key gone after the run")
+
+	result, err := ms.Primary().Incr(ctx, seqKey, 1, 0, 0)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(43), result, "primary counter should be seeded from fallback last_seq")
+}
+
+// TestMigrateMetadataUnknownPrefixCountedAsRemaining verifies that an in-scope key matching
+// none of the known families is warned about, counted as DocsUnknownPrefix, and reported as
+// remaining so the orchestrator's loop can decide what to do.
+func TestMigrateMetadataUnknownPrefixCountedAsRemaining(t *testing.T) {
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
+
+	const metadataID = "testUnknown"
+	ms := newMigrationTestStore(t, bucket)
+	// `_sync:m_testUnknown:wat` is in scope (matches our standard-form prefix
+	// `_sync:m_testUnknown:`) but doesn't match any known family (seq/hb/cfg/etc.).
+	unknownKey := base.SyncDocPrefix + base.MetadataIdPrefix + metadataID + ":wat"
+	seedFallback(ctx, t, ms, unknownKey, []byte(`{"body":"unknown"}`))
+
+	stats := &MigrationStats{}
+	remaining, err := MigrateMetadata(ctx, ms, metadataID, stats)
+	require.NoError(t, err)
+	assert.Equal(t, 1, remaining, "unknown-prefix doc should be reported as remaining")
+	assert.Equal(t, int64(1), stats.DocsUnknownPrefix.Load())
+
+	_, _, getErr := ms.Fallback().GetRaw(ctx, unknownKey)
+	assert.NoError(t, getErr, "unknown-prefix doc should not be deleted")
+}
+
+// TestMigrateMetadataNamespacedExcludesSiblingDB verifies that running with a namespaced
+// metadataID treats a sibling DB's standard-form keys as out-of-scope without inspecting
+// the registry.
+func TestMigrateMetadataNamespacedExcludesSiblingDB(t *testing.T) {
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
+
+	ms := newMigrationTestStore(t, bucket)
+
+	// Sibling DB's standard form is structurally distinguishable: it starts with
+	// `_sync:m_<other>:` (different namespace).
+	const siblingKey = "_sync:m_otherDB:hb:groupA"
+	seedFallback(ctx, t, ms, siblingKey, []byte(`{"heartbeat":"sibling"}`))
+
+	stats := &MigrationStats{}
+	_, err := MigrateMetadata(ctx, ms, "myDB", stats)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(1), stats.DocsOutOfScope.Load())
+
+	_, _, err = ms.Fallback().GetRaw(ctx, siblingKey)
+	assert.NoError(t, err, "sibling DB key must remain on the fallback")
+}
+
+// TestMigrateSeqCounterIdempotent verifies that a second invocation (e.g. after a manager
+// restart, or any retry path) doesn't re-pill the fallback and doesn't fail. The function's
+// idempotency guarantee is what lets the orchestrator simply call it once-per-attempt with
+// no special crash-recovery bookkeeping.
+func TestMigrateSeqCounterIdempotent(t *testing.T) {
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
+
+	const metadataID = "testIdempotent"
+	keys := base.NewMetadataKeys(metadataID)
+	seqKey := keys.SyncSeqKey()
+
+	ms := newMigrationTestStore(t, bucket)
+	_, err := ms.Fallback().Incr(ctx, seqKey, 7, 7, 0)
+	require.NoError(t, err)
+
+	first := &MigrationStats{}
+	require.NoError(t, migrateSeqCounter(ctx, ms, seqKey, first))
+	assert.Equal(t, int64(1), first.SeqPoisonPillApplied.Load())
+
+	second := &MigrationStats{}
+	require.NoError(t, migrateSeqCounter(ctx, ms, seqKey, second))
+	assert.Zero(t, second.SeqPoisonPillApplied.Load(), "no pill on second run — fallback already clean")
+}
+
+// TestMigrateMetadataMovesUserAndRoleDocs verifies the per-key migration action wired up
+// for user and role docs: each seeded key is byte-identically promoted to the primary
+// collection and removed from the fallback, and the stats counters reflect the moves.
+func TestMigrateMetadataMovesUserAndRoleDocs(t *testing.T) {
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
+
+	const metadataID = "testMoveUserRole"
+	keys := base.NewMetadataKeys(metadataID)
+
+	ms := newMigrationTestStore(t, bucket)
+	seeded := map[string][]byte{
+		keys.UserKey("alice"):   []byte(`{"name":"alice"}`),
+		keys.UserKey("bob"):     []byte(`{"name":"bob"}`),
+		keys.RoleKey("admins"):  []byte(`{"name":"admins"}`),
+		keys.RoleKey("readers"): []byte(`{"name":"readers"}`),
+	}
+	for k, v := range seeded {
+		seedFallback(ctx, t, ms, k, v)
+	}
+
+	stats := &MigrationStats{}
+	remaining, err := MigrateMetadata(ctx, ms, metadataID, stats)
+	require.NoError(t, err)
+	assert.Equal(t, 0, remaining)
+	assert.Equal(t, int64(len(seeded)), stats.DocsMigrated.Load())
+	assert.Zero(t, stats.Errors.Load())
+
+	for k, want := range seeded {
+		got, _, getErr := ms.Primary().GetRaw(ctx, k)
+		require.NoError(t, getErr, "primary should hold %s", k)
+		assert.Equal(t, want, got, "primary body for %s should match the seed", k)
+
+		_, _, getErr = ms.Fallback().GetRaw(ctx, k)
+		assert.True(t, base.IsDocNotFoundError(getErr), "fallback should no longer hold %s", k)
+	}
+}
+
+// TestMigrateMetadataMovesUserEmailAndSession verifies that the per-key move action is
+// also wired for useremail and session docs, and — critically for sessions — that the
+// fallback doc's expiry is preserved when the doc lands on the primary collection.
+// auth.Authenticator.CreateSession writes sessions with a TTL via Set's exp argument;
+// if the migration stripped that TTL, sessions would silently become immortal.
+func TestMigrateMetadataMovesUserEmailAndSession(t *testing.T) {
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
+
+	const metadataID = "testMoveUserEmailSession"
+	keys := base.NewMetadataKeys(metadataID)
+
+	ms := newMigrationTestStore(t, bucket)
+
+	emailKey := keys.UserEmailKey("alice@example.com")
+	emailBody := []byte(`{"username":"alice"}`)
+	seedFallback(ctx, t, ms, emailKey, emailBody)
+
+	sessionKey := keys.SessionKey("tok1")
+	sessionBody := []byte(`{"sid":"tok1","username":"alice"}`)
+	// Use a 1h offset; both Rosmar and CBS convert this to an absolute epoch at write
+	// time, so a later GetExpiry returns a non-zero value we can compare against.
+	const sessionExpRelative uint32 = 3600
+	_, err := ms.Fallback().AddRaw(ctx, sessionKey, sessionExpRelative, sessionBody)
+	require.NoError(t, err, "seed fallback session with TTL")
+
+	seededSessionExpiry, err := ms.Fallback().GetExpiry(ctx, sessionKey)
+	require.NoError(t, err)
+	require.NotZero(t, seededSessionExpiry, "fallback should have a non-zero absolute expiry after a TTL write")
+
+	stats := &MigrationStats{}
+	remaining, err := MigrateMetadata(ctx, ms, metadataID, stats)
+	require.NoError(t, err)
+	assert.Equal(t, 0, remaining)
+	assert.Equal(t, int64(2), stats.DocsMigrated.Load(), "useremail and session should both be moved")
+	assert.Zero(t, stats.Errors.Load())
+
+	// useremail — body intact, no expiry.
+	gotEmail, _, err := ms.Primary().GetRaw(ctx, emailKey)
+	require.NoError(t, err, "primary should hold useremail key")
+	assert.Equal(t, emailBody, gotEmail)
+	_, _, err = ms.Fallback().GetRaw(ctx, emailKey)
+	assert.True(t, base.IsDocNotFoundError(err), "fallback useremail shadow should be gone")
+
+	// session — body intact AND expiry preserved.
+	gotSession, _, err := ms.Primary().GetRaw(ctx, sessionKey)
+	require.NoError(t, err, "primary should hold session key")
+	assert.Equal(t, sessionBody, gotSession)
+	primarySessionExpiry, err := ms.Primary().GetExpiry(ctx, sessionKey)
+	require.NoError(t, err)
+	assert.Equal(t, seededSessionExpiry, primarySessionExpiry, "session expiry must round-trip through migration unchanged")
+	_, _, err = ms.Fallback().GetRaw(ctx, sessionKey)
+	assert.True(t, base.IsDocNotFoundError(err), "fallback session shadow should be gone")
+}
+
+// TestMigrateMetadataUserDocPrimaryWinsOnConflict verifies the already-exists short-
+// circuit: when primary already has a (fresher) copy from an in-flight read-through
+// Update, the migration must not overwrite it — but should still clean up the stale
+// fallback shadow.
+func TestMigrateMetadataUserDocPrimaryWinsOnConflict(t *testing.T) {
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
+
+	const metadataID = "testMoveConflict"
+	keys := base.NewMetadataKeys(metadataID)
+	key := keys.UserKey("alice")
+
+	ms := newMigrationTestStore(t, bucket)
+	fresherPrimary := []byte(`{"name":"alice","fresh":true}`)
+	stalerFallback := []byte(`{"name":"alice","fresh":false}`)
+	_, err := ms.Primary().AddRaw(ctx, key, 0, fresherPrimary)
+	require.NoError(t, err)
+	seedFallback(ctx, t, ms, key, stalerFallback)
+
+	stats := &MigrationStats{}
+	remaining, err := MigrateMetadata(ctx, ms, metadataID, stats)
+	require.NoError(t, err)
+	assert.Equal(t, 0, remaining)
+	assert.Equal(t, int64(1), stats.DocsMigrated.Load(), "already-exists short-circuit should count as migrated")
+	assert.Zero(t, stats.Errors.Load())
+
+	got, _, err := ms.Primary().GetRaw(ctx, key)
+	require.NoError(t, err)
+	assert.Equal(t, fresherPrimary, got, "primary body must not be overwritten by the stale fallback shadow")
+
+	_, _, err = ms.Fallback().GetRaw(ctx, key)
+	assert.True(t, base.IsDocNotFoundError(err), "stale fallback shadow should be cleaned up")
+}
+
+// TestMigrateMetadataLegacyDefaultUserAndRole verifies user/role moves work for the
+// legacy default metadataID, whose keys have no `m_<id>:` infix (e.g. `_sync:user:alice`).
+// The existing TestHandleMigrationKeyScoping/LegacyDefaultOurs case only verifies
+// classification; this exercises the actual move.
+func TestMigrateMetadataLegacyDefaultUserAndRole(t *testing.T) {
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
+
+	keys := base.NewMetadataKeys(base.DefaultMetadataID)
+
+	ms := newMigrationTestStore(t, bucket)
+	seeded := map[string][]byte{
+		keys.UserKey("alice"):  []byte(`{"name":"alice","legacy":true}`),
+		keys.RoleKey("admins"): []byte(`{"name":"admins","legacy":true}`),
+	}
+	for k, v := range seeded {
+		seedFallback(ctx, t, ms, k, v)
+	}
+
+	stats := &MigrationStats{}
+	remaining, err := MigrateMetadata(ctx, ms, base.DefaultMetadataID, stats)
+	require.NoError(t, err)
+	assert.Equal(t, 0, remaining)
+	assert.Equal(t, int64(len(seeded)), stats.DocsMigrated.Load())
+	assert.Zero(t, stats.Errors.Load())
+
+	for k, want := range seeded {
+		got, _, getErr := ms.Primary().GetRaw(ctx, k)
+		require.NoError(t, getErr, "primary should hold legacy-default %s", k)
+		assert.Equal(t, want, got)
+
+		_, _, getErr = ms.Fallback().GetRaw(ctx, k)
+		assert.True(t, base.IsDocNotFoundError(getErr), "fallback should no longer hold legacy-default %s", k)
+	}
+}
+
+// TestMigrateMetadataDefaultModeUnknownPreservedHeartbeatDeleted exercises the precise
+// heartbeater-vs-unknown distinction in default mode end-to-end. The default-mode
+// heartbeater prefix is bare `_sync:`, so before IsLegacyHeartbeaterKey the unknown legacy
+// key would have been classified as a heartbeat and deleted. Both branches need a live
+// fallback (Delete + leave-on-fallback), so this is a bucket-backed test rather than a
+// nil-ms classification subtest.
+func TestMigrateMetadataDefaultModeUnknownPreservedHeartbeatDeleted(t *testing.T) {
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
+
+	ms := newMigrationTestStore(t, bucket)
+
+	const unknownKey = "_sync:somethingnew:foo"
+	const heartbeatKey = "_sync:heartbeat_timeout:nodeA"
+	seedFallback(ctx, t, ms, unknownKey, []byte(`{"unknown":"shape"}`))
+	seedFallback(ctx, t, ms, heartbeatKey, []byte("nodeA"))
+
+	stats := &MigrationStats{}
+	remaining, err := MigrateMetadata(ctx, ms, base.DefaultMetadataID, stats)
+	require.NoError(t, err)
+	assert.Equal(t, 1, remaining, "unknown-prefix doc must keep the migration in 'work remaining' state")
+	assert.Equal(t, int64(1), stats.DocsUnknownPrefix.Load(), "%q must be classified as unknown-prefix, not as a heartbeat", unknownKey)
+	assert.Equal(t, int64(1), stats.DocsMigrated.Load(), "%q (real heartbeat) should be deleted and counted as migrated", heartbeatKey)
+	assert.Zero(t, stats.Errors.Load())
+
+	_, _, getErr := ms.Fallback().GetRaw(ctx, unknownKey)
+	assert.NoError(t, getErr, "unknown-prefix doc must NOT be deleted — that was the bug")
+
+	_, _, getErr = ms.Fallback().GetRaw(ctx, heartbeatKey)
+	assert.True(t, base.IsDocNotFoundError(getErr), "heartbeat doc should be removed from fallback")
+}
+
+// TestMigrateMetadataNamespacedHeartbeatDeletedViaShapeMatch verifies the same shape-based
+// heartbeater match works for namespaced metadataIDs, where the heartbeater prefix is
+// `_sync:m_<id>:hb:` and the doc shape is `<prefix>heartbeat_timeout:<nodeUUID>`.
+func TestMigrateMetadataNamespacedHeartbeatDeletedViaShapeMatch(t *testing.T) {
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
+
+	const metadataID = "testHbShape"
+	keys := base.NewMetadataKeys(metadataID)
+	heartbeatKey := keys.HeartbeaterPrefix("") + "heartbeat_timeout:nodeA"
+
+	ms := newMigrationTestStore(t, bucket)
+	seedFallback(ctx, t, ms, heartbeatKey, []byte("nodeA"))
+
+	stats := &MigrationStats{}
+	remaining, err := MigrateMetadata(ctx, ms, metadataID, stats)
+	require.NoError(t, err)
+	assert.Equal(t, 0, remaining)
+	assert.Equal(t, int64(1), stats.DocsMigrated.Load(), "namespaced heartbeat doc should be deleted via the shape match")
+	assert.Zero(t, stats.DocsUnknownPrefix.Load())
+
+	_, _, getErr := ms.Fallback().GetRaw(ctx, heartbeatKey)
+	assert.True(t, base.IsDocNotFoundError(getErr), "namespaced heartbeat doc should be removed from fallback")
+}
+
+// TestHandleMigrationKeyScoping covers the in-scope/out-of-scope decision baked into
+// handleMigrationKey, verifying that namespaced and legacy-default modes classify keys
+// correctly without going through the full scan path.
+//
+// Keys here are constructed via the live MetadataKeys helpers so the test follows the
+// actual on-disk shape rather than the (currently inaccurate) shape suggested in the
+// metadata-migration design notes.
+func TestHandleMigrationKeyScoping(t *testing.T) {
+	ctx := base.TestCtx(t)
+
+	classify := func(metadataID, key string) *MigrationStats {
+		stats := &MigrationStats{}
+		handleMigrationKey(ctx, nil, base.NewMetadataKeys(metadataID), metadataID, key, stats)
+		return stats
+	}
+
+	t.Run("NamespacedSiblingStandardForm", func(t *testing.T) {
+		// Sibling DBs' standard-form keys are `_sync:m_<other>:…` — structurally
+		// distinguishable from ours via the metadataID infix.
+		for _, k := range []string{
+			"_sync:m_otherDB:seq",
+			"_sync:m_otherDB:hb:groupA",
+		} {
+			s := classify("myDB", k)
+			assert.Equal(t, int64(1), s.DocsOutOfScope.Load(), "%q should be out of scope for myDB", k)
+		}
+	})
+	t.Run("BucketLevelOutOfScope", func(t *testing.T) {
+		for _, k := range []string{
+			"_sync:registry",
+			"_sync:dbconfig:default",
+			"_sync:syncInfo",
+		} {
+			s := classify("myDB", k)
+			assert.Equal(t, int64(1), s.DocsOutOfScope.Load(), "%q is a bucket-level doc — out of scope", k)
+		}
+	})
+
+	// DefaultModeUnknownPrefixNotSwallowed pins the fix for the heartbeater catch-all
+	// shadowing problem: with DefaultMetadataID the heartbeater prefix is bare `_sync:`,
+	// which previously meant any unrecognised in-scope `_sync:…` key fell into the
+	// heartbeater branch and got deleted. With the IsLegacyHeartbeaterKey shape check the
+	// dispatcher must instead route unknown keys to the warn/DocsUnknownPrefix branch.
+	t.Run("DefaultModeUnknownPrefixNotSwallowed", func(t *testing.T) {
+		for _, k := range []string{
+			"_sync:somethingnew:foo",
+			"_sync:futurefeature",
+		} {
+			s := classify(base.DefaultMetadataID, k)
+			assert.Equal(t, int64(1), s.DocsUnknownPrefix.Load(), "%q must be unknown-prefix, not classified as a heartbeat", k)
+			assert.Zero(t, s.DocsOutOfScope.Load(), "%q is in-scope (default mode owns `_sync:…`) so should not be out-of-scope", k)
+		}
+	})
+}

--- a/db/metadata_migration_test.go
+++ b/db/metadata_migration_test.go
@@ -332,7 +332,7 @@ func TestMigrateMetadataLegacyDefaultUserAndRole(t *testing.T) {
 
 // TestMigrateMetadataDefaultModeUnknownPreservedHeartbeatDeleted exercises the precise
 // heartbeater-vs-unknown distinction in default mode end-to-end. The default-mode
-// heartbeater prefix is bare `_sync:`, so before IsLegacyHeartbeaterKey the unknown legacy
+// heartbeater prefix is bare `_sync:`, so before IsHeartbeaterKey the unknown legacy
 // key would have been classified as a heartbeat and deleted. Both branches need a live
 // fallback (Delete + leave-on-fallback), so this is a bucket-backed test rather than a
 // nil-ms classification subtest.
@@ -368,7 +368,7 @@ func TestMigrateMetadataDefaultModeUnknownPreservedHeartbeatDeleted(t *testing.T
 // `HeartbeaterPrefix` returns `_sync:m_<id>:hb:<groupID>:`, so the heartbeater writes
 // `<heartbeaterPrefix>heartbeat_timeout:<nodeUUID>` — i.e. the on-disk key has an extra
 // `<groupID>:` colon-segment between the namespace and the literal `heartbeat_timeout:`
-// token. The original `IsLegacyHeartbeaterKey` only matched the no-groupID form, so the
+// token. The original `IsHeartbeaterKey` only matched the no-groupID form, so the
 // with-groupID heartbeat key fell into DocsUnknownPrefix and wedged the migration on
 // every real EE bucket.
 func TestMigrateMetadataNamespacedHeartbeatWithGroupIDDeletedViaShapeMatch(t *testing.T) {
@@ -462,7 +462,7 @@ func TestHandleMigrationKeyScoping(t *testing.T) {
 	// DefaultModeUnknownPrefixNotSwallowed pins the fix for the heartbeater catch-all
 	// shadowing problem: with DefaultMetadataID the heartbeater prefix is bare `_sync:`,
 	// which previously meant any unrecognised in-scope `_sync:…` key fell into the
-	// heartbeater branch and got deleted. With the IsLegacyHeartbeaterKey shape check the
+	// heartbeater branch and got deleted. With the IsHeartbeaterKey shape check the
 	// dispatcher must instead route unknown keys to the warn/DocsUnknownPrefix branch.
 	t.Run("DefaultModeUnknownPrefixNotSwallowed", func(t *testing.T) {
 		for _, k := range []string{
@@ -490,22 +490,6 @@ func TestHandleMigrationKeyScoping(t *testing.T) {
 		} {
 			s := classify(base.DefaultMetadataID, k)
 			assert.Equal(t, int64(1), s.DocsOutOfScope.Load(), "%q is a sibling-DB inverted-form key — must remain out-of-scope", k)
-		}
-	})
-
-	// SyncFunctionDocsOutOfScope pins the design-plan decision that the per-collection
-	// sync-function docs (`_sync:syncdata*`) stay in the source collection — they're
-	// classified out-of-scope rather than left as unknown-prefix (which would block the
-	// migration on every real DB, since every DB writes at least one syncdata doc).
-	t.Run("SyncFunctionDocsOutOfScope", func(t *testing.T) {
-		for _, k := range []string{
-			"_sync:syncdata",
-			"_sync:syncdata:groupA",
-			"_sync:syncdata_collection:scope1.coll1",
-			"_sync:syncdata_collection:scope1.coll1:groupA",
-		} {
-			s := classify("myDB", k)
-			assert.Equal(t, int64(1), s.DocsOutOfScope.Load(), "%q is per-collection sync-function doc — design plan keeps it in source collection", k)
 		}
 	})
 }

--- a/db/query.go
+++ b/db/query.go
@@ -597,16 +597,24 @@ func (context *DatabaseContext) QueryPrincipals(ctx context.Context, startKey st
 	params := make(map[string]any)
 	params[QueryParamStartKey] = startKey
 
-	// N1QL Query — when a dual MetadataStore is active query both keystores and merge.
-	// LIMIT is handled internally by dualMetadataN1QLQuery; do not append it to the statement.
-	if ms, ok := context.MetadataStore.(*base.MetadataStore); ok && !ms.MigrationComplete() {
-		return dualMetadataN1QLQuery[PrincipalRow](ctx, ms, QueryPrincipals.name, queryStatement, params, base.RequestPlus, QueryPrincipals.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold, limit)
+	// N1QL Query. context.MetadataStore is a dual-collection wrapper for an opted-in database.
+	// While its migration is in flight, query both keystores and merge in SG (LIMIT is handled
+	// internally by dualMetadataN1QLQuery). Once complete — or for a database that never opted in
+	// — all metadata lives in a single collection, so target it directly: the wrapper's primary
+	// (the migration is complete by the time we reach here) or the plain store. The wrapper itself
+	// cannot run a query.
+	metadataStore := context.MetadataStore
+	if ms, ok := metadataStore.(*base.MetadataStore); ok {
+		if !ms.MigrationComplete() {
+			return dualMetadataN1QLQuery[PrincipalRow](ctx, ms, QueryPrincipals.name, queryStatement, params, base.RequestPlus, QueryPrincipals.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold, limit)
+		}
+		metadataStore = ms.Primary()
 	}
 
 	if limit > 0 {
 		queryStatement = fmt.Sprintf("%s LIMIT %d", queryStatement, limit)
 	}
-	return N1QLQueryWithStats(ctx, context.MetadataStore, QueryPrincipals.name, queryStatement, params, base.RequestPlus, QueryPrincipals.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold)
+	return N1QLQueryWithStats(ctx, metadataStore, QueryPrincipals.name, queryStatement, params, base.RequestPlus, QueryPrincipals.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold)
 }
 
 // Query to retrieve user details, using the syncDocs or users index
@@ -617,14 +625,17 @@ func (context *DatabaseContext) QueryUsers(ctx context.Context, startKey string,
 		return nil, errors.New("QueryUsers does not support views")
 	}
 
-	// N1QL Query — when a dual MetadataStore is active query both keystores and merge.
-	// LIMIT is handled internally by dualMetadataN1QLQuery; build the statement without it.
-	if ms, ok := context.MetadataStore.(*base.MetadataStore); ok && !ms.MigrationComplete() {
-		queryStatement, params := context.BuildUsersQuery(startKey, 0)
-		return dualMetadataN1QLQuery[QueryUsersRow](ctx, ms, QueryTypeUsers, queryStatement, params, base.RequestPlus, QueryUsers.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold, limit)
+	// N1QL Query. See QueryPrincipals for the dual-collection wrapper handling.
+	metadataStore := context.MetadataStore
+	if ms, ok := metadataStore.(*base.MetadataStore); ok {
+		if !ms.MigrationComplete() {
+			queryStatement, params := context.BuildUsersQuery(startKey, 0)
+			return dualMetadataN1QLQuery[QueryUsersRow](ctx, ms, QueryTypeUsers, queryStatement, params, base.RequestPlus, QueryUsers.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold, limit)
+		}
+		metadataStore = ms.Primary()
 	}
 	queryStatement, params := context.BuildUsersQuery(startKey, limit)
-	return N1QLQueryWithStats(ctx, context.MetadataStore, QueryTypeUsers, queryStatement, params, base.RequestPlus, QueryUsers.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold)
+	return N1QLQueryWithStats(ctx, metadataStore, QueryTypeUsers, queryStatement, params, base.RequestPlus, QueryUsers.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold)
 }
 
 // BuildUsersQuery builds the query statement and query parameters for a Users N1QL query. Also used by unit tests to validate
@@ -664,14 +675,17 @@ func (context *DatabaseContext) QueryRoles(ctx context.Context, startKey string,
 		return context.ViewQueryWithStats(ctx, context.MetadataStore, DesignDocSyncGateway(), ViewRolesExcludeDeleted, opts)
 	}
 
-	// N1QL Query — when a dual MetadataStore is active query both keystores and merge.
-	// LIMIT is handled internally by dualMetadataN1QLQuery; build the statement without it.
-	if ms, ok := context.MetadataStore.(*base.MetadataStore); ok && !ms.MigrationComplete() {
-		queryStatement, params := context.BuildRolesQuery(startKey, 0)
-		return dualMetadataN1QLQuery[PrincipalRow](ctx, ms, QueryRolesExcludeDeleted.name, queryStatement, params, base.RequestPlus, QueryRolesExcludeDeleted.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold, limit)
+	// N1QL Query. See QueryPrincipals for the dual-collection wrapper handling.
+	metadataStore := context.MetadataStore
+	if ms, ok := metadataStore.(*base.MetadataStore); ok {
+		if !ms.MigrationComplete() {
+			queryStatement, params := context.BuildRolesQuery(startKey, 0)
+			return dualMetadataN1QLQuery[PrincipalRow](ctx, ms, QueryRolesExcludeDeleted.name, queryStatement, params, base.RequestPlus, QueryRolesExcludeDeleted.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold, limit)
+		}
+		metadataStore = ms.Primary()
 	}
 	queryStatement, params := context.BuildRolesQuery(startKey, limit)
-	return N1QLQueryWithStats(ctx, context.MetadataStore, QueryRolesExcludeDeleted.name, queryStatement, params, base.RequestPlus, QueryRolesExcludeDeleted.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold)
+	return N1QLQueryWithStats(ctx, metadataStore, QueryRolesExcludeDeleted.name, queryStatement, params, base.RequestPlus, QueryRolesExcludeDeleted.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold)
 }
 
 // BuildRolesQuery builds the query statement and query parameters for a Roles N1QL query. Also used by unit tests to validate
@@ -716,16 +730,19 @@ func (context *DatabaseContext) QueryAllRoles(ctx context.Context, startKey stri
 	params := make(map[string]any)
 	params[QueryParamStartKey] = startKey
 
-	// N1QL Query — when a dual MetadataStore is active query both keystores and merge.
-	// LIMIT is handled internally by dualMetadataN1QLQuery; do not append it to the statement.
-	if ms, ok := context.MetadataStore.(*base.MetadataStore); ok && !ms.MigrationComplete() {
-		return dualMetadataN1QLQuery[PrincipalRow](ctx, ms, queryName, queryStatement, params, base.RequestPlus, QueryRolesExcludeDeleted.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold, limit)
+	// N1QL Query. See QueryPrincipals for the dual-collection wrapper handling.
+	metadataStore := context.MetadataStore
+	if ms, ok := metadataStore.(*base.MetadataStore); ok {
+		if !ms.MigrationComplete() {
+			return dualMetadataN1QLQuery[PrincipalRow](ctx, ms, queryName, queryStatement, params, base.RequestPlus, QueryRolesExcludeDeleted.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold, limit)
+		}
+		metadataStore = ms.Primary()
 	}
 
 	if limit > 0 {
 		queryStatement = fmt.Sprintf("%s LIMIT %d", queryStatement, limit)
 	}
-	return N1QLQueryWithStats(ctx, context.MetadataStore, queryName, queryStatement, params, base.RequestPlus, QueryRolesExcludeDeleted.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold)
+	return N1QLQueryWithStats(ctx, metadataStore, queryName, queryStatement, params, base.RequestPlus, QueryRolesExcludeDeleted.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold)
 }
 
 type AllDocsViewQueryRow struct {

--- a/db/sequence_allocator_test.go
+++ b/db/sequence_allocator_test.go
@@ -35,7 +35,7 @@ func TestSequenceAllocator(t *testing.T) {
 
 	sgw, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := sgw.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := sgw.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	testStats := dbstats.Database()
 
@@ -105,7 +105,7 @@ func TestReleaseSequencesOnStop(t *testing.T) {
 
 	sgw, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := sgw.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := sgw.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	testStats := dbstats.Database()
 
@@ -182,7 +182,7 @@ func TestSequenceAllocatorDeadlock(t *testing.T) {
 
 	sgw, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := sgw.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := sgw.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	testStats := dbstats.Database()
 
@@ -217,7 +217,7 @@ func TestReleaseSequenceWait(t *testing.T) {
 
 	sgw, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := sgw.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := sgw.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	testStats := dbstats.Database()
 	a, err := newSequenceAllocator(ctx, bucket.GetSingleDataStore(), testStats, base.DefaultMetadataKeys)
@@ -254,7 +254,7 @@ func TestNextSequenceGreaterThanSingleNode(t *testing.T) {
 
 	sgw, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := sgw.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := sgw.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	testStats := dbstats.Database()
 
@@ -335,9 +335,9 @@ func TestNextSequenceGreaterThanMultiNode(t *testing.T) {
 	// Set sequenceBatchSize=10 to test variations of batching
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	statsA, err := stats.NewDBStats("A", false, false, false, nil, nil)
+	statsA, err := stats.NewDBStats("A", false, false, false, false, nil, nil)
 	require.NoError(t, err)
-	statsB, err := stats.NewDBStats("B", false, false, false, nil, nil)
+	statsB, err := stats.NewDBStats("B", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbStatsA := statsA.DatabaseStats
 	dbStatsB := statsB.DatabaseStats
@@ -413,7 +413,7 @@ func TestSingleNodeSyncSeqRollback(t *testing.T) {
 
 	sgw, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := sgw.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := sgw.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	testStats := dbstats.Database()
 	ds := bucket.GetSingleDataStore()
@@ -494,7 +494,7 @@ func TestSingleNodeNextSeqGreaterThanRollbackHandling(t *testing.T) {
 
 	sgw, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := sgw.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := sgw.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	testStats := dbstats.Database()
 	ds := bucket.GetSingleDataStore()
@@ -575,9 +575,9 @@ func TestSyncSeqRollbackMultiNode(t *testing.T) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	statsA, err := stats.NewDBStats("A", false, false, false, nil, nil)
+	statsA, err := stats.NewDBStats("A", false, false, false, false, nil, nil)
 	require.NoError(t, err)
-	statsB, err := stats.NewDBStats("B", false, false, false, nil, nil)
+	statsB, err := stats.NewDBStats("B", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbStatsA := statsA.DatabaseStats
 	dbStatsB := statsB.DatabaseStats
@@ -665,15 +665,15 @@ func TestFiveNodeRollbackMiddleNodesDetects(t *testing.T) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	statsA, err := stats.NewDBStats("A", false, false, false, nil, nil)
+	statsA, err := stats.NewDBStats("A", false, false, false, false, nil, nil)
 	require.NoError(t, err)
-	statsB, err := stats.NewDBStats("B", false, false, false, nil, nil)
+	statsB, err := stats.NewDBStats("B", false, false, false, false, nil, nil)
 	require.NoError(t, err)
-	statsC, err := stats.NewDBStats("C", false, false, false, nil, nil)
+	statsC, err := stats.NewDBStats("C", false, false, false, false, nil, nil)
 	require.NoError(t, err)
-	statsD, err := stats.NewDBStats("D", false, false, false, nil, nil)
+	statsD, err := stats.NewDBStats("D", false, false, false, false, nil, nil)
 	require.NoError(t, err)
-	statsE, err := stats.NewDBStats("E", false, false, false, nil, nil)
+	statsE, err := stats.NewDBStats("E", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbStatsA := statsA.DatabaseStats
 	dbStatsB := statsB.DatabaseStats
@@ -777,7 +777,7 @@ func TestVariableRateAllocators(t *testing.T) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
 
-	importStats, err := stats.NewDBStats("import", false, false, false, nil, nil)
+	importStats, err := stats.NewDBStats("import", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 
 	importFeedAllocator, err := newSequenceAllocator(ctx, dataStore, importStats.DatabaseStats, base.DefaultMetadataKeys)
@@ -799,7 +799,7 @@ func TestVariableRateAllocators(t *testing.T) {
 	clientAllocators := make([]*sequenceAllocator, 0)
 	clientAllocatorCount := 10
 	for i := 0; i <= clientAllocatorCount; i++ {
-		clientStats, err := stats.NewDBStats(fmt.Sprintf("client%d", i), false, false, false, nil, nil)
+		clientStats, err := stats.NewDBStats(fmt.Sprintf("client%d", i), false, false, false, false, nil, nil)
 		require.NoError(t, err)
 		clientAllocator, err := newSequenceAllocator(ctx, dataStore, clientStats.DatabaseStats, base.DefaultMetadataKeys)
 		require.NoError(t, err)

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -147,6 +147,8 @@ paths:
     $ref: './paths/admin/db-_compact.yaml'
   '/{db}/_attachment_migration':
     $ref: './paths/admin/db-_attachment_migration.yaml'
+  '/{db}/_metadata_migration':
+    $ref: './paths/admin/db-_metadata_migration.yaml'
   '/{keyspace}/':
     $ref: './paths/admin/keyspace-.yaml'
   /_expvar:

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -2064,6 +2064,57 @@ Attachment-Migration-status:
     - docs_changed
     - docs_processed
   title: Attachment-Migration-status
+Metadata-Migration-status:
+  description: The status of a metadata migration operation, which moves a database's `_sync:`-rooted metadata from the legacy `_default._default` keyspace into the `_system._mobile` collection.
+  type: object
+  properties:
+    status:
+      description: The status of the current metadata migration operation.
+      type: string
+      enum:
+        - running
+        - completed
+        - stopping
+        - stopped
+        - error
+    start_time:
+      description: The ISO-8601 date and time the metadata migration operation was started.
+      type: string
+    last_error:
+      description: The last error that occurred in the metadata migration operation (if any).
+      type: string
+    migration_id:
+      description: The UUID given to the metadata migration operation.
+      type: string
+    docs_processed:
+      description: The cumulative count of docs successfully moved (or deleted, for transient docs like heartbeats) across all passes.
+      type: integer
+    docs_failed:
+      description: The cumulative count of per-doc errors observed during metadata migration moves or deletes across all passes.
+      type: integer
+    docs_attempted:
+      description: The sum of `docs_processed` and `docs_failed`.
+      type: integer
+    docs_out_of_scope:
+      description: |-
+        The number of fallback keys classified as out-of-scope on the most recent pass.
+
+        These are keys that belong to sibling databases in the same bucket, or to bucket-level docs that have their own migration logic. They are left in place rather than being moved.
+      type: integer
+    passes:
+      description: |-
+        The total number of range-scan passes executed against the fallback collection.
+
+        Most migrations complete in a single pass — additional passes are triggered when documents written under an in-flight scan were missed and need to be caught on a follow-up pass.
+      type: integer
+  required:
+    - status
+    - start_time
+    - last_error
+    - docs_processed
+    - docs_failed
+    - passes
+  title: Metadata-Migration-status
 Compact-status:
   description: The status returned from a compaction.
   type: object

--- a/docs/api/paths/admin/db-_metadata_migration.yaml
+++ b/docs/api/paths/admin/db-_metadata_migration.yaml
@@ -1,0 +1,91 @@
+# Copyright 2026-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+parameters:
+  - $ref: ../../components/parameters.yaml#/db
+post:
+  summary: Manage a metadata migration operation
+  description: |-
+    This allows a metadata migration operation to be started on the database, or to stop an existing running metadata migration operation.
+
+    Metadata migration moves a database's `_sync:`-rooted metadata from the legacy `_default._default` keyspace into the `_system._mobile` collection. It is normally armed automatically the moment all nodes in the cluster have applied the database configuration that opts into the system metadata collection — this endpoint is provided for operators that need to drive the lifecycle directly (e.g. retry after a give-up, stop a runaway migration).
+
+    Metadata migration is a single-node process and only one node in the cluster can be running it at a time. Other nodes contend for a cluster-wide heartbeat lock.
+
+    Required Sync Gateway RBAC roles:
+
+    * Sync Gateway Architect
+  parameters:
+    - name: action
+      in: query
+      description: Defines whether a metadata migration operation is being started or stopped.
+      schema:
+        type: string
+        default: start
+        enum:
+          - start
+          - stop
+    - name: reset
+      in: query
+      description: |-
+        This forces a fresh metadata migration start instead of trying to resume the previous failed migration operation.
+      schema:
+        type: boolean
+  responses:
+    '200':
+      description: Started or stopped metadata migration operation successfully.
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas.yaml#/Metadata-Migration-status
+    '400':
+      $ref: ../../components/responses.yaml#/request-problem
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
+    '404':
+      description: Metadata migration manager is not initialized for this database.
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas.yaml#/HTTP-Error
+    '503':
+      description: Cannot start metadata migration due to another migration operation still running.
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas.yaml#/HTTP-Error
+  tags:
+    - Database Management
+  operationId: post_db-_metadata_migration
+get:
+  summary: Get the status of the most recent metadata migration operation
+  description: |-
+    This will retrieve the current status of the most recent metadata migration operation for the database.
+
+    Required Sync Gateway RBAC roles:
+
+    * Sync Gateway Architect
+  responses:
+    '200':
+      description: Metadata migration status retrieved successfully.
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas.yaml#/Metadata-Migration-status
+    '400':
+      $ref: ../../components/responses.yaml#/request-problem
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
+    '404':
+      description: Metadata migration manager is not initialized for this database.
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas.yaml#/HTTP-Error
+  tags:
+    - Database Management
+  operationId: get_db-_metadata_migration

--- a/rest/api.go
+++ b/rest/api.go
@@ -186,10 +186,10 @@ func (h *handler) handleGetAttachmentMigration() error {
 // metadata migration arming logic in DatabaseContext.armMetadataMigrationTask. The
 // migration normally arms itself the moment all nodes report the opted-in config
 // applied — this endpoint exists for operators who need to drive the lifecycle
-// directly (e.g. retry after a give-up, stop a runaway migration). It does NOT
-// gate on UseSystemMetadataCollection: a manual start against a DB that never
-// opted in will simply find the MetadataStore is not a dual-collection wrapper
-// and no-op through to the per-DB complete write.
+// directly (e.g. retry after a give-up, stop a runaway migration). A manual start is
+// rejected unless the database has enabled use_system_metadata_collection (nothing to
+// migrate otherwise) and every node has applied that opted-in config (so peers aren't
+// still writing metadata to the legacy collection mid-migration).
 func (h *handler) handleMetadataMigration() error {
 	if h.db.MetadataMigrationManager == nil {
 		return base.HTTPErrorf(http.StatusNotFound, "Metadata migration manager is not initialized for this database")
@@ -206,6 +206,27 @@ func (h *handler) handleMetadataMigration() error {
 	}
 
 	if action == string(db.BackgroundProcessActionStart) {
+		// Migration only makes sense once the database has opted in to the system metadata
+		// collection. Without it the MetadataStore is not a dual-collection wrapper and there is
+		// nothing to migrate, so reject the start rather than silently no-op'ing.
+		if !h.db.Options.UseSystemMetadataCollection {
+			return base.HTTPErrorf(http.StatusBadRequest, "cannot start metadata migration: use_system_metadata_collection is not enabled for this database")
+		}
+		// Gate a manual start on the same cluster-readiness check the auto-arming path uses
+		// (DatabaseContext.tryStartMetadataMigration). Starting before every node has applied the
+		// opted-in config would let peers still on the old config keep writing metadata to
+		// _default._default while this node migrates it to _system._mobile, splitting or losing
+		// those writes. ConfigFullyAppliedFunc is nil only outside persistent-config mode, where
+		// there is no cluster to coordinate, so a nil func skips the gate.
+		if h.db.ConfigFullyAppliedFunc != nil {
+			applied, missing, err := h.db.ConfigFullyAppliedFunc(h.ctx())
+			if err != nil {
+				return base.HTTPErrorf(http.StatusServiceUnavailable, "unable to verify the database config has been applied across the cluster before starting metadata migration: %v", err)
+			}
+			if !applied {
+				return base.HTTPErrorf(http.StatusServiceUnavailable, "cannot start metadata migration until the opted-in database config has been applied on all nodes (waiting on: %v)", missing)
+			}
+		}
 		if err := h.db.MetadataMigrationManager.Start(h.ctx(), map[string]any{
 			"reset": reset,
 		}); err != nil {

--- a/rest/api.go
+++ b/rest/api.go
@@ -182,6 +182,61 @@ func (h *handler) handleGetAttachmentMigration() error {
 	return nil
 }
 
+// handleMetadataMigration is the admin-API counterpart to the automatic, cluster-aware
+// metadata migration arming logic in DatabaseContext.armMetadataMigrationTask. The
+// migration normally arms itself the moment all nodes report the opted-in config
+// applied — this endpoint exists for operators who need to drive the lifecycle
+// directly (e.g. retry after a give-up, stop a runaway migration). It does NOT
+// gate on UseSystemMetadataCollection: a manual start against a DB that never
+// opted in will simply find the MetadataStore is not a dual-collection wrapper
+// and no-op through to the per-DB complete write.
+func (h *handler) handleMetadataMigration() error {
+	if h.db.MetadataMigrationManager == nil {
+		return base.HTTPErrorf(http.StatusNotFound, "Metadata migration manager is not initialized for this database")
+	}
+
+	action := h.getQuery("action")
+	if action == "" {
+		action = string(db.BackgroundProcessActionStart)
+	}
+	reset := h.getBoolQuery("reset")
+
+	if action != string(db.BackgroundProcessActionStart) && action != string(db.BackgroundProcessActionStop) {
+		return base.HTTPErrorf(http.StatusBadRequest, "Unknown parameter for 'action'. Must be start or stop")
+	}
+
+	if action == string(db.BackgroundProcessActionStart) {
+		if err := h.db.MetadataMigrationManager.Start(h.ctx(), map[string]any{
+			"reset": reset,
+		}); err != nil {
+			return err
+		}
+	} else {
+		if err := h.db.MetadataMigrationManager.Stop(h.ctx()); err != nil {
+			return err
+		}
+	}
+
+	status, err := h.db.MetadataMigrationManager.GetStatus(h.ctx())
+	if err != nil {
+		return err
+	}
+	h.writeRawJSON(status)
+	return nil
+}
+
+func (h *handler) handleGetMetadataMigration() error {
+	if h.db.MetadataMigrationManager == nil {
+		return base.HTTPErrorf(http.StatusNotFound, "Metadata migration manager is not initialized for this database")
+	}
+	status, err := h.db.MetadataMigrationManager.GetStatus(h.ctx())
+	if err != nil {
+		return err
+	}
+	h.writeRawJSON(status)
+	return nil
+}
+
 func (h *handler) handleCompact() error {
 	action := h.getQuery("action")
 	if action == "" {

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -2623,7 +2623,7 @@ func TestProcessRevIncrementsStat(t *testing.T) {
 
 		replicationID := SafeDocumentName(t, t.Name())
 
-		stats, err := base.SyncGatewayStats.NewDBStats("test", false, false, false, nil, nil)
+		stats, err := base.SyncGatewayStats.NewDBStats("test", false, false, false, false, nil, nil)
 		require.NoError(t, err)
 		dbstats, err := stats.DBReplicatorStats(replicationID)
 		require.NoError(t, err)

--- a/rest/config.go
+++ b/rest/config.go
@@ -777,6 +777,13 @@ func (dbConfig *DbConfig) validateVersion(ctx context.Context, isEnterpriseEditi
 			fmt.Sprintf("%g-%g", db.CompactIntervalMinDays, db.CompactIntervalMaxDays)))
 	}
 
+	// System-scoped metadata relies on N1QL principal queries against _system._mobile and is not
+	// supported with views. Reject the combination at config validation rather than letting a
+	// post-migration principal listing fail at query time.
+	if base.ValDefault(dbConfig.UseSystemMobileMetadataCollection, false) && base.ValDefault(dbConfig.UseViews, false) {
+		multiError = multiError.Append(fmt.Errorf("use_system_metadata_collection is not supported with use_views=true"))
+	}
+
 	if dbConfig.CacheConfig != nil {
 
 		if dbConfig.CacheConfig.ChannelCacheConfig != nil {

--- a/rest/metadatamigrationtest/metadata_migration_test.go
+++ b/rest/metadatamigrationtest/metadata_migration_test.go
@@ -197,6 +197,72 @@ func TestMetadataMigrationRESTGetReportsStatus(t *testing.T) {
 	assert.Contains(t, body, "passes")
 }
 
+// TestMetadataMigrationPreservesJSONDatatypeForUserDocs is a regression test for the
+// AddRaw → SGRawTranscoder datatype regression: prior to the moveFallbackDoc datatype
+// fix, every user/role/session doc migrated to _system._mobile landed with the Binary
+// datatype flag (0x03000000), and subsequent reads through gocb.NewRawJSONTranscoder
+// (used by the auth path) failed with HTTP 500 "binary datatype is not supported by
+// RawJSONTranscoder". The seq-counter equivalent was fixed via Incr in CBG-5228;
+// this test pins the same invariant for the per-doc move.
+//
+// The test only exercises the regression on a Couchbase Server backing store: Rosmar's
+// transcoder handling is lax enough that the bug doesn't manifest in-memory. We rely on
+// CI to run the SG_TEST_BACKING_STORE=Couchbase variant — under Rosmar the test still
+// runs but the assertion is effectively trivial.
+func TestMetadataMigrationPreservesJSONDatatypeForUserDocs(t *testing.T) {
+	rt := rest.NewRestTesterPersistentConfigNoDB(t)
+	defer rt.Close()
+
+	// Create the database without the opt-in so the user write lands in
+	// _default._default (the eventual fallback collection). Authenticator.Update writes
+	// users with the JSON datatype on disk — this gives us a real pre-migration shadow.
+	dbConfig := rt.NewDbConfig()
+	dbConfig.UseSystemMobileMetadataCollection = base.Ptr(false)
+	resp := rt.CreateDatabase("db", dbConfig)
+	rest.RequireStatus(t, resp, http.StatusCreated)
+
+	const userPayload = `{"name":"alice","password":"letmein","admin_channels":["public"]}`
+	resp = rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_user/alice", userPayload)
+	rest.RequireStatus(t, resp, http.StatusCreated)
+
+	// Read alice back to capture the working pre-migration shape.
+	resp = rt.SendAdminRequest(http.MethodGet, "/{{.db}}/_user/alice", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	assert.Contains(t, resp.Body.String(), `"name":"alice"`)
+
+	// Flip the opt-in on the existing database. This rebuilds the MetadataStore as a
+	// dual-collection wrapper with primary=_system._mobile, fallback=_default._default —
+	// so alice now lives on fallback exactly as she would after the upgrade in production.
+	dbConfig.UseSystemMobileMetadataCollection = base.Ptr(true)
+	resp = rt.UpsertDbConfig("db", dbConfig)
+	rest.RequireStatus(t, resp, http.StatusCreated)
+
+	// Drive the migration directly through the admin endpoint — the auto-arming path
+	// gates on ConfigFullyAppliedFunc which depends on cluster-compat polling cycles we
+	// don't want to wait on for a single-node test. The POST returns the running status;
+	// poll the GET endpoint until it reports completed (or error, which fails the test).
+	resp = rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_metadata_migration?action=start", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		st := rt.SendAdminRequest(http.MethodGet, "/{{.db}}/_metadata_migration", "")
+		body := st.Body.String()
+		// "completed" is the happy path; bail out on "error" so we don't poll forever.
+		assert.NotContains(c, body, `"status":"error"`, "migration must not error — payload: %s", body)
+		assert.Contains(c, body, `"status":"completed"`, "migration should reach completed — payload: %s", body)
+	}, 30*time.Second, 200*time.Millisecond)
+
+	// THE regression check: reading alice goes through `auth.Authenticator.GetPrincipal`,
+	// which on Couchbase Server uses gocb.NewRawJSONTranscoder. A Binary-tagged primary
+	// doc surfaces here as a 500 with the message "binary datatype is not supported by
+	// RawJSONTranscoder" — exactly the failure mode this fix addresses. A JSON-tagged
+	// doc decodes cleanly and we get the user payload back at 200 OK.
+	resp = rt.SendAdminRequest(http.MethodGet, "/{{.db}}/_user/alice", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	assert.Contains(t, resp.Body.String(), `"name":"alice"`, "post-migration user read must succeed — Binary datatype on the migrated doc would surface as a 500 here")
+	assert.NotContains(t, resp.Body.String(), "binary datatype", "the migrated user doc must not be Binary-tagged on primary")
+}
+
 // TestMetadataMigrationOptInIsIrreversibleViaREST verifies that, once a database has opted in
 // to the system metadata collection, a config update over the REST API that attempts to disable
 // the opt-in (set to false or omit it) is rejected.

--- a/rest/metadatamigrationtest/metadata_migration_test.go
+++ b/rest/metadatamigrationtest/metadata_migration_test.go
@@ -146,6 +146,58 @@ func TestMetadataMigrationStartsAfterAllNodesApplyConfig(t *testing.T) {
 	}, 30*time.Second, 100*time.Millisecond)
 }
 
+// TestMetadataMigrationStatsNotInitialisedWithoutOptIn verifies that the per-DB
+// MigrationStats Prometheus section is omitted entirely for databases that have not
+// opted into the system metadata collection. Pairs with InitMigrationStats being
+// gated on the UseSystemMetadataCollection flag in NewDBStats.
+func TestMetadataMigrationStatsNotInitialisedWithoutOptIn(t *testing.T) {
+	rt := rest.NewRestTesterPersistentConfig(t)
+	defer rt.Close()
+
+	dbCtx := rt.GetDatabase()
+	require.NotNil(t, dbCtx.DbStats)
+	assert.Nil(t, dbCtx.DbStats.MetadataMigration(), "migration stats section must be omitted when UseSystemMobileMetadataCollection is unset")
+}
+
+// TestMetadataMigrationStatsInitialisedWithOptIn verifies that opting into the
+// system metadata collection wires up the per-DB MigrationStats Prometheus
+// section and that its state gauge starts at idle.
+func TestMetadataMigrationStatsInitialisedWithOptIn(t *testing.T) {
+	rt := rest.NewRestTesterPersistentConfigNoDB(t)
+	defer rt.Close()
+
+	dbConfig := rt.NewDbConfig()
+	dbConfig.UseSystemMobileMetadataCollection = base.Ptr(true)
+	resp := rt.CreateDatabase("db", dbConfig)
+	rest.RequireStatus(t, resp, http.StatusCreated)
+
+	dbCtx := rt.GetDatabase()
+	require.NotNil(t, dbCtx.DbStats)
+	migStats := dbCtx.DbStats.MetadataMigration()
+	require.NotNil(t, migStats, "migration stats must be initialized when UseSystemMobileMetadataCollection=true")
+	// Default counters all start at 0; state gauge starts idle.
+	assert.Equal(t, int64(0), migStats.DocsMigrated.Value())
+	assert.Equal(t, int64(0), migStats.Errors.Value())
+	assert.Equal(t, int64(0), migStats.Passes.Value())
+	assert.Equal(t, base.MigrationStatsStateIdle, migStats.State.Value())
+}
+
+// TestMetadataMigrationRESTGetReportsStatus verifies the new GET
+// /{db}/_metadata_migration endpoint returns the background-task status payload.
+func TestMetadataMigrationRESTGetReportsStatus(t *testing.T) {
+	rt := rest.NewRestTesterPersistentConfig(t)
+	defer rt.Close()
+
+	resp := rt.SendAdminRequest(http.MethodGet, "/{{.db}}/_metadata_migration", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	body := resp.Body.String()
+	// The payload is the BackgroundManager status JSON — assert on a couple of
+	// stable fields rather than the full shape so the test isn't brittle to
+	// additions to MigrationManagerResponse.
+	assert.Contains(t, body, "docs_processed")
+	assert.Contains(t, body, "passes")
+}
+
 // TestMetadataMigrationOptInIsIrreversibleViaREST verifies that, once a database has opted in
 // to the system metadata collection, a config update over the REST API that attempts to disable
 // the opt-in (set to false or omit it) is rejected.

--- a/rest/metadatamigrationtest/metadata_migration_test.go
+++ b/rest/metadatamigrationtest/metadata_migration_test.go
@@ -263,6 +263,109 @@ func TestMetadataMigrationPreservesJSONDatatypeForUserDocs(t *testing.T) {
 	assert.NotContains(t, resp.Body.String(), "binary datatype", "the migrated user doc must not be Binary-tagged on primary")
 }
 
+// TestMetadataMigrationSkipsPrimaryWriteWhenUpdatedUserAlreadyMigrated pins the
+// in-flight-update / stale-fallback-shadow race through the real auth path:
+//
+//  1. A user is created in legacy mode, so the user doc lands on the eventual fallback
+//     collection (_default._default).
+//  2. The opt-in is flipped, switching the MetadataStore to the dual-collection wrapper.
+//     At this point fallback still holds the original user body; primary is empty.
+//  3. The user is updated via the admin API *before* the migration runs.
+//     `auth.Authenticator.Update` → `MetadataStore.Update` is read-through-fallback /
+//     write-to-primary, so the fresh body lands on primary while the stale original
+//     stays on fallback as a shadow.
+//  4. Migration runs and walks the fallback. For the user key, moveFallbackDoc's
+//     Primary().Add returns (added=false, err=nil) because primary already holds the
+//     fresher copy. That outcome MUST be treated as success — not an error — and the
+//     stale fallback shadow MUST be deleted, leaving the fresh primary copy intact.
+//
+// What this would catch:
+//   - moveFallbackDoc surfacing the already-exists Add as a stats.Errors increment.
+//   - A naive migration that overwrote primary with the stale fallback bytes.
+//   - A migration that skipped the fallback delete on the already-exists branch, leaving
+//     a stale shadow that would resurrect on the next non-xattr read.
+func TestMetadataMigrationSkipsPrimaryWriteWhenUpdatedUserAlreadyMigrated(t *testing.T) {
+	rt := rest.NewRestTesterPersistentConfigNoDB(t)
+	defer rt.Close()
+
+	// 1. Legacy mode: user write lands on _default._default.
+	dbConfig := rt.NewDbConfig()
+	dbConfig.UseSystemMobileMetadataCollection = base.Ptr(false)
+	resp := rt.CreateDatabase("db", dbConfig)
+	rest.RequireStatus(t, resp, http.StatusCreated)
+
+	const originalUser = `{"name":"alice","password":"letmein","admin_channels":["public"]}`
+	resp = rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_user/alice", originalUser)
+	rest.RequireStatus(t, resp, http.StatusCreated)
+
+	// 2. Flip the opt-in: MetadataStore becomes the dual-collection wrapper. The user
+	// doc lives on fallback (_default._default); primary (_system._mobile) is empty.
+	dbConfig.UseSystemMobileMetadataCollection = base.Ptr(true)
+	resp = rt.UpsertDbConfig("db", dbConfig)
+	rest.RequireStatus(t, resp, http.StatusCreated)
+
+	ms, ok := rt.GetDatabase().MetadataStore.(*base.MetadataStore)
+	require.True(t, ok, "after opt-in the MetadataStore must be the dual-collection wrapper")
+	userKey := rt.GetDatabase().MetadataKeys.UserKey("alice")
+
+	// Sanity: before any update, the user body is only on fallback.
+	_, _, err := ms.Fallback().GetRaw(rt.Context(), userKey)
+	require.NoError(t, err, "user doc must be on fallback before the in-flight update")
+	primaryExists, err := ms.Primary().Exists(rt.Context(), userKey)
+	require.NoError(t, err)
+	require.False(t, primaryExists, "primary must be empty before the in-flight update")
+
+	// 3. Update the user before the migration runs. Authenticator.Update goes through
+	// MetadataStore.Update, which reads through fallback and writes the fresh body to
+	// primary. After this the fallback still holds the original body as a stale shadow.
+	const updatedUser = `{"name":"alice","admin_channels":["public","secrets"]}`
+	resp = rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_user/alice", updatedUser)
+	rest.RequireStatus(t, resp, http.StatusOK)
+
+	primaryBodyBeforeMigration, _, err := ms.Primary().GetRaw(rt.Context(), userKey)
+	require.NoError(t, err, "primary must hold the post-update user body after the in-flight Update")
+	require.Contains(t, string(primaryBodyBeforeMigration), `"secrets"`,
+		"primary should carry the updated admin_channels, fallback should still hold the original")
+	fallbackBodyBeforeMigration, _, err := ms.Fallback().GetRaw(rt.Context(), userKey)
+	require.NoError(t, err, "stale fallback shadow must still exist before migration runs")
+	require.NotEqual(t, primaryBodyBeforeMigration, fallbackBodyBeforeMigration,
+		"primary fresh body and fallback stale shadow must structurally differ — otherwise this test isn't exercising the race")
+
+	// 4. Drive the migration directly through the admin endpoint and assert it reaches
+	// completed with zero failures — the already-exists Add MUST NOT be classified as
+	// an error.
+	resp = rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_metadata_migration?action=start", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		st := rt.SendAdminRequest(http.MethodGet, "/{{.db}}/_metadata_migration", "")
+		body := st.Body.String()
+		assert.NotContains(c, body, `"status":"error"`, "migration must not error on the already-exists branch — payload: %s", body)
+		assert.Contains(c, body, `"status":"completed"`, "migration should reach completed — payload: %s", body)
+		assert.Contains(c, body, `"docs_failed":0`, "already-exists Add must not be counted as a failure — payload: %s", body)
+	}, 30*time.Second, 200*time.Millisecond)
+
+	// 5a. Primary must still hold the FRESH body — the migration must not have
+	// overwritten it with the stale fallback shadow.
+	primaryBodyAfterMigration, _, err := ms.Primary().GetRaw(rt.Context(), userKey)
+	require.NoError(t, err, "primary must still hold the user post-migration")
+	assert.Equal(t, primaryBodyBeforeMigration, primaryBodyAfterMigration,
+		"primary body must be byte-identical to the pre-migration fresh write — a regression that overwrote with the stale fallback shadow would change this")
+
+	// 5b. Fallback shadow must be gone — the already-exists short-circuit must still
+	// run the cleanup delete. Leaving the shadow would resurrect the stale body on
+	// any subsequent non-xattr read path.
+	_, _, err = ms.Fallback().GetRaw(rt.Context(), userKey)
+	assert.True(t, base.IsDocNotFoundError(err),
+		"stale fallback shadow must be cleaned up even when primary already held a fresher copy — got err: %v", err)
+
+	// 5c. End-to-end: the public auth view of the user is the fresh post-update shape.
+	resp = rt.SendAdminRequest(http.MethodGet, "/{{.db}}/_user/alice", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	assert.Contains(t, resp.Body.String(), `"secrets"`,
+		"GET /_user/alice must reflect the in-flight update — not the pre-update fallback shadow")
+}
+
 // TestMetadataMigrationOptInIsIrreversibleViaREST verifies that, once a database has opted in
 // to the system metadata collection, a config update over the REST API that attempts to disable
 // the opt-in (set to false or omit it) is rejected.

--- a/rest/metadatamigrationtest/metadata_migration_test.go
+++ b/rest/metadatamigrationtest/metadata_migration_test.go
@@ -12,6 +12,7 @@ package metadatamigrationtest
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -237,10 +238,11 @@ func TestMetadataMigrationPreservesJSONDatatypeForUserDocs(t *testing.T) {
 	resp = rt.UpsertDbConfig("db", dbConfig)
 	rest.RequireStatus(t, resp, http.StatusCreated)
 
-	// Drive the migration directly through the admin endpoint — the auto-arming path
-	// gates on ConfigFullyAppliedFunc which depends on cluster-compat polling cycles we
-	// don't want to wait on for a single-node test. The POST returns the running status;
-	// poll the GET endpoint until it reports completed (or error, which fails the test).
+	// The manual start endpoint gates on ConfigFullyAppliedFunc just like the auto-arming path,
+	// so flush this node's registry entry to record its applied config version — even a
+	// single-node cluster must report the opt-in config applied before it can start. Then drive
+	// the migration and poll the GET endpoint until it reports completed (or error).
+	rt.ServerContext().ForceClusterCompatRefresh(t, rt.Context())
 	resp = rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_metadata_migration?action=start", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
 
@@ -331,9 +333,10 @@ func TestMetadataMigrationSkipsPrimaryWriteWhenUpdatedUserAlreadyMigrated(t *tes
 	require.NotEqual(t, primaryBodyBeforeMigration, fallbackBodyBeforeMigration,
 		"primary fresh body and fallback stale shadow must structurally differ — otherwise this test isn't exercising the race")
 
-	// 4. Drive the migration directly through the admin endpoint and assert it reaches
-	// completed with zero failures — the already-exists Add MUST NOT be classified as
-	// an error.
+	// 4. Flush this node's applied config version (the manual start gates on config-fully-applied),
+	// then drive the migration through the admin endpoint and assert it reaches completed with zero
+	// failures — the already-exists Add MUST NOT be classified as an error.
+	rt.ServerContext().ForceClusterCompatRefresh(t, rt.Context())
 	resp = rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_metadata_migration?action=start", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
 
@@ -394,4 +397,344 @@ func TestMetadataMigrationOptInIsIrreversibleViaREST(t *testing.T) {
 	dbConfig.UseSystemMobileMetadataCollection = base.Ptr(true)
 	resp = rt.ReplaceDbConfig("db", dbConfig)
 	rest.RequireStatus(t, resp, http.StatusCreated)
+}
+
+func TestMetadataMigrationLegacyDefaultDBSiblingClassifiesAsUnknown(t *testing.T) {
+	base.TestRequiresCollections(t)
+
+	ctx := base.TestCtx(t)
+	tb := base.GetTestBucket(t)
+	defer tb.Close(ctx)
+
+	const namedCollection = "sg_test_0"
+	require.NoError(t, tb.CreateDataStore(ctx, base.ScopeAndCollectionName{Scope: base.DefaultScope, Collection: namedCollection}))
+	defer func() {
+		assert.NoError(t, tb.DropDataStore(ctx, base.ScopeAndCollectionName{Scope: base.DefaultScope, Collection: namedCollection}))
+	}()
+
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		CustomTestBucket: tb.NoCloseClone(),
+		PersistentConfig: true,
+	})
+	defer rt.Close()
+
+	// dbdefault: only _default._default → metadataID="_default", keys unprefixed.
+	const dbDefaultName = "dbdefault"
+	dbDefaultCfg := rt.NewDbConfig()
+	dbDefaultCfg.Scopes = rest.ScopesConfig{
+		base.DefaultScope: rest.ScopeConfig{
+			Collections: rest.CollectionsConfig{
+				base.DefaultCollection: {},
+			},
+		},
+	}
+	rest.RequireStatus(t, rt.CreateDatabase(dbDefaultName, dbDefaultCfg), http.StatusCreated)
+
+	// Real legacy user key for dbdefault — `_sync:user:alice` lands in _default._default.
+	resp := rt.SendAdminRequest(http.MethodPut, "/"+dbDefaultName+"/_user/alice",
+		`{"name":"alice","password":"letmein","admin_channels":["public"]}`)
+	rest.RequireStatus(t, resp, http.StatusCreated)
+
+	// dbnamed: only _default.sg_test_0 → metadataID is the db name (non-default).
+	// Start in legacy mode (opt-in=false) so dbnamed's own metadata also lands in
+	// _default._default alongside dbdefault's. This matches the production pre-migration
+	// state for a namespaced DB about to be upgraded.
+	const dbNamedName = "dbnamed"
+	dbNamedCfg := rt.NewDbConfig()
+	dbNamedCfg.UseSystemMobileMetadataCollection = base.Ptr(false)
+	dbNamedCfg.Scopes = rest.ScopesConfig{
+		base.DefaultScope: rest.ScopeConfig{
+			Collections: rest.CollectionsConfig{
+				namedCollection: {},
+			},
+		},
+	}
+	rest.RequireStatus(t, rt.CreateDatabase(dbNamedName, dbNamedCfg), http.StatusCreated)
+
+	// Real per-DB user key for dbnamed — `_sync:user:m_<id>:bob` lands in _default._default.
+	resp = rt.SendAdminRequest(http.MethodPut, "/"+dbNamedName+"/_user/bob",
+		`{"name":"bob","password":"letmein","admin_channels":["public"]}`)
+	rest.RequireStatus(t, resp, http.StatusCreated)
+
+	// Sanity-check that the topology actually matches the test's premise.
+	dbDefaultCtx, err := rt.ServerContext().GetDatabase(ctx, dbDefaultName)
+	require.NoError(t, err)
+	require.Equal(t, base.DefaultMetadataID, dbDefaultCtx.Options.MetadataID,
+		"dbdefault must use the legacy default metadataID (this is what makes its keys land unprefixed in _default._default)")
+
+	dbNamedCtx, err := rt.ServerContext().GetDatabase(ctx, dbNamedName)
+	require.NoError(t, err)
+	require.NotEqual(t, base.DefaultMetadataID, dbNamedCtx.Options.MetadataID,
+		"dbnamed must have a non-default metadataID (this is what gives its keys the m_<id>: prefix)")
+	require.NotEmpty(t, dbNamedCtx.Options.MetadataID)
+
+	// Sanity-check that both DBs' legacy keys are actually colocated in _default._default
+	// — that's the precondition for the dispatcher classification scenario we're testing.
+	defaultDS := tb.Bucket.DefaultDataStore(ctx)
+	aliceKey := base.DefaultMetadataKeys.UserKey("alice")
+	exists, err := defaultDS.Exists(ctx, aliceKey)
+	require.NoError(t, err)
+	require.True(t, exists, "dbdefault's user key %q must exist in _default._default before migration", aliceKey)
+
+	bobKey := dbNamedCtx.MetadataKeys.UserKey("bob")
+	exists, err = defaultDS.Exists(ctx, bobKey)
+	require.NoError(t, err)
+	require.True(t, exists, "dbnamed's user key %q must exist in _default._default before migration", bobKey)
+
+	// Flip dbnamed's opt-in. The MetadataStore is rebuilt as the dual-collection wrapper
+	// with primary=_system._mobile, fallback=_default._default. dbnamed's own legacy keys
+	// are still on fallback exactly as they would be after a production opt-in upgrade.
+	dbNamedCfg.UseSystemMobileMetadataCollection = base.Ptr(true)
+	rest.RequireStatus(t, rt.UpsertDbConfig(dbNamedName, dbNamedCfg), http.StatusCreated)
+
+	// Flush this node's applied config versions so the manual start passes the config-fully-applied
+	// gate, then drive dbnamed's migration through the admin endpoint.
+	rt.ServerContext().ForceClusterCompatRefresh(t, rt.Context())
+	resp = rt.SendAdminRequest(http.MethodPost, "/"+dbNamedName+"/_metadata_migration?action=start", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+
+	// Poll until the migration reaches a terminal state. maxPasses=16 of range scans
+	// over a tiny bucket should be fast, but give the test a generous deadline.
+	var finalBody string
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		st := rt.SendAdminRequest(http.MethodGet, "/"+dbNamedName+"/_metadata_migration", "")
+		finalBody = st.Body.String()
+		terminal := strings.Contains(finalBody, `"status":"completed"`) ||
+			strings.Contains(finalBody, `"status":"error"`) ||
+			strings.Contains(finalBody, `"status":"stopped"`)
+		assert.True(c, terminal, "migration should reach a terminal state — payload: %s", finalBody)
+	}, 90*time.Second, 500*time.Millisecond)
+	t.Logf("dbnamed final migration status: %s", finalBody)
+
+	// Whatever the dispatcher decides about classification, the test must never cause
+	// data loss in dbdefault — dbdefault's user MUST still be on _default._default and
+	// MUST still be readable through dbdefault's admin API.
+	exists, err = defaultDS.Exists(ctx, aliceKey)
+	require.NoError(t, err)
+	assert.True(t, exists, "dbdefault's user key %q must still exist after dbnamed's migration", aliceKey)
+
+	resp = rt.SendAdminRequest(http.MethodGet, "/"+dbDefaultName+"/_user/alice", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	assert.Contains(t, resp.Body.String(), `"name":"alice"`,
+		"dbdefault's user must still be readable through its own admin API after dbnamed's migration")
+
+	// The hypothesis assertion. If dbnamed's migration completes cleanly the hypothesis is
+	// disproven and the test fails — fix the code review note. If it errors, the hypothesis
+	// is confirmed and the error message should reference the maxPasses give-up.
+	assert.Contains(t, finalBody, `"status":"completed"`,
+		"HYPOTHESIS: dbnamed's migration should NOT complete cleanly — dbdefault's legacy keys "+
+			"should be classified as DocsUnknownPrefix and trigger the maxPasses=16 give-up. "+
+			"If this assertion fails the hypothesis is wrong and the code review note can be retracted. "+
+			"Final payload: %s", finalBody)
+	assert.NotContains(t, finalBody, `"status":"error"`,
+		"HYPOTHESIS: dbnamed's migration should error out with the maxPasses give-up. Final payload: %s", finalBody)
+}
+
+// TestMetadataMigrationOptInRejectedWithViews verifies the DbConfig.validateVersion guard:
+// system-scoped metadata relies on N1QL principal queries, so explicitly opting in while
+// use_views is enabled is rejected at config-validation time rather than failing later at query
+// time. Runs on any backing store — the config is rejected before the database starts.
+func TestMetadataMigrationOptInRejectedWithViews(t *testing.T) {
+	rt := rest.NewRestTesterPersistentConfigNoDB(t)
+	defer rt.Close()
+
+	dbConfig := rt.NewDbConfig()
+	dbConfig.UseViews = base.Ptr(true)
+	dbConfig.UseSystemMobileMetadataCollection = base.Ptr(true)
+
+	resp := rt.CreateDatabase("db", dbConfig)
+	rest.RequireStatus(t, resp, http.StatusBadRequest)
+	assert.Contains(t, resp.Body.String(), "use_system_metadata_collection is not supported with use_views=true")
+}
+
+// TestMetadataMigrationListsPrincipalsAfterCompletion is a regression test for the
+// post-completion principal-listing path. Single-principal reads (GET /{db}/_user/alice) are
+// KV lookups the dual-collection wrapper handles, but *listing* runs an N1QL query. Before the
+// fix the wrapper was passed straight to N1QLQueryWithStats once migration completed, which
+// failed with "Cannot perform N1QL query on non-Couchbase bucket" because the wrapper is
+// intentionally not an N1QLStore. The query functions now target the wrapper's primary
+// collection directly once migration is complete.
+//
+// Couchbase-Server-only: system-scoped metadata is a GSI feature (principal listing under
+// use_views was never supported with the dual store — and Rosmar only ever uses views), so this
+// regression relies on the Couchbase Server (N1QL) test path.
+func TestMetadataMigrationListsPrincipalsAfterCompletion(t *testing.T) {
+	if base.TestsDisableGSI() {
+		t.Skip("system-scoped metadata principal listing is a GSI/N1QL path; not supported under views (Rosmar)")
+	}
+	rt := rest.NewRestTesterPersistentConfigNoDB(t)
+	defer rt.Close()
+
+	// Legacy mode: principals (and the seq counter created alongside them) land in
+	// _default._default, so the new-DB fast path does not fire and the migration runs.
+	dbConfig := rt.NewDbConfig()
+	dbConfig.UseSystemMobileMetadataCollection = base.Ptr(false)
+	resp := rt.CreateDatabase("db", dbConfig)
+	rest.RequireStatus(t, resp, http.StatusCreated)
+
+	resp = rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_user/alice", `{"name":"alice","password":"letmein","admin_channels":["public"]}`)
+	rest.RequireStatus(t, resp, http.StatusCreated)
+	resp = rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_user/bob", `{"name":"bob","password":"hunter2","admin_channels":["public"]}`)
+	rest.RequireStatus(t, resp, http.StatusCreated)
+	resp = rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_role/observer", `{"name":"observer","admin_channels":["public"]}`)
+	rest.RequireStatus(t, resp, http.StatusCreated)
+
+	// Opt in, flush this node's applied config version so the manual start passes the
+	// config-fully-applied gate, then drive the migration to completion.
+	dbConfig.UseSystemMobileMetadataCollection = base.Ptr(true)
+	resp = rt.UpsertDbConfig("db", dbConfig)
+	rest.RequireStatus(t, resp, http.StatusCreated)
+
+	rt.ServerContext().ForceClusterCompatRefresh(t, rt.Context())
+	resp = rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_metadata_migration?action=start", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		st := rt.SendAdminRequest(http.MethodGet, "/{{.db}}/_metadata_migration", "")
+		body := st.Body.String()
+		assert.NotContains(c, body, `"status":"error"`, "migration must not error — payload: %s", body)
+		assert.Contains(c, body, `"status":"completed"`, "migration should reach completed — payload: %s", body)
+	}, 30*time.Second, 200*time.Millisecond)
+
+	// Regression check: after completion the principals live in _system._mobile and fallback
+	// reads are disabled. Listing must query the primary and still return every principal.
+	resp = rt.SendAdminRequest(http.MethodGet, "/{{.db}}/_user/", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	assert.Contains(t, resp.Body.String(), "alice", "alice must be listable after migration completes")
+	assert.Contains(t, resp.Body.String(), "bob", "bob must be listable after migration completes")
+
+	resp = rt.SendAdminRequest(http.MethodGet, "/{{.db}}/_role/", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	assert.Contains(t, resp.Body.String(), "observer", "roles must be listable after migration completes")
+}
+
+// TestMetadataMigrationEndToEndBucketComplete is a full end-to-end check of the bucket-level
+// completion handoff: migrate a single database's metadata (a user doc), then assert that once
+// it is the last database in the bucket to finish, PostMetadataMigrationCompleteFunc migrates
+// the bucket bootstrap docs (registry/dbconfig/cfg) and the bucket-level bootstrap state in
+// _sync:metadata_migration_status flips to complete.
+func TestMetadataMigrationEndToEndBucketComplete(t *testing.T) {
+	ctx := base.TestCtx(t)
+	rt := rest.NewRestTesterPersistentConfigNoDB(t)
+	defer rt.Close()
+
+	// Legacy mode so the user (and seq counter) land in _default._default and the migration runs.
+	dbConfig := rt.NewDbConfig()
+	dbConfig.UseSystemMobileMetadataCollection = base.Ptr(false)
+	resp := rt.CreateDatabase("db", dbConfig)
+	rest.RequireStatus(t, resp, http.StatusCreated)
+
+	resp = rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_user/alice", `{"name":"alice","password":"letmein","admin_channels":["public"]}`)
+	rest.RequireStatus(t, resp, http.StatusCreated)
+
+	dbCtx := rt.GetDatabase()
+	metadataID := dbCtx.Options.MetadataID
+	require.NotEmpty(t, metadataID)
+	bucketName := rt.Bucket().GetName()
+
+	// Opt in, flush this node's applied config version so the manual start passes the
+	// config-fully-applied gate, then drive the migration to completion.
+	dbConfig.UseSystemMobileMetadataCollection = base.Ptr(true)
+	resp = rt.UpsertDbConfig("db", dbConfig)
+	rest.RequireStatus(t, resp, http.StatusCreated)
+
+	rt.ServerContext().ForceClusterCompatRefresh(t, rt.Context())
+	resp = rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_metadata_migration?action=start", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		st := rt.SendAdminRequest(http.MethodGet, "/{{.db}}/_metadata_migration", "")
+		body := st.Body.String()
+		assert.NotContains(c, body, `"status":"error"`, "migration must not error — payload: %s", body)
+		assert.Contains(c, body, `"status":"completed"`, "migration should reach completed — payload: %s", body)
+	}, 30*time.Second, 200*time.Millisecond)
+
+	// End-to-end assertion on the durable status doc: the per-DB entry is complete AND, because
+	// this is the only (hence last) database in the bucket, the bucket bootstrap migration has
+	// also completed.
+	conn := rt.ServerContext().BootstrapContext.Connection
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		status, _, err := conn.GetMetadataMigrationStatus(ctx, bucketName)
+		require.NoError(c, err)
+		require.NotNil(c, status)
+		entry, ok := status.Databases[metadataID]
+		require.True(c, ok, "status doc must have a per-DB entry for %q", metadataID)
+		assert.Equal(c, base.MigrationStateComplete, entry.State, "per-DB migration entry should be complete")
+		assert.Equal(c, base.MigrationStateComplete, status.Bootstrap.State, "bucket bootstrap migration should be complete once the last DB finishes")
+	}, 30*time.Second, 200*time.Millisecond)
+}
+
+// TestMetadataMigrationRESTStartRejectedWithoutOptIn verifies a manual start via the admin API is
+// rejected for a database that has not enabled use_system_metadata_collection — its MetadataStore
+// is not a dual-collection wrapper, so there is nothing to migrate.
+func TestMetadataMigrationRESTStartRejectedWithoutOptIn(t *testing.T) {
+	rt := rest.NewRestTesterPersistentConfig(t)
+	defer rt.Close()
+
+	resp := rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_metadata_migration?action=start", "")
+	rest.RequireStatus(t, resp, http.StatusBadRequest)
+	assert.Contains(t, resp.Body.String(), "use_system_metadata_collection is not enabled")
+}
+
+// TestMetadataMigrationRESTStartRejectedBeforeConfigApplied verifies the manual REST start path
+// (POST /{db}/_metadata_migration?action=start) is gated on cluster config convergence, exactly
+// like the auto-arming path (DatabaseContext.tryStartMetadataMigration). Starting while a peer
+// node has not yet applied the opt-in config would let that peer keep writing metadata to
+// _default._default while this node migrates it to _system._mobile — splitting or losing those
+// writes. The POST must be rejected until every node has applied the config.
+func TestMetadataMigrationRESTStartRejectedBeforeConfigApplied(t *testing.T) {
+	ctx := base.TestCtx(t)
+	tb := base.GetTestBucket(t)
+	defer tb.Close(ctx)
+
+	rtConfig := &rest.RestTesterConfig{
+		CustomTestBucket: tb.NoCloseClone(),
+		PersistentConfig: true,
+		GroupID:          base.Ptr("metadata_migration_cluster"),
+	}
+	rtA := rest.NewRestTester(t, rtConfig)
+	defer rtA.Close()
+	rtB := rest.NewRestTester(t, rtConfig)
+	defer rtB.Close()
+
+	// Create db on node A with migration disabled, let node B pick it up, register both nodes.
+	dbConfig := rtA.NewDbConfig()
+	dbConfig.UseSystemMobileMetadataCollection = base.Ptr(false)
+	rest.RequireStatus(t, rtA.CreateDatabase("db", dbConfig), http.StatusCreated)
+	rtB.ServerContext().ForceDbConfigsReload(t, ctx)
+	rtA.ServerContext().ForceClusterCompatRefresh(t, ctx)
+	rtB.ServerContext().ForceClusterCompatRefresh(t, ctx)
+
+	// Seed a legacy seq counter so the new-DB fast path doesn't auto-complete the migration (see
+	// TestMetadataMigrationStartsAfterAllNodesApplyConfig for the rationale on using Incr).
+	_, err := tb.Bucket.DefaultDataStore(ctx).Incr(ctx, rtA.GetDatabase().MetadataKeys.SyncSeqKey(), 1, 0, 0)
+	require.NoError(t, err)
+
+	// Opt in on node A and flush its registry entry. Node B has NOT applied the new config version.
+	dbConfig.UseSystemMobileMetadataCollection = base.Ptr(true)
+	rest.RequireStatus(t, rtA.UpsertDbConfig("db", dbConfig), http.StatusCreated)
+	rtA.ServerContext().ForceClusterCompatRefresh(t, ctx)
+
+	// Sanity: the gate the handler consults reports not-applied, with node B outstanding.
+	applied, missing, err := rtA.GetDatabase().ConfigFullyAppliedFunc(ctx)
+	require.NoError(t, err)
+	require.False(t, applied, "config must not be fully applied while node B is behind")
+	require.Contains(t, missing, rtB.ServerContext().NodeUID)
+
+	// Manual REST start must be rejected while node B is behind, and migration must not start.
+	resp := rtA.SendAdminRequest(http.MethodPost, "/db/_metadata_migration?action=start", "")
+	rest.RequireStatus(t, resp, http.StatusServiceUnavailable)
+	assert.Contains(t, resp.Body.String(), "has been applied on all nodes")
+	assert.Equal(t, db.BackgroundProcessState(""), rtA.GetDatabase().MetadataMigrationManager.GetRunState(),
+		"migration must not start via the REST API while a peer node has not applied the opt-in config")
+
+	// Node B applies the config; the cluster has now converged.
+	rtB.ServerContext().ForceDbConfigsReload(t, ctx)
+	rtB.ServerContext().ForceClusterCompatRefresh(t, ctx)
+
+	applied, _, err = rtA.GetDatabase().ConfigFullyAppliedFunc(ctx)
+	require.NoError(t, err)
+	require.True(t, applied, "config should be fully applied once node B has applied the new version")
+
+	// Manual REST start now succeeds.
+	resp = rtA.SendAdminRequest(http.MethodPost, "/db/_metadata_migration?action=start", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
 }

--- a/rest/metadatamigrationtest/metadata_migration_test.go
+++ b/rest/metadatamigrationtest/metadata_migration_test.go
@@ -399,7 +399,7 @@ func TestMetadataMigrationOptInIsIrreversibleViaREST(t *testing.T) {
 	rest.RequireStatus(t, resp, http.StatusCreated)
 }
 
-func TestMetadataMigrationLegacyDefaultDBSiblingClassifiesAsUnknown(t *testing.T) {
+func TestMetadataMigrationLegacyDefaultDBSiblingClassifiedOutOfScope(t *testing.T) {
 	base.TestRequiresCollections(t)
 
 	ctx := base.TestCtx(t)
@@ -518,16 +518,18 @@ func TestMetadataMigrationLegacyDefaultDBSiblingClassifiesAsUnknown(t *testing.T
 	assert.Contains(t, resp.Body.String(), `"name":"alice"`,
 		"dbdefault's user must still be readable through its own admin API after dbnamed's migration")
 
-	// The hypothesis assertion. If dbnamed's migration completes cleanly the hypothesis is
-	// disproven and the test fails — fix the code review note. If it errors, the hypothesis
-	// is confirmed and the error message should reference the maxPasses give-up.
+	// dbnamed's migration completes cleanly in a single pass. dbdefault's colocated legacy keys
+	// carry a metadata prefix that doesn't match dbnamed's metadataID, so the dispatcher
+	// classifies them as out-of-scope (DocsOutOfScope) and leaves them in place. They are NOT
+	// treated as an unrecognised prefix (DocsUnknownPrefix) — that would keep remaining>0 and
+	// stall the run until the maxPasses=16 give-up.
 	assert.Contains(t, finalBody, `"status":"completed"`,
-		"HYPOTHESIS: dbnamed's migration should NOT complete cleanly — dbdefault's legacy keys "+
-			"should be classified as DocsUnknownPrefix and trigger the maxPasses=16 give-up. "+
-			"If this assertion fails the hypothesis is wrong and the code review note can be retracted. "+
+		"dbnamed's migration should complete cleanly — dbdefault's colocated legacy keys are "+
+			"classified out-of-scope, not as an unrecognised prefix that would stall the run. "+
 			"Final payload: %s", finalBody)
 	assert.NotContains(t, finalBody, `"status":"error"`,
-		"HYPOTHESIS: dbnamed's migration should error out with the maxPasses give-up. Final payload: %s", finalBody)
+		"dbnamed's migration should not error — its own keys migrate and the sibling DB's "+
+			"out-of-scope keys are skipped. Final payload: %s", finalBody)
 }
 
 // TestMetadataMigrationOptInRejectedWithViews verifies the DbConfig.validateVersion guard:

--- a/rest/metadatamigrationtest/metadata_migration_test.go
+++ b/rest/metadatamigrationtest/metadata_migration_test.go
@@ -175,11 +175,10 @@ func TestMetadataMigrationStatsInitialisedWithOptIn(t *testing.T) {
 	require.NotNil(t, dbCtx.DbStats)
 	migStats := dbCtx.DbStats.MetadataMigration()
 	require.NotNil(t, migStats, "migration stats must be initialized when UseSystemMobileMetadataCollection=true")
-	// Default counters all start at 0; state gauge starts idle.
+	// Default counters all start at 0.
 	assert.Equal(t, int64(0), migStats.DocsMigrated.Value())
 	assert.Equal(t, int64(0), migStats.Errors.Value())
 	assert.Equal(t, int64(0), migStats.Passes.Value())
-	assert.Equal(t, base.MigrationStatsStateIdle, migStats.State.Value())
 }
 
 // TestMetadataMigrationRESTGetReportsStatus verifies the new GET

--- a/rest/replicatortest/replicator_collection_test.go
+++ b/rest/replicatortest/replicator_collection_test.go
@@ -142,7 +142,7 @@ func TestActiveReplicatorMultiCollection(t *testing.T) {
 			passiveDBURL, err := url.Parse(srv.URL + "/" + rt2DbName)
 			require.NoError(t, err)
 
-			stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+			stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 			require.NoError(t, err)
 			dbstats, err := stats.DBReplicatorStats(t.Name())
 			require.NoError(t, err)
@@ -330,7 +330,7 @@ func TestActiveReplicatorMultiCollectionMismatchedLocalRemote(t *testing.T) {
 	sgrRunner.Run(func(t *testing.T) {
 		activeRT, _, remoteDbURLString := sgrRunner.SetupSGRPeers(t)
 
-		stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+		stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 		require.NoError(t, err)
 		dbstats, err := stats.DBReplicatorStats(t.Name())
 		require.NoError(t, err)
@@ -374,7 +374,7 @@ func TestActiveReplicatorMultiCollectionMissingRemote(t *testing.T) {
 		localCollections := []string{localCollection}
 		remoteCollections := []string{"missing.collection"}
 
-		stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+		stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 		require.NoError(t, err)
 		dbstats, err := stats.DBReplicatorStats(t.Name())
 		require.NoError(t, err)
@@ -419,7 +419,7 @@ func TestActiveReplicatorMultiCollectionMissingLocal(t *testing.T) {
 		remoteCollection := passiveRT.GetSingleDataStore().ScopeName() + "." + passiveRT.GetSingleDataStore().CollectionName()
 		remoteCollections := []string{remoteCollection}
 
-		stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+		stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 		require.NoError(t, err)
 		dbstats, err := stats.DBReplicatorStats(t.Name())
 		require.NoError(t, err)

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -3349,7 +3349,7 @@ func TestActiveReplicatorPushFromCheckpoint(t *testing.T) {
 		}
 
 		// Create the first active replicator to pull from seq:0
-		stats, err := base.SyncGatewayStats.NewDBStats(t.Name()+"1", false, false, false, nil, nil)
+		stats, err := base.SyncGatewayStats.NewDBStats(t.Name()+"1", false, false, false, false, nil, nil)
 		require.NoError(t, err)
 		dbstats, err := stats.DBReplicatorStats(t.Name())
 		require.NoError(t, err)
@@ -3405,7 +3405,7 @@ func TestActiveReplicatorPushFromCheckpoint(t *testing.T) {
 		}
 
 		// Create a new replicator using the same config, which should use the checkpoint set from the first.
-		stats, err = base.SyncGatewayStats.NewDBStats(t.Name()+"2", false, false, false, nil, nil)
+		stats, err = base.SyncGatewayStats.NewDBStats(t.Name()+"2", false, false, false, false, nil, nil)
 		require.NoError(t, err)
 		dbstats, err = stats.DBReplicatorStats(t.Name())
 		require.NoError(t, err)
@@ -3508,7 +3508,7 @@ func TestActiveReplicatorEdgeCheckpointNameCollisions(t *testing.T) {
 		arConfig.SetCheckpointPrefix(t, "cluster1:")
 
 		// Create the first active replicator to pull from seq:0
-		stats, err := base.SyncGatewayStats.NewDBStats(t.Name()+"edge1", false, false, false, nil, nil)
+		stats, err := base.SyncGatewayStats.NewDBStats(t.Name()+"edge1", false, false, false, false, nil, nil)
 		require.NoError(t, err)
 		dbstats, err := stats.DBReplicatorStats(t.Name())
 		require.NoError(t, err)
@@ -3572,7 +3572,7 @@ func TestActiveReplicatorEdgeCheckpointNameCollisions(t *testing.T) {
 		ctx2 := edge2.Context()
 
 		// Create a new replicator using the same ID, which should NOT use the checkpoint set by the first edge.
-		stats, err = base.SyncGatewayStats.NewDBStats(t.Name()+"edge2", false, false, false, nil, nil)
+		stats, err = base.SyncGatewayStats.NewDBStats(t.Name()+"edge2", false, false, false, false, nil, nil)
 		require.NoError(t, err)
 		dbstats, err = stats.DBReplicatorStats(t.Name())
 		require.NoError(t, err)
@@ -3603,7 +3603,7 @@ func TestActiveReplicatorEdgeCheckpointNameCollisions(t *testing.T) {
 		rt2.WaitForPendingChanges()
 
 		// run a replicator on edge1 again to make sure that edge2 didn't blow away its checkpoint
-		stats, err = base.SyncGatewayStats.NewDBStats(t.Name()+"edge1", false, false, false, nil, nil)
+		stats, err = base.SyncGatewayStats.NewDBStats(t.Name()+"edge1", false, false, false, false, nil, nil)
 		require.NoError(t, err)
 		dbstats, err = stats.DBReplicatorStats(t.Name())
 		require.NoError(t, err)
@@ -3947,7 +3947,7 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 
 				customConflictResolver, err := db.NewCustomConflictResolver(ctx1, test.conflictResolver, rt1.GetDatabase().Options.JavascriptTimeout)
 				require.NoError(t, err)
-				stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+				stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 				require.NoError(t, err)
 				replicationStats, err := stats.DBReplicatorStats(t.Name())
 				require.NoError(t, err)
@@ -4189,7 +4189,7 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 				require.NoError(t, err)
 
 				replicationID := rest.SafeDocumentName(t, t.Name())
-				stats, err := base.SyncGatewayStats.NewDBStats(replicationID, false, false, false, nil, nil)
+				stats, err := base.SyncGatewayStats.NewDBStats(replicationID, false, false, false, false, nil, nil)
 				require.NoError(t, err)
 				dbstats, err := stats.DBReplicatorStats(replicationID)
 				require.NoError(t, err)
@@ -4331,7 +4331,7 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyEnabled(t *testing.T) {
 		rt1.WaitForPendingChanges()
 
 		replicationID := rest.SafeDocumentName(t, t.Name())
-		stats, err := base.SyncGatewayStats.NewDBStats(replicationID, false, false, false, nil, nil)
+		stats, err := base.SyncGatewayStats.NewDBStats(replicationID, false, false, false, false, nil, nil)
 		require.NoError(t, err)
 		dbstats, err := stats.DBReplicatorStats(replicationID)
 		require.NoError(t, err)
@@ -4410,7 +4410,7 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyDisabled(t *testing.T) {
 		passiveDBURL.User = url.UserPassword(username, rest.RestTesterDefaultUserPassword)
 
 		replicationID := rest.SafeDocumentName(t, t.Name())
-		stats, err := base.SyncGatewayStats.NewDBStats(replicationID, false, false, false, nil, nil)
+		stats, err := base.SyncGatewayStats.NewDBStats(replicationID, false, false, false, false, nil, nil)
 		require.NoError(t, err)
 		dbstats, err := stats.DBReplicatorStats(replicationID)
 		require.NoError(t, err)
@@ -4483,7 +4483,7 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 		ctx1 := rt1.Context()
 
 		replicationID := rest.SafeDocumentName(t, t.Name())
-		stats, err := base.SyncGatewayStats.NewDBStats(replicationID, false, false, false, nil, nil)
+		stats, err := base.SyncGatewayStats.NewDBStats(replicationID, false, false, false, false, nil, nil)
 		require.NoError(t, err)
 		dbstats, err := stats.DBReplicatorStats(replicationID)
 		require.NoError(t, err)
@@ -4656,7 +4656,7 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 		}
 
 		// Create the first active replicator to pull from seq:0
-		stats, err := base.SyncGatewayStats.NewDBStats(t.Name()+"1", false, false, false, nil, nil)
+		stats, err := base.SyncGatewayStats.NewDBStats(t.Name()+"1", false, false, false, false, nil, nil)
 		require.NoError(t, err)
 		dbstats, err := stats.DBReplicatorStats(t.Name())
 		require.NoError(t, err)
@@ -4719,7 +4719,7 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 		require.NoError(t, err)
 		passiveDBURL.User = url.UserPassword(username, rest.RestTesterDefaultUserPassword)
 		arConfig.RemoteDBURL = passiveDBURL
-		stats, err = base.SyncGatewayStats.NewDBStats(t.Name()+"2", false, false, false, nil, nil)
+		stats, err = base.SyncGatewayStats.NewDBStats(t.Name()+"2", false, false, false, false, nil, nil)
 		require.NoError(t, err)
 		dbstats, err = stats.DBReplicatorStats(t.Name())
 		require.NoError(t, err)
@@ -4801,7 +4801,7 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 
 		activeRT.WaitForPendingChanges()
 		replicationID := rest.SafeDocumentName(t, t.Name())
-		stats, err := base.SyncGatewayStats.NewDBStats(replicationID, false, false, false, nil, nil)
+		stats, err := base.SyncGatewayStats.NewDBStats(replicationID, false, false, false, false, nil, nil)
 		require.NoError(t, err)
 		dbstats, err := stats.DBReplicatorStats(replicationID)
 		require.NoError(t, err)
@@ -4943,7 +4943,7 @@ func TestActiveReplicatorRecoverFromMismatchedRev(t *testing.T) {
 
 		ctx1 := rt1.Context()
 		replicationID := rest.SafeDocumentName(t, t.Name())
-		stats, err := base.SyncGatewayStats.NewDBStats(replicationID, false, false, false, nil, nil)
+		stats, err := base.SyncGatewayStats.NewDBStats(replicationID, false, false, false, false, nil, nil)
 		require.NoError(t, err)
 		dbstats, err := stats.DBReplicatorStats(replicationID)
 		require.NoError(t, err)
@@ -5035,7 +5035,7 @@ func TestActiveReplicatorIgnoreNoConflicts(t *testing.T) {
 		rt1Version := rt1.PutDoc(rt1docID, `{"source":"rt1","channels":["alice"]}`)
 
 		replicationID := rest.SafeDocumentName(t, t.Name())
-		stats, err := base.SyncGatewayStats.NewDBStats(replicationID, false, false, false, nil, nil)
+		stats, err := base.SyncGatewayStats.NewDBStats(replicationID, false, false, false, false, nil, nil)
 		require.NoError(t, err)
 		dbstats, err := stats.DBReplicatorStats(replicationID)
 		require.NoError(t, err)
@@ -5128,7 +5128,7 @@ func TestActiveReplicatorPullModifiedHash(t *testing.T) {
 
 		ctx1 := rt1.Context()
 		replicationID := rest.SafeDocumentName(t, t.Name())
-		stats, err := base.SyncGatewayStats.NewDBStats(replicationID, false, false, false, nil, nil)
+		stats, err := base.SyncGatewayStats.NewDBStats(replicationID, false, false, false, false, nil, nil)
 		require.NoError(t, err)
 		dbstats, err := stats.DBReplicatorStats(replicationID)
 		require.NoError(t, err)
@@ -5326,7 +5326,7 @@ func TestActiveReplicatorReconnectOnStart(t *testing.T) {
 
 						id, err := base.GenerateRandomID()
 						require.NoError(t, err)
-						sgwStats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, nil, nil)
+						sgwStats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, false, nil, nil)
 						require.NoError(t, err)
 						dbstats, err := sgwStats.DBReplicatorStats(id)
 						require.NoError(t, err)
@@ -5414,7 +5414,7 @@ func TestActiveReplicatorReconnectOnStartEventualSuccess(t *testing.T) {
 
 		id, err := base.GenerateRandomID()
 		require.NoError(t, err)
-		stats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, nil, nil)
+		stats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, false, nil, nil)
 		require.NoError(t, err)
 		dbstats, err := stats.DBReplicatorStats(id)
 		require.NoError(t, err)
@@ -5734,7 +5734,7 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 				id := rest.SafeDocumentName(t, t.Name())
 				customConflictResolver, err := db.NewCustomConflictResolver(ctx1, test.conflictResolver, rt1.GetDatabase().Options.JavascriptTimeout)
 				require.NoError(t, err)
-				dbstats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, nil, nil)
+				dbstats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, false, nil, nil)
 				require.NoError(t, err)
 				replicationStats, err := dbstats.DBReplicatorStats(id)
 				require.NoError(t, err)
@@ -6690,7 +6690,7 @@ func TestConflictResolveMergeWithMutatedRev(t *testing.T) {
 		require.NoError(t, err)
 
 		id := rest.SafeDocumentName(t, t.Name())
-		sgwStats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, nil, nil)
+		sgwStats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, false, nil, nil)
 		require.NoError(t, err)
 		dbstats, err := sgwStats.DBReplicatorStats(id)
 		require.NoError(t, err)
@@ -6768,7 +6768,7 @@ func TestReplicatorDoNotSendDeltaWhenSrcIsTombstone(t *testing.T) {
 
 		// Set-up replicator //
 		id := rest.SafeDocumentName(t, t.Name())
-		sgwStats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, nil, nil)
+		sgwStats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, false, nil, nil)
 		require.NoError(t, err)
 		dbstats, err := sgwStats.DBReplicatorStats(id)
 		require.NoError(t, err)
@@ -7076,7 +7076,7 @@ func TestActiveReplicatorBlipsync(t *testing.T) {
 		require.NoError(t, err)
 		ctx := rt.Context()
 
-		stats, err := base.SyncGatewayStats.NewDBStats("test", false, false, false, nil, nil)
+		stats, err := base.SyncGatewayStats.NewDBStats("test", false, false, false, false, nil, nil)
 		require.NoError(t, err)
 		dbstats, err := stats.DBReplicatorStats(t.Name())
 		require.NoError(t, err)
@@ -7962,7 +7962,7 @@ func requireBodyEqual(t *testing.T, expected string, doc *db.Document) {
 }
 
 func dbReplicatorStats(t *testing.T) *base.DbReplicatorStats {
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)

--- a/rest/replicatortest/replicator_test_legacy_rev_test.go
+++ b/rest/replicatortest/replicator_test_legacy_rev_test.go
@@ -503,7 +503,7 @@ func TestActiveReplicatorPushPullNewDocLegacyRevAndAllowUpdateAfter(t *testing.T
 		legacyRevRt2 := rt2InitDoc.GetRevTreeID()
 
 		id := rest.SafeDocumentName(t, t.Name())
-		stats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, nil, nil)
+		stats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, false, nil, nil)
 		require.NoError(t, err)
 		replicationStats, err := stats.DBReplicatorStats(id)
 		require.NoError(t, err)
@@ -738,7 +738,7 @@ func TestActiveReplicatorConflictPreUpgradedVersionEachSide(t *testing.T) {
 				require.NoError(t, err)
 
 				id := rest.SafeDocumentName(t, t.Name())
-				stats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, nil, nil)
+				stats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, false, nil, nil)
 				require.NoError(t, err)
 				replicationStats, err := stats.DBReplicatorStats(id)
 				require.NoError(t, err)
@@ -913,7 +913,7 @@ func TestActiveReplicatorConflictPreUpgradedVersionOneSide(t *testing.T) {
 				require.NoError(t, err)
 
 				id := rest.SafeDocumentName(t, t.Name())
-				stats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, nil, nil)
+				stats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, false, nil, nil)
 				require.NoError(t, err)
 				replicationStats, err := stats.DBReplicatorStats(id)
 				require.NoError(t, err)
@@ -1069,7 +1069,7 @@ func TestActiveReplicatorDeltaSyncWhenBothSidesLegacy(t *testing.T) {
 
 		require.Equal(t, legacyInitRevRt1, legacyRevRt2)
 
-		stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+		stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 		require.NoError(t, err)
 		replicationStats, err := stats.DBReplicatorStats(t.Name())
 		require.NoError(t, err)
@@ -1144,7 +1144,7 @@ func TestDeltaSyncWhenOneSideHasEncodedCV(t *testing.T) {
 		rt1InitDoc := rt1.CreateDocNoHLV(docIDToPush, bodyRT1)
 		legacyInitRevRt1 := rt1InitDoc.GetRevTreeID()
 
-		stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+		stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 		require.NoError(t, err)
 		replicationStats, err := stats.DBReplicatorStats(t.Name())
 		require.NoError(t, err)

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -1532,7 +1532,7 @@ func TestReplicatorRevocations(t *testing.T) {
 
 		passiveDBURL.User = url.UserPassword("user", RestTesterDefaultUserPassword)
 		id := SafeDocumentName(t, t.Name())
-		sgwStats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, nil, nil)
+		sgwStats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, false, nil, nil)
 		require.NoError(t, err)
 		dbstats, err := sgwStats.DBReplicatorStats(id)
 		require.NoError(t, err)
@@ -1603,7 +1603,7 @@ func TestReplicatorRevocationsNoRev(t *testing.T) {
 
 		passiveDBURL.User = url.UserPassword("user", RestTesterDefaultUserPassword)
 		id := SafeDocumentName(t, t.Name())
-		sgwStats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, nil, nil)
+		sgwStats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, false, nil, nil)
 		require.NoError(t, err)
 		dbstats, err := sgwStats.DBReplicatorStats(id)
 		require.NoError(t, err)
@@ -1683,7 +1683,7 @@ func TestReplicatorRevocationsNoRevButAlternateAccess(t *testing.T) {
 
 		passiveDBURL.User = url.UserPassword("user", RestTesterDefaultUserPassword)
 		id := SafeDocumentName(t, t.Name())
-		sgwStats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, nil, nil)
+		sgwStats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, false, nil, nil)
 		require.NoError(t, err)
 		dbstats, err := sgwStats.DBReplicatorStats(id)
 		require.NoError(t, err)
@@ -1758,7 +1758,7 @@ func TestReplicatorRevocationsMultipleAlternateAccess(t *testing.T) {
 
 		passiveDBURL.User = url.UserPassword(revocationTestUser, RestTesterDefaultUserPassword)
 		id := SafeDocumentName(t, t.Name())
-		sgwStats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, nil, nil)
+		sgwStats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, false, nil, nil)
 		require.NoError(t, err)
 		dbstats, err := sgwStats.DBReplicatorStats(id)
 		require.NoError(t, err)
@@ -1883,7 +1883,7 @@ func TestReplicatorRevocationsWithTombstoneResurrection(t *testing.T) {
 
 		passiveDBURL.User = url.UserPassword("user", "letmein")
 		id := SafeDocumentName(t, t.Name())
-		sgwStats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, nil, nil)
+		sgwStats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, false, nil, nil)
 		require.NoError(t, err)
 		dbstats, err := sgwStats.DBReplicatorStats(id)
 		require.NoError(t, err)
@@ -1982,7 +1982,7 @@ func TestReplicatorRevocationsWithChannelFilter(t *testing.T) {
 
 		id := SafeDocumentName(t, t.Name())
 		passiveDBURL.User = url.UserPassword(username, password)
-		sgwStats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, nil, nil)
+		sgwStats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, false, nil, nil)
 		require.NoError(t, err)
 		dbstats, err := sgwStats.DBReplicatorStats(id)
 		require.NoError(t, err)
@@ -2065,7 +2065,7 @@ func TestReplicatorRevocationsWithStarChannel(t *testing.T) {
 
 		passiveDBURL.User = url.UserPassword("user", RestTesterDefaultUserPassword)
 		id := SafeDocumentName(t, t.Name())
-		sgwStats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, nil, nil)
+		sgwStats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, false, nil, nil)
 		require.NoError(t, err)
 		dbstats, err := sgwStats.DBReplicatorStats(id)
 		require.NoError(t, err)
@@ -2168,7 +2168,7 @@ func TestReplicatorRevocationsFromZero(t *testing.T) {
 
 		passiveDBURL.User = url.UserPassword("user", "letmein")
 		id := SafeDocumentName(t, t.Name())
-		sgwStats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, nil, nil)
+		sgwStats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, false, nil, nil)
 		require.NoError(t, err)
 		dbstats, err := sgwStats.DBReplicatorStats(id)
 		require.NoError(t, err)
@@ -2582,7 +2582,7 @@ func TestReplicatorSwitchPurgeNoReset(t *testing.T) {
 
 		passiveDBURL.User = url.UserPassword("user", "letmein")
 		id := SafeDocumentName(t, t.Name())
-		sgwStats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, nil, nil)
+		sgwStats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, false, nil, nil)
 		require.NoError(t, err)
 		dbstats, err := sgwStats.DBReplicatorStats(id)
 		require.NoError(t, err)
@@ -2638,7 +2638,7 @@ func TestReplicatorSwitchPurgeNoReset(t *testing.T) {
 
 		require.NoError(t, ar.Stop())
 		rt1.WaitForReplicationStatus(ar.ID, db.ReplicationStateStopped)
-		sgwStats, err = base.SyncGatewayStats.NewDBStats(id, false, false, false, nil, nil)
+		sgwStats, err = base.SyncGatewayStats.NewDBStats(id, false, false, false, false, nil, nil)
 		require.NoError(t, err)
 		dbstats, err = sgwStats.DBReplicatorStats(id)
 		require.NoError(t, err)

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -169,6 +169,10 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handleAttachmentMigration)).Methods("POST")
 	dbr.Handle("/_attachment_migration",
 		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handleGetAttachmentMigration)).Methods("GET")
+	dbr.Handle("/_metadata_migration",
+		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handleMetadataMigration)).Methods("POST")
+	dbr.Handle("/_metadata_migration",
+		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handleGetMetadataMigration)).Methods("GET")
 	dbr.Handle("/_session",
 		makeHandler(sc, adminPrivs, []Permission{PermWritePrincipal}, nil, (*handler).createUserSession)).Methods("POST")
 	dbr.Handle("/_session/{sessionid}",

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -817,7 +817,15 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		metaStore := base.NewMetadataStore(primaryMetadataStore, fallbackStore)
 		if !probeLegacyPerDBMetadata(ctx, fallbackStore, config.MetadataID) {
 			metaStore.SetMigrationComplete()
-			base.InfofCtx(ctx, base.KeyConfig, "db:%s no legacy metadata in _default._default — marking per-DB MetadataStore wrapper migration-complete (new-database fast path)", base.MD(dbName))
+			// Same SetMigrationComplete action covers two distinct cases — log them
+			// separately so operators don't see "new-database fast path" against a DB
+			// that just finished migrating.
+			primarySeqKey := base.NewMetadataKeys(config.MetadataID).SyncSeqKey()
+			if primaryHasSeq, _ := primaryMetadataStore.Exists(ctx, primarySeqKey); primaryHasSeq {
+				base.InfofCtx(ctx, base.KeyConfig, "db:%s primary metadata present and no legacy data in _default._default — marking per-DB MetadataStore wrapper migration-complete", base.MD(dbName))
+			} else {
+				base.InfofCtx(ctx, base.KeyConfig, "db:%s no legacy metadata in _default._default — marking per-DB MetadataStore wrapper migration-complete (new-database fast path)", base.MD(dbName))
+			}
 		}
 		contextOptions.MetadataStore = metaStore
 	} else {

--- a/tools/stats-definition-exporter/main.go
+++ b/tools/stats-definition-exporter/main.go
@@ -133,7 +133,7 @@ func registerStats() (*base.GlobalStat, *base.DbStats, error) {
 		return nil, nil, fmt.Errorf("could not create sg stats: %w", err)
 	}
 
-	dbStats, err := sgStats.NewDBStats("", true, true, false, []string{""}, []string{""})
+	dbStats, err := sgStats.NewDBStats("", true, true, false, true, []string{""}, []string{""})
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not create db stats: %w", err)
 	}


### PR DESCRIPTION
CBG-5228

- Implements metadata migration function and wires up to database metadata migration task.
  - special handling for `_sync:seq` safe move
  - KV Range Scan based metadata migration for known _sync doc prefixes. Iterates until no more eligible items remain (or we hit a retry limit). Preserves expiry values on move (i.e. user session docs)
- Adds REST APIs around Metadata migration task for error observability/stats/basic management
- Adds metadata migration task stats wired up to Prometheus metrics

## Key changes

### _sync:seq Migration

* Implemented a robust self-healing mechanism in `MetadataStore.Incr` to handle migration of sequence counters from fallback to primary storage, including detection and handling of migration "poison pills" (JSON object format). This ensures counters are safely moved and prevents loss of sequence contiguity during migration underneath in-flight Incr ops.
* The `SyncSeqMigrationPill` struct marks fallback-stored sequence counters as ready for migration and stores the counter value inside the doc body for moving to the new location. Any in-flight Incr ops fail against this JSON object and can take over moving the counter to the new location.
* Introduced the `IsCounterNonNumeric` error to reliably detect when a counter document is malformed (e.g., due to the migration pill, or manual corruption), enabling correct migration flow across storage CBS and Rosmar data stores.

### Metadata Migration Management and Observability

* Enhanced the `MetadataMigrationManager` to track additional migration metrics, such as out-of-scope documents, number of passes, and attempted documents. Updated logging and status reporting to provide detailed progress and outcomes for each migration pass.
* Stats exposed via Prometheus underneath Database.MetadataStats
* Stats and job error state visible through a new metadata migration REST API for observability

## Diagrams

Logic for MetadataStore migration task

  ```mermaid
  flowchart TD
      A[MetadataMigrationManager.Run] --> B{MetadataStore<br/>in dual fallback+primary mode?}
      B -- no --> Z[return early — nothing to migrate]
      B -- yes --> C[Bridge SafeTerminator → ctx cancel<br/>so seq-counter retry + range scan<br/>interrupt promptly on stop]
      C --> S["One-shot setup · migrateSeqCounter<br/>poison-pill fallback seq doc,<br/>nudge wrapper Incr to promote
  it.<br/>Idempotent; runs once per attempt."]
      S --> D{{Pass loop · maxPasses = 16}}
      D --> F[Range-scan fallback for `_sync:` keys<br/>IDsOnly=true]
      F --> G[handleMigrationKey per scanned key:<br/>move · delete · out-of-scope · unknown]
      G --> H[Persist per-pass status<br/>processed/failed/out-of-scope/passes]
      H --> I{remaining<br/>DocsUnknownPrefix == 0?}
      I -- yes --> J[SetMigrationComplete · wrapper<br/>now bypasses fallback for all reads]
      I -- no, pass+1 < maxPasses --> D
      I -- no, pass+1 ≥ maxPasses --> K[Return error<br/>manager transitions to Errored<br/>SetMigrationComplete NOT called]
  ```

`_sync:seq` poison-pill based migration

  ```mermaid
  sequenceDiagram
      autonumber
      participant MM as MigrationManager
      participant W as MetadataStore.Incr<br/>(wrapper · any SG node)
      participant FB as Fallback collection
      participant PR as Primary collection

      rect rgb(245, 245, 255)
      Note over MM,PR: Phase 1 — pill the fallback counter (idempotent, runs before scan)
      MM->>FB: GetRaw(seqKey)
      alt empty fallback (new DB)
          FB-->>MM: NotFound · nothing to do
      else legacy numeric counter
          FB-->>MM: "42", cas
          MM->>MM: build SyncSeqMigrationPill<br/>{LastSeq: 42, SGMetadataMigrationPill: true}
          MM->>FB: WriteCas(pill, cas)
      else already pilled from a prior run
          FB-->>MM: pill JSON, cas
          MM->>MM: discriminator check passes · skip rewrite
      end
      end

      rect rgb(245, 255, 245)
      Note over MM,PR: Phase 2 — any node's Incr completes the handoff
      MM->>W: Incr(seqKey, 0, 0, 0) (nudge)
      W->>PR: Incr(amt, def=MaxUint64)
      PR-->>W: NotFound (MaxUint64 forbids auto-create)
      W->>FB: Incr(amt, def=MaxUint64)
      FB-->>W: DELTA_BADVAL (body is the pill JSON)
      W->>FB: GetRaw(seqKey)
      FB-->>W: pill bytes
      W->>W: JSONUnmarshal + verify SGMetadataMigrationPill
      W->>PR: AddRaw(seqKey, 0, "42")
      Note right of PR: added=false on race<br/>(sibling node already promoted)<br/>treated as benign success
      PR-->>W: ok
      W->>FB: Delete(seqKey)
      W->>PR: Incr(amt, def, exp)
      PR-->>W: bootstrapped counter value
      W-->>MM: value
      end
  ```

Similar to above - flowchart style for `MetadataStore` `Incr` logic:

  ```mermaid
  flowchart TD
      Start["wrapper Incr(key, amt, def, exp)"] --> MC{"migrationComplete flag set?"}
      MC -- yes --> Direct["primary.Incr(amt, def, exp) → return"]
      MC -- no --> P1["primary.Incr(amt, def=MaxUint64)<br/>(no-create sentinel)"]
      P1 --> P1r{"result?"}
      P1r -- ok --> Ret1["return value · happy path<br/>(already migrated)"]
      P1r -- "non-NotFound error" --> Err1["bubble error"]
      P1r -- NotFound --> F1["fallback.Incr(amt, def=MaxUint64)"]
      F1 --> F1r{"result?"}
      F1r -- ok --> Ret2["return value · legacy unmigrated counter<br/>(no pill yet)"]
      F1r -- NotFound --> New["primary.Incr(amt, def) · create-on-primary<br/>at caller's default · brand-new DB"]
      F1r -- "DELTA_BADVAL<br/>(IsCounterNonNumeric)" --> SH["Self-heal:<br/>1 · GetRaw(fallback) — read pill<br/>2 ·
  AddRaw(primary, key, 0, pill.LastSeq)<br/>3 · Delete(fallback)<br/>4 · primary.Incr(amt, def, exp)"]
      F1r -- "other error" --> Err2["bubble error"]
      SH --> ShRet["return primary value"]
      SH -.->|"if fallback gone mid-flight<br/>(sibling won)"| Loop["loop back to top<br/>(bounded · max 2 attempts)"]
      Loop --> MC
  ```

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/717/
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/718/
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/721/