### PR TITLE
Don't run database state polling when distributed resync isn't running

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -62,6 +62,10 @@ const (
 	// Can be used to set a global log level for all tests at runtime.
 	TestEnvGlobalLogLevel = "SG_TEST_LOG_LEVEL"
 
+	// TestEnvDistributedResync if set to true enables distributed resync test cases (CBG-5419).
+	// Requires Couchbase Server and Enterprise Edition.
+	TestEnvDistributedResync = "SG_TEST_DISTRIBUTED_RESYNC"
+
 	// Should x509 tests deploy certs to local macOS Couchbase Server?
 	TestEnvX509Local = "SG_TEST_X509_LOCAL"
 

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -296,9 +296,6 @@ func TestResyncManagerDCPStart(t *testing.T) {
 					"collections":         base.NewCollectionNames(),
 				}
 
-				if testCase.Distributed {
-					db.ResyncManager = NewResyncManagerDCP(db.DatabaseContext, true)
-				}
 				err := db.ResyncManager.Start(ctx, options)
 				require.NoError(t, err)
 
@@ -460,6 +457,9 @@ func TestResyncManagerDCPResumeStoppedProcessChangeCollections(t *testing.T) {
 			const numCollections = 2
 			totalDocCount := docsPerCollection * numCollections
 
+			if testCase.Distributed {
+				AllowDistributedResync(t)
+			}
 			tb := base.GetTestBucket(t)
 			defer tb.Close(base.TestCtx(t))
 			dbOptions := DatabaseContextOptions{}
@@ -467,15 +467,6 @@ func TestResyncManagerDCPResumeStoppedProcessChangeCollections(t *testing.T) {
 
 			db, ctx := SetupTestDBForBucketWithOptions(t, tb, dbOptions)
 			defer db.Close(ctx)
-
-			rs, ok := db.ResyncManager.Process.(*ResyncManagerDCP)
-			require.True(t, ok)
-
-			if testCase.Distributed {
-				db.ResyncManager = NewResyncManagerDCP(db.DatabaseContext, true)
-			} else {
-				require.False(t, rs.Distributed, "Expected this database ResyncManager to be in non distributed mode")
-			}
 
 			dbCollections := make([]*DatabaseCollectionWithUser, numCollections)
 			for i, scName := range db.DataStoreNames() {
@@ -558,21 +549,15 @@ type testDBForResyncOptions struct {
 
 // setupTestDBForResyncWithDocs creates a databases and seeds it with documents for setupTestDBForResyncWithDocs
 func setupTestDBForResyncWithDocs(t testing.TB, opts testDBForResyncOptions) (*Database, context.Context) {
+	if opts.distributed {
+		AllowDistributedResync(t)
+	}
 	db, ctx := setupTestDB(t)
 	syncFn := `
 function sync(doc, oldDoc){
 	channel("channel.ABC");
 }
 `
-	rs, ok := db.ResyncManager.Process.(*ResyncManagerDCP)
-	require.True(t, ok)
-
-	if opts.distributed {
-		db.ResyncManager = NewResyncManagerDCP(db.DatabaseContext, true)
-	} else {
-		require.False(t, rs.Distributed, "Expected this database ResyncManager to be in non distributed mode")
-	}
-
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 
 	_, err := collection.UpdateSyncFun(ctx, syncFn)

--- a/db/database.go
+++ b/db/database.go
@@ -91,6 +91,10 @@ var (
 	BypassReleasedSequenceWait atomic.Bool // Used to optimize single-node testing, see DisableSequenceWaitOnDbRestart
 )
 
+// allowDistributedResync controls whether NewDatabaseContext creates a distributed ResyncManagerDCP.
+// Toggle via AllowDistributedResync in test code only.
+var allowDistributedResync bool
+
 const (
 	CompactIntervalMinDays = float32(0.04) // ~1 Hour in days
 	CompactIntervalMaxDays = float32(60)   // 60 Days in days
@@ -624,11 +628,15 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 		return nil, err
 	}
 
-	distributedResync := false // when ready, this will flip to  db.useShardedDCP()
-	dbContext.ResyncManager = NewResyncManagerDCP(dbContext, distributedResync)
+	useDistributedResync := allowDistributedResync && dbContext.useShardedDCP()
+	dbContext.ResyncManager = NewResyncManagerDCP(dbContext, useDistributedResync)
 	dbContext.AsyncIndexInitManager = NewAsyncIndexInitManager(metadataStore, dbContext.MetadataKeys)
 
-	dbContext.DBStateManager = NewDatabaseStateMgr(metadataStore, metaKeys.DatabaseStateKey(), dbContext.ResyncManager.Resume)
+	var resumeResync resumeResyncFunc
+	if useDistributedResync {
+		resumeResync = dbContext.ResyncManager.Resume
+	}
+	dbContext.DBStateManager = NewDatabaseStateMgr(metadataStore, metaKeys.DatabaseStateKey(), resumeResync)
 
 	return dbContext, nil
 }

--- a/db/database_state.go
+++ b/db/database_state.go
@@ -21,16 +21,23 @@ type DatabaseState struct {
 	ResyncRunning *bool `json:"resync,omitempty"`
 }
 
+// resumeResyncFunc can be a function used to resume the resync process.
+type resumeResyncFunc func(ctx context.Context) error
+
 type DatabaseStateMgr struct {
 	CAS              uint64
 	dbStateID        string
 	metadataStore    base.DataStore
 	pollingInterval  time.Duration
-	resumeResyncFunc func(ctx context.Context) error
+	resumeResyncFunc resumeResyncFunc // optional callback invoked by the polling loop when a state change is detected.
 	lock             sync.Mutex
 	terminator       chan struct{}
 	done             chan struct{}
 }
+
+// databaseStatePollingInterval is the default polling interval for DatabaseStateMgr. It can be overridden in tests
+// via UpdateDatabaseStatePolling.
+var databaseStatePollingInterval = 10 * time.Second
 
 // NewDatabaseStateMgr creates a DatabaseStateMgr for the given database. resumeResyncFunc is called by the polling loop
 // when a state change is detected with ResyncRunning set to true; it should resume the resync process.
@@ -39,7 +46,7 @@ func NewDatabaseStateMgr(metadataStore base.DataStore, dbStateID string, resumeR
 		dbStateID:        dbStateID,
 		CAS:              0,
 		metadataStore:    metadataStore,
-		pollingInterval:  10 * time.Second,
+		pollingInterval:  databaseStatePollingInterval,
 		resumeResyncFunc: resumeResyncFunc,
 	}
 }

--- a/db/database_state.go
+++ b/db/database_state.go
@@ -127,6 +127,9 @@ func (dbMgr *DatabaseStateMgr) poll(ctx context.Context) {
 	if !ok {
 		return
 	}
+	if dbMgr.resumeResyncFunc == nil {
+		return
+	}
 	if state.ResyncRunning != nil && *state.ResyncRunning {
 		err := dbMgr.resumeResyncFunc(ctx)
 		if err != nil {

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -1208,8 +1208,9 @@ type ResyncTestCase struct {
 // AllowDistributedResync sets allowDistributedResync to true for the duration of the test. Call this before
 // creating any DatabaseContext that should use distributed resync.
 func AllowDistributedResync(t testing.TB) {
+	orig := allowDistributedResync
 	allowDistributedResync = true
-	t.Cleanup(func() { allowDistributedResync = false })
+	t.Cleanup(func() { allowDistributedResync = orig })
 }
 
 // ResyncTestModes returns the test modes to run resync tests in for a given test run. Distributed resync requires Couchbase Server and EE.

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -1192,12 +1192,28 @@ func (db *DatabaseContext) FlushChannelCache(t testing.TB) {
 	db.RestartChangeListener(t, true)
 }
 
+// UpdateDatabaseStatePolling overrides the polling interval used by NewDatabaseStateMgr and restores the original
+// value via t.Cleanup.
+func UpdateDatabaseStatePolling(t testing.TB, pollInterval time.Duration) {
+	orig := databaseStatePollingInterval
+	databaseStatePollingInterval = pollInterval
+	t.Cleanup(func() { databaseStatePollingInterval = orig })
+}
+
 type ResyncTestCase struct {
 	Name        string // name of test case
 	Distributed bool   // use distributed resync
 }
 
+// AllowDistributedResync sets allowDistributedResync to true for the duration of the test. Call this before
+// creating any DatabaseContext that should use distributed resync.
+func AllowDistributedResync(t testing.TB) {
+	allowDistributedResync = true
+	t.Cleanup(func() { allowDistributedResync = false })
+}
+
 // ResyncTestModes returns the test modes to run resync tests in for a given test run. Distributed resync requires Couchbase Server and EE.
+// Set SG_TEST_DISTRIBUTED_RESYNC=true to include the distributed=true case (CBG-5419).
 func ResyncTestModes() []ResyncTestCase {
 	testCases := []ResyncTestCase{
 		{
@@ -1205,13 +1221,12 @@ func ResyncTestModes() []ResyncTestCase {
 			Distributed: false,
 		},
 	}
-	/* CBG-5419 enable tests
-	if !base.UnitTestUrlIsWalrus() && base.IsEnterpriseEdition() {
+	if strings.EqualFold(os.Getenv(base.TestEnvDistributedResync), "true") &&
+		!base.UnitTestUrlIsWalrus() && base.IsEnterpriseEdition() {
 		testCases = append(testCases, ResyncTestCase{
 			Name:        "distributed=true",
 			Distributed: true,
 		})
 	}
-	*/
 	return testCases
 }

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -625,6 +625,9 @@ func TestDBGetConfigCustomLogging(t *testing.T) {
 func TestDBOfflineSingleResyncUsingDCPStream(t *testing.T) {
 	for _, testCase := range db.ResyncTestModes() {
 		t.Run(testCase.Name, func(t *testing.T) {
+			if testCase.Distributed {
+				db.AllowDistributedResync(t)
+			}
 
 			syncFn := `
 	function(doc) {
@@ -640,7 +643,6 @@ func TestDBOfflineSingleResyncUsingDCPStream(t *testing.T) {
 			assert.Equal(t, int64(1000), rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
 
 			rt.TakeDbOffline()
-			rt.SetDistributedResync(testCase.Distributed)
 
 			response := rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
 			rest.RequireStatus(t, response, http.StatusOK)
@@ -659,6 +661,9 @@ func TestDCPResyncCollectionsStatus(t *testing.T) {
 	base.TestRequiresCollections(t)
 	for _, distributedTestCase := range db.ResyncTestModes() {
 		t.Run(distributedTestCase.Name, func(t *testing.T) {
+			if distributedTestCase.Distributed {
+				db.AllowDistributedResync(t)
+			}
 
 			testCases := []struct {
 				name              string
@@ -695,7 +700,6 @@ func TestDCPResyncCollectionsStatus(t *testing.T) {
 					}
 
 					rt.TakeDbOffline()
-					rt.SetDistributedResync(distributedTestCase.Distributed)
 
 					if !testCase.specifyCollection {
 						resp := rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
@@ -719,6 +723,9 @@ func TestDCPResyncCollectionsStatus(t *testing.T) {
 func TestResyncUsingDCPStream(t *testing.T) {
 	for _, distributedTestCase := range db.ResyncTestModes() {
 		t.Run(distributedTestCase.Name, func(t *testing.T) {
+			if distributedTestCase.Distributed {
+				db.AllowDistributedResync(t)
+			}
 
 			testCases := []struct {
 				docsCreated int
@@ -759,7 +766,6 @@ func TestResyncUsingDCPStream(t *testing.T) {
 					rest.RequireStatus(t, response, http.StatusServiceUnavailable)
 
 					rt.TakeDbOffline()
-					rt.SetDistributedResync(distributedTestCase.Distributed)
 
 					response = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
 					rest.RequireStatus(t, response, http.StatusOK)
@@ -789,6 +795,9 @@ func TestResyncUsingDCPStream(t *testing.T) {
 func TestResyncUsingDCPStreamReset(t *testing.T) {
 	for _, testCase := range db.ResyncTestModes() {
 		t.Run(testCase.Name, func(t *testing.T) {
+			if testCase.Distributed {
+				db.AllowDistributedResync(t)
+			}
 
 			syncFn := `
 	function(doc) {
@@ -810,7 +819,6 @@ func TestResyncUsingDCPStreamReset(t *testing.T) {
 			}
 
 			rt.TakeDbOffline()
-			rt.SetDistributedResync(testCase.Distributed)
 
 			// start a resync run
 			response := rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
@@ -859,6 +867,9 @@ func TestResyncUsingDCPStreamForNamedCollection(t *testing.T) {
 	base.RequireNumTestDataStores(t, numCollections)
 	for _, testCase := range db.ResyncTestModes() {
 		t.Run(testCase.Name, func(t *testing.T) {
+			if testCase.Distributed {
+				db.AllowDistributedResync(t)
+			}
 
 			base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyConfig)
 
@@ -887,7 +898,6 @@ func TestResyncUsingDCPStreamForNamedCollection(t *testing.T) {
 			}
 
 			rt.TakeDbOffline()
-			rt.SetDistributedResync(testCase.Distributed)
 
 			rest.RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/{{.keyspace1}}/_config/sync", `function(doc){channel("A")}`), http.StatusOK)
 			rest.RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/{{.keyspace2}}/_config/sync", `function(doc){channel("A")}`), http.StatusOK)
@@ -921,6 +931,9 @@ func TestResyncUsingDCPStreamForNamedCollection(t *testing.T) {
 func TestResyncErrorScenariosUsingDCPStream(t *testing.T) {
 	for _, testCase := range db.ResyncTestModes() {
 		t.Run(testCase.Name, func(t *testing.T) {
+			if testCase.Distributed {
+				db.AllowDistributedResync(t)
+			}
 
 			syncFn := `
 	function(doc) {
@@ -955,7 +968,6 @@ func TestResyncErrorScenariosUsingDCPStream(t *testing.T) {
 			rest.RequireStatus(t, response, http.StatusBadRequest)
 
 			rt.TakeDbOffline()
-			rt.SetDistributedResync(testCase.Distributed)
 
 			response = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
 			rest.RequireStatus(t, response, http.StatusOK)
@@ -1451,6 +1463,9 @@ func TestConfigPollingRemoveDatabase(t *testing.T) {
 func TestResyncStopUsingDCPStream(t *testing.T) {
 	for _, testCase := range db.ResyncTestModes() {
 		t.Run(testCase.Name, func(t *testing.T) {
+			if testCase.Distributed {
+				db.AllowDistributedResync(t)
+			}
 
 			syncFn := `
 	function(doc) {
@@ -1481,7 +1496,6 @@ func TestResyncStopUsingDCPStream(t *testing.T) {
 			require.Equal(t, int64(numOfDocs), rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
 
 			rt.TakeDbOffline()
-			rt.SetDistributedResync(testCase.Distributed)
 
 			response := rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
 			rest.RequireStatus(t, response, http.StatusOK)

--- a/rest/adminapitest/collections_admin_api_test.go
+++ b/rest/adminapitest/collections_admin_api_test.go
@@ -173,6 +173,9 @@ func TestRequireResync(t *testing.T) {
 	}
 	for _, testCase := range db.ResyncTestModes() {
 		t.Run(testCase.Name, func(t *testing.T) {
+			if testCase.Distributed {
+				db.AllowDistributedResync(t)
+			}
 
 			base.TestRequiresCollections(t)
 			base.RequireNumTestDataStores(t, 2)
@@ -209,7 +212,6 @@ func TestRequireResync(t *testing.T) {
 
 			resp := rt.CreateDatabase(db1Name, dbConfig)
 			rest.RequireStatus(t, resp, http.StatusCreated)
-			rt.SetDistributedResync(testCase.Distributed)
 
 			// Write documents to collection 1 and 2
 			ks_db1_c1 := db1Name + "." + scope + "." + collection1
@@ -225,7 +227,6 @@ func TestRequireResync(t *testing.T) {
 			dbConfig.Scopes = scopesConfigC2Only
 			resp = rt.ReplaceDbConfig(db1Name, dbConfig)
 			rest.RequireStatus(t, resp, http.StatusCreated)
-			rt.SetDistributedResync(testCase.Distributed)
 
 			// Validate that doc can still be retrieved from collection 2
 			resp = rt.SendAdminRequest("GET", "/"+ks_db1_c2+"/testDoc2", "")
@@ -237,15 +238,6 @@ func TestRequireResync(t *testing.T) {
 
 			resp = rt.CreateDatabase(db2Name, db2Config)
 			rest.RequireStatus(t, resp, http.StatusCreated)
-			for _, database := range rt.ServerContext().AllDatabases() {
-				rs, ok := database.ResyncManager.Process.(*db.ResyncManagerDCP)
-				require.True(rt.TB(), ok)
-				if testCase.Distributed {
-					rs.Distributed = true
-				} else {
-					require.False(rt.TB(), rs.Distributed, "Expected this database ResyncManager to be in non distributed mode")
-				}
-			}
 
 			dbConfigCas1 := getDBConfigCas(rt, db2Name)
 

--- a/rest/adminapitest/resync_test.go
+++ b/rest/adminapitest/resync_test.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/couchbase/gocbcore/v10"
 	"github.com/couchbase/sync_gateway/base"
@@ -463,6 +464,89 @@ func TestResyncRequireResyncDefaultMetadataID(t *testing.T) {
 	rest.RequireStatus(t, resp, http.StatusCreated)
 
 	rt.WaitForDatabaseState(db2Name, db.RunStateString[db.DBOnline])
+}
+
+// TestResyncCrossNode verifies that two nodes sharing the same bucket both transition to offline
+// when one node takes the database offline (via persistent config), and that resync started on
+// one node completes and is visible to both nodes.
+func TestResyncCrossNode(t *testing.T) {
+	for _, testCase := range db.ResyncTestModes() {
+		t.Run(testCase.Name, func(t *testing.T) {
+			if testCase.Distributed {
+				db.AllowDistributedResync(t)
+				db.UpdateDatabaseStatePolling(t, 100*time.Millisecond)
+			}
+			ctx := base.TestCtx(t)
+			tb := base.GetTestBucket(t)
+			defer tb.Close(ctx)
+
+			groupID := t.Name()
+			rtConfig := &rest.RestTesterConfig{
+				CustomTestBucket: tb.NoCloseClone(),
+				PersistentConfig: true,
+				GroupID:          &groupID,
+			}
+
+			rt1 := rest.NewRestTester(t, rtConfig)
+			defer rt1.Close()
+
+			rt2 := rest.NewRestTester(t, rtConfig)
+			defer rt2.Close()
+
+			const dbName = "db"
+
+			// Create database on node 1
+			dbConfig := rt1.NewDbConfig()
+			rest.RequireStatus(t, rt1.CreateDatabase(dbName, dbConfig), http.StatusCreated)
+
+			// Node 2 discovers database from the shared bucket
+			rt2.ServerContext().ForceDbConfigsReload(t, ctx)
+			rt2.WaitForDatabaseState(dbName, db.RunStateString[db.DBOnline])
+
+			// Seed 100 documents via node 1
+			const numDocs = 100
+			for i := range numDocs {
+				rt1.CreateTestDoc(fmt.Sprintf("doc%d", i))
+			}
+
+			// Take node 1 offline — persists StartOffline=true to the shared bucket
+			rt1.TakeDbOffline()
+
+			// Node 2 picks up offline state from the shared bucket via config reload
+			rt2.ServerContext().ForceDbConfigsReload(t, ctx)
+			rt2.WaitForDatabaseState(dbName, db.RunStateString[db.DBOffline])
+
+			// Start resync on node 1
+			resp := rt1.SendAdminRequest(http.MethodPost, "/{{.db}}/_resync?action=start", "")
+			rest.RequireStatus(t, resp, http.StatusOK)
+
+			// Both nodes observe the completed resync status via the shared bucket
+			status := rt1.WaitForResyncDCPStatusForDB(db.BackgroundProcessStateCompleted, dbName)
+			require.GreaterOrEqual(t, status.DocsProcessed, int64(numDocs))
+
+			// rt1 local stats: processed ≥ numDocs, nothing changed (same sync fn),
+			// DocsTargeted resets to 0 on completion, no errors
+			rt1DB := rt1.GetDatabase()
+			assert.GreaterOrEqual(t, rt1DB.DbStats.Database().ResyncNumProcessed.Value(), int64(numDocs))
+			assert.Equal(t, int64(0), rt1DB.DbStats.Database().ResyncNumChanged.Value())
+			assert.Equal(t, int64(0), rt1DB.DbStats.Database().ResyncDocsTargeted.Value()) // reset to 0 after completion
+			assert.Equal(t, int64(0), rt1DB.DbStats.Database().ResyncErrorsTotal.Value())
+
+			rt2.WaitForResyncDCPStatusForDB(db.BackgroundProcessStateCompleted, dbName)
+
+			// rt2 local stats: 0 in non-distributed mode (rt2 processed no vbuckets);
+			// in distributed mode rt2 would have non-zero ResyncNumProcessed
+			rt2DB := rt2.GetDatabase()
+			assert.Equal(t, int64(0), rt2DB.DbStats.Database().ResyncNumChanged.Value())
+			assert.Equal(t, int64(0), rt2DB.DbStats.Database().ResyncDocsTargeted.Value())
+			assert.Equal(t, int64(0), rt2DB.DbStats.Database().ResyncErrorsTotal.Value())
+			if testCase.Distributed {
+				assert.GreaterOrEqual(t, rt2DB.DbStats.Database().ResyncNumProcessed.Value(), int64(0))
+			} else {
+				assert.Equal(t, int64(0), rt2DB.DbStats.Database().ResyncNumProcessed.Value())
+			}
+		})
+	}
 }
 
 func TestResyncPartitionsMaximumValidation(t *testing.T) {

--- a/rest/sync_fn_test.go
+++ b/rest/sync_fn_test.go
@@ -407,6 +407,9 @@ func TestSyncFnTimeout(t *testing.T) {
 func TestResyncRegenerateSequences(t *testing.T) {
 	for _, testCase := range db.ResyncTestModes() {
 		t.Run(testCase.Name, func(t *testing.T) {
+			if testCase.Distributed {
+				db.AllowDistributedResync(t)
+			}
 
 			ctx := base.TestCtx(t)
 			syncFn := `
@@ -484,7 +487,6 @@ func TestResyncRegenerateSequences(t *testing.T) {
 
 			response = rt.SendAdminRequest("POST", "/db/_offline", "")
 			RequireStatus(t, response, http.StatusOK)
-			rt.SetDistributedResync(testCase.Distributed)
 
 			response = rt.SendAdminRequest("POST", "/db/_resync?action=start&regenerate_sequences=true", "")
 			RequireStatus(t, response, http.StatusOK)
@@ -540,6 +542,9 @@ func TestResyncRegenerateSequences(t *testing.T) {
 func TestResyncPersistence(t *testing.T) {
 	for _, testCase := range db.ResyncTestModes() {
 		t.Run(testCase.Name, func(t *testing.T) {
+			if testCase.Distributed {
+				db.AllowDistributedResync(t)
+			}
 
 			tb := base.GetTestBucket(t)
 			noCloseTB := tb.NoCloseClone()
@@ -560,8 +565,6 @@ func TestResyncPersistence(t *testing.T) {
 
 			// Start resync
 			rt1.TakeDbOffline()
-			rt1.SetDistributedResync(testCase.Distributed)
-			rt2.SetDistributedResync(testCase.Distributed)
 
 			resp := rt1.SendAdminRequest("POST", "/{{.db}}/_resync?action=start", "")
 			RequireStatus(t, resp, http.StatusOK)

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -540,7 +540,6 @@ func (rt *RestTester) WaitForDBInitializationCompleted(dbName string) {
 	}, 30*time.Second, 100*time.Millisecond, "Database initialization did not complete within expected time")
 }
 
-
 type RawDocResponse struct {
 	Xattrs RawDocXattrs `json:"_xattrs"`
 }

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -540,18 +540,6 @@ func (rt *RestTester) WaitForDBInitializationCompleted(dbName string) {
 	}, 30*time.Second, 100*time.Millisecond, "Database initialization did not complete within expected time")
 }
 
-// SetDistributedResync forces the ResyncManager into a single node or distributed resync mode. This should only be called before
-// resync is run for the first time and needs to be called each time a DatabaseContext is reinitialized.
-func (rt *RestTester) SetDistributedResync(useDistributed bool) {
-	database := rt.GetDatabase()
-	rs, ok := database.ResyncManager.Process.(*db.ResyncManagerDCP)
-	require.True(rt.TB(), ok)
-	if useDistributed {
-		rt.GetDatabase().ResyncManager = db.NewResyncManagerDCP(database, true)
-	} else {
-		require.False(rt.TB(), rs.Distributed, "Expected this database ResyncManager to be in non distributed mode")
-	}
-}
 
 type RawDocResponse struct {
 	Xattrs RawDocXattrs `json:"_xattrs"`


### PR DESCRIPTION
- Create a variable to allow setting distributed resync, since distributed resync has interactions with database state mgr and needs to be set on instantiation of NewDatabaseContext
- Don't call ResumeResync if distributed resync isn't set, this spews WRN messages about being invalid to call on non multi node background manager
- Add a new test `TestResyncCrossNode` to be able to test "real" cross node issues.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/758/ (test flakes for independent reason)
