### PR TITLE
CBG-5345: Remove major and minor versions from checkpoint names

### DIFF
--- a/db/attachment_compaction.go
+++ b/db/attachment_compaction.go
@@ -583,9 +583,8 @@ func getCompactionDCPClientOptions(db *Database, compactionID string, collection
 // compaction.
 func GetAttachmentCompactionDCPCheckpointPrefix(db *DatabaseContext, compactionID string, phase attachmentCompactionPhase) string {
 	return fmt.Sprintf(
-		"%s:sg-%v:att_compaction:%v_%v",
+		"%s:sg:att_compaction:%v_%v",
 		db.MetadataKeys.DCPCheckpointPrefix(db.Options.GroupID),
-		base.ProductAPIVersion,
 		compactionID,
 		phase,
 	)

--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -64,7 +64,7 @@ func TestAttachmentMark(t *testing.T) {
 	attachmentsMarked, dcpClient, err := attachmentCompactMarkPhase(ctx, dataStore, collectionID, testDb, t.Name(), terminator, &base.AtomicInt{})
 	assert.NoError(t, err)
 	assert.Equal(t, int64(13), attachmentsMarked)
-	require.Equal(t, fmt.Sprintf("_sync:dcp_ck::sg-%v:att_compaction:TestAttachmentMark_mark", base.ProductAPIVersion), dcpClient.GetMetadataKeyPrefix())
+	require.Equal(t, fmt.Sprintf("_sync:dcp_ck::sg:att_compaction:TestAttachmentMark_mark"), dcpClient.GetMetadataKeyPrefix())
 
 	for _, attDocKey := range attKeys {
 		xattrs, _, err := dataStore.GetXattrs(ctx, attDocKey, []string{base.AttachmentCompactionXattrName})
@@ -129,7 +129,7 @@ func TestAttachmentSweep(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, int64(11), purged)
-	require.Equal(t, fmt.Sprintf("_sync:dcp_ck::sg-%v:att_compaction:TestAttachmentSweep_sweep", base.ProductAPIVersion), dcpClient.GetMetadataKeyPrefix())
+	require.Equal(t, fmt.Sprintf("_sync:dcp_ck::sg:att_compaction:TestAttachmentSweep_sweep"), dcpClient.GetMetadataKeyPrefix())
 }
 
 func TestAttachmentCleanup(t *testing.T) {
@@ -205,7 +205,7 @@ func TestAttachmentCleanup(t *testing.T) {
 	terminator := base.NewSafeTerminator()
 	checkpointPrefix, err := attachmentCompactCleanupPhase(ctx, dataStore, collectionID, testDb, t.Name(), nil, terminator)
 	require.NoError(t, err)
-	require.Equal(t, fmt.Sprintf("_sync:dcp_ck::sg-%v:att_compaction:TestAttachmentCleanup_cleanup", base.ProductAPIVersion), checkpointPrefix)
+	require.Equal(t, fmt.Sprintf("_sync:dcp_ck::sg:att_compaction:TestAttachmentCleanup_cleanup"), checkpointPrefix)
 
 	for _, docID := range singleMarkedAttIDs {
 		_, _, err := dataStore.GetXattrs(ctx, docID, []string{base.AttachmentCompactionXattrName})
@@ -366,13 +366,13 @@ func TestAttachmentMarkAndSweepAndCleanup(t *testing.T) {
 	attachmentsMarked, dcpClient, err := attachmentCompactMarkPhase(ctx, dataStore, collectionID, testDb, t.Name(), terminator, &base.AtomicInt{})
 	assert.NoError(t, err)
 	assert.Equal(t, int64(10), attachmentsMarked)
-	require.Equal(t, fmt.Sprintf("_sync:dcp_ck::sg-%v:att_compaction:TestAttachmentMarkAndSweepAndCleanup_mark", base.ProductAPIVersion), dcpClient.GetMetadataKeyPrefix())
+	require.Equal(t, fmt.Sprintf("_sync:dcp_ck::sg:att_compaction:TestAttachmentMarkAndSweepAndCleanup_mark"), dcpClient.GetMetadataKeyPrefix())
 	vbUUIDS := base.GetVBUUIDs(dcpClient.GetMetadata())
 
 	attachmentsPurged, dcpClient, err := attachmentCompactSweepPhase(ctx, dataStore, collectionID, testDb, t.Name(), vbUUIDS, false, terminator, &base.AtomicInt{})
 	require.NoError(t, err)
 	assert.Equal(t, int64(5), attachmentsPurged)
-	require.Equal(t, fmt.Sprintf("_sync:dcp_ck::sg-%v:att_compaction:TestAttachmentMarkAndSweepAndCleanup_sweep", base.ProductAPIVersion), dcpClient.GetMetadataKeyPrefix())
+	require.Equal(t, fmt.Sprintf("_sync:dcp_ck::sg:att_compaction:TestAttachmentMarkAndSweepAndCleanup_sweep"), dcpClient.GetMetadataKeyPrefix())
 
 	for _, attDocKey := range attKeys {
 		var back any
@@ -393,7 +393,7 @@ func TestAttachmentMarkAndSweepAndCleanup(t *testing.T) {
 
 	checkpointPrefix, err := attachmentCompactCleanupPhase(ctx, dataStore, collectionID, testDb, t.Name(), vbUUIDS, terminator)
 	require.NoError(t, err)
-	require.Equal(t, fmt.Sprintf("_sync:dcp_ck::sg-%v:att_compaction:TestAttachmentMarkAndSweepAndCleanup_cleanup", base.ProductAPIVersion), checkpointPrefix)
+	require.Equal(t, fmt.Sprintf("_sync:dcp_ck::sg:att_compaction:TestAttachmentMarkAndSweepAndCleanup_cleanup"), checkpointPrefix)
 
 	for _, attDocKey := range attKeys {
 		var back any
@@ -708,7 +708,7 @@ func TestAttachmentDifferentVBUUIDsBetweenPhases(t *testing.T) {
 	terminator := base.NewSafeTerminator()
 	_, dcpClient, err := attachmentCompactMarkPhase(ctx, dataStore, collectionID, testDB, t.Name(), terminator, &base.AtomicInt{})
 	require.NoError(t, err)
-	require.Equal(t, fmt.Sprintf("_sync:dcp_ck::sg-%v:att_compaction:TestAttachmentDifferentVBUUIDsBetweenPhases_mark", base.ProductAPIVersion), dcpClient.GetMetadataKeyPrefix())
+	require.Equal(t, fmt.Sprintf("_sync:dcp_ck::sg:att_compaction:TestAttachmentDifferentVBUUIDsBetweenPhases_mark"), dcpClient.GetMetadataKeyPrefix())
 	vbUUIDs := base.GetVBUUIDs(dcpClient.GetMetadata())
 
 	// Manually modify a vbUUID and ensure the Sweep phase errors
@@ -718,7 +718,7 @@ func TestAttachmentDifferentVBUUIDsBetweenPhases(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorAs(t, err, &base.ErrVbUUIDMismatch)
 	assert.Contains(t, err.Error(), "error opening stream for vb 0: VbUUID mismatch when failOnRollback set")
-	require.Equal(t, fmt.Sprintf("_sync:dcp_ck::sg-%v:att_compaction:TestAttachmentDifferentVBUUIDsBetweenPhases_sweep", base.ProductAPIVersion), dcpClient.GetMetadataKeyPrefix())
+	require.Equal(t, fmt.Sprintf("_sync:dcp_ck::sg:att_compaction:TestAttachmentDifferentVBUUIDsBetweenPhases_sweep"), dcpClient.GetMetadataKeyPrefix())
 }
 
 func WaitForConditionWithOptions(t testing.TB, successFunc func() bool, maxNumAttempts, timeToSleepMs int) error {

--- a/db/background_mgr_attachment_migration.go
+++ b/db/background_mgr_attachment_migration.go
@@ -292,9 +292,8 @@ func (a *AttachmentMigrationManager) GetProcessStatus(status BackgroundManagerSt
 
 // getCheckpointPrefix returns the checkpoint prefix for attachment migration checkpoints.
 func (a *AttachmentMigrationManager) getCheckpointPrefix(migrationID string) string {
-	return fmt.Sprintf("%s:sg-%v:att_migration:%v",
+	return fmt.Sprintf("%s:sg:att_migration:%v",
 		a.databaseCtx.MetadataKeys.DCPCheckpointPrefix(a.databaseCtx.Options.GroupID),
-		base.ProductAPIVersion,
 		migrationID,
 	)
 }

--- a/db/background_mgr_attachment_migration_test.go
+++ b/db/background_mgr_attachment_migration_test.go
@@ -257,25 +257,25 @@ func TestAttachmentMigrationCheckpointPrefix(t *testing.T) {
 			name:          "default collection, no group id",
 			collectionIDs: []uint32{base.DefaultCollectionID},
 			groupID:       "",
-			expected:      fmt.Sprintf("_sync:dcp_ck::sg-%v:att_migration:1234", base.ProductAPIVersion),
+			expected:      fmt.Sprintf("_sync:dcp_ck::sg:att_migration:1234"),
 		},
 		{
 			name:          "default collection, group ID=foo",
 			collectionIDs: []uint32{base.DefaultCollectionID},
 			groupID:       "foo",
-			expected:      fmt.Sprintf("_sync:dcp_ck:foo::sg-%v:att_migration:1234", base.ProductAPIVersion),
+			expected:      fmt.Sprintf("_sync:dcp_ck:foo::sg:att_migration:1234" ),
 		},
 		{
 			name:          "default collection + collection 1, no group id",
 			collectionIDs: []uint32{base.DefaultCollectionID, 1},
 			groupID:       "",
-			expected:      fmt.Sprintf("_sync:dcp_ck::sg-%v:att_migration:1234", base.ProductAPIVersion),
+			expected:      fmt.Sprintf("_sync:dcp_ck::sg:att_migration:1234"),
 		},
 		{
 			name:          "default collection + collection 1, group ID=foo",
 			collectionIDs: []uint32{base.DefaultCollectionID, 1},
 			groupID:       "foo",
-			expected:      fmt.Sprintf("_sync:dcp_ck:foo::sg-%v:att_migration:1234", base.ProductAPIVersion),
+			expected:      fmt.Sprintf("_sync:dcp_ck:foo::sg:att_migration:1234"),
 		},
 	}
 	for _, test := range testCases {

--- a/db/background_mgr_attachment_migration_test.go
+++ b/db/background_mgr_attachment_migration_test.go
@@ -263,7 +263,7 @@ func TestAttachmentMigrationCheckpointPrefix(t *testing.T) {
 			name:          "default collection, group ID=foo",
 			collectionIDs: []uint32{base.DefaultCollectionID},
 			groupID:       "foo",
-			expected:      fmt.Sprintf("_sync:dcp_ck:foo::sg:att_migration:1234" ),
+			expected:      fmt.Sprintf("_sync:dcp_ck:foo::sg:att_migration:1234"),
 		},
 		{
 			name:          "default collection + collection 1, no group id",

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -762,16 +762,14 @@ func GetResyncDCPCheckpointPrefix(db *DatabaseContext, resyncID string, distribu
 	var checkpointPrefix string
 	if distributed {
 		checkpointPrefix = fmt.Sprintf(
-			"%s:sg-%v:resync-distributed:%v",
+			"%s:sg:resync-distributed:%v",
 			db.MetadataKeys.DCPCheckpointPrefix(""),
-			base.ProductAPIVersion,
 			resyncID,
 		)
 	} else {
 		checkpointPrefix = fmt.Sprintf(
-			"%s:sg-%v:resync:%v",
+			"%s:sg:resync:%v",
 			db.MetadataKeys.DCPCheckpointPrefix(db.Options.GroupID),
-			base.ProductAPIVersion,
 			resyncID,
 		)
 	}

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -758,14 +758,14 @@ func TestResyncCheckpointPrefix(t *testing.T) {
 			collectionNames: base.NewCollectionNameSet(defaultCollection),
 			groupID:         "",
 			distributed:     false,
-			expected:        fmt.Sprintf("_sync:dcp_ck::sg-%v:resync:1234", base.ProductAPIVersion),
+			expected:        fmt.Sprintf("_sync:dcp_ck::sg:resync:1234"),
 		},
 		{
 			name:            "default collection, group id=foo",
 			collectionNames: base.NewCollectionNameSet(defaultCollection),
 			groupID:         "foo",
 			distributed:     false,
-			expected:        fmt.Sprintf("_sync:dcp_ck:foo::sg-%v:resync:1234", base.ProductAPIVersion),
+			expected:        fmt.Sprintf("_sync:dcp_ck:foo::sg:resync:1234"),
 		},
 		{
 			name: "default collection + collection 1, no group id",
@@ -775,7 +775,7 @@ func TestResyncCheckpointPrefix(t *testing.T) {
 			),
 			groupID:     "",
 			distributed: false,
-			expected:    fmt.Sprintf("_sync:dcp_ck::sg-%v:resync:1234", base.ProductAPIVersion),
+			expected:    fmt.Sprintf("_sync:dcp_ck::sg:resync:1234"),
 		},
 		{
 			name: "default collection + collection 1, group id=foo",
@@ -785,21 +785,21 @@ func TestResyncCheckpointPrefix(t *testing.T) {
 			),
 			groupID:     "foo",
 			distributed: false,
-			expected:    fmt.Sprintf("_sync:dcp_ck:foo::sg-%v:resync:1234", base.ProductAPIVersion),
+			expected:    fmt.Sprintf("_sync:dcp_ck:foo::sg:resync:1234"),
 		},
 		{
 			name:            "distributed, default collection, no group id",
 			collectionNames: base.NewCollectionNameSet(defaultCollection),
 			groupID:         "",
 			distributed:     true,
-			expected:        fmt.Sprintf("_sync:dcp_ck::sg-%v:resync-distributed:1234", base.ProductAPIVersion),
+			expected:        fmt.Sprintf("_sync:dcp_ck::sg:resync-distributed:1234"),
 		},
 		{
 			name:            "distributed, default collection, group id=foo",
 			collectionNames: base.NewCollectionNameSet(defaultCollection),
 			groupID:         "foo",
 			distributed:     true,
-			expected:        fmt.Sprintf("_sync:dcp_ck::sg-%v:resync-distributed:1234", base.ProductAPIVersion),
+			expected:        fmt.Sprintf("_sync:dcp_ck::sg:resync-distributed:1234"),
 		},
 		{
 			name: "distributed, default collection + collection 1, no group id",
@@ -809,7 +809,7 @@ func TestResyncCheckpointPrefix(t *testing.T) {
 			),
 			groupID:     "",
 			distributed: true,
-			expected:    fmt.Sprintf("_sync:dcp_ck::sg-%v:resync-distributed:1234", base.ProductAPIVersion),
+			expected:    fmt.Sprintf("_sync:dcp_ck::sg:resync-distributed:1234"),
 		},
 		{
 			name: "distributed, default collection + collection 1, group id=foo",
@@ -819,7 +819,7 @@ func TestResyncCheckpointPrefix(t *testing.T) {
 			),
 			groupID:     "foo",
 			distributed: true,
-			expected:    fmt.Sprintf("_sync:dcp_ck::sg-%v:resync-distributed:1234", base.ProductAPIVersion),
+			expected:    fmt.Sprintf("_sync:dcp_ck::sg:resync-distributed:1234"),
 		},
 	}
 	for _, test := range testCases {


### PR DESCRIPTION
CBG-5345

Describe your PR here...
- Remove major and minor versions from checkpoints of one shot background tasks
- edit test cases to reflect the changes

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/732/
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/739/