### PR TITLE
CBG-5183 resync: integrate background manager and database state

### DIFF
--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -571,7 +571,9 @@ func (b *BackgroundManager) markStop(ctx context.Context) error {
 		return errBackgroundManagerStatusAlreadyStopping
 	}
 
-	if slices.Contains([]BackgroundProcessState{BackgroundProcessStateCompleted, BackgroundProcessStateStopped, BackgroundProcessStateError}, currentState) {
+	// Treat the initial zero state ("") the same as a terminal state: the process was never
+	// started on this node, so there is nothing to stop.
+	if currentState == "" || slices.Contains([]BackgroundProcessState{BackgroundProcessStateCompleted, BackgroundProcessStateStopped, BackgroundProcessStateError}, currentState) {
 		return errBackgroundManagerProcessAlreadyStopped
 	}
 	b.setRunState(BackgroundProcessStateStopping)

--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -289,6 +289,7 @@ func (b *BackgroundManager) start(ctx context.Context, options map[string]any, p
 		err := b.UpdateStatusClusterAware(ctx)
 		if err != nil {
 			base.ErrorfCtx(ctx, "Failed to update background manager status: %v", err)
+			return err
 		}
 	}
 

--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -70,6 +70,10 @@ type BackgroundManager struct {
 	clusterAwareOptions                    *ClusterAwareBackgroundManagerOptions
 	lock                                   sync.Mutex
 	Process                                BackgroundManagerProcessI
+	// updateDatabaseState, when non-nil, is called from UpdateStatusClusterAware and from Resume
+	// (when the cluster is not running) to mirror the local run state into the DatabaseState document.
+	// running is true when the process is locally active, false otherwise.
+	updateDatabaseState func(ctx context.Context, running bool) error
 }
 
 const (
@@ -127,6 +131,51 @@ type updateStatusCallbackFunc func(ctx context.Context) error
 // GetName returns name of the background manager
 func (b *BackgroundManager) GetName() string {
 	return b.name
+}
+
+// callUpdateDatabaseState invokes updateDatabaseState if it is set, logging any error.
+func (b *BackgroundManager) callUpdateDatabaseState(ctx context.Context, running bool) {
+	if b.updateDatabaseState == nil {
+		return
+	}
+	if err := b.updateDatabaseState(ctx, running); err != nil {
+		base.WarnfCtx(ctx, "failed to update database state: %v", err)
+	}
+}
+
+// Resume joins an already-running multi-node background process on this node using the options stored in
+// the status document.  It only starts the local process when the cluster state is
+// BackgroundProcessStateRunning; any other state (including no status document) returns
+// errBackgroundManagerStatusNotRunning.  Only supported for multi-node background managers.
+func (b *BackgroundManager) Resume(ctx context.Context) error {
+	if b.mode() != backgroundManagerModeMultiNode {
+		return fmt.Errorf("Resume is only supported for multi-node background managers (process %q)", b.name)
+	}
+
+	clusterState, err := b.getClusterStatusState(ctx)
+	if err != nil {
+		if base.IsDocNotFoundError(err) {
+			b.callUpdateDatabaseState(ctx, false)
+			return errBackgroundManagerStatusNotRunning
+		}
+		return fmt.Errorf("failed to read cluster state for background process %q: %w", b.name, err)
+	}
+	if clusterState != BackgroundProcessStateRunning {
+		b.callUpdateDatabaseState(ctx, false)
+		return errBackgroundManagerStatusNotRunning
+	}
+
+	optionsBytes, _, err := b.clusterAwareOptions.metadataStore.GetSubDocRaw(ctx, b.clusterAwareOptions.StatusDocID(), "meta.options")
+	if err != nil {
+		return fmt.Errorf("failed to read meta.options for background process %q: %w", b.name, err)
+	}
+
+	var options map[string]any
+	if err := base.JSONUnmarshal(optionsBytes, &options); err != nil {
+		return fmt.Errorf("failed to unmarshal meta.options for background process %q: %w", b.name, err)
+	}
+
+	return b.Start(ctx, options)
 }
 
 func (b *BackgroundManager) Start(ctx context.Context, options map[string]any) error {
@@ -555,16 +604,19 @@ func (b *BackgroundManager) SetError(err error) {
 
 // UpdateStatusClusterAware reads the local status and writes that value to the bucket. This will update the "status" and "meta" keys of the status document.
 func (b *BackgroundManager) UpdateStatusClusterAware(ctx context.Context) error {
+	var err error
 	switch b.mode() {
 	case backgroundManagerModeSingleNode:
-		return b.UpdateSingleNodeClusterAwareStatus(ctx)
+		err = b.UpdateSingleNodeClusterAwareStatus(ctx)
 	case backgroundManagerModeMultiNode:
-		return b.updateMultiNodeClusterAwareStatus(ctx)
+		err = b.updateMultiNodeClusterAwareStatus(ctx)
 	case backgroundManagerModeLocal:
 		return nil
 	default:
 		return fmt.Errorf("unknown background manager mode: %v", b.mode())
 	}
+	b.callUpdateDatabaseState(ctx, b.GetRunState() == BackgroundProcessStateRunning)
+	return err
 }
 
 // UpdateSingleNodeClusterAwareStatus gets the current local status from the running process and updates the status document in
@@ -594,7 +646,7 @@ func (b *BackgroundManager) UpdateSingleNodeClusterAwareStatus(ctx context.Conte
 	return err
 }
 
-// updateMultiNodeClusterAwareStatus updates the cluster status document with the current local status. If the bucket status is in a stopping / stopped / completed / error state but the local status is running, then this method will not update the bucket status and instead return. The caller is responsible for taking appropriate action.
+// updateMultiNodeClusterAwareStatus updates the cluster status document with the current local status. If the bucket status is in a stopping / stopped / completed / error state but the local status is running, then this method will not update the bucket status and instead return.
 func (b *BackgroundManager) updateMultiNodeClusterAwareStatus(ctx context.Context) error {
 	docID := b.clusterAwareOptions.StatusDocID()
 	var previousStatus []byte
@@ -634,6 +686,7 @@ func (b *BackgroundManager) updateMultiNodeClusterAwareStatus(ctx context.Contex
 		return err
 	}
 	b.Process.SetProcessStatus(ctx, previousStatus, newStatus)
+	b.callUpdateDatabaseState(ctx, b.GetRunState() == BackgroundProcessStateRunning)
 	return nil
 }
 

--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -162,7 +162,7 @@ func (b *BackgroundManager) Resume(ctx context.Context) error {
 	}
 	if clusterState != BackgroundProcessStateRunning {
 		b.callUpdateDatabaseState(ctx, false)
-		return errBackgroundManagerStatusNotRunning
+		return nil
 	}
 
 	optionsBytes, _, err := b.clusterAwareOptions.metadataStore.GetSubDocRaw(ctx, b.clusterAwareOptions.StatusDocID(), "meta.options")
@@ -615,7 +615,6 @@ func (b *BackgroundManager) UpdateStatusClusterAware(ctx context.Context) error 
 	default:
 		return fmt.Errorf("unknown background manager mode: %v", b.mode())
 	}
-	b.callUpdateDatabaseState(ctx, b.GetRunState() == BackgroundProcessStateRunning)
 	return err
 }
 

--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -196,6 +196,9 @@ func (b *BackgroundManager) Start(ctx context.Context, options map[string]any) e
 }
 
 func (b *BackgroundManager) start(ctx context.Context, options map[string]any, processClusterStatus []byte) error {
+	if b.mode() != backgroundManagerModeMultiNode && b.updateDatabaseState != nil {
+		return fmt.Errorf("updateDatabaseState should only be set for multi-node background managers")
+	}
 	var previousStatus BackgroundManagerStatus
 	if processClusterStatus != nil {
 		var err error

--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -152,34 +152,60 @@ func (b *BackgroundManager) Resume(ctx context.Context) error {
 		return fmt.Errorf("Resume is only supported for multi-node background managers (process %q)", b.name)
 	}
 
-	clusterState, err := b.getClusterStatusState(ctx)
+	docID := b.clusterAwareOptions.StatusDocID()
+	raw, _, err := b.clusterAwareOptions.metadataStore.GetRaw(ctx, docID)
 	if err != nil {
 		if base.IsDocNotFoundError(err) {
 			b.callUpdateDatabaseState(ctx, false)
 			return errBackgroundManagerStatusNotRunning
 		}
-		return fmt.Errorf("failed to read cluster state for background process %q: %w", b.name, err)
+		return fmt.Errorf("failed to read status doc for background process %q: %w", b.name, err)
 	}
-	if clusterState != BackgroundProcessStateRunning {
+
+	previousStatus, err := unmarshalBackgroundManagerStatus(raw)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal status doc %q for background process %q: %w", docID, b.name, err)
+	}
+	if previousStatus.State != BackgroundProcessStateRunning {
 		b.callUpdateDatabaseState(ctx, false)
 		return nil
 	}
 
-	optionsBytes, _, err := b.clusterAwareOptions.metadataStore.GetSubDocRaw(ctx, b.clusterAwareOptions.StatusDocID(), "meta.options")
-	if err != nil {
-		return fmt.Errorf("failed to read meta.options for background process %q: %w", b.name, err)
+	var doc struct {
+		Meta struct {
+			Options map[string]any `json:"options"`
+		} `json:"meta"`
+	}
+	if err := base.JSONUnmarshal(raw, &doc); err != nil {
+		return fmt.Errorf("failed to unmarshal meta for background process %q: %w", b.name, err)
 	}
 
-	var options map[string]any
-	if err := base.JSONUnmarshal(optionsBytes, &options); err != nil {
-		return fmt.Errorf("failed to unmarshal meta.options for background process %q: %w", b.name, err)
-	}
-
-	return b.Start(ctx, options)
+	return b.start(ctx, doc.Meta.Options, raw)
 }
 
 func (b *BackgroundManager) Start(ctx context.Context, options map[string]any) error {
-	err := b.markStart(ctx)
+	var processClusterStatus []byte
+	if b.mode() != backgroundManagerModeLocal {
+		var err error
+		processClusterStatus, _, err = b.clusterAwareOptions.metadataStore.GetRaw(ctx, b.clusterAwareOptions.StatusDocID())
+		if err != nil && !base.IsDocNotFoundError(err) {
+			return pkgerrors.Wrap(err, "Failed to get current process status")
+		}
+	}
+	return b.start(ctx, options, processClusterStatus)
+}
+
+func (b *BackgroundManager) start(ctx context.Context, options map[string]any, processClusterStatus []byte) error {
+	var previousStatus BackgroundManagerStatus
+	if processClusterStatus != nil {
+		var err error
+		previousStatus, err = unmarshalBackgroundManagerStatus(processClusterStatus)
+		if err != nil {
+			base.InfofCtx(ctx, base.KeyAll, "Could not unmarshal the cluster status before calling BackgroundManager.Run %v", err)
+		}
+	}
+
+	err := b.markStart(ctx, previousStatus)
 	if err != nil {
 		if b.mode() == backgroundManagerModeMultiNode && errors.Is(err, errBackgroundManagerProcessAlreadyRunning) {
 			return nil
@@ -187,30 +213,12 @@ func (b *BackgroundManager) Start(ctx context.Context, options map[string]any) e
 		return err
 	}
 
-	var processClusterStatus []byte
-	if b.mode() != backgroundManagerModeLocal {
-		processClusterStatus, _, err = b.clusterAwareOptions.metadataStore.GetRaw(ctx, b.clusterAwareOptions.StatusDocID())
-		if err != nil && !base.IsDocNotFoundError(err) {
-			return pkgerrors.Wrap(err, "Failed to get current process status")
-		}
-	}
-
 	b.resetStatus()
 	b.setStartTime(time.Now().UTC())
 
-	// If we're resuming a cluster-aware process, try to reuse the previous start time
-	if processClusterStatus != nil {
-		var clusterStatus struct {
-			Status BackgroundManagerStatus `json:"status"`
-		}
-
-		err := base.JSONUnmarshal(processClusterStatus, &clusterStatus)
-		if err != nil {
-			base.InfofCtx(ctx, base.KeyAll, "Could not unmarshal the cluster status before calling BackgroundManager.Run %v", err)
-		}
-		if clusterStatus.Status.State == BackgroundProcessStateRunning && !clusterStatus.Status.StartTime.IsZero() {
-			b.setStartTime(clusterStatus.Status.StartTime)
-		}
+	// If we're resuming a cluster-aware process, try to reuse the previous start time.
+	if previousStatus.State == BackgroundProcessStateRunning && !previousStatus.StartTime.IsZero() {
+		b.setStartTime(previousStatus.StartTime)
 	}
 
 	err = b.Process.Init(ctx, options, processClusterStatus)
@@ -284,7 +292,12 @@ func (b *BackgroundManager) Start(ctx context.Context, options map[string]any) e
 	return nil
 }
 
-func (b *BackgroundManager) markStart(ctx context.Context) error {
+// markStart changes the local status to started.
+//
+// If local or single node process and the bucket status is running, return errBackgroundManagerProcessAlreadyRunning.
+// If the status is stopping, return errBackgroundManagerStatusAlreadyStopping
+// that should be stopping or is already stopped.
+func (b *BackgroundManager) markStart(ctx context.Context, previousStatus BackgroundManagerStatus) error {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
@@ -327,7 +340,7 @@ func (b *BackgroundManager) markStart(ctx context.Context) error {
 	}
 
 	if b.mode() == backgroundManagerModeMultiNode {
-		if b.clusterStateIs(ctx, BackgroundProcessStateStopping) {
+		if previousStatus.State == BackgroundProcessStateStopping {
 			return errBackgroundManagerStatusAlreadyStopping
 		}
 	}
@@ -347,18 +360,6 @@ func (b *BackgroundManager) markStart(ctx context.Context) error {
 	return nil
 }
 
-// clusterStateIs returns if the state matches the serialized state in the bucket. If the document is not present, it will not match.
-func (b *BackgroundManager) clusterStateIs(ctx context.Context, state BackgroundProcessState) bool {
-	clusterState, err := b.getClusterStatusState(ctx)
-	if err != nil {
-		if !base.IsDocNotFoundError(err) {
-			base.TracefCtx(ctx, base.KeyAll, "Error getting cluster status: %v, assuming no status", err)
-		}
-		return false
-	}
-	return clusterState == state
-}
-
 // getClusterStatusState gets the current background process state of the cluster.
 func (b *BackgroundManager) getClusterStatusState(ctx context.Context) (BackgroundProcessState, error) {
 	docID := b.clusterAwareOptions.StatusDocID()
@@ -366,7 +367,7 @@ func (b *BackgroundManager) getClusterStatusState(ctx context.Context) (Backgrou
 	if err != nil {
 		return "", err
 	}
-	state, err := getBackgroundManagerState(statusRaw)
+	state, err := unmarshalBackgroundProcessState(statusRaw)
 	if err != nil {
 		return "", fmt.Errorf("could not get background manager state from cluster status doc %q: %w", docID, err)
 	}
@@ -374,13 +375,24 @@ func (b *BackgroundManager) getClusterStatusState(ctx context.Context) (Backgrou
 
 }
 
-// getBackgroundManagerState returns the getBackgroundManagerState from raw bytes of the status document.
-func getBackgroundManagerState(statusRaw []byte) (BackgroundProcessState, error) {
+// unmarshalBackgroundProcessState returns the BackgroundProcessState from raw bytes of the status document.
+func unmarshalBackgroundProcessState(statusRaw []byte) (BackgroundProcessState, error) {
 	var clusterStatus struct {
 		Status BackgroundProcessState `json:"status"`
 	}
 	if err := base.JSONUnmarshal(statusRaw, &clusterStatus); err != nil {
 		return "", err
+	}
+	return clusterStatus.Status, nil
+}
+
+// unmarshalBackgroundManagerStatus returns the BackgroundManagerStatus from raw bytes of the status document.
+func unmarshalBackgroundManagerStatus(statusRaw []byte) (BackgroundManagerStatus, error) {
+	var clusterStatus struct {
+		Status BackgroundManagerStatus `json:"status"`
+	}
+	if err := base.JSONUnmarshal(statusRaw, &clusterStatus); err != nil {
+		return BackgroundManagerStatus{}, err
 	}
 	return clusterStatus.Status, nil
 }
@@ -662,7 +674,7 @@ func (b *BackgroundManager) updateMultiNodeClusterAwareStatus(ctx context.Contex
 				return nil, nil, false, fmt.Errorf("Could not unmarshal doc(%q) within updateClusterAwareStatus: %w", docID, err)
 			}
 			if status, ok := output["status"]; ok {
-				bucketState, err := getBackgroundManagerState(status)
+				bucketState, err := unmarshalBackgroundProcessState(status)
 				if err != nil {
 					return nil, nil, false, err
 				}

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -58,23 +58,30 @@ type resyncCollectionInfo struct {
 
 var _ BackgroundManagerProcessI = &ResyncManagerDCP{}
 
-func NewResyncManagerDCP(metadataStore base.DataStore, metaKeys *base.MetadataKeys, db *DatabaseContext) *BackgroundManager {
-	return &BackgroundManager{
+// NewResyncManagerDCP returns a new instance of ResyncManagerDCP wrapped in a BackgroundManager. If distributed is
+// true, the manager will be set up to run in a distributed manner across multiple nodes, otherwise it will run on a
+// single node.
+func NewResyncManagerDCP(db *DatabaseContext, distributed bool) *BackgroundManager {
+	b := &BackgroundManager{
 		name:    "resync",
-		Process: &ResyncManagerDCP{db: db},
+		Process: &ResyncManagerDCP{db: db, Distributed: distributed},
 		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
-			metadataStore: metadataStore,
-			metaKeys:      metaKeys,
+			metadataStore: db.MetadataStore,
+			metaKeys:      db.MetadataKeys,
 			processSuffix: "resync",
+			multiNode:     distributed,
 		},
 		terminator: base.NewSafeTerminator(),
-		updateDatabaseState: func(ctx context.Context, running bool) error {
+	}
+	if distributed {
+		b.updateDatabaseState = func(ctx context.Context, running bool) error {
 			if db.DBStateManager == nil {
 				return nil
 			}
 			return db.DBStateManager.UpdateState(ctx, DatabaseState{ResyncRunning: base.Ptr(running)})
-		},
+		}
 	}
+	return b
 }
 
 // Init processes the options to start a resync process and sets them as struct memebers.

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -44,6 +44,7 @@ type ResyncManagerDCP struct {
 	ResyncID                     string
 	VBUUIDs                      []uint64
 	ResyncedCollections          base.CollectionNames
+	startOptions                 map[string]any // options from the most recent Start call, persisted to meta for Resume
 	resyncCollectionInfo
 	lock        sync.RWMutex
 	Distributed bool
@@ -67,6 +68,12 @@ func NewResyncManagerDCP(metadataStore base.DataStore, metaKeys *base.MetadataKe
 			processSuffix: "resync",
 		},
 		terminator: base.NewSafeTerminator(),
+		updateDatabaseState: func(ctx context.Context, running bool) error {
+			if db.DBStateManager == nil {
+				return nil
+			}
+			return db.DBStateManager.UpdateState(ctx, DatabaseState{ResyncRunning: base.Ptr(running)})
+		},
 	}
 }
 
@@ -76,6 +83,7 @@ func (r *ResyncManagerDCP) Init(ctx context.Context, options map[string]any, clu
 	if !ok {
 		return errors.New("collections option is required and must be of type base.CollectionNames")
 	}
+	r.setStartOptions(options)
 
 	var collections DatabaseCollections
 	if len(resyncCollections) > 0 {
@@ -155,6 +163,13 @@ func (r *ResyncManagerDCP) purgeCheckpoints(ctx context.Context, resyncID string
 		GetResyncDCPCheckpointPrefix(r.db, resyncID, r.Distributed),
 		r.db.distributedDCPFeedMode(),
 	)
+}
+
+// setStartOptions stores the options used to start the current run so that Resume can reconstruct them.
+func (r *ResyncManagerDCP) setStartOptions(options map[string]any) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	r.startOptions = options
 }
 
 // SetVBUUIDs updates vbuuids in the manager.
@@ -586,6 +601,7 @@ func (r *ResyncManagerDCP) GetProcessStatus(status BackgroundManagerStatus, prev
 	meta := ResyncManagerMeta{
 		VBUUIDs:       r.VBUUIDs,
 		CollectionIDs: r.collectionIDs,
+		Options:       r.startOptions,
 	}
 
 	statusJSON, err := base.JSONMarshal(response)
@@ -619,8 +635,9 @@ func (r *ResyncManagerDCP) DocsErrored() int64 {
 }
 
 type ResyncManagerMeta struct {
-	VBUUIDs       []uint64 `json:"vbuuids"`
-	CollectionIDs []uint32 `json:"collection_ids,omitempty"`
+	VBUUIDs       []uint64       `json:"vbuuids"`
+	CollectionIDs []uint32       `json:"collection_ids,omitempty"`
+	Options       map[string]any `json:"options,omitempty"` // start options, persisted for Resume
 }
 
 type ResyncManagerStatusDocDCP struct {

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -965,3 +965,97 @@ func TestResyncManagerDCPWritesV1SyncInfoAtCcv41(t *testing.T) {
 	require.NotEmpty(t, raw)
 	require.Equal(t, byte(base.SyncInfoTypeV1), raw[0], "expected V1 prefix byte from resync write at ccv 4.1")
 }
+
+// TestResyncManagerOptionsStoredInMeta verifies that the options passed when starting a resync are embedded
+// in the "options" field of the meta returned by GetProcessStatus, so that BackgroundManager.Resume can
+// read them back from the status document.
+func TestResyncManagerOptionsStoredInMeta(t *testing.T) {
+	inputCollections := base.CollectionNames{"scope1": []string{"col1", "col2"}}
+
+	r := &ResyncManagerDCP{}
+	r.setStartOptions(map[string]any{
+		"regenerateSequences": false,
+		"collections":         inputCollections,
+		"reset":               true,
+	})
+
+	_, metaBytes, err := r.GetProcessStatus(BackgroundManagerStatus{State: BackgroundProcessStateStopped}, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, metaBytes)
+
+	// BackgroundManager.Resume reads "options" directly from the meta subdoc.
+	var metaDoc struct {
+		Options map[string]any `json:"options"`
+	}
+	require.NoError(t, base.JSONUnmarshal(metaBytes, &metaDoc))
+	require.NotNil(t, metaDoc.Options)
+
+	require.Equal(t, false, metaDoc.Options["regenerateSequences"])
+	require.Equal(t, true, metaDoc.Options["reset"])
+
+	// collections round-trips through JSON as map[string]interface{}; re-marshal and unmarshal to recover the typed value.
+	collectionsRaw, err := base.JSONMarshal(metaDoc.Options["collections"])
+	require.NoError(t, err)
+	var recoveredCollections base.CollectionNames
+	require.NoError(t, base.JSONUnmarshal(collectionsRaw, &recoveredCollections))
+	require.Equal(t, inputCollections, recoveredCollections)
+}
+
+// TestResyncDCPInitStoresOptionsInMeta verifies that Init stores the options it receives in the meta returned
+// by GetProcessStatus.  This ensures that BackgroundManager.Resume can read options back from the bucket after
+// a Start call.
+func TestResyncDCPInitStoresOptionsInMeta(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
+
+	// Use all collections by passing an empty CollectionNames — avoids hard-coding scope/collection names
+	// that might not match the test bucket configuration.
+	options := map[string]any{
+		"collections":         base.NewCollectionNames(),
+		"regenerateSequences": false,
+		"reset":               false,
+	}
+
+	require.NoError(t, db.ResyncManager.Process.Init(ctx, options, nil))
+
+	_, metaBytes, err := db.ResyncManager.Process.GetProcessStatus(BackgroundManagerStatus{State: BackgroundProcessStateStopped}, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, metaBytes)
+
+	var metaDoc ResyncManagerMeta
+	require.NoError(t, base.JSONUnmarshal(metaBytes, &metaDoc))
+	require.NotNil(t, metaDoc.Options, "Init must call setStartOptions so that Resume can recover the options")
+	require.Equal(t, false, metaDoc.Options["regenerateSequences"])
+	require.Equal(t, false, metaDoc.Options["reset"])
+}
+
+// TestNewResyncManagerDCPUpdateDatabaseState verifies that NewResyncManagerDCP wires updateDatabaseState
+// to DatabaseStateMgr.UpdateState: calling the hook with running=true/false must persist the corresponding
+// ResyncRunning value in the state document.
+func TestNewResyncManagerDCPUpdateDatabaseState(t *testing.T) {
+	testBucket := base.GetTestBucket(t)
+	ctx := base.TestCtx(t)
+	defer testBucket.Close(ctx)
+	metadataStore := testBucket.DefaultDataStore(ctx)
+	metaKeys := base.NewMetadataKeys("test-resync-update-db-state")
+
+	dbStateMgr := NewDatabaseStateMgr(metadataStore, metaKeys.DatabaseStateKey(), nil)
+	db := &DatabaseContext{DBStateManager: dbStateMgr}
+
+	mgr := NewResyncManagerDCP(metadataStore, metaKeys, db)
+	require.NotNil(t, mgr.updateDatabaseState, "NewResyncManagerDCP must set updateDatabaseState")
+
+	// Calling with running=true must write ResyncRunning=true to the state document.
+	require.NoError(t, mgr.updateDatabaseState(ctx, true))
+	state, _, err := dbStateMgr.GetState(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, state.ResyncRunning)
+	require.True(t, *state.ResyncRunning)
+
+	// Calling with running=false must write ResyncRunning=false to the state document.
+	require.NoError(t, mgr.updateDatabaseState(ctx, false))
+	state, _, err = dbStateMgr.GetState(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, state.ResyncRunning)
+	require.False(t, *state.ResyncRunning)
+}

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -295,9 +295,7 @@ func TestResyncManagerDCPStart(t *testing.T) {
 				}
 
 				if testCase.Distributed {
-					rs, ok := db.ResyncManager.Process.(*ResyncManagerDCP)
-					require.True(t, ok)
-					rs.Distributed = true
+					db.ResyncManager = NewResyncManagerDCP(db.DatabaseContext, true)
 				}
 				err := db.ResyncManager.Start(ctx, options)
 				require.NoError(t, err)
@@ -477,7 +475,7 @@ func TestResyncManagerDCPResumeStoppedProcessChangeCollections(t *testing.T) {
 			require.True(t, ok)
 
 			if testCase.Distributed {
-				rs.Distributed = true
+				db.ResyncManager = NewResyncManagerDCP(db.DatabaseContext, true)
 			} else {
 				require.False(t, rs.Distributed, "Expected this database ResyncManager to be in non distributed mode")
 			}
@@ -573,7 +571,7 @@ function sync(doc, oldDoc){
 	require.True(t, ok)
 
 	if opts.distributed {
-		rs.Distributed = true
+		db.ResyncManager = NewResyncManagerDCP(db.DatabaseContext, true)
 	} else {
 		require.False(t, rs.Distributed, "Expected this database ResyncManager to be in non distributed mode")
 	}
@@ -1042,7 +1040,8 @@ func TestNewResyncManagerDCPUpdateDatabaseState(t *testing.T) {
 	dbStateMgr := NewDatabaseStateMgr(metadataStore, metaKeys.DatabaseStateKey(), nil)
 	db := &DatabaseContext{DBStateManager: dbStateMgr}
 
-	mgr := NewResyncManagerDCP(metadataStore, metaKeys, db)
+	distributedResync := true
+	mgr := NewResyncManagerDCP(db, distributedResync)
 	require.NotNil(t, mgr.updateDatabaseState, "NewResyncManagerDCP must set updateDatabaseState")
 
 	// Calling with running=true must write ResyncRunning=true to the state document.

--- a/db/background_mgr_test.go
+++ b/db/background_mgr_test.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -451,4 +452,860 @@ func TestResyncMultiNodeStatsAggregation(t *testing.T) {
 
 	require.Equal(t, int64(15), respB.DocsProcessed)
 
+}
+
+// ResumableMockProcess is a MockProcess that also implements BackgroundManagerResumable.
+// It stores the options passed to Init and serialises them into the "meta" returned by GetProcessStatus.
+type ResumableMockProcess struct {
+	MockProcess
+	receivedOptions map[string]any
+	optionsLock     sync.RWMutex
+}
+
+func (r *ResumableMockProcess) Init(ctx context.Context, options map[string]any, clusterStatus []byte) error {
+	r.optionsLock.Lock()
+	r.receivedOptions = options
+	r.optionsLock.Unlock()
+	return r.MockProcess.Init(ctx, options, clusterStatus)
+}
+
+func (r *ResumableMockProcess) GetProcessStatus(status BackgroundManagerStatus, previousStatus []byte) ([]byte, []byte, error) {
+	statusBytes, _, err := r.MockProcess.GetProcessStatus(status, previousStatus)
+	if err != nil {
+		return nil, nil, err
+	}
+	r.optionsLock.RLock()
+	opts := r.receivedOptions
+	r.optionsLock.RUnlock()
+
+	type mockMeta struct {
+		Options map[string]any `json:"options,omitempty"`
+	}
+	metaBytes, err := base.JSONMarshal(mockMeta{Options: opts})
+	if err != nil {
+		return nil, nil, err
+	}
+	return statusBytes, metaBytes, nil
+}
+
+// ReceivedOptions returns the options most recently passed to Init (safe for concurrent use).
+func (r *ResumableMockProcess) ReceivedOptions() map[string]any {
+	r.optionsLock.RLock()
+	defer r.optionsLock.RUnlock()
+	return r.receivedOptions
+}
+
+// TestBackgroundManagerResume verifies that a second multi-node manager can join an already-running process
+// via Resume, picking up the stored options without being given them explicitly.
+func TestBackgroundManagerResume(t *testing.T) {
+	testBucket := base.GetTestBucket(t)
+	ctx := base.TestCtx(t)
+	defer testBucket.Close(ctx)
+	metadataStore := testBucket.DefaultDataStore(ctx)
+	metaKeys := base.NewMetadataKeys("test-resume")
+
+	clusterOpts := &ClusterAwareBackgroundManagerOptions{
+		metadataStore: metadataStore,
+		metaKeys:      metaKeys,
+		processSuffix: "resume",
+		multiNode:     true,
+	}
+
+	process := &ResumableMockProcess{}
+	mgr := &BackgroundManager{
+		name:                "test-resume-mgr",
+		Process:             process,
+		clusterAwareOptions: clusterOpts,
+		terminator:          base.NewSafeTerminator(),
+	}
+
+	startOptions := map[string]any{"key": "value", "num": float64(42)}
+
+	// Start mgr — this writes the options into the status document and sets cluster state to running.
+	require.NoError(t, mgr.Start(ctx, startOptions))
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, BackgroundProcessStateRunning, mgr.GetRunState())
+	}, 5*time.Second, 100*time.Millisecond)
+
+	// While cluster state is running, a second manager sharing the same status document should join via Resume.
+	process2 := &ResumableMockProcess{}
+	mgr2 := &BackgroundManager{
+		name:                "test-resume-mgr2",
+		Process:             process2,
+		clusterAwareOptions: clusterOpts,
+		terminator:          base.NewSafeTerminator(),
+	}
+
+	require.NoError(t, mgr2.Resume(ctx))
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, BackgroundProcessStateRunning, mgr2.GetRunState())
+	}, 5*time.Second, 100*time.Millisecond)
+	require.Equal(t, startOptions, process2.ReceivedOptions())
+
+	require.NoError(t, mgr.Stop(ctx))
+	require.NoError(t, mgr2.Stop(ctx))
+}
+
+// TestBackgroundManagerResumeNoDoc verifies that Resume returns errBackgroundManagerStatusNotRunning when
+// no status document exists (i.e. Start has never been called).
+func TestBackgroundManagerResumeNoDoc(t *testing.T) {
+	testBucket := base.GetTestBucket(t)
+	ctx := base.TestCtx(t)
+	defer testBucket.Close(ctx)
+	metadataStore := testBucket.DefaultDataStore(ctx)
+	metaKeys := base.NewMetadataKeys("test-resume-no-doc")
+
+	mgr := &BackgroundManager{
+		name:    "test-resume-no-doc-mgr",
+		Process: &ResumableMockProcess{},
+		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
+			metadataStore: metadataStore,
+			metaKeys:      metaKeys,
+			processSuffix: "resume-no-doc",
+			multiNode:     true,
+		},
+		terminator: base.NewSafeTerminator(),
+	}
+
+	require.ErrorIs(t, mgr.Resume(ctx), errBackgroundManagerStatusNotRunning)
+}
+
+// TestBackgroundManagerResumeSingleNodeError verifies that Resume returns an error for single-node managers
+// since Resume is only supported for multi-node background managers.
+func TestBackgroundManagerResumeSingleNodeError(t *testing.T) {
+	testBucket := base.GetTestBucket(t)
+	ctx := base.TestCtx(t)
+	defer testBucket.Close(ctx)
+	metadataStore := testBucket.DefaultDataStore(ctx)
+	metaKeys := base.NewMetadataKeys("test-resume-single-node")
+
+	process := &ResumableMockProcess{}
+	mgr := &BackgroundManager{
+		name:    "test-resume-single-node-mgr",
+		Process: process,
+		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
+			metadataStore: metadataStore,
+			metaKeys:      metaKeys,
+			processSuffix: "resume-single-node",
+			multiNode:     false, // single-node
+		},
+		terminator: base.NewSafeTerminator(),
+	}
+
+	err := mgr.Resume(ctx)
+	require.Error(t, err)
+}
+
+// TestBackgroundManagerResumeWhileRunning verifies that calling Resume on a multi-node manager that is
+// already running is idempotent: it returns nil and does not start a second instance of the process.
+func TestBackgroundManagerResumeWhileRunning(t *testing.T) {
+	testBucket := base.GetTestBucket(t)
+	ctx := base.TestCtx(t)
+	defer testBucket.Close(ctx)
+	metadataStore := testBucket.DefaultDataStore(ctx)
+	metaKeys := base.NewMetadataKeys("test-resume-running")
+
+	process := &ResumableMockProcess{}
+	mgr := &BackgroundManager{
+		name:    "test-resume-running-mgr",
+		Process: process,
+		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
+			metadataStore: metadataStore,
+			metaKeys:      metaKeys,
+			processSuffix: "resume-running",
+			multiNode:     true,
+		},
+		terminator: base.NewSafeTerminator(),
+	}
+
+	startOptions := map[string]any{"key": "value"}
+	require.NoError(t, mgr.Start(ctx, startOptions))
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, BackgroundProcessStateRunning, mgr.GetRunState())
+	}, 5*time.Second, 100*time.Millisecond)
+
+	// Resume while running is idempotent for multi-node managers.
+	require.NoError(t, mgr.Resume(ctx))
+	require.Equal(t, BackgroundProcessStateRunning, mgr.GetRunState())
+	require.Equal(t, startOptions, process.ReceivedOptions())
+
+	require.NoError(t, mgr.Stop(ctx))
+}
+
+// TestBackgroundManagerResumeWhenNotRunning verifies that Resume returns errBackgroundManagerStatusNotRunning
+// when the cluster state is not running (e.g., after the process has been stopped).
+func TestBackgroundManagerResumeWhenNotRunning(t *testing.T) {
+	testBucket := base.GetTestBucket(t)
+	ctx := base.TestCtx(t)
+	defer testBucket.Close(ctx)
+	metadataStore := testBucket.DefaultDataStore(ctx)
+	metaKeys := base.NewMetadataKeys("test-resume-not-running")
+
+	clusterOpts := &ClusterAwareBackgroundManagerOptions{
+		metadataStore: metadataStore,
+		metaKeys:      metaKeys,
+		processSuffix: "resume-not-running",
+		multiNode:     true,
+	}
+
+	mgr := &BackgroundManager{
+		name:                "test-resume-not-running-mgr",
+		Process:             &ResumableMockProcess{},
+		clusterAwareOptions: clusterOpts,
+		terminator:          base.NewSafeTerminator(),
+	}
+
+	require.NoError(t, mgr.Start(ctx, map[string]any{"key": "value"}))
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, BackgroundProcessStateRunning, mgr.GetRunState())
+	}, 5*time.Second, 100*time.Millisecond)
+	require.NoError(t, mgr.Stop(ctx))
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		rawStatus, err := mgr.GetStatus(ctx)
+		assert.NoError(c, err)
+		var status BackgroundManagerStatus
+		assert.NoError(c, base.JSONUnmarshal(rawStatus, &status))
+		assert.Contains(c, []BackgroundProcessState{BackgroundProcessStateStopped, BackgroundProcessStateCompleted}, status.State)
+	}, 5*time.Second, 100*time.Millisecond)
+
+	// Cluster state is now stopped; a second manager must not be able to Resume.
+	mgr2 := &BackgroundManager{
+		name:                "test-resume-not-running-mgr2",
+		Process:             &ResumableMockProcess{},
+		clusterAwareOptions: clusterOpts,
+		terminator:          base.NewSafeTerminator(),
+	}
+	require.ErrorIs(t, mgr2.Resume(ctx), errBackgroundManagerStatusNotRunning)
+}
+
+// TestBackgroundManagerResumeLocalModeError verifies that Resume returns an error for a local-mode manager
+// since Resume is only supported for multi-node background managers.
+func TestBackgroundManagerResumeLocalModeError(t *testing.T) {
+	ctx := base.TestCtx(t)
+	process := &ResumableMockProcess{}
+	mgr := &BackgroundManager{
+		name:       "test-resume-local-mgr",
+		Process:    process,
+		terminator: base.NewSafeTerminator(),
+		// no clusterAwareOptions → local mode
+	}
+
+	err := mgr.Resume(ctx)
+	require.Error(t, err)
+}
+
+// TestBackgroundManagerUpdateDatabaseStateRunning verifies that updateDatabaseState is called with running=true
+// when UpdateStatusClusterAware is invoked while the process is running.
+func TestBackgroundManagerUpdateDatabaseStateRunning(t *testing.T) {
+	testBucket := base.GetTestBucket(t)
+	ctx := base.TestCtx(t)
+	defer testBucket.Close(ctx)
+	metadataStore := testBucket.DefaultDataStore(ctx)
+	metaKeys := base.NewMetadataKeys("test-update-db-state-running")
+
+	var dbStateCalls []bool
+	var mu sync.Mutex
+
+	mgr := &BackgroundManager{
+		name:    "test-update-db-state-running",
+		Process: &MockProcess{},
+		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
+			metadataStore: metadataStore,
+			metaKeys:      metaKeys,
+			processSuffix: "update-db-state-running",
+		},
+		terminator: base.NewSafeTerminator(),
+		updateDatabaseState: func(_ context.Context, running bool) error {
+			mu.Lock()
+			dbStateCalls = append(dbStateCalls, running)
+			mu.Unlock()
+			return nil
+		},
+	}
+
+	require.NoError(t, mgr.Start(ctx, nil))
+	defer func() { assert.NoError(t, mgr.Stop(ctx)) }()
+
+	// UpdateStatusClusterAware is called synchronously at the end of Start, so by the time
+	// Start returns, updateDatabaseState must have been called with running=true.
+	mu.Lock()
+	calls := make([]bool, len(dbStateCalls))
+	copy(calls, dbStateCalls)
+	mu.Unlock()
+
+	require.Contains(t, calls, true, "expected updateDatabaseState(true) after Start")
+}
+
+// TestBackgroundManagerUpdateDatabaseStateOnCompletion verifies that updateDatabaseState is called
+// with running=false when the background process finishes (via UpdateStatusClusterAware in the run goroutine).
+func TestBackgroundManagerUpdateDatabaseStateOnCompletion(t *testing.T) {
+	testBucket := base.GetTestBucket(t)
+	ctx := base.TestCtx(t)
+	defer testBucket.Close(ctx)
+	metadataStore := testBucket.DefaultDataStore(ctx)
+	metaKeys := base.NewMetadataKeys("test-update-db-state-done")
+
+	calledWithFalse := make(chan struct{}, 1)
+
+	mgr := &BackgroundManager{
+		name:    "test-update-db-state-done",
+		Process: &MockProcess{},
+		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
+			metadataStore: metadataStore,
+			metaKeys:      metaKeys,
+			processSuffix: "update-db-state-done",
+		},
+		terminator: base.NewSafeTerminator(),
+		updateDatabaseState: func(_ context.Context, running bool) error {
+			if !running {
+				select {
+				case calledWithFalse <- struct{}{}:
+				default:
+				}
+			}
+			return nil
+		},
+	}
+
+	require.NoError(t, mgr.Start(ctx, nil))
+
+	// Stopping the manager causes the run goroutine to exit, which transitions the state to
+	// Stopped and then calls UpdateStatusClusterAware — which must call updateDatabaseState(false).
+	require.NoError(t, mgr.Stop(ctx))
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Contains(c, []BackgroundProcessState{
+			BackgroundProcessStateStopped,
+			BackgroundProcessStateCompleted,
+		}, mgr.GetRunState())
+	}, 5*time.Second, 100*time.Millisecond)
+
+	base.RequireChanRecvWithTimeout(t, calledWithFalse, 5*time.Second)
+}
+
+// TestBackgroundManagerResumeCallsUpdateDatabaseStateWhenNotRunning verifies that Resume calls
+// updateDatabaseState(false) when the cluster has no status document (not running).
+func TestBackgroundManagerResumeCallsUpdateDatabaseStateWhenNotRunning(t *testing.T) {
+	testBucket := base.GetTestBucket(t)
+	ctx := base.TestCtx(t)
+	defer testBucket.Close(ctx)
+	metadataStore := testBucket.DefaultDataStore(ctx)
+	metaKeys := base.NewMetadataKeys("test-resume-db-state-not-running")
+
+	var dbStateCalls []bool
+	var mu sync.Mutex
+
+	mgr := &BackgroundManager{
+		name:    "test-resume-db-state-not-running",
+		Process: &ResumableMockProcess{},
+		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
+			metadataStore: metadataStore,
+			metaKeys:      metaKeys,
+			processSuffix: "resume-db-state-not-running",
+			multiNode:     true,
+		},
+		terminator: base.NewSafeTerminator(),
+		updateDatabaseState: func(_ context.Context, running bool) error {
+			mu.Lock()
+			dbStateCalls = append(dbStateCalls, running)
+			mu.Unlock()
+			return nil
+		},
+	}
+
+	// No status doc exists → Resume must return errBackgroundManagerStatusNotRunning.
+	err := mgr.Resume(ctx)
+	require.ErrorIs(t, err, errBackgroundManagerStatusNotRunning)
+
+	mu.Lock()
+	calls := make([]bool, len(dbStateCalls))
+	copy(calls, dbStateCalls)
+	mu.Unlock()
+
+	require.Len(t, calls, 1, "expected exactly one updateDatabaseState call from Resume")
+	require.False(t, calls[0], "expected updateDatabaseState(false) when cluster is not running")
+}
+
+// TestBackgroundManagerResumeCallsUpdateDatabaseStateWhenStopped verifies that Resume calls
+// updateDatabaseState(false) when the cluster state is stopped (not running).
+func TestBackgroundManagerResumeCallsUpdateDatabaseStateWhenStopped(t *testing.T) {
+	testBucket := base.GetTestBucket(t)
+	ctx := base.TestCtx(t)
+	defer testBucket.Close(ctx)
+	metadataStore := testBucket.DefaultDataStore(ctx)
+	metaKeys := base.NewMetadataKeys("test-resume-db-state-stopped")
+
+	clusterOpts := &ClusterAwareBackgroundManagerOptions{
+		metadataStore: metadataStore,
+		metaKeys:      metaKeys,
+		processSuffix: "resume-db-state-stopped",
+		multiNode:     true,
+	}
+
+	// Start and then stop a manager so the cluster status doc shows Stopped.
+	starter := &BackgroundManager{
+		name:                "test-resume-db-state-stopped-starter",
+		Process:             &ResumableMockProcess{},
+		clusterAwareOptions: clusterOpts,
+		terminator:          base.NewSafeTerminator(),
+	}
+	require.NoError(t, starter.Start(ctx, map[string]any{"key": "value"}))
+	require.NoError(t, starter.Stop(ctx))
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		rawStatus, err := starter.GetStatus(ctx)
+		assert.NoError(c, err)
+		var status BackgroundManagerStatus
+		assert.NoError(c, base.JSONUnmarshal(rawStatus, &status))
+		assert.Contains(c, []BackgroundProcessState{
+			BackgroundProcessStateStopped,
+			BackgroundProcessStateCompleted,
+		}, status.State)
+	}, 5*time.Second, 100*time.Millisecond)
+
+	// A fresh manager observing the same (stopped) cluster state should call updateDatabaseState(false).
+	var dbStateCalls []bool
+	var mu sync.Mutex
+	observer := &BackgroundManager{
+		name:                "test-resume-db-state-stopped-observer",
+		Process:             &ResumableMockProcess{},
+		clusterAwareOptions: clusterOpts,
+		terminator:          base.NewSafeTerminator(),
+		updateDatabaseState: func(_ context.Context, running bool) error {
+			mu.Lock()
+			dbStateCalls = append(dbStateCalls, running)
+			mu.Unlock()
+			return nil
+		},
+	}
+
+	err := observer.Resume(ctx)
+	require.ErrorIs(t, err, errBackgroundManagerStatusNotRunning)
+
+	mu.Lock()
+	calls := make([]bool, len(dbStateCalls))
+	copy(calls, dbStateCalls)
+	mu.Unlock()
+
+	require.Len(t, calls, 1, "expected exactly one updateDatabaseState call")
+	require.False(t, calls[0], "expected updateDatabaseState(false) when cluster is stopped")
+}
+
+// immediateCallbackProcess is a MockProcess whose Run calls the status callback once then returns
+// immediately, making the goroutine race window between the goroutine cleanup and the parent
+// Start body as tight as possible.
+type immediateCallbackProcess struct {
+	MockProcess
+}
+
+func (m *immediateCallbackProcess) Run(ctx context.Context, _ map[string]any, cb updateStatusCallbackFunc, _ *base.SafeTerminator) error {
+	m.lock.Lock()
+	m.RunCalled = true
+	m.lock.Unlock()
+	if cb != nil {
+		_ = cb(ctx)
+	}
+	return nil
+}
+
+// newTestManagerWithStateDoc returns a multi-node BackgroundManager whose updateDatabaseState is wired
+// to a DatabaseStateMgr backed by the given metadata store.
+func newTestManagerWithStateDoc(metadataStore base.DataStore, metaKeys *base.MetadataKeys, suffix string, proc BackgroundManagerProcessI) (*BackgroundManager, *DatabaseStateMgr) {
+	dbStateMgr := NewDatabaseStateMgr(metadataStore, metaKeys.DatabaseStateKey(), nil)
+	mgr := &BackgroundManager{
+		name:    "test-" + suffix,
+		Process: proc,
+		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
+			metadataStore: metadataStore,
+			metaKeys:      metaKeys,
+			processSuffix: suffix,
+			multiNode:     true,
+		},
+		terminator: base.NewSafeTerminator(),
+		updateDatabaseState: func(ctx context.Context, running bool) error {
+			return dbStateMgr.UpdateState(ctx, DatabaseState{ResyncRunning: base.Ptr(running)})
+		},
+	}
+	return mgr, dbStateMgr
+}
+
+// assertResyncRunningEventually polls the DatabaseStateMgr until ResyncRunning equals want or the
+// deadline is exceeded.
+func assertResyncRunningEventually(t *testing.T, dbStateMgr *DatabaseStateMgr, want bool, ctx context.Context) {
+	t.Helper()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		state, _, err := dbStateMgr.GetState(ctx)
+		assert.NoError(c, err)
+		if assert.NotNil(c, state) && assert.NotNil(c, state.ResyncRunning) {
+			assert.Equal(c, want, *state.ResyncRunning)
+		}
+	}, 5*time.Second, 20*time.Millisecond)
+}
+
+// TestUpdateDatabaseStateRapidCycles exercises repeated start/stop cycles and verifies that
+// ResyncRunning always settles to false after each stop, and to true after each start.
+// Run with -race to exercise the race detector.
+func TestUpdateDatabaseStateRapidCycles(t *testing.T) {
+	testBucket := base.GetTestBucket(t)
+	ctx := base.TestCtx(t)
+	defer testBucket.Close(ctx)
+	metadataStore := testBucket.DefaultDataStore(ctx)
+
+	const cycles = 8
+	for i := range cycles {
+		// Use a fresh key each cycle so status docs don't interfere.
+		metaKeys := base.NewMetadataKeys(fmt.Sprintf("rapid-cycle-%d", i))
+		mgr, dbStateMgr := newTestManagerWithStateDoc(metadataStore, metaKeys, "rapid", &ResumableMockProcess{})
+
+		require.NoError(t, mgr.Start(ctx, nil))
+		assertResyncRunningEventually(t, dbStateMgr, true, ctx)
+
+		require.NoError(t, mgr.Stop(ctx))
+		assertResyncRunningEventually(t, dbStateMgr, false, ctx)
+	}
+}
+
+// TestUpdateDatabaseStateProcessCompletesBeforeStartReturns exercises the ordering race where a
+// process returns from Run (and the goroutine writes false) before Start's own synchronous
+// UpdateStatusClusterAware call. The final state must be false once everything settles.
+// Run with -race.
+func TestUpdateDatabaseStateProcessCompletesBeforeStartReturns(t *testing.T) {
+	testBucket := base.GetTestBucket(t)
+	ctx := base.TestCtx(t)
+	defer testBucket.Close(ctx)
+	metadataStore := testBucket.DefaultDataStore(ctx)
+	metaKeys := base.NewMetadataKeys("test-immediate-complete")
+
+	mgr, dbStateMgr := newTestManagerWithStateDoc(metadataStore, metaKeys, "immediate", &immediateCallbackProcess{})
+
+	// immediateCallbackProcess returns from Run immediately, making the goroutine cleanup race
+	// with the synchronous UpdateStatusClusterAware call at the end of Start.
+	require.NoError(t, mgr.Start(ctx, nil))
+
+	// Regardless of ordering, the final state must settle to false because the process completed.
+	assertResyncRunningEventually(t, dbStateMgr, false, ctx)
+}
+
+// TestUpdateDatabaseStateConcurrentManagersSharedStateDoc starts and stops many multi-node managers
+// that all share the same DatabaseStateMgr. It verifies no data races and that the state document
+// eventually reflects "not running" once all managers have stopped.
+// Run with -race.
+func TestUpdateDatabaseStateConcurrentManagersSharedStateDoc(t *testing.T) {
+	testBucket := base.GetTestBucket(t)
+	ctx := base.TestCtx(t)
+	defer testBucket.Close(ctx)
+	metadataStore := testBucket.DefaultDataStore(ctx)
+	metaKeys := base.NewMetadataKeys("test-concurrent-shared-state")
+
+	dbStateMgr := NewDatabaseStateMgr(metadataStore, metaKeys.DatabaseStateKey(), nil)
+
+	const numNodes = 5
+	managers := make([]*BackgroundManager, numNodes)
+	for i := range numNodes {
+		managers[i] = &BackgroundManager{
+			name:    fmt.Sprintf("test-concurrent-shared-%d", i),
+			Process: &ResumableMockProcess{},
+			clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
+				metadataStore: metadataStore,
+				metaKeys:      metaKeys,
+				processSuffix: "concurrent-shared",
+				multiNode:     true,
+			},
+			terminator: base.NewSafeTerminator(),
+			updateDatabaseState: func(ctx context.Context, running bool) error {
+				return dbStateMgr.UpdateState(ctx, DatabaseState{ResyncRunning: base.Ptr(running)})
+			},
+		}
+	}
+
+	// All managers start simultaneously.
+	var startWG sync.WaitGroup
+	for i := range numNodes {
+		startWG.Add(1)
+		go func(i int) {
+			defer startWG.Done()
+			assert.NoError(t, managers[i].Start(ctx, nil))
+		}(i)
+	}
+	startWG.Wait()
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		for i := range numNodes {
+			assert.Equal(c, BackgroundProcessStateRunning, managers[i].GetRunState())
+		}
+	}, 5*time.Second, 50*time.Millisecond)
+
+	// All managers stop simultaneously.
+	var stopWG sync.WaitGroup
+	for i := range numNodes {
+		stopWG.Add(1)
+		go func(i int) {
+			defer stopWG.Done()
+			assert.NoError(t, managers[i].Stop(ctx))
+		}(i)
+	}
+	stopWG.Wait()
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		for i := range numNodes {
+			assert.Contains(c, []BackgroundProcessState{
+				BackgroundProcessStateStopped,
+				BackgroundProcessStateCompleted,
+			}, managers[i].GetRunState())
+		}
+	}, 10*time.Second, 100*time.Millisecond)
+
+	// Once all managers have stopped, ResyncRunning must be false.
+	assertResyncRunningEventually(t, dbStateMgr, false, ctx)
+}
+
+// TestUpdateDatabaseStateResumeOverwritesRunningState exercises a design-level race: a node whose
+// Resume fails (stale cluster state) calls updateDatabaseState(false) and can overwrite the true
+// written by a concurrently running node. This verifies that the system eventually self-corrects via
+// the DatabaseStateMgr polling loop.
+func TestUpdateDatabaseStateResumeOverwritesRunningState(t *testing.T) {
+	testBucket := base.GetTestBucket(t)
+	ctx := base.TestCtx(t)
+	defer testBucket.Close(ctx)
+	metadataStore := testBucket.DefaultDataStore(ctx)
+	metaKeys := base.NewMetadataKeys("test-resume-overwrite")
+
+	// Manager A is the running node.
+	mgrA, dbStateMgr := newTestManagerWithStateDoc(metadataStore, metaKeys, "resume-overwrite", &ResumableMockProcess{})
+	require.NoError(t, mgrA.Start(ctx, nil))
+	defer func() { assert.NoError(t, mgrA.Stop(ctx)) }()
+
+	assertResyncRunningEventually(t, dbStateMgr, true, ctx)
+
+	// Manager B is an observer that has a stale cluster status. We simulate Resume seeing
+	// "not running" by stopping the cluster state doc before B calls Resume.
+	// In practice this can happen when B reads the status doc during a brief window between
+	// an old run completing and a new one starting.
+	mgrB := &BackgroundManager{
+		name:    "test-resume-overwrite-observer",
+		Process: &ResumableMockProcess{},
+		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
+			metadataStore: metadataStore,
+			metaKeys:      base.NewMetadataKeys("test-resume-overwrite-stale"), // different key → no status doc
+			processSuffix: "resume-overwrite-stale",
+			multiNode:     true,
+		},
+		terminator: base.NewSafeTerminator(),
+		updateDatabaseState: func(ctx context.Context, running bool) error {
+			// B's updateDatabaseState writes to the SAME state doc as A.
+			return dbStateMgr.UpdateState(ctx, DatabaseState{ResyncRunning: base.Ptr(running)})
+		},
+	}
+
+	// B's Resume will see no cluster status doc → errBackgroundManagerStatusNotRunning → callUpdateDatabaseState(false).
+	err := mgrB.Resume(ctx)
+	require.ErrorIs(t, err, errBackgroundManagerStatusNotRunning)
+
+	// B wrote false to the shared state doc, even though A is still running.
+	// A's next UpdateStatusClusterAware call must restore true.
+	require.NoError(t, mgrA.UpdateStatusClusterAware(ctx))
+	assertResyncRunningEventually(t, dbStateMgr, true, ctx)
+}
+
+// TestDatabaseStateMgrShouldRunResyncHandlerConcurrentWithUpdateState stress-tests the interaction
+// between ShouldRunResyncHandler (which reads CAS outside the lock) and concurrent UpdateState calls.
+// The test verifies no data races and that the handler fires at least once per logical state change.
+// Run with -race.
+func TestDatabaseStateMgrShouldRunResyncHandlerConcurrentWithUpdateState(t *testing.T) {
+	testBucket := base.GetTestBucket(t)
+	ctx := base.TestCtx(t)
+	defer testBucket.Close(ctx)
+	metadataStore := testBucket.DefaultDataStore(ctx)
+	metaKeys := base.NewMetadataKeys("test-should-run-concurrent")
+	docID := metaKeys.DatabaseStateKey()
+
+	dbStateMgr := NewDatabaseStateMgr(metadataStore, docID, nil)
+
+	var handlerFires atomic.Int32
+
+	const workers = 8
+	const iters = 20
+	var wg sync.WaitGroup
+
+	// Writers: alternate true/false updates.
+	for w := range workers / 2 {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for range iters {
+				running := w%2 == 0
+				_ = dbStateMgr.UpdateState(ctx, DatabaseState{ResyncRunning: base.Ptr(running)})
+			}
+		}(w)
+	}
+
+	// Readers: call ShouldRunResyncHandler, count triggers.
+	for range workers / 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range iters {
+				if ok, state := dbStateMgr.ShouldRunResyncHandler(ctx); ok && state != nil && state.ResyncRunning != nil && *state.ResyncRunning {
+					handlerFires.Add(1)
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// The race detector (run with -race) is the primary assertion here. We also verify that
+	// at least some handler fires occurred, showing the machinery ran.
+	t.Logf("handler fired %d times", handlerFires.Load())
+}
+
+// TestUpdateDatabaseStateConcurrentStartStopWithPoller starts a DatabaseStateMgr polling loop and
+// rapidly starts/stops a BackgroundManager to verify that the poller never incorrectly triggers
+// Resume when the cluster status is not running.
+func TestUpdateDatabaseStateConcurrentStartStopWithPoller(t *testing.T) {
+	testBucket := base.GetTestBucket(t)
+	ctx := base.TestCtx(t)
+	defer testBucket.Close(ctx)
+	metadataStore := testBucket.DefaultDataStore(ctx)
+	metaKeys := base.NewMetadataKeys("test-poller-start-stop")
+
+	var badResumeCalls atomic.Int32
+
+	mgr, dbStateMgr := newTestManagerWithStateDoc(metadataStore, metaKeys, "poller-start-stop", &ResumableMockProcess{})
+
+	// Wire a resumeFunc that records any call where the cluster status is not actually running.
+	// A correct implementation should only call resume when the cluster IS running.
+	dbStateMgr.resumeFunc = func(pollCtx context.Context) error {
+		clusterState, err := mgr.getClusterStatusState(pollCtx)
+		if err != nil || clusterState != BackgroundProcessStateRunning {
+			badResumeCalls.Add(1)
+		}
+		return mgr.Resume(pollCtx)
+	}
+	dbStateMgr.pollingInterval = 10 * time.Millisecond
+	dbStateMgr.StartPolling(ctx)
+	defer dbStateMgr.StopPolling(ctx)
+
+	const cycles = 5
+	for range cycles {
+		require.NoError(t, mgr.Start(ctx, nil))
+		assertResyncRunningEventually(t, dbStateMgr, true, ctx)
+
+		require.NoError(t, mgr.Stop(ctx))
+		assertResyncRunningEventually(t, dbStateMgr, false, ctx)
+
+		// Allow the poller a few ticks to settle.
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// The poller must never have fired Resume when the cluster was not running.
+	require.Zero(t, badResumeCalls.Load(), "Resume was invoked when cluster state was not running")
+}
+func TestBackgroundManagerResumeConcurrentWhileStopping(t *testing.T) {
+	testBucket := base.GetTestBucket(t)
+	ctx := base.TestCtx(t)
+	defer testBucket.Close(ctx)
+	metadataStore := testBucket.DefaultDataStore(ctx)
+	metaKeys := base.NewMetadataKeys("test-resume-race")
+
+	clusterOpts := &ClusterAwareBackgroundManagerOptions{
+		metadataStore: metadataStore,
+		metaKeys:      metaKeys,
+		processSuffix: "resume-race",
+		multiNode:     true,
+	}
+
+	startOptions := map[string]any{"key": "value"}
+
+	// mgr1 is the "originating" node that starts the process and then stops it.
+	mgr1 := &BackgroundManager{
+		name:                "test-resume-race-mgr1",
+		Process:             &ResumableMockProcess{},
+		clusterAwareOptions: clusterOpts,
+		terminator:          base.NewSafeTerminator(),
+	}
+	require.NoError(t, mgr1.Start(ctx, startOptions))
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, BackgroundProcessStateRunning, mgr1.GetRunState())
+	}, 5*time.Second, 100*time.Millisecond)
+
+	// Ensure the running state is persisted to the cluster so that Resume callers can see it.
+	require.NoError(t, mgr1.UpdateStatusClusterAware(ctx))
+
+	const numResumeCallers = 10
+
+	// Build a fleet of managers that will all call Resume concurrently.
+	resumeManagers := make([]*BackgroundManager, numResumeCallers)
+	for i := range numResumeCallers {
+		resumeManagers[i] = &BackgroundManager{
+			name:                fmt.Sprintf("test-resume-race-caller%d", i),
+			Process:             &ResumableMockProcess{},
+			clusterAwareOptions: clusterOpts,
+			terminator:          base.NewSafeTerminator(),
+		}
+	}
+
+	// Use a barrier so all goroutines fire Resume at the same instant that Stop is called.
+	var barrier sync.WaitGroup
+	barrier.Add(numResumeCallers + 1) // +1 for the Stop goroutine
+
+	// resumeErrs receives one result per Resume caller; buffered so goroutines never block.
+	resumeErrs := make(chan error, numResumeCallers)
+
+	var resumeWG sync.WaitGroup
+	for i := range numResumeCallers {
+		resumeWG.Add(1)
+		go func(i int) {
+			defer resumeWG.Done()
+			barrier.Done()
+			barrier.Wait()
+			resumeErrs <- resumeManagers[i].Resume(ctx)
+		}(i)
+	}
+
+	// Stop mgr1 concurrently with the Resume calls.
+	go func() {
+		barrier.Done()
+		barrier.Wait()
+		assert.NoError(t, mgr1.Stop(ctx))
+	}()
+
+	// Wait for all Resume callers to finish before reading their results.
+	resumeWG.Wait()
+	close(resumeErrs)
+
+	// Collect results.
+	var resumeErrors []error
+	for err := range resumeErrs {
+		resumeErrors = append(resumeErrors, err)
+	}
+
+	// Wait for mgr1 to reach a terminal state.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Contains(c, []BackgroundProcessState{
+			BackgroundProcessStateStopped,
+			BackgroundProcessStateCompleted,
+		}, mgr1.GetRunState())
+	}, 10*time.Second, 100*time.Millisecond)
+
+	// Stop any resume callers that managed to start running.
+	for i := range numResumeCallers {
+		if resumeErrors[i] == nil {
+			// Resume succeeded → process may be running; stop it.
+			_ = resumeManagers[i].Stop(ctx)
+		}
+	}
+
+	// Wait for all resume callers that started to reach a terminal state.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		for i := range numResumeCallers {
+			if resumeErrors[i] != nil {
+				// Resume returned an error — no goroutine running, nothing to wait for.
+				continue
+			}
+			state := resumeManagers[i].GetRunState()
+			assert.Contains(c, []BackgroundProcessState{
+				BackgroundProcessStateStopped,
+				BackgroundProcessStateCompleted,
+			}, state, "mgr %d should be in terminal state", i)
+		}
+	}, 10*time.Second, 100*time.Millisecond)
 }

--- a/db/background_mgr_test.go
+++ b/db/background_mgr_test.go
@@ -716,6 +716,7 @@ func TestBackgroundManagerUpdateDatabaseStateRunning(t *testing.T) {
 			metadataStore: metadataStore,
 			metaKeys:      metaKeys,
 			processSuffix: "update-db-state-running",
+			multiNode:     true,
 		},
 		terminator: base.NewSafeTerminator(),
 		updateDatabaseState: func(_ context.Context, running bool) error {
@@ -757,6 +758,7 @@ func TestBackgroundManagerUpdateDatabaseStateOnCompletion(t *testing.T) {
 			metadataStore: metadataStore,
 			metaKeys:      metaKeys,
 			processSuffix: "update-db-state-done",
+			multiNode:     true,
 		},
 		terminator: base.NewSafeTerminator(),
 		updateDatabaseState: func(_ context.Context, running bool) error {

--- a/db/background_mgr_test.go
+++ b/db/background_mgr_test.go
@@ -675,7 +675,10 @@ func TestBackgroundManagerResumeWhenNotRunning(t *testing.T) {
 		clusterAwareOptions: clusterOpts,
 		terminator:          base.NewSafeTerminator(),
 	}
-	require.ErrorIs(t, mgr2.Resume(ctx), errBackgroundManagerStatusNotRunning)
+	require.NoError(t, mgr2.Resume(ctx))
+	mgr2State, err := mgr2.getClusterStatusState(ctx)
+	require.NoError(t, err)
+	require.Equal(t, mgr.GetRunState(), mgr2State)
 }
 
 // TestBackgroundManagerResumeLocalModeError verifies that Resume returns an error for a local-mode manager
@@ -878,7 +881,7 @@ func TestBackgroundManagerResumeCallsUpdateDatabaseStateWhenStopped(t *testing.T
 	}
 
 	err := observer.Resume(ctx)
-	require.ErrorIs(t, err, errBackgroundManagerStatusNotRunning)
+	require.NoError(t, err)
 
 	mu.Lock()
 	calls := make([]bool, len(dbStateCalls))
@@ -1105,11 +1108,11 @@ func TestUpdateDatabaseStateResumeOverwritesRunningState(t *testing.T) {
 	assertResyncRunningEventually(t, dbStateMgr, true, ctx)
 }
 
-// TestDatabaseStateMgrShouldRunResyncHandlerConcurrentWithUpdateState stress-tests the interaction
-// between ShouldRunResyncHandler (which reads CAS outside the lock) and concurrent UpdateState calls.
+// TestDatabaseStateMgrIsUpdatedConcurrentWithUpdateState stress-tests the interaction between
+// isUpdated (which reads CAS outside the lock) and concurrent UpdateState calls.
 // The test verifies no data races and that the handler fires at least once per logical state change.
 // Run with -race.
-func TestDatabaseStateMgrShouldRunResyncHandlerConcurrentWithUpdateState(t *testing.T) {
+func TestDatabaseStateMgrIsUpdatedConcurrentWithUpdateState(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	ctx := base.TestCtx(t)
 	defer testBucket.Close(ctx)
@@ -1137,14 +1140,19 @@ func TestDatabaseStateMgrShouldRunResyncHandlerConcurrentWithUpdateState(t *test
 		}(w)
 	}
 
-	// Readers: call ShouldRunResyncHandler, count triggers.
+	// Readers: call isUpdated and advance CAS on detection, mirroring what poll does.
 	for range workers / 2 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			for range iters {
-				if ok, state := dbStateMgr.ShouldRunResyncHandler(ctx); ok && state != nil && state.ResyncRunning != nil && *state.ResyncRunning {
-					handlerFires.Add(1)
+				if newCAS, state, ok := dbStateMgr.isUpdated(ctx); ok {
+					if state != nil && state.ResyncRunning != nil && *state.ResyncRunning {
+						handlerFires.Add(1)
+					}
+					dbStateMgr.lock.Lock()
+					dbStateMgr.CAS = newCAS
+					dbStateMgr.lock.Unlock()
 				}
 			}
 		}()
@@ -1171,9 +1179,9 @@ func TestUpdateDatabaseStateConcurrentStartStopWithPoller(t *testing.T) {
 
 	mgr, dbStateMgr := newTestManagerWithStateDoc(metadataStore, metaKeys, "poller-start-stop", &ResumableMockProcess{})
 
-	// Wire a resumeFunc that records any call where the cluster status is not actually running.
+	// Wire a resumeResyncFunc that records any call where the cluster status is not actually running.
 	// A correct implementation should only call resume when the cluster IS running.
-	dbStateMgr.resumeFunc = func(pollCtx context.Context) error {
+	dbStateMgr.resumeResyncFunc = func(pollCtx context.Context) error {
 		clusterState, err := mgr.getClusterStatusState(pollCtx)
 		if err != nil || clusterState != BackgroundProcessStateRunning {
 			badResumeCalls.Add(1)
@@ -1273,10 +1281,12 @@ func TestBackgroundManagerResumeConcurrentWhileStopping(t *testing.T) {
 
 	// Wait for mgr1 to reach a terminal state.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		state, err := mgr1.getClusterStatusState(ctx)
+		require.NoError(c, err)
 		assert.Contains(c, []BackgroundProcessState{
 			BackgroundProcessStateStopped,
 			BackgroundProcessStateCompleted,
-		}, mgr1.GetRunState())
+		}, state)
 	}, 10*time.Second, 100*time.Millisecond)
 
 	// Stop any resume callers that managed to start running.

--- a/db/background_mgr_test.go
+++ b/db/background_mgr_test.go
@@ -1167,48 +1167,6 @@ func TestDatabaseStateMgrIsUpdatedConcurrentWithUpdateState(t *testing.T) {
 	t.Logf("handler fired %d times", handlerFires.Load())
 }
 
-// TestUpdateDatabaseStateConcurrentStartStopWithPoller starts a DatabaseStateMgr polling loop and
-// rapidly starts/stops a BackgroundManager to verify that the poller never incorrectly triggers
-// Resume when the cluster status is not running.
-func TestUpdateDatabaseStateConcurrentStartStopWithPoller(t *testing.T) {
-	testBucket := base.GetTestBucket(t)
-	ctx := base.TestCtx(t)
-	defer testBucket.Close(ctx)
-	metadataStore := testBucket.DefaultDataStore(ctx)
-	metaKeys := base.NewMetadataKeys("test-poller-start-stop")
-
-	var badResumeCalls atomic.Int32
-
-	mgr, dbStateMgr := newTestManagerWithStateDoc(metadataStore, metaKeys, "poller-start-stop", &ResumableMockProcess{})
-
-	// Wire a resumeResyncFunc that records any call where the cluster status is not actually running.
-	// A correct implementation should only call resume when the cluster IS running.
-	dbStateMgr.resumeResyncFunc = func(pollCtx context.Context) error {
-		clusterState, err := mgr.getClusterStatusState(pollCtx)
-		if err != nil || clusterState != BackgroundProcessStateRunning {
-			badResumeCalls.Add(1)
-		}
-		return mgr.Resume(pollCtx)
-	}
-	dbStateMgr.pollingInterval = 10 * time.Millisecond
-	dbStateMgr.StartPolling(ctx)
-	defer dbStateMgr.StopPolling(ctx)
-
-	const cycles = 5
-	for range cycles {
-		require.NoError(t, mgr.Start(ctx, nil))
-		assertResyncRunningEventually(t, dbStateMgr, true, ctx)
-
-		require.NoError(t, mgr.Stop(ctx))
-		assertResyncRunningEventually(t, dbStateMgr, false, ctx)
-
-		// Allow the poller a few ticks to settle.
-		time.Sleep(50 * time.Millisecond)
-	}
-
-	// The poller must never have fired Resume when the cluster was not running.
-	require.Zero(t, badResumeCalls.Load(), "Resume was invoked when cluster state was not running")
-}
 func TestBackgroundManagerResumeConcurrentWhileStopping(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	ctx := base.TestCtx(t)

--- a/db/background_mgr_test.go
+++ b/db/background_mgr_test.go
@@ -1247,8 +1247,8 @@ func TestBackgroundManagerResumeConcurrentWhileStopping(t *testing.T) {
 	var barrier sync.WaitGroup
 	barrier.Add(numResumeCallers + 1) // +1 for the Stop goroutine
 
-	// resumeErrs receives one result per Resume caller; buffered so goroutines never block.
-	resumeErrs := make(chan error, numResumeCallers)
+	// resumeErrors[i] holds the error returned by resumeManagers[i].Resume.
+	resumeErrors := make([]error, numResumeCallers)
 
 	var resumeWG sync.WaitGroup
 	for i := range numResumeCallers {
@@ -1257,7 +1257,7 @@ func TestBackgroundManagerResumeConcurrentWhileStopping(t *testing.T) {
 			defer resumeWG.Done()
 			barrier.Done()
 			barrier.Wait()
-			resumeErrs <- resumeManagers[i].Resume(ctx)
+			resumeErrors[i] = resumeManagers[i].Resume(ctx)
 		}(i)
 	}
 
@@ -1270,13 +1270,6 @@ func TestBackgroundManagerResumeConcurrentWhileStopping(t *testing.T) {
 
 	// Wait for all Resume callers to finish before reading their results.
 	resumeWG.Wait()
-	close(resumeErrs)
-
-	// Collect results.
-	var resumeErrors []error
-	for err := range resumeErrs {
-		resumeErrors = append(resumeErrors, err)
-	}
 
 	// Wait for mgr1 to reach a terminal state.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {

--- a/db/background_mgr_test.go
+++ b/db/background_mgr_test.go
@@ -1307,6 +1307,11 @@ func TestBackgroundManagerResumeConcurrentWhileStopping(t *testing.T) {
 				continue
 			}
 			state := resumeManagers[i].GetRunState()
+			if state == "" {
+				// Resume returned nil but the process never started: the cluster transitioned
+				// out of "running" before this node called start(). Nothing to wait for.
+				continue
+			}
 			assert.Contains(c, []BackgroundProcessState{
 				BackgroundProcessStateStopped,
 				BackgroundProcessStateCompleted,

--- a/db/database.go
+++ b/db/database.go
@@ -627,7 +627,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 	dbContext.ResyncManager = NewResyncManagerDCP(metadataStore, metaKeys, dbContext)
 	dbContext.AsyncIndexInitManager = NewAsyncIndexInitManager(metadataStore, dbContext.MetadataKeys)
 
-	dbContext.DBStateManager = NewDatabaseStateMgr(metadataStore, metaKeys.DatabaseStateKey())
+	dbContext.DBStateManager = NewDatabaseStateMgr(metadataStore, metaKeys.DatabaseStateKey(), dbContext.ResyncManager.Resume)
 
 	return dbContext, nil
 }
@@ -2707,8 +2707,6 @@ func (db *DatabaseContext) NumVBuckets() uint16 {
 // while it is offline. The polling mechanism watches the metadata store for updates to the database state
 // document and invokes registered handlers when changes are detected.
 func (db *DatabaseContext) InitializeOfflineMode() {
-	// TODO: Add the appropriate handler function to handle this - CBG-5183
-	db.DBStateManager.SetResyncFunc(TempResyncHandler)
 	db.DBStateManager.StartPolling(db.CancelContext)
 }
 

--- a/db/database.go
+++ b/db/database.go
@@ -624,7 +624,8 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 		return nil, err
 	}
 
-	dbContext.ResyncManager = NewResyncManagerDCP(metadataStore, metaKeys, dbContext)
+	distributedResync := false // when ready, this will flip to  db.useShardedDCP()
+	dbContext.ResyncManager = NewResyncManagerDCP(dbContext, distributedResync)
 	dbContext.AsyncIndexInitManager = NewAsyncIndexInitManager(metadataStore, dbContext.MetadataKeys)
 
 	dbContext.DBStateManager = NewDatabaseStateMgr(metadataStore, metaKeys.DatabaseStateKey(), dbContext.ResyncManager.Resume)

--- a/db/database_state.go
+++ b/db/database_state.go
@@ -22,25 +22,25 @@ type DatabaseState struct {
 }
 
 type DatabaseStateMgr struct {
-	CAS             uint64
-	dbStateID       string
-	metadataStore   base.DataStore
-	pollingInterval time.Duration
-	resumeFunc      func(ctx context.Context) error
-	lock            sync.Mutex
-	terminator      chan struct{}
-	done            chan struct{}
+	CAS              uint64
+	dbStateID        string
+	metadataStore    base.DataStore
+	pollingInterval  time.Duration
+	resumeResyncFunc func(ctx context.Context) error
+	lock             sync.Mutex
+	terminator       chan struct{}
+	done             chan struct{}
 }
 
-// NewDatabaseStateMgr creates a DatabaseStateMgr for the given database. resumeFunc is called by the polling loop
+// NewDatabaseStateMgr creates a DatabaseStateMgr for the given database. resumeResyncFunc is called by the polling loop
 // when a state change is detected with ResyncRunning set to true; it should resume the resync process.
-func NewDatabaseStateMgr(metadataStore base.DataStore, dbStateID string, resumeFunc func(ctx context.Context) error) *DatabaseStateMgr {
+func NewDatabaseStateMgr(metadataStore base.DataStore, dbStateID string, resumeResyncFunc func(ctx context.Context) error) *DatabaseStateMgr {
 	return &DatabaseStateMgr{
-		dbStateID:       dbStateID,
-		CAS:             0,
-		metadataStore:   metadataStore,
-		pollingInterval: 10 * time.Second,
-		resumeFunc:      resumeFunc,
+		dbStateID:        dbStateID,
+		CAS:              0,
+		metadataStore:    metadataStore,
+		pollingInterval:  10 * time.Second,
+		resumeResyncFunc: resumeResyncFunc,
 	}
 }
 
@@ -112,41 +112,45 @@ func (dbMgr *DatabaseStateMgr) StartPolling(ctx context.Context) {
 	}()
 }
 
-// poll checks whether the resync handler should be invoked and, if so, calls it.
-// It delegates the state-change decision to ShouldRunResyncHandler.
+// poll checks whether the state document has been updated and, if ResyncRunning is true, invokes
+// resumeResyncFunc. The locally held CAS is only advanced after resumeResyncFunc succeeds (or when no handler
+// action is required), so a transient resumeResyncFunc error leaves the CAS stale and the next tick retries.
 func (dbMgr *DatabaseStateMgr) poll(ctx context.Context) {
-	if ok, state := dbMgr.ShouldRunResyncHandler(ctx); ok {
-		if state.ResyncRunning != nil && *state.ResyncRunning {
-			if err := dbMgr.resumeFunc(ctx); err != nil && !errors.Is(err, errBackgroundManagerStatusNotRunning) {
-				base.WarnfCtx(ctx, "failed to resume resync: %v", err)
-			}
+	newCAS, state, ok := dbMgr.isUpdated(ctx)
+	if !ok {
+		return
+	}
+	if state.ResyncRunning != nil && *state.ResyncRunning {
+		err := dbMgr.resumeResyncFunc(ctx)
+		if err != nil {
+			base.WarnfCtx(ctx, "failed to resume resync from DatabaseStateMgr: %v, will try again.", err)
+			return // leave CAS stale so next tick retries
 		}
 	}
-}
-
-// ShouldRunResyncHandler reads the current state document and determines whether the resync handler
-// should be invoked. It returns (true, state) when the store CAS differs from the locally held CAS
-// and ResyncRunning is non-nil. It returns (false, nil) when the CAS is unchanged, the document is
-// not found, or ResyncRunning is nil. On any other store error it logs a warning and returns (false, nil).
-// When a CAS change is detected the locally held CAS is updated regardless of whether the handler fires.
-func (dbMgr *DatabaseStateMgr) ShouldRunResyncHandler(ctx context.Context) (bool, *DatabaseState) {
-	state, cas, err := dbMgr.GetState(ctx)
 	dbMgr.lock.Lock()
 	defer dbMgr.lock.Unlock()
+	dbMgr.CAS = newCAS
+}
+
+// isUpdated reads the current state document and reports whether it has changed since the last
+// successful poll. It returns (newCAS, state, true) when the store CAS differs from the locally
+// held CAS, or (0, nil, false) when the CAS is unchanged, the document is not found, or a store
+// error occurs. The locally held CAS is never modified here; callers are responsible for advancing
+// it after they have successfully acted on the change.
+func (dbMgr *DatabaseStateMgr) isUpdated(ctx context.Context) (uint64, *DatabaseState, bool) {
+	state, cas, err := dbMgr.GetState(ctx)
 	if err != nil {
 		if !base.IsDocNotFoundError(err) {
 			base.WarnfCtx(ctx, "error while polling for offline database state: %v", err)
 		}
-		return false, nil
+		return 0, nil, false
 	}
+	dbMgr.lock.Lock()
+	defer dbMgr.lock.Unlock()
 	if cas == dbMgr.CAS {
-		return false, nil
+		return 0, nil, false
 	}
-	dbMgr.CAS = cas
-	if state.ResyncRunning == nil {
-		return false, nil
-	}
-	return true, state
+	return cas, state, true
 }
 
 // StopPolling signals the background polling goroutine started by StartPolling to exit.

--- a/db/database_state.go
+++ b/db/database_state.go
@@ -10,6 +10,7 @@ package db
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -20,30 +21,26 @@ type DatabaseState struct {
 	ResyncRunning *bool `json:"resync,omitempty"`
 }
 
-type ResyncHandler func(resume bool)
-
-func TempResyncHandler(resume bool) {
-	return
-}
-
 type DatabaseStateMgr struct {
 	CAS             uint64
 	dbStateID       string
 	metadataStore   base.DataStore
 	pollingInterval time.Duration
-	resyncHandler   ResyncHandler
+	resumeFunc      func(ctx context.Context) error
 	lock            sync.Mutex
 	terminator      chan struct{}
 	done            chan struct{}
 }
 
-// NewDatabaseStateMgr creates an OfflineDatabaseStateMgr for the given database.
-func NewDatabaseStateMgr(metadataStore base.DataStore, dbStateID string) *DatabaseStateMgr {
+// NewDatabaseStateMgr creates a DatabaseStateMgr for the given database. resumeFunc is called by the polling loop
+// when a state change is detected with ResyncRunning set to true; it should resume the resync process.
+func NewDatabaseStateMgr(metadataStore base.DataStore, dbStateID string, resumeFunc func(ctx context.Context) error) *DatabaseStateMgr {
 	return &DatabaseStateMgr{
 		dbStateID:       dbStateID,
 		CAS:             0,
 		metadataStore:   metadataStore,
 		pollingInterval: 10 * time.Second,
+		resumeFunc:      resumeFunc,
 	}
 }
 
@@ -61,6 +58,9 @@ func (dbMgr *DatabaseStateMgr) UpdateState(ctx context.Context, newState Databas
 			}
 		}
 		if newState.ResyncRunning != nil {
+			if state.ResyncRunning != nil && *state.ResyncRunning == *newState.ResyncRunning {
+				return nil, nil, false, base.ErrUpdateCancel
+			}
 			state.ResyncRunning = newState.ResyncRunning
 		}
 		bodyBytes, err := base.JSONMarshal(state)
@@ -69,6 +69,9 @@ func (dbMgr *DatabaseStateMgr) UpdateState(ctx context.Context, newState Databas
 		}
 		return bodyBytes, nil, false, nil
 	})
+	if errors.Is(err, base.ErrUpdateCancel) {
+		return nil
+	}
 	if err != nil {
 		return err
 	}
@@ -88,15 +91,8 @@ func (dbMgr *DatabaseStateMgr) GetState(ctx context.Context) (*DatabaseState, ui
 	return &state, cas, nil
 }
 
-// SetResyncFunc registers the callback that is invoked by the polling loop when a state change is detected.
-// The callback receives true if a resync should resume, or false if the state document was removed (resync complete).
-func (dbMgr *DatabaseStateMgr) SetResyncFunc(resyncFunc ResyncHandler) {
-	dbMgr.resyncHandler = resyncFunc
-}
-
 // StartPolling launches a background goroutine that periodically calls poll() at dbMgr.pollingInterval.
-// The goroutine exits when StopPolling is called (via the terminator). SetResyncFunc must be called before
-// StartPolling so that state change notifications have a registered handler.
+// The goroutine exits when StopPolling is called (via the terminator).
 func (dbMgr *DatabaseStateMgr) StartPolling(ctx context.Context) {
 	dbMgr.terminator = make(chan struct{})
 	dbMgr.done = make(chan struct{})
@@ -116,12 +112,14 @@ func (dbMgr *DatabaseStateMgr) StartPolling(ctx context.Context) {
 	}()
 }
 
-// poll checks whether the resync handler should be invoked and, if so, calls it with the current
-// ResyncRunning value. It delegates the state-change decision to ShouldRunResyncHandler.
+// poll checks whether the resync handler should be invoked and, if so, calls it.
+// It delegates the state-change decision to ShouldRunResyncHandler.
 func (dbMgr *DatabaseStateMgr) poll(ctx context.Context) {
 	if ok, state := dbMgr.ShouldRunResyncHandler(ctx); ok {
-		if state.ResyncRunning != nil {
-			dbMgr.resyncHandler(*state.ResyncRunning)
+		if state.ResyncRunning != nil && *state.ResyncRunning {
+			if err := dbMgr.resumeFunc(ctx); err != nil && !errors.Is(err, errBackgroundManagerStatusNotRunning) {
+				base.WarnfCtx(ctx, "failed to resume resync: %v", err)
+			}
 		}
 	}
 }

--- a/db/database_state_test.go
+++ b/db/database_state_test.go
@@ -9,6 +9,7 @@
 package db
 
 import (
+	"context"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -27,7 +28,7 @@ func TestDatabaseStateUpdate(t *testing.T) {
 
 	t.Run("persists state and updates in-memory CAS", func(t *testing.T) {
 		docID := base.NewMetadataKeys(t.Name()).DatabaseStateKey()
-		mgr := NewDatabaseStateMgr(metadataStore, docID)
+		mgr := NewDatabaseStateMgr(metadataStore, docID, nil)
 		require.NoError(t, mgr.UpdateState(ctx, DatabaseState{ResyncRunning: base.Ptr(true)}))
 		require.NotZero(t, mgr.CAS)
 
@@ -37,9 +38,28 @@ func TestDatabaseStateUpdate(t *testing.T) {
 		require.Equal(t, mgr.CAS, storeCAS)
 	})
 
+	t.Run("no-op when resulting state is unchanged", func(t *testing.T) {
+		docID := base.NewMetadataKeys(t.Name()).DatabaseStateKey()
+		mgr := NewDatabaseStateMgr(metadataStore, docID, nil)
+
+		// Write the initial state and capture the resulting CAS.
+		require.NoError(t, mgr.UpdateState(ctx, DatabaseState{ResyncRunning: base.Ptr(true)}))
+		casBefore := mgr.CAS
+		require.NotZero(t, casBefore)
+
+		// Calling UpdateState with the same value should be a no-op: no write occurs,
+		// so neither the in-memory CAS nor the store CAS should change.
+		require.NoError(t, mgr.UpdateState(ctx, DatabaseState{ResyncRunning: base.Ptr(true)}))
+		require.Equal(t, casBefore, mgr.CAS, "CAS should not change on a no-op update")
+
+		_, storeCAS, err := mgr.GetState(ctx)
+		require.NoError(t, err)
+		require.Equal(t, casBefore, storeCAS, "store CAS should not change on a no-op update")
+	})
+
 	t.Run("returns no error on stale CAS", func(t *testing.T) {
 		docID := base.NewMetadataKeys(t.Name()).DatabaseStateKey()
-		mgr := NewDatabaseStateMgr(metadataStore, docID)
+		mgr := NewDatabaseStateMgr(metadataStore, docID, nil)
 		require.NoError(t, mgr.UpdateState(ctx, DatabaseState{ResyncRunning: base.Ptr(true)}))
 		mgr.CAS = 0 // force stale CAS
 		require.NoError(t, mgr.UpdateState(ctx, DatabaseState{ResyncRunning: base.Ptr(true)}))
@@ -56,7 +76,7 @@ func TestGetState(t *testing.T) {
 
 	t.Run("returns zero-value state when doc not found", func(t *testing.T) {
 		docID := base.NewMetadataKeys(t.Name()).DatabaseStateKey()
-		mgr := NewDatabaseStateMgr(metadataStore, docID)
+		mgr := NewDatabaseStateMgr(metadataStore, docID, nil)
 		state, cas, err := mgr.GetState(ctx)
 		require.Error(t, err)
 		require.True(t, base.IsDocNotFoundError(err))
@@ -66,7 +86,7 @@ func TestGetState(t *testing.T) {
 
 	t.Run("returns persisted state and CAS", func(t *testing.T) {
 		docID := base.NewMetadataKeys(t.Name()).DatabaseStateKey()
-		mgr := NewDatabaseStateMgr(metadataStore, docID)
+		mgr := NewDatabaseStateMgr(metadataStore, docID, nil)
 		require.NoError(t, mgr.UpdateState(ctx, DatabaseState{ResyncRunning: base.Ptr(true)}))
 		state, cas, err := mgr.GetState(ctx)
 		require.NoError(t, err)
@@ -75,8 +95,8 @@ func TestGetState(t *testing.T) {
 	})
 }
 
-// TestDatabaseStateMgrPolling verifies SetResyncFunc, StartPolling and StopPolling behaviour:
-// the registered callback is invoked with the correct resume value on CAS changes or doc-not-found, skipped
+// TestDatabaseStateMgrPolling verifies StartPolling and StopPolling behaviour:
+// the registered resumeFunc is invoked on CAS changes when ResyncRunning is true, skipped
 // when the CAS is unchanged, and driven automatically by the polling goroutine.
 func TestDatabaseStateMgrPolling(t *testing.T) {
 	ctx := base.TestCtx(t)
@@ -84,36 +104,35 @@ func TestDatabaseStateMgrPolling(t *testing.T) {
 	defer tBucket.Close(ctx)
 	metadataStore := tBucket.GetMetadataStore()
 
-	t.Run("callback invoked with true when doc exists and CAS changed", func(t *testing.T) {
+	t.Run("resumeFunc invoked when doc exists and CAS changed", func(t *testing.T) {
 		docID := base.NewMetadataKeys(t.Name()).DatabaseStateKey()
-		mgr := NewDatabaseStateMgr(metadataStore, docID)
+		var callCount atomic.Int32
+		mgr := NewDatabaseStateMgr(metadataStore, docID, func(_ context.Context) error {
+			callCount.Add(1)
+			return nil
+		})
 		mgr.pollingInterval = 10 * time.Millisecond
 		require.NoError(t, mgr.UpdateState(ctx, DatabaseState{ResyncRunning: base.Ptr(true)}))
 		mgr.CAS = 0 // simulate stale CAS so the poller sees a change
 
-		var callCount atomic.Int32
-		var resumeVal atomic.Bool
-		mgr.SetResyncFunc(func(resume bool) {
-			callCount.Add(1)
-			resumeVal.Store(resume)
-		})
 		mgr.StartPolling(ctx)
 		defer mgr.StopPolling(ctx)
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			assert.Equal(c, int32(1), callCount.Load())
-			assert.True(c, resumeVal.Load())
 		}, 2*time.Second, 10*time.Millisecond)
 	})
 
 	t.Run("no callback when CAS unchanged", func(t *testing.T) {
 		docID := base.NewMetadataKeys(t.Name()).DatabaseStateKey()
-		mgr := NewDatabaseStateMgr(metadataStore, docID)
+		var callCount atomic.Int32
+		mgr := NewDatabaseStateMgr(metadataStore, docID, func(_ context.Context) error {
+			callCount.Add(1)
+			return nil
+		})
 		mgr.pollingInterval = 10 * time.Millisecond
 		require.NoError(t, mgr.UpdateState(ctx, DatabaseState{ResyncRunning: base.Ptr(true)}))
 
-		var callCount atomic.Int32
-		mgr.SetResyncFunc(func(_ bool) { callCount.Add(1) })
 		mgr.StartPolling(ctx)
 
 		time.Sleep(50 * time.Millisecond)
@@ -123,27 +142,26 @@ func TestDatabaseStateMgrPolling(t *testing.T) {
 
 	t.Run("StopPolling halts the goroutine", func(t *testing.T) {
 		docID := base.NewMetadataKeys(t.Name()).DatabaseStateKey()
-		mgr := NewDatabaseStateMgr(metadataStore, docID)
-		mgr.pollingInterval = 10 * time.Millisecond
 
-		// Register a callback that forwards the resume value to a buffered channel.
+		// Register a resumeFunc that signals a channel on each call.
 		// The select/default prevents blocking if the channel is already full.
-		called := make(chan bool, 1)
+		called := make(chan struct{}, 1)
 		var callCount atomic.Int32
-		mgr.SetResyncFunc(func(resume bool) {
+		mgr := NewDatabaseStateMgr(metadataStore, docID, func(_ context.Context) error {
 			callCount.Add(1)
 			select {
-			case called <- resume:
-				return
+			case called <- struct{}{}:
 			default:
 			}
+			return nil
 		})
+		mgr.pollingInterval = 10 * time.Millisecond
 
 		// Start the polling goroutine.
 		mgr.StartPolling(ctx)
 
 		// Write a state document directly via the datastore (bypassing mgr.CAS) so that
-		// the poller sees a CAS mismatch and invokes the callback.
+		// the poller sees a CAS mismatch and invokes the resumeFunc.
 		_, err := metadataStore.Update(ctx, docID, 0, func(current []byte) (updated []byte, expiry *uint32, delete bool, err error) {
 			bodyBytes, err := base.JSONMarshal(DatabaseState{ResyncRunning: base.Ptr(true)})
 			if err != nil {
@@ -153,15 +171,16 @@ func TestDatabaseStateMgrPolling(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		// Confirm the goroutine is running by waiting for the callback to fire.
+		// Confirm the goroutine is running by waiting for the resumeFunc to fire.
 		base.RequireChanRecvWithTimeout(t, called, 2*time.Second)
 		require.Equal(t, int32(1), callCount.Load(), "expected exactly one callback before stopping")
 
 		// Stop the polling goroutine.
 		mgr.StopPolling(ctx)
 
-		// Write a new state change directly to the store. If the goroutine were still
-		// running it would detect the CAS mismatch and fire the callback again.
+		// Write a new state change (ResyncRunning=false) directly to the store. The goroutine
+		// must not invoke resumeFunc because ResyncRunning is false, and it must not run at all
+		// because the poller has been stopped.
 		_, err = metadataStore.Update(ctx, docID, 0, func(current []byte) (updated []byte, expiry *uint32, delete bool, err error) {
 			bodyBytes, err := base.JSONMarshal(DatabaseState{ResyncRunning: base.Ptr(false)})
 			if err != nil {

--- a/db/database_state_test.go
+++ b/db/database_state_test.go
@@ -10,6 +10,7 @@ package db
 
 import (
 	"context"
+	"errors"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -96,7 +97,7 @@ func TestGetState(t *testing.T) {
 }
 
 // TestDatabaseStateMgrPolling verifies StartPolling and StopPolling behaviour:
-// the registered resumeFunc is invoked on CAS changes when ResyncRunning is true, skipped
+// the registered resumeResyncFunc is invoked on CAS changes when ResyncRunning is true, skipped
 // when the CAS is unchanged, and driven automatically by the polling goroutine.
 func TestDatabaseStateMgrPolling(t *testing.T) {
 	ctx := base.TestCtx(t)
@@ -104,7 +105,7 @@ func TestDatabaseStateMgrPolling(t *testing.T) {
 	defer tBucket.Close(ctx)
 	metadataStore := tBucket.GetMetadataStore()
 
-	t.Run("resumeFunc invoked when doc exists and CAS changed", func(t *testing.T) {
+	t.Run("resumeResyncFunc invoked when doc exists and CAS changed", func(t *testing.T) {
 		docID := base.NewMetadataKeys(t.Name()).DatabaseStateKey()
 		var callCount atomic.Int32
 		mgr := NewDatabaseStateMgr(metadataStore, docID, func(_ context.Context) error {
@@ -140,10 +141,35 @@ func TestDatabaseStateMgrPolling(t *testing.T) {
 		require.Equal(t, int32(0), callCount.Load())
 	})
 
+	t.Run("retries resumeResyncFunc after transient error", func(t *testing.T) {
+		// Regression: when resumeResyncFunc returns an error the CAS must be reset so
+		// the next polling tick sees a mismatch and retries, rather than treating
+		// the state change as already handled.
+		docID := base.NewMetadataKeys(t.Name()).DatabaseStateKey()
+		var callCount atomic.Int32
+		mgr := NewDatabaseStateMgr(metadataStore, docID, func(_ context.Context) error {
+			if callCount.Add(1) == 1 {
+				return errors.New("transient error")
+			}
+			return nil
+		})
+		mgr.pollingInterval = 10 * time.Millisecond
+		require.NoError(t, mgr.UpdateState(ctx, DatabaseState{ResyncRunning: base.Ptr(true)}))
+		mgr.CAS = 0 // simulate stale CAS so the poller sees a change on first tick
+
+		mgr.StartPolling(ctx)
+		defer mgr.StopPolling(ctx)
+
+		// The first call returns an error; the poller must retry and reach a second call.
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.GreaterOrEqual(c, callCount.Load(), int32(2))
+		}, 2*time.Second, 10*time.Millisecond)
+	})
+
 	t.Run("StopPolling halts the goroutine", func(t *testing.T) {
 		docID := base.NewMetadataKeys(t.Name()).DatabaseStateKey()
 
-		// Register a resumeFunc that signals a channel on each call.
+		// Register a resumeResyncFunc that signals a channel on each call.
 		// The select/default prevents blocking if the channel is already full.
 		called := make(chan struct{}, 1)
 		var callCount atomic.Int32
@@ -161,7 +187,7 @@ func TestDatabaseStateMgrPolling(t *testing.T) {
 		mgr.StartPolling(ctx)
 
 		// Write a state document directly via the datastore (bypassing mgr.CAS) so that
-		// the poller sees a CAS mismatch and invokes the resumeFunc.
+		// the poller sees a CAS mismatch and invokes the resumeResyncFunc.
 		_, err := metadataStore.Update(ctx, docID, 0, func(current []byte) (updated []byte, expiry *uint32, delete bool, err error) {
 			bodyBytes, err := base.JSONMarshal(DatabaseState{ResyncRunning: base.Ptr(true)})
 			if err != nil {
@@ -171,7 +197,7 @@ func TestDatabaseStateMgrPolling(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		// Confirm the goroutine is running by waiting for the resumeFunc to fire.
+		// Confirm the goroutine is running by waiting for the resumeResyncFunc to fire.
 		base.RequireChanRecvWithTimeout(t, called, 2*time.Second)
 		require.Equal(t, int32(1), callCount.Load(), "expected exactly one callback before stopping")
 
@@ -179,7 +205,7 @@ func TestDatabaseStateMgrPolling(t *testing.T) {
 		mgr.StopPolling(ctx)
 
 		// Write a new state change (ResyncRunning=false) directly to the store. The goroutine
-		// must not invoke resumeFunc because ResyncRunning is false, and it must not run at all
+		// must not invoke resumeResyncFunc because ResyncRunning is false, and it must not run at all
 		// because the poller has been stopped.
 		_, err = metadataStore.Update(ctx, docID, 0, func(current []byte) (updated []byte, expiry *uint32, delete bool, err error) {
 			bodyBytes, err := base.JSONMarshal(DatabaseState{ResyncRunning: base.Ptr(false)})

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -543,10 +543,11 @@ func (rt *RestTester) WaitForDBInitializationCompleted(dbName string) {
 // SetDistributedResync forces the ResyncManager into a single node or distributed resync mode. This should only be called before
 // resync is run for the first time and needs to be called each time a DatabaseContext is reinitialized.
 func (rt *RestTester) SetDistributedResync(useDistributed bool) {
-	rs, ok := rt.GetDatabase().ResyncManager.Process.(*db.ResyncManagerDCP)
+	database := rt.GetDatabase()
+	rs, ok := database.ResyncManager.Process.(*db.ResyncManagerDCP)
 	require.True(rt.TB(), ok)
 	if useDistributed {
-		rs.Distributed = true
+		rt.GetDatabase().ResyncManager = db.NewResyncManagerDCP(database, true)
 	} else {
 		require.False(rt.TB(), rs.Distributed, "Expected this database ResyncManager to be in non distributed mode")
 	}


### PR DESCRIPTION
CBG-5183 resync: integrate background manager and database state
## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/734/
