### PR TITLE
CBG-5176: add resync targeted and resync errors to prometheus stats

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -695,6 +695,10 @@ type DatabaseStats struct {
 	ResyncNumProcessed *SgwIntStat `json:"resync_num_processed"`
 	// The total number of changed documents for resync on this database.
 	ResyncNumChanged *SgwIntStat `json:"resync_num_changed"`
+	// The number of documents targeted for resync for the current or most recent resync run on this database.
+	ResyncDocsTargeted *SgwIntStat `json:"resync_docs_targeted"`
+	// The total number of documents that failed during resync on this database.
+	ResyncErrorsTotal *SgwIntStat `json:"resync_errors_total"`
 
 	// These can be cleaned up in future versions of SGW, implemented as maps to reduce amount of potential risk
 	// prior to Hydrogen release. These are not exported as part of prometheus and only exposed through expvars
@@ -1934,6 +1938,14 @@ func (d *DbStats) initDatabaseStats() error {
 	if err != nil {
 		return err
 	}
+	resUtil.ResyncDocsTargeted, err = NewIntStat(SubsystemDatabaseKey, "resync_docs_targeted", StatUnitNoUnits, ResyncDocsTargetedDesc, StatAddedVersion4dot1dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.GaugeValue, 0)
+	if err != nil {
+		return err
+	}
+	resUtil.ResyncErrorsTotal, err = NewIntStat(SubsystemDatabaseKey, "resync_errors_total", StatUnitNoUnits, ResyncErrorsTotalDesc, StatAddedVersion4dot1dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
 	resUtil.NumPublicRestRequests, err = NewIntStat(SubsystemDatabaseKey, "num_public_rest_requests", StatUnitNoUnits, NumPublicRestRequestsDesc, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityVolatile, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
@@ -2017,6 +2029,8 @@ func (d *DbStats) unregisterDatabaseStats() {
 	prometheus.Unregister(d.DatabaseStats.NumReplicationsRejectedLimit)
 	prometheus.Unregister(d.DatabaseStats.ResyncNumProcessed)
 	prometheus.Unregister(d.DatabaseStats.ResyncNumChanged)
+	prometheus.Unregister(d.DatabaseStats.ResyncDocsTargeted)
+	prometheus.Unregister(d.DatabaseStats.ResyncErrorsTotal)
 	prometheus.Unregister(d.DatabaseStats.NumPublicRestRequests)
 	prometheus.Unregister(d.DatabaseStats.TotalSyncTime)
 	prometheus.Unregister(d.DatabaseStats.PublicRestBytesRead)

--- a/base/stats_descriptions.go
+++ b/base/stats_descriptions.go
@@ -318,6 +318,10 @@ const (
 
 	ResyncNumChangedDesc = "The total number of changed documents for resync on this database."
 
+	ResyncDocsTargetedDesc = "The number of documents targeted for resync for the current or most recent resync run on this database."
+
+	ResyncErrorsTotalDesc = "The total number of documents that failed during resync on this database."
+
 	NumPublicRestRequestsDesc = "The total number of requests sent over the public REST api."
 
 	TotalSyncTimeDesc = "The total total sync time is a proxy for websocket connections. Tracking long lived and potentially idle connections. " +

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -128,6 +128,7 @@ func (r *ResyncManagerDCP) Init(ctx context.Context, options map[string]any, clu
 		base.WarnfCtx(ctx, "Failed to count total documents for resync: %v, continuing resync", err)
 	}
 	r.docsTargeted.Store(docsTargeted)
+	r.db.DbStats.Database().ResyncDocsTargeted.Set(int64(docsTargeted))
 
 	r.ResyncID = newID.String()
 	base.InfofCtx(ctx, base.KeyAll, "Running new resync process with ID: %q - %s", r.ResyncID, resetMsg)
@@ -250,6 +251,7 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 			databaseCollection.collectionStats.ResyncNumChanged.Add(1)
 		} else if err != base.ErrUpdateCancel {
 			r.docsErroredLocal.Add(1)
+			db.DbStats.Database().ResyncErrorsTotal.Add(1)
 			base.WarnfCtx(ctx, "Resync: Error updating doc %q: %v", base.UD(docID), err)
 			return false
 		}
@@ -494,6 +496,7 @@ func (r *ResyncManagerDCP) initializeFromPreviousStatus(statusDoc ResyncManagerS
 	r.docsProcessedLocal.Store(statusDoc.DocsProcessed)
 	r.docsErroredLocal.Store(statusDoc.DocsErrored)
 	r.docsTargeted.Store(statusDoc.DocsTargeted)
+	r.db.DbStats.Database().ResyncDocsTargeted.Set(int64(statusDoc.DocsTargeted))
 }
 
 // setCollectionStatus sets the active collections being resynced.

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -394,6 +394,8 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 		if regenerateSequences {
 			updateSyncInfo(ctx, db, r.collectionIDs)
 		}
+		// resync finished, drop back to 0
+		db.DbStats.Database().ResyncDocsTargeted.Set(0)
 	case <-terminator.Done():
 
 		base.DebugfCtx(ctx, base.KeyAll, "Terminator closed. Ending Resync process.")

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -179,6 +179,7 @@ func TestResyncDCPInit(t *testing.T) {
 				assert.Equal(t, testCase.initialClusterState.DocsProcessed, response.DocsProcessed)
 			}
 			assert.Equal(t, testCase.expectedDocsTargeted, response.DocsTargeted)
+			assert.Equal(t, testCase.expectedDocsTargeted, uint64(db.DbStats.Database().ResyncDocsTargeted.Value()))
 
 			assert.Equal(t, int64(0), db.DbStats.Database().ResyncNumChanged.Value())
 			assert.Equal(t, int64(0), db.DbStats.Database().ResyncNumProcessed.Value())
@@ -260,6 +261,7 @@ func TestResyncManagerDCPStart(t *testing.T) {
 				assert.GreaterOrEqual(t, stats.DocsProcessed, int64(docsToCreate)) // may be processing tombstones from previous tests
 				assert.Equal(t, int64(0), stats.DocsChanged)
 				assert.GreaterOrEqual(t, stats.DocsTargeted, uint64(docsToCreate))
+				assert.GreaterOrEqual(t, db.DbStats.Database().ResyncDocsTargeted.Value(), int64(docsToCreate))
 
 				assert.GreaterOrEqual(t, db.DbStats.Database().ResyncNumProcessed.Value(), int64(docsToCreate))
 				assert.Equal(t, db.DbStats.Database().ResyncNumChanged.Value(), int64(0))
@@ -316,6 +318,7 @@ func TestResyncManagerDCPStart(t *testing.T) {
 				assert.GreaterOrEqual(t, stats.DocsProcessed, int64(docsToCreate))
 				assert.Equal(t, int64(docsToCreate), stats.DocsChanged)
 				assert.GreaterOrEqual(t, stats.DocsTargeted, uint64(docsToCreate))
+				assert.GreaterOrEqual(t, db.DbStats.Database().ResyncDocsTargeted.Value(), int64(docsToCreate))
 
 				assert.GreaterOrEqual(t, db.DbStats.Database().ResyncNumProcessed.Value(), int64(docsToCreate))
 				assert.Equal(t, db.DbStats.Database().ResyncNumChanged.Value(), int64(docsToCreate))
@@ -426,6 +429,7 @@ func TestResyncManagerDCPResumeStoppedProcess(t *testing.T) {
 			assert.Less(t, stats.DocsChanged, int64(docsToCreate))
 			// DocsTargeted is computed once at run start and should be >= docsToCreate
 			assert.GreaterOrEqual(t, stats.DocsTargeted, uint64(docsToCreate))
+			assert.GreaterOrEqual(t, db.DbStats.Database().ResyncDocsTargeted.Value(), int64(docsToCreate))
 			initialDocsTargeted := stats.DocsTargeted
 
 			assert.Less(t, db.DbStats.Database().ResyncNumProcessed.Value(), int64(docsToCreate))
@@ -441,6 +445,7 @@ func TestResyncManagerDCPResumeStoppedProcess(t *testing.T) {
 			assert.Equal(t, int64(docsToCreate), stats.DocsChanged)
 			// DocsTargeted is preserved from the original run start, even after resume
 			assert.Equal(t, initialDocsTargeted, stats.DocsTargeted)
+			assert.Equal(t, initialDocsTargeted, uint64(db.DbStats.Database().ResyncDocsTargeted.Value()))
 
 			assert.GreaterOrEqual(t, db.DbStats.Database().ResyncNumProcessed.Value(), int64(docsToCreate))
 			assert.Equal(t, int64(docsToCreate), db.DbStats.Database().ResyncNumChanged.Value())

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -261,7 +261,7 @@ func TestResyncManagerDCPStart(t *testing.T) {
 				assert.GreaterOrEqual(t, stats.DocsProcessed, int64(docsToCreate)) // may be processing tombstones from previous tests
 				assert.Equal(t, int64(0), stats.DocsChanged)
 				assert.GreaterOrEqual(t, stats.DocsTargeted, uint64(docsToCreate))
-				assert.GreaterOrEqual(t, db.DbStats.Database().ResyncDocsTargeted.Value(), int64(docsToCreate))
+				assert.GreaterOrEqual(t, int64(0), db.DbStats.Database().ResyncDocsTargeted.Value()) // resync finished so reset back to 0
 
 				assert.GreaterOrEqual(t, db.DbStats.Database().ResyncNumProcessed.Value(), int64(docsToCreate))
 				assert.Equal(t, db.DbStats.Database().ResyncNumChanged.Value(), int64(0))
@@ -318,7 +318,7 @@ func TestResyncManagerDCPStart(t *testing.T) {
 				assert.GreaterOrEqual(t, stats.DocsProcessed, int64(docsToCreate))
 				assert.Equal(t, int64(docsToCreate), stats.DocsChanged)
 				assert.GreaterOrEqual(t, stats.DocsTargeted, uint64(docsToCreate))
-				assert.GreaterOrEqual(t, db.DbStats.Database().ResyncDocsTargeted.Value(), int64(docsToCreate))
+				assert.Equal(t, int64(0), db.DbStats.Database().ResyncDocsTargeted.Value()) // resync finished so reset back to 0
 
 				assert.GreaterOrEqual(t, db.DbStats.Database().ResyncNumProcessed.Value(), int64(docsToCreate))
 				assert.Equal(t, db.DbStats.Database().ResyncNumChanged.Value(), int64(docsToCreate))
@@ -429,7 +429,7 @@ func TestResyncManagerDCPResumeStoppedProcess(t *testing.T) {
 			assert.Less(t, stats.DocsChanged, int64(docsToCreate))
 			// DocsTargeted is computed once at run start and should be >= docsToCreate
 			assert.GreaterOrEqual(t, stats.DocsTargeted, uint64(docsToCreate))
-			assert.GreaterOrEqual(t, db.DbStats.Database().ResyncDocsTargeted.Value(), int64(docsToCreate))
+			assert.GreaterOrEqual(t, uint64(db.DbStats.Database().ResyncDocsTargeted.Value()), uint64(docsToCreate))
 			initialDocsTargeted := stats.DocsTargeted
 
 			assert.Less(t, db.DbStats.Database().ResyncNumProcessed.Value(), int64(docsToCreate))
@@ -445,7 +445,7 @@ func TestResyncManagerDCPResumeStoppedProcess(t *testing.T) {
 			assert.Equal(t, int64(docsToCreate), stats.DocsChanged)
 			// DocsTargeted is preserved from the original run start, even after resume
 			assert.Equal(t, initialDocsTargeted, stats.DocsTargeted)
-			assert.Equal(t, initialDocsTargeted, uint64(db.DbStats.Database().ResyncDocsTargeted.Value()))
+			assert.Equal(t, int64(0), db.DbStats.Database().ResyncDocsTargeted.Value()) // resync finished so reset back to 0
 
 			assert.GreaterOrEqual(t, db.DbStats.Database().ResyncNumProcessed.Value(), int64(docsToCreate))
 			assert.Equal(t, int64(docsToCreate), db.DbStats.Database().ResyncNumChanged.Value())


### PR DESCRIPTION
CBG-5176

Resync targeted metric added to prometheus stats. Resets when resync is done.
Resync errors counter value that accumulates when resync encountered error

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
