### PR TITLE
CBG-5183 Fix TestAttachmentCompactionRunTwice

### DIFF
--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -308,20 +308,7 @@ func TestAttachmentCleanupRollback(t *testing.T) {
 	err = testDb.AttachmentCompactionManager.Process.Run(ctx, map[string]any{"database": testDb}, testDb.AttachmentCompactionManager.UpdateStatusClusterAware, terminator)
 	require.NoError(t, err)
 
-	err = WaitForConditionWithOptions(t, func() bool {
-		var status AttachmentManagerResponse
-		rawStatus, err := testDb.AttachmentCompactionManager.GetStatus(ctx)
-		assert.NoError(t, err)
-		err = base.JSONUnmarshal(rawStatus, &status)
-		require.NoError(t, err)
-
-		if status.State == BackgroundProcessStateCompleted {
-			return true
-		}
-
-		return false
-	}, 100, 1000)
-	require.NoError(t, err)
+	RequireBackgroundManagerState(t, testDb.AttachmentCompactionManager, BackgroundProcessStateCompleted)
 
 	// assert that the marked attachments have been "cleaned up"
 	for _, docID := range singleMarkedAttIDs {
@@ -407,61 +394,27 @@ func TestAttachmentMarkAndSweepAndCleanup(t *testing.T) {
 }
 
 func TestAttachmentCompactionRunTwice(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
-	}
-
-	b := base.GetTestBucket(t).LeakyBucketClone(base.LeakyBucketConfig{})
+	b := base.GetTestBucket(t)
 	defer b.Close(base.TestCtx(t))
 
 	testDB1, ctx1 := setupTestDBForBucketDefaultCollection(t, b)
 	defer testDB1.Close(ctx1)
-	db1DataStore := testDB1.Bucket.DefaultDataStore(ctx1)
 
 	testDB2, ctx2 := setupTestDBForBucketDefaultCollection(t, b.NoCloseClone())
 	defer testDB2.Close(ctx2)
 
 	var err error
 
-	lds, ok := base.AsLeakyDataStore(db1DataStore)
-	require.True(t, ok)
-
-	triggerCallback := false
-	triggerStopCallback := false
-	lds.SetGetRawCallback(func(s string) error {
-		if triggerCallback {
-			err = testDB2.AttachmentCompactionManager.Start(ctx2, map[string]any{"database": testDB2})
-			assert.Error(t, err)
-			assert.Contains(t, err.Error(), "Process already running")
-			triggerCallback = false
-		}
-		if triggerStopCallback {
-			triggerStopCallback = false
-			err = testDB2.AttachmentCompactionManager.Stop(ctx2)
-			assert.NoError(t, err)
-		}
-		return nil
-	})
-
 	// Trigger start with immediate abort. Then resume, ensure that dry run is resumed
-	triggerStopCallback = true
+	testDB2.AttachmentCompactionManager.Process.(*AttachmentCompactionManager).runFunctionStartedCallback = func(_ context.Context, _ map[string]any, _ updateStatusCallbackFunc, terminator *base.SafeTerminator) {
+		<-terminator.Done()
+	}
 	err = testDB2.AttachmentCompactionManager.Start(ctx2, map[string]any{"database": testDB2, "dryRun": true})
 	assert.NoError(t, err)
-
-	err = WaitForConditionWithOptions(t, func() bool {
-		var status AttachmentManagerResponse
-		rawStatus, err := testDB2.AttachmentCompactionManager.GetStatus(ctx2)
-		assert.NoError(t, err)
-		err = base.JSONUnmarshal(rawStatus, &status)
-		require.NoError(t, err)
-
-		if status.State == BackgroundProcessStateStopped {
-			return true
-		}
-
-		return false
-	}, 200, 1000)
+	err = testDB2.AttachmentCompactionManager.Stop(ctx2)
 	assert.NoError(t, err)
+
+	RequireBackgroundManagerState(t, testDB2.AttachmentCompactionManager, BackgroundProcessStateStopped)
 
 	var testStatus AttachmentManagerResponse
 	testRawStatus, err := testDB2.AttachmentCompactionManager.GetStatus(ctx2)
@@ -473,20 +426,7 @@ func TestAttachmentCompactionRunTwice(t *testing.T) {
 	err = testDB2.AttachmentCompactionManager.Start(ctx2, map[string]any{"database": testDB2, "dryRun": false})
 	assert.NoError(t, err)
 
-	err = WaitForConditionWithOptions(t, func() bool {
-		var status AttachmentManagerResponse
-		rawStatus, err := testDB2.AttachmentCompactionManager.GetStatus(ctx2)
-		assert.NoError(t, err)
-		err = base.JSONUnmarshal(rawStatus, &status)
-		require.NoError(t, err)
-
-		if status.State == BackgroundProcessStateCompleted {
-			return true
-		}
-
-		return false
-	}, 200, 1000)
-	assert.NoError(t, err)
+	RequireBackgroundManagerState(t, testDB2.AttachmentCompactionManager, BackgroundProcessStateCompleted)
 
 	testRawStatus, err = testDB2.AttachmentCompactionManager.GetStatus(ctx2)
 	assert.NoError(t, err)
@@ -495,43 +435,26 @@ func TestAttachmentCompactionRunTwice(t *testing.T) {
 	assert.True(t, testStatus.DryRun)
 
 	// Trigger start with immediate stop (stopped from db2)
-	triggerStopCallback = true
+	testDB1.AttachmentCompactionManager.Process.(*AttachmentCompactionManager).runFunctionStartedCallback = func(_ context.Context, _ map[string]any, _ updateStatusCallbackFunc, terminator *base.SafeTerminator) {
+		<-terminator.Done()
+	}
 	err = testDB1.AttachmentCompactionManager.Start(ctx1, map[string]any{"database": testDB1})
 	assert.NoError(t, err)
+	err = testDB2.AttachmentCompactionManager.Stop(ctx2)
+	assert.NoError(t, err)
 
-	err = WaitForConditionWithOptions(t, func() bool {
-		var status AttachmentManagerResponse
-		rawStatus, err := testDB1.AttachmentCompactionManager.GetStatus(ctx1)
-		assert.NoError(t, err)
-		err = base.JSONUnmarshal(rawStatus, &status)
-		require.NoError(t, err)
-
-		if status.State == BackgroundProcessStateStopped {
-			return true
-		}
-
-		return false
-	}, 200, 1000)
+	RequireBackgroundManagerState(t, testDB1.AttachmentCompactionManager, BackgroundProcessStateStopped)
 
 	// Kick off another run with an attempted start from the other node, checks for error on other node
-	triggerCallback = true
+	testDB1.AttachmentCompactionManager.Process.(*AttachmentCompactionManager).runFunctionStartedCallback = func(_ context.Context, _ map[string]any, _ updateStatusCallbackFunc, _ *base.SafeTerminator) {
+		err = testDB2.AttachmentCompactionManager.Start(ctx2, map[string]any{"database": testDB2})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "Process already running")
+	}
 	err = testDB1.AttachmentCompactionManager.Start(ctx1, map[string]any{"database": testDB1})
 	assert.NoError(t, err)
 
-	err = WaitForConditionWithOptions(t, func() bool {
-		var status AttachmentManagerResponse
-		rawStatus, err := testDB1.AttachmentCompactionManager.GetStatus(ctx1)
-		assert.NoError(t, err)
-		err = base.JSONUnmarshal(rawStatus, &status)
-		require.NoError(t, err)
-
-		if status.State == BackgroundProcessStateCompleted {
-			return true
-		}
-
-		return false
-	}, 200, 1000)
-	assert.NoError(t, err)
+	RequireBackgroundManagerState(t, testDB1.AttachmentCompactionManager, BackgroundProcessStateCompleted)
 
 	var testDB1Status AttachmentManagerResponse
 	var testDB2Status AttachmentManagerResponse
@@ -553,61 +476,27 @@ func TestAttachmentCompactionRunTwice(t *testing.T) {
 }
 
 func TestAttachmentCompactionStopImmediateStart(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
-	}
-
-	b := base.GetTestBucket(t).LeakyBucketClone(base.LeakyBucketConfig{})
+	b := base.GetTestBucket(t)
 	defer b.Close(base.TestCtx(t))
 
 	testDB1, ctx1 := setupTestDBForBucketDefaultCollection(t, b)
 	defer testDB1.Close(ctx1)
-	db1DataStore := testDB1.Bucket.DefaultDataStore(ctx1)
 
 	testDB2, ctx2 := setupTestDBForBucketDefaultCollection(t, b.NoCloseClone())
 	defer testDB2.Close(ctx2)
 
 	var err error
 
-	lds, ok := base.AsLeakyDataStore(db1DataStore)
-	require.True(t, ok)
-
-	triggerCallback := false
-	triggerStopCallback := false
-	lds.SetGetRawCallback(func(s string) error {
-		if triggerCallback {
-			err = testDB2.AttachmentCompactionManager.Start(ctx2, map[string]any{"database": testDB2})
-			assert.Error(t, err)
-			assert.Contains(t, err.Error(), "Process already running")
-			triggerCallback = false
-		}
-		if triggerStopCallback {
-			triggerStopCallback = false
-			err = testDB2.AttachmentCompactionManager.Stop(ctx2)
-			assert.NoError(t, err)
-		}
-		return nil
-	})
-
 	// Trigger start with immediate abort. Then resume, ensure that dry run is resumed
-	triggerStopCallback = true
+	testDB2.AttachmentCompactionManager.Process.(*AttachmentCompactionManager).runFunctionStartedCallback = func(_ context.Context, _ map[string]any, _ updateStatusCallbackFunc, terminator *base.SafeTerminator) {
+		<-terminator.Done()
+	}
 	err = testDB2.AttachmentCompactionManager.Start(ctx2, map[string]any{"database": testDB2, "dryRun": true})
 	assert.NoError(t, err)
-
-	err = WaitForConditionWithOptions(t, func() bool {
-		var status AttachmentManagerResponse
-		rawStatus, err := testDB2.AttachmentCompactionManager.GetStatus(ctx2)
-		assert.NoError(t, err)
-		err = base.JSONUnmarshal(rawStatus, &status)
-		require.NoError(t, err)
-
-		if status.State == BackgroundProcessStateStopped {
-			return true
-		}
-
-		return false
-	}, 200, 1000)
+	err = testDB2.AttachmentCompactionManager.Stop(ctx2)
 	assert.NoError(t, err)
+
+	RequireBackgroundManagerState(t, testDB2.AttachmentCompactionManager, BackgroundProcessStateStopped)
 
 	var testStatus AttachmentManagerResponse
 	testRawStatus, err := testDB2.AttachmentCompactionManager.GetStatus(ctx2)
@@ -619,20 +508,7 @@ func TestAttachmentCompactionStopImmediateStart(t *testing.T) {
 	err = testDB2.AttachmentCompactionManager.Start(ctx2, map[string]any{"database": testDB2, "dryRun": false})
 	assert.NoError(t, err)
 
-	err = WaitForConditionWithOptions(t, func() bool {
-		var status AttachmentManagerResponse
-		rawStatus, err := testDB2.AttachmentCompactionManager.GetStatus(ctx2)
-		assert.NoError(t, err)
-		err = base.JSONUnmarshal(rawStatus, &status)
-		require.NoError(t, err)
-
-		if status.State == BackgroundProcessStateCompleted {
-			return true
-		}
-
-		return false
-	}, 200, 1000)
-	assert.NoError(t, err)
+	RequireBackgroundManagerState(t, testDB2.AttachmentCompactionManager, BackgroundProcessStateCompleted)
 
 	testRawStatus, err = testDB2.AttachmentCompactionManager.GetStatus(ctx2)
 	assert.NoError(t, err)
@@ -641,8 +517,12 @@ func TestAttachmentCompactionStopImmediateStart(t *testing.T) {
 	assert.True(t, testStatus.DryRun)
 
 	// Trigger start with immediate stop (stopped from db2)
-	triggerStopCallback = true
+	testDB1.AttachmentCompactionManager.Process.(*AttachmentCompactionManager).runFunctionStartedCallback = func(_ context.Context, _ map[string]any, _ updateStatusCallbackFunc, terminator *base.SafeTerminator) {
+		<-terminator.Done()
+	}
 	err = testDB1.AttachmentCompactionManager.Start(ctx1, map[string]any{"database": testDB1})
+	assert.NoError(t, err)
+	err = testDB2.AttachmentCompactionManager.Stop(ctx2)
 	assert.NoError(t, err)
 
 	// Kick off another run with an attempted start, verify we don't get 'process already running' error
@@ -676,22 +556,7 @@ func TestAttachmentProcessError(t *testing.T) {
 	err := testDB1.AttachmentCompactionManager.Start(ctx1, map[string]any{"database": testDB1})
 	assert.NoError(t, err)
 
-	var status AttachmentManagerResponse
-	err = WaitForConditionWithOptions(t, func() bool {
-		rawStatus, err := testDB1.AttachmentCompactionManager.GetStatus(ctx1)
-		assert.NoError(t, err)
-		err = base.JSONUnmarshal(rawStatus, &status)
-		assert.NoError(t, err)
-
-		if status.State == BackgroundProcessStateError {
-			return true
-		}
-
-		return false
-	}, 200, 1000)
-	require.NoError(t, err)
-
-	assert.Equal(t, status.State, BackgroundProcessStateError)
+	RequireBackgroundManagerState(t, testDB1.AttachmentCompactionManager, BackgroundProcessStateError)
 }
 
 func TestAttachmentDifferentVBUUIDsBetweenPhases(t *testing.T) {

--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -406,9 +406,10 @@ func TestAttachmentCompactionRunTwice(t *testing.T) {
 	var err error
 
 	// Trigger start with immediate abort. Then resume, ensure that dry run is resumed
-	testDB2.AttachmentCompactionManager.Process.(*AttachmentCompactionManager).runFunctionStartedCallback = func(_ context.Context, _ map[string]any, _ updateStatusCallbackFunc, terminator *base.SafeTerminator) {
+	cb1 := runFunctionStartedCallbackFunc(func(_ context.Context, _ map[string]any, _ updateStatusCallbackFunc, terminator *base.SafeTerminator) {
 		<-terminator.Done()
-	}
+	})
+	testDB2.AttachmentCompactionManager.Process.(*AttachmentCompactionManager).runFunctionStartedCallback.Store(&cb1)
 	err = testDB2.AttachmentCompactionManager.Start(ctx2, map[string]any{"database": testDB2, "dryRun": true})
 	assert.NoError(t, err)
 	err = testDB2.AttachmentCompactionManager.Stop(ctx2)
@@ -435,9 +436,10 @@ func TestAttachmentCompactionRunTwice(t *testing.T) {
 	assert.True(t, testStatus.DryRun)
 
 	// Trigger start with immediate stop (stopped from db2)
-	testDB1.AttachmentCompactionManager.Process.(*AttachmentCompactionManager).runFunctionStartedCallback = func(_ context.Context, _ map[string]any, _ updateStatusCallbackFunc, terminator *base.SafeTerminator) {
+	cb2 := runFunctionStartedCallbackFunc(func(_ context.Context, _ map[string]any, _ updateStatusCallbackFunc, terminator *base.SafeTerminator) {
 		<-terminator.Done()
-	}
+	})
+	testDB1.AttachmentCompactionManager.Process.(*AttachmentCompactionManager).runFunctionStartedCallback.Store(&cb2)
 	err = testDB1.AttachmentCompactionManager.Start(ctx1, map[string]any{"database": testDB1})
 	assert.NoError(t, err)
 	err = testDB2.AttachmentCompactionManager.Stop(ctx2)
@@ -446,11 +448,12 @@ func TestAttachmentCompactionRunTwice(t *testing.T) {
 	RequireBackgroundManagerState(t, testDB1.AttachmentCompactionManager, BackgroundProcessStateStopped)
 
 	// Kick off another run with an attempted start from the other node, checks for error on other node
-	testDB1.AttachmentCompactionManager.Process.(*AttachmentCompactionManager).runFunctionStartedCallback = func(_ context.Context, _ map[string]any, _ updateStatusCallbackFunc, _ *base.SafeTerminator) {
-		startErr := testDB2.AttachmentCompactionManager.Start(ctx2, map[string]any{"database": testDB2})
-		assert.Error(t, startErr)
-		assert.Contains(t, startErr.Error(), "Process already running")
-	}
+	cb3 := runFunctionStartedCallbackFunc(func(_ context.Context, _ map[string]any, _ updateStatusCallbackFunc, _ *base.SafeTerminator) {
+		err := testDB2.AttachmentCompactionManager.Start(ctx2, map[string]any{"database": testDB2})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "Process already running")
+	})
+	testDB1.AttachmentCompactionManager.Process.(*AttachmentCompactionManager).runFunctionStartedCallback.Store(&cb3)
 	err = testDB1.AttachmentCompactionManager.Start(ctx1, map[string]any{"database": testDB1})
 	assert.NoError(t, err)
 
@@ -488,9 +491,10 @@ func TestAttachmentCompactionStopImmediateStart(t *testing.T) {
 	var err error
 
 	// Trigger start with immediate abort. Then resume, ensure that dry run is resumed
-	testDB2.AttachmentCompactionManager.Process.(*AttachmentCompactionManager).runFunctionStartedCallback = func(_ context.Context, _ map[string]any, _ updateStatusCallbackFunc, terminator *base.SafeTerminator) {
+	stopCb1 := runFunctionStartedCallbackFunc(func(_ context.Context, _ map[string]any, _ updateStatusCallbackFunc, terminator *base.SafeTerminator) {
 		<-terminator.Done()
-	}
+	})
+	testDB2.AttachmentCompactionManager.Process.(*AttachmentCompactionManager).runFunctionStartedCallback.Store(&stopCb1)
 	err = testDB2.AttachmentCompactionManager.Start(ctx2, map[string]any{"database": testDB2, "dryRun": true})
 	assert.NoError(t, err)
 	err = testDB2.AttachmentCompactionManager.Stop(ctx2)
@@ -517,9 +521,10 @@ func TestAttachmentCompactionStopImmediateStart(t *testing.T) {
 	assert.True(t, testStatus.DryRun)
 
 	// Trigger start with immediate stop (stopped from db2)
-	testDB1.AttachmentCompactionManager.Process.(*AttachmentCompactionManager).runFunctionStartedCallback = func(_ context.Context, _ map[string]any, _ updateStatusCallbackFunc, terminator *base.SafeTerminator) {
+	stopCb2 := runFunctionStartedCallbackFunc(func(_ context.Context, _ map[string]any, _ updateStatusCallbackFunc, terminator *base.SafeTerminator) {
 		<-terminator.Done()
-	}
+	})
+	testDB1.AttachmentCompactionManager.Process.(*AttachmentCompactionManager).runFunctionStartedCallback.Store(&stopCb2)
 	err = testDB1.AttachmentCompactionManager.Start(ctx1, map[string]any{"database": testDB1})
 	assert.NoError(t, err)
 	err = testDB2.AttachmentCompactionManager.Stop(ctx2)

--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -447,9 +447,9 @@ func TestAttachmentCompactionRunTwice(t *testing.T) {
 
 	// Kick off another run with an attempted start from the other node, checks for error on other node
 	testDB1.AttachmentCompactionManager.Process.(*AttachmentCompactionManager).runFunctionStartedCallback = func(_ context.Context, _ map[string]any, _ updateStatusCallbackFunc, _ *base.SafeTerminator) {
-		err = testDB2.AttachmentCompactionManager.Start(ctx2, map[string]any{"database": testDB2})
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "Process already running")
+		startErr := testDB2.AttachmentCompactionManager.Start(ctx2, map[string]any{"database": testDB2})
+		assert.Error(t, startErr)
+		assert.Contains(t, startErr.Error(), "Process already running")
 	}
 	err = testDB1.AttachmentCompactionManager.Start(ctx1, map[string]any{"database": testDB1})
 	assert.NoError(t, err)

--- a/db/background_mgr_attachment_compaction.go
+++ b/db/background_mgr_attachment_compaction.go
@@ -31,6 +31,8 @@ type AttachmentCompactionManager struct {
 	VBUUIDs           []uint64
 	dryRun            bool
 	lock              sync.Mutex
+	// runFunctionStartedCallback is a test seam: if set, it is called at the top of Run before any compaction phases execute.
+	runFunctionStartedCallback func(context.Context, map[string]any, updateStatusCallbackFunc, *base.SafeTerminator)
 }
 
 var _ BackgroundManagerProcessI = &AttachmentCompactionManager{}
@@ -103,6 +105,10 @@ func (a *AttachmentCompactionManager) Init(ctx context.Context, options map[stri
 }
 
 func (a *AttachmentCompactionManager) Run(ctx context.Context, options map[string]any, persistClusterStatusCallback updateStatusCallbackFunc, terminator *base.SafeTerminator) error {
+	if a.runFunctionStartedCallback != nil {
+		a.runFunctionStartedCallback(ctx, options, persistClusterStatusCallback, terminator)
+		a.runFunctionStartedCallback = nil
+	}
 	database := options["database"].(*Database)
 
 	// Attachment compaction only needs to operate the default scope/collection,

--- a/db/background_mgr_attachment_compaction.go
+++ b/db/background_mgr_attachment_compaction.go
@@ -28,13 +28,13 @@ import (
 type runFunctionStartedCallbackFunc func(context.Context, map[string]any, updateStatusCallbackFunc, *base.SafeTerminator)
 
 type AttachmentCompactionManager struct {
-	MarkedAttachments base.AtomicInt
-	PurgedAttachments base.AtomicInt
-	CompactID         string
-	Phase             string
-	VBUUIDs           []uint64
-	dryRun            bool
-	lock              sync.Mutex
+	MarkedAttachments          base.AtomicInt
+	PurgedAttachments          base.AtomicInt
+	CompactID                  string
+	Phase                      string
+	VBUUIDs                    []uint64
+	dryRun                     bool
+	lock                       sync.Mutex
 	runFunctionStartedCallback atomic.Pointer[runFunctionStartedCallbackFunc]
 }
 

--- a/db/background_mgr_attachment_compaction.go
+++ b/db/background_mgr_attachment_compaction.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/couchbase/gocbcore/v10"
@@ -23,6 +24,9 @@ import (
 // Attachment Compaction Implementation of Background Manager Process
 // =====================================================================
 
+// runFunctionStartedCallbackFunc is a test seam called at the top of Run before any compaction phases execute.
+type runFunctionStartedCallbackFunc func(context.Context, map[string]any, updateStatusCallbackFunc, *base.SafeTerminator)
+
 type AttachmentCompactionManager struct {
 	MarkedAttachments base.AtomicInt
 	PurgedAttachments base.AtomicInt
@@ -31,8 +35,7 @@ type AttachmentCompactionManager struct {
 	VBUUIDs           []uint64
 	dryRun            bool
 	lock              sync.Mutex
-	// runFunctionStartedCallback is a test seam: if set, it is called at the top of Run before any compaction phases execute.
-	runFunctionStartedCallback func(context.Context, map[string]any, updateStatusCallbackFunc, *base.SafeTerminator)
+	runFunctionStartedCallback atomic.Pointer[runFunctionStartedCallbackFunc]
 }
 
 var _ BackgroundManagerProcessI = &AttachmentCompactionManager{}
@@ -105,9 +108,9 @@ func (a *AttachmentCompactionManager) Init(ctx context.Context, options map[stri
 }
 
 func (a *AttachmentCompactionManager) Run(ctx context.Context, options map[string]any, persistClusterStatusCallback updateStatusCallbackFunc, terminator *base.SafeTerminator) error {
-	if a.runFunctionStartedCallback != nil {
-		a.runFunctionStartedCallback(ctx, options, persistClusterStatusCallback, terminator)
-		a.runFunctionStartedCallback = nil
+	if cb := a.runFunctionStartedCallback.Load(); cb != nil {
+		(*cb)(ctx, options, persistClusterStatusCallback, terminator)
+		a.runFunctionStartedCallback.Store(nil)
 	}
 	database := options["database"].(*Database)
 


### PR DESCRIPTION
Accidental regression from 6b03dc039ba72270546aab6a3ab2e7ffdc606ac7

- The order in which GetRaw is called is now different than before and GetRaw was called in BackgroundManager.Start before the full state transition would occur. Made this test less fragile by introducing a runFunctionStartedCallback seam which functions to do a state transition instead of relying on the order of GetRaw.
- Changed some test assertions to use helper function RequireBackgroundManagerState function which reports errors more clearly

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/754/
