### PR TITLE
CBG-5428: flaky test fixes relating to metadata migration

### DIFF
--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -1084,8 +1084,9 @@ func RequireChanClosed[T any](t testing.TB, ch <-chan T) {
 //
 // The datastore must support range scan; the test fails if it does not. On Rosmar (in-memory)
 // docs are visible immediately, so this returns on the first poll.
-func RequireDocsVisibleToRangeScan(t testing.TB, ctx context.Context, dataStore sgbucket.DataStore, docIDs []string) {
+func RequireDocsVisibleToRangeScan(t testing.TB, dataStore sgbucket.DataStore, docIDs []string) {
 	t.Helper()
+	ctx := TestCtx(t)
 	rss, ok := AsRangeScanStore(dataStore)
 	require.True(t, ok, "datastore does not support range scan")
 

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -1073,6 +1073,46 @@ func RequireChanClosed[T any](t testing.TB, ch <-chan T) {
 	RequireChanClosedWithTimeout(t, ch, TestChanTimeout)
 }
 
+// RequireDocsVisibleToRangeScan blocks until every docID is returned by a KV range scan of
+// the given datastore, failing the test if they are not all visible within 30 seconds.
+//
+// KV range scan reads from a per-vBucket snapshot view rather than from in-memory mutations,
+// so a scan issued immediately after a write can miss the just-written doc until the
+// vBucket's scan view catches up. Tests that seed docs and then exercise range-scan-backed
+// code (e.g. metadata migration) must call this between the seed and the scan, otherwise the
+// scan can observe zero docs and the test flakes. The wait is independent of the on-disk
+// storage engine (couchstore vs magma) and is not about persistence to disk.
+//
+// The datastore must support range scan; the test fails if it does not. On Rosmar (in-memory)
+// docs are visible immediately, so this returns on the first poll.
+func RequireDocsVisibleToRangeScan(t testing.TB, ctx context.Context, dataStore sgbucket.DataStore, docIDs []string) {
+	t.Helper()
+	rss, ok := AsRangeScanStore(dataStore)
+	require.True(t, ok, "datastore does not support range scan")
+
+	want := make(map[string]struct{}, len(docIDs))
+	for _, id := range docIDs {
+		want[id] = struct{}{}
+	}
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		remaining := maps.Clone(want)
+		// One scan per doc keyed on its full ID as the prefix - cheaper than scanning a
+		// shared prefix and filtering, and robust to the docIDs not sharing a common prefix.
+		for id := range remaining {
+			iter, scanErr := rss.Scan(ctx, sgbucket.NewRangeScanForPrefix(id), sgbucket.ScanOptions{IDsOnly: true})
+			if !assert.NoError(c, scanErr) {
+				return
+			}
+			for item := iter.Next(ctx); item != nil; item = iter.Next(ctx) {
+				delete(remaining, item.ID)
+			}
+			assert.NoError(c, iter.Close(ctx))
+		}
+		assert.Empty(c, remaining, "docs not yet visible to range scan")
+	}, 30*time.Second, 100*time.Millisecond)
+}
+
 // WaitWithTimeout calls for the WaitGroup.Wait() and fails the test if the Wait does not return within the timeout.
 func WaitWithTimeout(t testing.TB, wg *sync.WaitGroup, timeout time.Duration) {
 	t.Helper()

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -1079,9 +1079,8 @@ func RequireChanClosed[T any](t testing.TB, ch <-chan T) {
 // KV range scan reads from a per-vBucket snapshot view rather than from in-memory mutations,
 // so a scan issued immediately after a write can miss the just-written doc until the
 // vBucket's scan view catches up. Tests that seed docs and then exercise range-scan-backed
-// code (e.g. metadata migration) must call this between the seed and the scan, otherwise the
-// scan can observe zero docs and the test flakes. The wait is independent of the on-disk
-// storage engine (couchstore vs magma) and is not about persistence to disk.
+// code must call this between the seed and the scan, otherwise the
+// scan can observe zero docs and the test flakes.
 //
 // The datastore must support range scan; the test fails if it does not. On Rosmar (in-memory)
 // docs are visible immediately, so this returns on the first poll.

--- a/db/background_mgr_metadata_migration_test.go
+++ b/db/background_mgr_metadata_migration_test.go
@@ -12,6 +12,8 @@ package db
 
 import (
 	"context"
+	"maps"
+	"slices"
 	"testing"
 	"time"
 
@@ -173,6 +175,11 @@ func TestMetadataMigrationManagerMovesUsersAndRoles(t *testing.T) {
 		require.NoError(t, err, "seed fallback %s", k)
 	}
 
+	// A first-pass range scan that misses the just-seeded docs would migrate nothing and
+	// complete with DocsProcessed=0, failing the assertions below. Wait for the seeds to be
+	// visible to scan before starting.
+	base.RequireDocsVisibleToRangeScan(t, ctx, ms.Fallback(), slices.Collect(maps.Keys(seeded)))
+
 	dbCtx := &DatabaseContext{
 		Name:                           "test",
 		terminator:                     make(chan bool),
@@ -230,6 +237,13 @@ func TestMetadataMigrationManagerErrorsOnUnclearableUnknownPrefix(t *testing.T) 
 	stuckKey := base.SyncDocPrefix + base.MetadataIdPrefix + metadataID + ":wat"
 	_, err = ms.Fallback().AddRaw(ctx, stuckKey, 0, []byte(`{"body":"stuck"}`))
 	require.NoError(t, err, "seed in-scope unknown-prefix fallback doc")
+
+	// KV range scan reads from a per-vBucket snapshot view, so a scan issued immediately
+	// after the write can miss the seeded doc until the vBucket's scan view catches up. If this
+	// occurs and the migration's first pass doesn't see the doc, it reports remaining=0 and completes
+	// immediately instead of hitting the bounded-pass error path, flaking this test. Wait for the
+	// seed to be visible to scan before starting.
+	base.RequireDocsVisibleToRangeScan(t, ctx, ms.Fallback(), []string{stuckKey})
 
 	dbCtx := &DatabaseContext{
 		Name:                           "test",

--- a/db/background_mgr_metadata_migration_test.go
+++ b/db/background_mgr_metadata_migration_test.go
@@ -178,7 +178,7 @@ func TestMetadataMigrationManagerMovesUsersAndRoles(t *testing.T) {
 	// A first-pass range scan that misses the just-seeded docs would migrate nothing and
 	// complete with DocsProcessed=0, failing the assertions below. Wait for the seeds to be
 	// visible to scan before starting.
-	base.RequireDocsVisibleToRangeScan(t, ctx, ms.Fallback(), slices.Collect(maps.Keys(seeded)))
+	base.RequireDocsVisibleToRangeScan(t, ms.Fallback(), slices.Collect(maps.Keys(seeded)))
 
 	dbCtx := &DatabaseContext{
 		Name:                           "test",
@@ -243,7 +243,7 @@ func TestMetadataMigrationManagerErrorsOnUnclearableUnknownPrefix(t *testing.T) 
 	// occurs and the migration's first pass doesn't see the doc, it reports remaining=0 and completes
 	// immediately instead of hitting the bounded-pass error path, flaking this test. Wait for the
 	// seed to be visible to scan before starting.
-	base.RequireDocsVisibleToRangeScan(t, ctx, ms.Fallback(), []string{stuckKey})
+	base.RequireDocsVisibleToRangeScan(t, ms.Fallback(), []string{stuckKey})
 
 	dbCtx := &DatabaseContext{
 		Name:                           "test",

--- a/db/metadata_migration_test.go
+++ b/db/metadata_migration_test.go
@@ -10,6 +10,8 @@ package db
 
 import (
 	"context"
+	"maps"
+	"slices"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -95,6 +97,9 @@ func TestMigrateMetadataUnknownPrefixCountedAsRemaining(t *testing.T) {
 	unknownKey := base.SyncDocPrefix + base.MetadataIdPrefix + metadataID + ":wat"
 	seedFallback(ctx, t, ms, unknownKey, []byte(`{"body":"unknown"}`))
 
+	// Wait for the fallback doc to be visible to range scans before running the migration.
+	base.RequireDocsVisibleToRangeScan(t, ctx, ms.Fallback(), []string{unknownKey})
+
 	stats := &MigrationStats{}
 	remaining, err := MigrateMetadata(ctx, ms, metadataID, stats)
 	require.NoError(t, err)
@@ -119,6 +124,9 @@ func TestMigrateMetadataNamespacedExcludesSiblingDB(t *testing.T) {
 	// `_sync:m_<other>:` (different namespace).
 	const siblingKey = "_sync:m_otherDB:hb:groupA"
 	seedFallback(ctx, t, ms, siblingKey, []byte(`{"heartbeat":"sibling"}`))
+
+	// Wait for the fallback doc to be visible to range scans before running the migration.
+	base.RequireDocsVisibleToRangeScan(t, ctx, ms.Fallback(), []string{siblingKey})
 
 	stats := &MigrationStats{}
 	_, err := MigrateMetadata(ctx, ms, "myDB", stats)
@@ -178,6 +186,9 @@ func TestMigrateMetadataMovesUserAndRoleDocs(t *testing.T) {
 		seedFallback(ctx, t, ms, k, v)
 	}
 
+	// Wait for fallback docs to be visible to range scans before running the migration.
+	base.RequireDocsVisibleToRangeScan(t, ctx, ms.Fallback(), slices.Collect(maps.Keys(seeded)))
+
 	stats := &MigrationStats{}
 	remaining, err := MigrateMetadata(ctx, ms, metadataID, stats)
 	require.NoError(t, err)
@@ -225,6 +236,9 @@ func TestMigrateMetadataMovesUserEmailAndSession(t *testing.T) {
 	seededSessionExpiry, err := ms.Fallback().GetExpiry(ctx, sessionKey)
 	require.NoError(t, err)
 	require.NotZero(t, seededSessionExpiry, "fallback should have a non-zero absolute expiry after a TTL write")
+
+	// Wait for the fallback docs to be visible to range scans before running the migration.
+	base.RequireDocsVisibleToRangeScan(t, ctx, ms.Fallback(), []string{emailKey, sessionKey})
 
 	stats := &MigrationStats{}
 	remaining, err := MigrateMetadata(ctx, ms, metadataID, stats)
@@ -278,6 +292,9 @@ func TestMigrateMetadataUserDocPrimaryWinsOnConflict(t *testing.T) {
 	require.NoError(t, err)
 	seedFallback(ctx, t, ms, key, stalerFallback)
 
+	// Wait for fallback doc ot be visible to range scans before running the migration, to reliably trigger the conflict scenario.
+	base.RequireDocsVisibleToRangeScan(t, ctx, ms.Fallback(), []string{key})
+
 	stats := &MigrationStats{}
 	remaining, err := MigrateMetadata(ctx, ms, metadataID, stats)
 	require.NoError(t, err)
@@ -313,6 +330,9 @@ func TestMigrateMetadataLegacyDefaultUserAndRole(t *testing.T) {
 		seedFallback(ctx, t, ms, k, v)
 	}
 
+	// Wait for the fallback docs to be visible to range scans before running the migration.
+	base.RequireDocsVisibleToRangeScan(t, ctx, ms.Fallback(), slices.Collect(maps.Keys(seeded)))
+
 	stats := &MigrationStats{}
 	remaining, err := MigrateMetadata(ctx, ms, base.DefaultMetadataID, stats)
 	require.NoError(t, err)
@@ -347,6 +367,9 @@ func TestMigrateMetadataDefaultModeUnknownPreservedHeartbeatDeleted(t *testing.T
 	const heartbeatKey = "_sync:heartbeat_timeout:nodeA"
 	seedFallback(ctx, t, ms, unknownKey, []byte(`{"unknown":"shape"}`))
 	seedFallback(ctx, t, ms, heartbeatKey, []byte("nodeA"))
+
+	// Wait for the fallback docs to be visible to range scans before running the migration.
+	base.RequireDocsVisibleToRangeScan(t, ctx, ms.Fallback(), []string{unknownKey, heartbeatKey})
 
 	stats := &MigrationStats{}
 	remaining, err := MigrateMetadata(ctx, ms, base.DefaultMetadataID, stats)
@@ -384,6 +407,9 @@ func TestMigrateMetadataNamespacedHeartbeatWithGroupIDDeletedViaShapeMatch(t *te
 	ms := newMigrationTestStore(t, bucket)
 	seedFallback(ctx, t, ms, heartbeatKey, []byte("nodeA"))
 
+	// Wait for the fallback doc to be visible to range scans before running the migration.
+	base.RequireDocsVisibleToRangeScan(t, ctx, ms.Fallback(), []string{heartbeatKey})
+
 	stats := &MigrationStats{}
 	remaining, err := MigrateMetadata(ctx, ms, metadataID, stats)
 	require.NoError(t, err)
@@ -409,6 +435,9 @@ func TestMigrateMetadataNamespacedHeartbeatDeletedViaShapeMatch(t *testing.T) {
 
 	ms := newMigrationTestStore(t, bucket)
 	seedFallback(ctx, t, ms, heartbeatKey, []byte("nodeA"))
+
+	// Wait for the fallback doc to be visible to range scans before running the migration.
+	base.RequireDocsVisibleToRangeScan(t, ctx, ms.Fallback(), []string{heartbeatKey})
 
 	stats := &MigrationStats{}
 	remaining, err := MigrateMetadata(ctx, ms, metadataID, stats)
@@ -530,6 +559,9 @@ func TestMigrateMetadataUnusedSeqMoves(t *testing.T) {
 	_, err = ms.Fallback().AddRaw(ctx, rangeKey, 0, rangeBody)
 	require.NoError(t, err, "seed fallback unusedSeqs range")
 
+	// Wait for the fallback docs to be visible to range scans before running the migration.
+	base.RequireDocsVisibleToRangeScan(t, ctx, ms.Fallback(), []string{singletonKey, rangeKey})
+
 	stats := &MigrationStats{}
 	remaining, err := MigrateMetadata(ctx, ms, metadataID, stats)
 	require.NoError(t, err)
@@ -560,6 +592,9 @@ func TestMigrateMetadataLegacyDefaultUserWithMPrefixUsername(t *testing.T) {
 	mUserKey := keys.UserKey("m_alice")
 	body := []byte(`{"name":"m_alice","legacy":true}`)
 	seedFallback(ctx, t, ms, mUserKey, body)
+
+	// Wait for the fallback doc to be visible to range scans before running the migration.
+	base.RequireDocsVisibleToRangeScan(t, ctx, ms.Fallback(), []string{mUserKey})
 
 	stats := &MigrationStats{}
 	remaining, err := MigrateMetadata(ctx, ms, base.DefaultMetadataID, stats)

--- a/db/metadata_migration_test.go
+++ b/db/metadata_migration_test.go
@@ -10,8 +10,6 @@ package db
 
 import (
 	"context"
-	"maps"
-	"slices"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -35,6 +33,10 @@ func seedFallback(ctx context.Context, t *testing.T, ms *base.MetadataStore, key
 	t.Helper()
 	_, err := ms.Fallback().AddRaw(ctx, key, 0, body)
 	require.NoError(t, err, "seed fallback %s", key)
+	// KV range scans read from a per-vBucket snapshot view, so a scan issued immediately after
+	// the write can miss the just-seeded doc until the vBucket's scan view catches up. Block here
+	// so callers can't forget to wait for visibility before exercising scan-backed code.
+	base.RequireDocsVisibleToRangeScan(t, ms.Fallback(), []string{key})
 }
 
 // TestMigrateMetadataEmptyFallback verifies the new-DB fast path: empty fallback yields a
@@ -97,9 +99,6 @@ func TestMigrateMetadataUnknownPrefixCountedAsRemaining(t *testing.T) {
 	unknownKey := base.SyncDocPrefix + base.MetadataIdPrefix + metadataID + ":wat"
 	seedFallback(ctx, t, ms, unknownKey, []byte(`{"body":"unknown"}`))
 
-	// Wait for the fallback doc to be visible to range scans before running the migration.
-	base.RequireDocsVisibleToRangeScan(t, ctx, ms.Fallback(), []string{unknownKey})
-
 	stats := &MigrationStats{}
 	remaining, err := MigrateMetadata(ctx, ms, metadataID, stats)
 	require.NoError(t, err)
@@ -124,9 +123,6 @@ func TestMigrateMetadataNamespacedExcludesSiblingDB(t *testing.T) {
 	// `_sync:m_<other>:` (different namespace).
 	const siblingKey = "_sync:m_otherDB:hb:groupA"
 	seedFallback(ctx, t, ms, siblingKey, []byte(`{"heartbeat":"sibling"}`))
-
-	// Wait for the fallback doc to be visible to range scans before running the migration.
-	base.RequireDocsVisibleToRangeScan(t, ctx, ms.Fallback(), []string{siblingKey})
 
 	stats := &MigrationStats{}
 	_, err := MigrateMetadata(ctx, ms, "myDB", stats)
@@ -186,9 +182,6 @@ func TestMigrateMetadataMovesUserAndRoleDocs(t *testing.T) {
 		seedFallback(ctx, t, ms, k, v)
 	}
 
-	// Wait for fallback docs to be visible to range scans before running the migration.
-	base.RequireDocsVisibleToRangeScan(t, ctx, ms.Fallback(), slices.Collect(maps.Keys(seeded)))
-
 	stats := &MigrationStats{}
 	remaining, err := MigrateMetadata(ctx, ms, metadataID, stats)
 	require.NoError(t, err)
@@ -238,7 +231,7 @@ func TestMigrateMetadataMovesUserEmailAndSession(t *testing.T) {
 	require.NotZero(t, seededSessionExpiry, "fallback should have a non-zero absolute expiry after a TTL write")
 
 	// Wait for the fallback docs to be visible to range scans before running the migration.
-	base.RequireDocsVisibleToRangeScan(t, ctx, ms.Fallback(), []string{emailKey, sessionKey})
+	base.RequireDocsVisibleToRangeScan(t, ms.Fallback(), []string{emailKey, sessionKey})
 
 	stats := &MigrationStats{}
 	remaining, err := MigrateMetadata(ctx, ms, metadataID, stats)
@@ -292,9 +285,6 @@ func TestMigrateMetadataUserDocPrimaryWinsOnConflict(t *testing.T) {
 	require.NoError(t, err)
 	seedFallback(ctx, t, ms, key, stalerFallback)
 
-	// Wait for fallback doc to be visible to range scans before running the migration, to reliably trigger the conflict scenario.
-	base.RequireDocsVisibleToRangeScan(t, ctx, ms.Fallback(), []string{key})
-
 	stats := &MigrationStats{}
 	remaining, err := MigrateMetadata(ctx, ms, metadataID, stats)
 	require.NoError(t, err)
@@ -330,9 +320,6 @@ func TestMigrateMetadataLegacyDefaultUserAndRole(t *testing.T) {
 		seedFallback(ctx, t, ms, k, v)
 	}
 
-	// Wait for the fallback docs to be visible to range scans before running the migration.
-	base.RequireDocsVisibleToRangeScan(t, ctx, ms.Fallback(), slices.Collect(maps.Keys(seeded)))
-
 	stats := &MigrationStats{}
 	remaining, err := MigrateMetadata(ctx, ms, base.DefaultMetadataID, stats)
 	require.NoError(t, err)
@@ -367,9 +354,6 @@ func TestMigrateMetadataDefaultModeUnknownPreservedHeartbeatDeleted(t *testing.T
 	const heartbeatKey = "_sync:heartbeat_timeout:nodeA"
 	seedFallback(ctx, t, ms, unknownKey, []byte(`{"unknown":"shape"}`))
 	seedFallback(ctx, t, ms, heartbeatKey, []byte("nodeA"))
-
-	// Wait for the fallback docs to be visible to range scans before running the migration.
-	base.RequireDocsVisibleToRangeScan(t, ctx, ms.Fallback(), []string{unknownKey, heartbeatKey})
 
 	stats := &MigrationStats{}
 	remaining, err := MigrateMetadata(ctx, ms, base.DefaultMetadataID, stats)
@@ -407,9 +391,6 @@ func TestMigrateMetadataNamespacedHeartbeatWithGroupIDDeletedViaShapeMatch(t *te
 	ms := newMigrationTestStore(t, bucket)
 	seedFallback(ctx, t, ms, heartbeatKey, []byte("nodeA"))
 
-	// Wait for the fallback doc to be visible to range scans before running the migration.
-	base.RequireDocsVisibleToRangeScan(t, ctx, ms.Fallback(), []string{heartbeatKey})
-
 	stats := &MigrationStats{}
 	remaining, err := MigrateMetadata(ctx, ms, metadataID, stats)
 	require.NoError(t, err)
@@ -435,9 +416,6 @@ func TestMigrateMetadataNamespacedHeartbeatDeletedViaShapeMatch(t *testing.T) {
 
 	ms := newMigrationTestStore(t, bucket)
 	seedFallback(ctx, t, ms, heartbeatKey, []byte("nodeA"))
-
-	// Wait for the fallback doc to be visible to range scans before running the migration.
-	base.RequireDocsVisibleToRangeScan(t, ctx, ms.Fallback(), []string{heartbeatKey})
 
 	stats := &MigrationStats{}
 	remaining, err := MigrateMetadata(ctx, ms, metadataID, stats)
@@ -560,7 +538,7 @@ func TestMigrateMetadataUnusedSeqMoves(t *testing.T) {
 	require.NoError(t, err, "seed fallback unusedSeqs range")
 
 	// Wait for the fallback docs to be visible to range scans before running the migration.
-	base.RequireDocsVisibleToRangeScan(t, ctx, ms.Fallback(), []string{singletonKey, rangeKey})
+	base.RequireDocsVisibleToRangeScan(t, ms.Fallback(), []string{singletonKey, rangeKey})
 
 	stats := &MigrationStats{}
 	remaining, err := MigrateMetadata(ctx, ms, metadataID, stats)
@@ -592,9 +570,6 @@ func TestMigrateMetadataLegacyDefaultUserWithMPrefixUsername(t *testing.T) {
 	mUserKey := keys.UserKey("m_alice")
 	body := []byte(`{"name":"m_alice","legacy":true}`)
 	seedFallback(ctx, t, ms, mUserKey, body)
-
-	// Wait for the fallback doc to be visible to range scans before running the migration.
-	base.RequireDocsVisibleToRangeScan(t, ctx, ms.Fallback(), []string{mUserKey})
 
 	stats := &MigrationStats{}
 	remaining, err := MigrateMetadata(ctx, ms, base.DefaultMetadataID, stats)

--- a/db/metadata_migration_test.go
+++ b/db/metadata_migration_test.go
@@ -292,7 +292,7 @@ func TestMigrateMetadataUserDocPrimaryWinsOnConflict(t *testing.T) {
 	require.NoError(t, err)
 	seedFallback(ctx, t, ms, key, stalerFallback)
 
-	// Wait for fallback doc ot be visible to range scans before running the migration, to reliably trigger the conflict scenario.
+	// Wait for fallback doc to be visible to range scans before running the migration, to reliably trigger the conflict scenario.
 	base.RequireDocsVisibleToRangeScan(t, ctx, ms.Fallback(), []string{key})
 
 	stats := &MigrationStats{}

--- a/rest/metadatamigrationtest/metadata_migration_test.go
+++ b/rest/metadatamigrationtest/metadata_migration_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbase/sync_gateway/rest"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -68,7 +69,11 @@ func TestMetadataMigrationStartsAfterAllNodesApplyConfig(t *testing.T) {
 	rtConfig := &rest.RestTesterConfig{
 		CustomTestBucket: tb.NoCloseClone(),
 		PersistentConfig: true,
-		GroupID:          base.Ptr("metadata_migration_cluster"),
+		// rtA and rtB share a group to simulate one two-node cluster, but it must be unique per
+		// run: a fixed group lets a stale "db" registry entry (from a recycled-but-still-flushing
+		// pool bucket, or a prior test's lingering config-poll/heartbeat) collide with this test's
+		// create ("Duplicate database name").
+		GroupID: base.Ptr(uuid.NewString()),
 	}
 
 	rtA := rest.NewRestTester(t, rtConfig)
@@ -690,7 +695,11 @@ func TestMetadataMigrationRESTStartRejectedBeforeConfigApplied(t *testing.T) {
 	rtConfig := &rest.RestTesterConfig{
 		CustomTestBucket: tb.NoCloseClone(),
 		PersistentConfig: true,
-		GroupID:          base.Ptr("metadata_migration_cluster"),
+		// rtA and rtB share a group to simulate one two-node cluster, but it must be unique per
+		// run: a fixed group lets a stale "db" registry entry (from a recycled-but-still-flushing
+		// pool bucket, or a prior test's lingering config-poll/heartbeat) collide with this test's
+		// create ("Duplicate database name").
+		GroupID: base.Ptr(uuid.NewString()),
 	}
 	rtA := rest.NewRestTester(t, rtConfig)
 	defer rtA.Close()


### PR DESCRIPTION
CBG-5428

Wait for range scan to be able to see fallback seeded docs. KV range scan requires docs to be present in vBucket snapshot and not just resident in memory. 
Bundles other fixes in seen in test flakes in the weekly:
- Need the node groupID to be unique to prevent registry conflicts (bucket not fully being clean in between test runs) 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/744/ (TestMetadataMigrationStartsAfterAllNodesApplyConfig run 100 times)
- [x] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/745/ (TestMetadataMigrationRESTStartRejectedBeforeConfigApplied run 100 times)
- [x] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/747/ (TestMetadataMigrationManagerMovesUsersAndRoles + TestMetadataMigrationManagerErrorsOnUnclearableUnknownPrefix run 100 times)
- [x] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/748/ (the tests listed below all run 100 times)
TestMigrateMetadataUnknownPrefixCountedAsRemaining
TestMigrateMetadataNamespacedExcludesSiblingDB
TestMigrateMetadataMovesUserEmailAndSession
TestMigrateMetadataLegacyDefaultUserAndRole
TestMigrateMetadataDefaultModeUnknownPreservedHeartbeatDeleted
TestMigrateMetadataNamespacedHeartbeatWithGroupIDDeletedViaShapeMatch
TestMigrateMetadataNamespacedHeartbeatDeletedViaShapeMatch
TestMigrateMetadataUnusedSeqMoves
TestMigrateMetadataLegacyDefaultUserWithMPrefixUsername
