### PR TITLE
CBG-5427: flake in TestSyncInfoUpgradeGate

### DIFF
--- a/rest/cluster_compat_test.go
+++ b/rest/cluster_compat_test.go
@@ -1607,7 +1607,9 @@ func TestSyncInfoUpgradeGate(t *testing.T) {
 	require.Equal(t, base.NewClusterCompatVersion(4, 0), *got, "mixed-version min should be 4.0")
 
 	// Resolve the production-wired accessor and feed its result to SetSyncInfoMetadataID
+	rt.ServerContext().ForceClusterCompatRefresh(t, rt.Context())
 	ccv := dbCtx.ClusterCompatVersion()
+	t.Logf("dbtx CCV: %v, got CCV: %v", ccv.String(), got.String())
 	require.NoError(t, base.SetSyncInfoMetadataID(ctx, ds, metadataID, ccv))
 	raw, _, err := ds.GetRaw(ctx, base.SGSyncInfo)
 	require.NoError(t, err)
@@ -1624,7 +1626,9 @@ func TestSyncInfoUpgradeGate(t *testing.T) {
 
 	// Same accessor, called again — must resolve to the new value at call time, not the value
 	// captured during phase 1.
+	rt.ServerContext().ForceClusterCompatRefresh(t, rt.Context())
 	ccv = dbCtx.ClusterCompatVersion()
+	t.Logf("dbtx CCV: %v, got CCV: %v", ccv.String(), got.String())
 	require.NoError(t, base.SetSyncInfoMetadataID(ctx, ds, metadataID, ccv))
 	raw, _, err = ds.GetRaw(ctx, base.SGSyncInfo)
 	require.NoError(t, err)

--- a/rest/cluster_compat_test.go
+++ b/rest/cluster_compat_test.go
@@ -1609,7 +1609,6 @@ func TestSyncInfoUpgradeGate(t *testing.T) {
 	// Resolve the production-wired accessor and feed its result to SetSyncInfoMetadataID
 	rt.ServerContext().ForceClusterCompatRefresh(t, rt.Context())
 	ccv := dbCtx.ClusterCompatVersion()
-	t.Logf("dbtx CCV: %v, got CCV: %v", ccv.String(), got.String())
 	require.NoError(t, base.SetSyncInfoMetadataID(ctx, ds, metadataID, ccv))
 	raw, _, err := ds.GetRaw(ctx, base.SGSyncInfo)
 	require.NoError(t, err)
@@ -1628,7 +1627,6 @@ func TestSyncInfoUpgradeGate(t *testing.T) {
 	// captured during phase 1.
 	rt.ServerContext().ForceClusterCompatRefresh(t, rt.Context())
 	ccv = dbCtx.ClusterCompatVersion()
-	t.Logf("dbtx CCV: %v, got CCV: %v", ccv.String(), got.String())
 	require.NoError(t, base.SetSyncInfoMetadataID(ctx, ds, metadataID, ccv))
 	raw, _, err = ds.GetRaw(ctx, base.SGSyncInfo)
 	require.NoError(t, err)


### PR DESCRIPTION
CBG-5427

Force refresh of the CCV so dbCtx can re-cache new CCV value

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/742/ (ran 100 times)
