### PR TITLE
Allow resync background manager Resume to round trip options

### DIFF
--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -59,8 +59,9 @@ const (
 	BackgroundProcessActionStop  BackgroundProcessAction = "stop"
 )
 
-// BackgroundManager this is the over-arching type which is exposed in DatabaseContext
-type BackgroundManager struct {
+// BackgroundManager this is the over-arching type which is exposed in DatabaseContext.
+// O is the type of the options struct passed to BackgroundManagerProcessI.Init and BackgroundManagerProcessI.Run.
+type BackgroundManager[O any] struct {
 	status                                 BackgroundManagerStatus
 	statusLock                             sync.RWMutex
 	name                                   string
@@ -69,7 +70,7 @@ type BackgroundManager struct {
 	backgroundManagerStatusUpdateWaitGroup sync.WaitGroup
 	clusterAwareOptions                    *ClusterAwareBackgroundManagerOptions
 	lock                                   sync.Mutex
-	Process                                BackgroundManagerProcessI
+	Process                                BackgroundManagerProcessI[O]
 	// updateDatabaseState, when non-nil, is called from UpdateStatusClusterAware and from Resume
 	// (when the cluster is not running) to mirror the local run state into the DatabaseState document.
 	// running is true when the process is locally active, false otherwise.
@@ -107,13 +108,14 @@ type BackgroundManagerStatus struct {
 	LastErrorMessage string                 `json:"last_error"`
 }
 
-// BackgroundManagerProcessI is an interface satisfied by any of the background processes
+// BackgroundManagerProcessI is an interface satisfied by any of the background processes.
+// O is the type of the options struct passed to Init and Run.
 // Examples of this: ReSync, Compaction, Attachment Migration
-type BackgroundManagerProcessI interface {
+type BackgroundManagerProcessI[O any] interface {
 	// Init is called before Run for setup purposes. If Init errors, Run will not happen.
-	Init(ctx context.Context, options map[string]any, clusterStatus []byte) error
+	Init(ctx context.Context, options O, clusterStatus []byte) error
 	// Run implements all of the work of the process.
-	Run(ctx context.Context, options map[string]any, persistClusterStatusCallback updateStatusCallbackFunc, terminator *base.SafeTerminator) error
+	Run(ctx context.Context, options O, persistClusterStatusCallback updateStatusCallbackFunc, terminator *base.SafeTerminator) error
 	// GetProcessStatus accepts the current BackgroundManagerStatus and the previousStatus that was serialized. previousStatus is
 	// only populated when updating cluster status, it may be nil in some circumstances. This is only used for multi
 	// node background managers.
@@ -126,15 +128,22 @@ type BackgroundManagerProcessI interface {
 	ResetStatus()
 }
 
+// StoppableBackgroundManager allows stopping of the generic background managers.
+type StoppableBackgroundManager interface {
+	GetName() string
+	GetRunState() BackgroundProcessState
+	Stop(ctx context.Context) error
+}
+
 type updateStatusCallbackFunc func(ctx context.Context) error
 
 // GetName returns name of the background manager
-func (b *BackgroundManager) GetName() string {
+func (b *BackgroundManager[O]) GetName() string {
 	return b.name
 }
 
 // callUpdateDatabaseState invokes updateDatabaseState if it is set, logging any error.
-func (b *BackgroundManager) callUpdateDatabaseState(ctx context.Context, running bool) {
+func (b *BackgroundManager[O]) callUpdateDatabaseState(ctx context.Context, running bool) {
 	if b.updateDatabaseState == nil {
 		return
 	}
@@ -147,7 +156,7 @@ func (b *BackgroundManager) callUpdateDatabaseState(ctx context.Context, running
 // the status document.  It only starts the local process when the cluster state is
 // BackgroundProcessStateRunning; any other state (including no status document) returns
 // errBackgroundManagerStatusNotRunning.  Only supported for multi-node background managers.
-func (b *BackgroundManager) Resume(ctx context.Context) error {
+func (b *BackgroundManager[O]) Resume(ctx context.Context) error {
 	if b.mode() != backgroundManagerModeMultiNode {
 		return fmt.Errorf("Resume is only supported for multi-node background managers (process %q)", b.name)
 	}
@@ -173,7 +182,7 @@ func (b *BackgroundManager) Resume(ctx context.Context) error {
 
 	var doc struct {
 		Meta struct {
-			Options map[string]any `json:"options"`
+			Options O `json:"options"`
 		} `json:"meta"`
 	}
 	if err := base.JSONUnmarshal(raw, &doc); err != nil {
@@ -183,7 +192,7 @@ func (b *BackgroundManager) Resume(ctx context.Context) error {
 	return b.start(ctx, doc.Meta.Options, raw)
 }
 
-func (b *BackgroundManager) Start(ctx context.Context, options map[string]any) error {
+func (b *BackgroundManager[O]) Start(ctx context.Context, options O) error {
 	var processClusterStatus []byte
 	if b.mode() != backgroundManagerModeLocal {
 		var err error
@@ -195,7 +204,7 @@ func (b *BackgroundManager) Start(ctx context.Context, options map[string]any) e
 	return b.start(ctx, options, processClusterStatus)
 }
 
-func (b *BackgroundManager) start(ctx context.Context, options map[string]any, processClusterStatus []byte) error {
+func (b *BackgroundManager[O]) start(ctx context.Context, options O, processClusterStatus []byte) error {
 	if b.mode() != backgroundManagerModeMultiNode && b.updateDatabaseState != nil {
 		return fmt.Errorf("updateDatabaseState should only be set for multi-node background managers")
 	}
@@ -301,7 +310,7 @@ func (b *BackgroundManager) start(ctx context.Context, options map[string]any, p
 // If local or single node process and the bucket status is running, return errBackgroundManagerProcessAlreadyRunning.
 // If the status is stopping, return errBackgroundManagerStatusAlreadyStopping
 // that should be stopping or is already stopped.
-func (b *BackgroundManager) markStart(ctx context.Context, previousStatus BackgroundManagerStatus) error {
+func (b *BackgroundManager[O]) markStart(ctx context.Context, previousStatus BackgroundManagerStatus) error {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
@@ -365,7 +374,7 @@ func (b *BackgroundManager) markStart(ctx context.Context, previousStatus Backgr
 }
 
 // getClusterStatusState gets the current background process state of the cluster.
-func (b *BackgroundManager) getClusterStatusState(ctx context.Context) (BackgroundProcessState, error) {
+func (b *BackgroundManager[O]) getClusterStatusState(ctx context.Context) (BackgroundProcessState, error) {
 	docID := b.clusterAwareOptions.StatusDocID()
 	statusRaw, _, err := b.clusterAwareOptions.metadataStore.GetSubDocRaw(ctx, docID, "status")
 	if err != nil {
@@ -401,7 +410,7 @@ func unmarshalBackgroundManagerStatus(statusRaw []byte) (BackgroundManagerStatus
 	return clusterStatus.Status, nil
 }
 
-func (b *BackgroundManager) GetStatus(ctx context.Context) ([]byte, error) {
+func (b *BackgroundManager[O]) GetStatus(ctx context.Context) ([]byte, error) {
 	if b.mode() != backgroundManagerModeLocal {
 		status, err := b.getStatusFromCluster(ctx)
 		if err != nil {
@@ -422,12 +431,12 @@ func (b *BackgroundManager) GetStatus(ctx context.Context) ([]byte, error) {
 	return status, err
 }
 
-func (b *BackgroundManager) getStatusLocalWithoutPrevious() ([]byte, []byte, error) {
+func (b *BackgroundManager[O]) getStatusLocalWithoutPrevious() ([]byte, []byte, error) {
 	return b.getStatusWithPrevious(nil)
 
 }
 
-func (b *BackgroundManager) getStatusWithPrevious(previous []byte) ([]byte, []byte, error) {
+func (b *BackgroundManager[O]) getStatusWithPrevious(previous []byte) ([]byte, []byte, error) {
 	b.statusLock.Lock()
 	defer b.statusLock.Unlock()
 
@@ -443,7 +452,7 @@ func (b *BackgroundManager) getStatusWithPrevious(previous []byte) ([]byte, []by
 	return b.Process.GetProcessStatus(backgroundStatus, previous)
 }
 
-func (b *BackgroundManager) getStatusFromCluster(ctx context.Context) ([]byte, error) {
+func (b *BackgroundManager[O]) getStatusFromCluster(ctx context.Context) ([]byte, error) {
 	status, statusCas, err := b.clusterAwareOptions.metadataStore.GetSubDocRaw(ctx, b.clusterAwareOptions.StatusDocID(), "status")
 	if err != nil {
 		if base.IsDocNotFoundError(err) {
@@ -505,7 +514,7 @@ func (b *BackgroundManager) getStatusFromCluster(ctx context.Context) ([]byte, e
 	return status, err
 }
 
-func (b *BackgroundManager) resetStatus() {
+func (b *BackgroundManager[O]) resetStatus() {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
@@ -515,7 +524,7 @@ func (b *BackgroundManager) resetStatus() {
 }
 
 // setLastErrorMessage sets the last error message
-func (b *BackgroundManager) clearLastErrorMessage() {
+func (b *BackgroundManager[O]) clearLastErrorMessage() {
 	b.statusLock.Lock()
 	defer b.statusLock.Unlock()
 	b.status.LastErrorMessage = ""
@@ -525,7 +534,7 @@ func (b *BackgroundManager) clearLastErrorMessage() {
 // return from this function.
 //
 // This will return an error if the status is not in a running state, as already stopped or stopping.
-func (b *BackgroundManager) Stop(ctx context.Context) error {
+func (b *BackgroundManager[O]) Stop(ctx context.Context) error {
 	if err := b.markStop(ctx); err != nil {
 		if errors.Is(err, errBackgroundManagerProcessAlreadyStopped) || errors.Is(err, errBackgroundManagerStatusAlreadyStopping) {
 			return nil
@@ -538,12 +547,12 @@ func (b *BackgroundManager) Stop(ctx context.Context) error {
 
 // Terminate stops the process via terminator channel
 // Only to be used internally to this file and by tests.
-func (b *BackgroundManager) Terminate() {
+func (b *BackgroundManager[O]) Terminate() {
 	b.terminator.Close()
 	b.backgroundManagerStatusUpdateWaitGroup.Wait()
 }
 
-func (b *BackgroundManager) markStop(ctx context.Context) error {
+func (b *BackgroundManager[O]) markStop(ctx context.Context) error {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
@@ -583,35 +592,35 @@ func (b *BackgroundManager) markStop(ctx context.Context) error {
 }
 
 // GetRunState returns the in memory state of the background process. This may different from the serialized bucket state.
-func (b *BackgroundManager) GetRunState() BackgroundProcessState {
+func (b *BackgroundManager[O]) GetRunState() BackgroundProcessState {
 	b.statusLock.RLock()
 	defer b.statusLock.RUnlock()
 	return b.status.State
 }
 
 // setRunState sets the in memory state of the background process. This does not updated the serialized bucket state.
-func (b *BackgroundManager) setRunState(state BackgroundProcessState) {
+func (b *BackgroundManager[O]) setRunState(state BackgroundProcessState) {
 	b.statusLock.Lock()
 	defer b.statusLock.Unlock()
 	b.status.State = state
 }
 
 // getStartTime returns the current start time of the background process from an in memory value. This may be different from the seraialized start time. If no start time is present, returns nil time.Time.
-func (b *BackgroundManager) getStartTime() time.Time {
+func (b *BackgroundManager[O]) getStartTime() time.Time {
 	b.statusLock.RLock()
 	defer b.statusLock.RUnlock()
 	return b.status.StartTime
 }
 
 // setStartTime sets the start time of the background process to an in memory value. This does not update the serialized bucket state.
-func (b *BackgroundManager) setStartTime(startTime time.Time) {
+func (b *BackgroundManager[O]) setStartTime(startTime time.Time) {
 	b.statusLock.Lock()
 	defer b.statusLock.Unlock()
 	b.status.StartTime = startTime
 }
 
 // SetError sets the last known error, transitions the state to BackgroundManagerStateError and terminates the process.
-func (b *BackgroundManager) SetError(err error) {
+func (b *BackgroundManager[O]) SetError(err error) {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
@@ -621,7 +630,7 @@ func (b *BackgroundManager) SetError(err error) {
 }
 
 // UpdateStatusClusterAware reads the local status and writes that value to the bucket. This will update the "status" and "meta" keys of the status document.
-func (b *BackgroundManager) UpdateStatusClusterAware(ctx context.Context) error {
+func (b *BackgroundManager[O]) UpdateStatusClusterAware(ctx context.Context) error {
 	var err error
 	switch b.mode() {
 	case backgroundManagerModeSingleNode:
@@ -638,7 +647,7 @@ func (b *BackgroundManager) UpdateStatusClusterAware(ctx context.Context) error 
 
 // UpdateSingleNodeClusterAwareStatus gets the current local status from the running process and updates the status document in
 // the bucket. Implements a retry. Used for Cluster Aware operations
-func (b *BackgroundManager) UpdateSingleNodeClusterAwareStatus(ctx context.Context) error {
+func (b *BackgroundManager[O]) UpdateSingleNodeClusterAwareStatus(ctx context.Context) error {
 	if b.clusterAwareOptions == nil {
 		return nil
 	}
@@ -664,7 +673,7 @@ func (b *BackgroundManager) UpdateSingleNodeClusterAwareStatus(ctx context.Conte
 }
 
 // updateMultiNodeClusterAwareStatus updates the cluster status document with the current local status. If the bucket status is in a stopping / stopped / completed / error state but the local status is running, then this method will not update the bucket status and instead return.
-func (b *BackgroundManager) updateMultiNodeClusterAwareStatus(ctx context.Context) error {
+func (b *BackgroundManager[O]) updateMultiNodeClusterAwareStatus(ctx context.Context) error {
 	docID := b.clusterAwareOptions.StatusDocID()
 	var previousStatus []byte
 	var newStatus []byte
@@ -713,7 +722,7 @@ type HeartbeatDoc struct {
 
 // UpdateHeartbeatDocClusterAware simply performs a touch operation on the heartbeat document to update its expiry.
 // Implements a retry. Used for Cluster Aware operations
-func (b *BackgroundManager) UpdateHeartbeatDocClusterAware(ctx context.Context) error {
+func (b *BackgroundManager[O]) UpdateHeartbeatDocClusterAware(ctx context.Context) error {
 	statusRaw, _, err := b.clusterAwareOptions.metadataStore.GetAndTouchRaw(ctx, b.clusterAwareOptions.HeartbeatDocID(), BackgroundManagerHeartbeatExpirySecs)
 	if err != nil {
 		// If we get an error but the error is doc not found and terminator closed it means we have terminated the
@@ -752,7 +761,7 @@ func (b *BackgroundManager) UpdateHeartbeatDocClusterAware(ctx context.Context) 
 // startPollingMultiNodeStatus starts a loop which polls the status document for changes. If the status document
 // indicates that the process should stop, then this will trigger a stop of the local process. This is used for
 // multi-node cluster aware background managers where we want all nodes to stop if any node triggers a stop.
-func (b *BackgroundManager) startPollingMultiNodeStatus(ctx context.Context, terminator *base.SafeTerminator) {
+func (b *BackgroundManager[O]) startPollingMultiNodeStatus(ctx context.Context, terminator *base.SafeTerminator) {
 	ticker := time.NewTicker(BackgroundManagerStatusUpdateIntervalSecs * time.Second)
 	for {
 		select {
@@ -774,7 +783,7 @@ func (b *BackgroundManager) startPollingMultiNodeStatus(ctx context.Context, ter
 }
 
 // stopProcess terminates the locally running process.
-func (b *BackgroundManager) stopProcess(ctx context.Context) {
+func (b *BackgroundManager[O]) stopProcess(ctx context.Context) {
 	b.terminator.Close()
 	b.compareAndSwapRunState(BackgroundProcessStateRunning, BackgroundProcessStateStopping)
 
@@ -790,7 +799,7 @@ func (b *BackgroundManager) stopProcess(ctx context.Context) {
 }
 
 // compareAndSwapRunState does a compare and swap on the run state. If the existing state does not match the old state then no update occurs.
-func (b *BackgroundManager) compareAndSwapRunState(oldState BackgroundProcessState, newState BackgroundProcessState) {
+func (b *BackgroundManager[O]) compareAndSwapRunState(oldState BackgroundProcessState, newState BackgroundProcessState) {
 	b.statusLock.Lock()
 	defer b.statusLock.Unlock()
 	if b.status.State == oldState {
@@ -811,7 +820,7 @@ const (
 )
 
 // mode returns the running mode a BackgroundManager.
-func (b *BackgroundManager) mode() backgroundManagerMode {
+func (b *BackgroundManager[O]) mode() backgroundManagerMode {
 	if b.clusterAwareOptions == nil {
 		return backgroundManagerModeLocal
 	}

--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -60,8 +60,8 @@ const (
 )
 
 // BackgroundManager this is the over-arching type which is exposed in DatabaseContext.
-// O is the type of the options struct passed to BackgroundManagerProcessI.Init and BackgroundManagerProcessI.Run - this allows BackgroundManager to unmarshal the options as 
-the (process-specific) options struct during Resume.
+// O is the type of the options struct passed to BackgroundManagerProcessI.Init and BackgroundManagerProcessI.Run - this allows BackgroundManager to unmarshal the options as
+// the (process-specific) options struct during Resume.
 type BackgroundManager[O any] struct {
 	status                                 BackgroundManagerStatus
 	statusLock                             sync.RWMutex

--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -60,7 +60,8 @@ const (
 )
 
 // BackgroundManager this is the over-arching type which is exposed in DatabaseContext.
-// O is the type of the options struct passed to BackgroundManagerProcessI.Init and BackgroundManagerProcessI.Run.
+// O is the type of the options struct passed to BackgroundManagerProcessI.Init and BackgroundManagerProcessI.Run - this allows BackgroundManager to unmarshal the options as 
+the (process-specific) options struct during Resume.
 type BackgroundManager[O any] struct {
 	status                                 BackgroundManagerStatus
 	statusLock                             sync.RWMutex

--- a/db/background_mgr_async_index_init.go
+++ b/db/background_mgr_async_index_init.go
@@ -89,10 +89,10 @@ func (a *AsyncIndexInitManager) ResetStatus() {
 	return
 }
 
-var _ BackgroundManagerProcessI = &AsyncIndexInitManager{}
+var _ BackgroundManagerProcessI[map[string]any] = &AsyncIndexInitManager{}
 
-func NewAsyncIndexInitManager(metadataStore base.DataStore, metaKeys *base.MetadataKeys) *BackgroundManager {
-	return &BackgroundManager{
+func NewAsyncIndexInitManager(metadataStore base.DataStore, metaKeys *base.MetadataKeys) *BackgroundManager[map[string]any] {
+	return &BackgroundManager[map[string]any]{
 		name:    "index_init",
 		Process: &AsyncIndexInitManager{},
 		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{

--- a/db/background_mgr_attachment_compaction.go
+++ b/db/background_mgr_attachment_compaction.go
@@ -38,10 +38,10 @@ type AttachmentCompactionManager struct {
 	runFunctionStartedCallback atomic.Pointer[runFunctionStartedCallbackFunc]
 }
 
-var _ BackgroundManagerProcessI = &AttachmentCompactionManager{}
+var _ BackgroundManagerProcessI[map[string]any] = &AttachmentCompactionManager{}
 
-func NewAttachmentCompactionManager(metadataStore base.DataStore, metaKeys *base.MetadataKeys) *BackgroundManager {
-	return &BackgroundManager{
+func NewAttachmentCompactionManager(metadataStore base.DataStore, metaKeys *base.MetadataKeys) *BackgroundManager[map[string]any] {
+	return &BackgroundManager[map[string]any]{
 		name:    "attachment_compaction",
 		Process: &AttachmentCompactionManager{},
 		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{

--- a/db/background_mgr_attachment_migration.go
+++ b/db/background_mgr_attachment_migration.go
@@ -31,14 +31,14 @@ type AttachmentMigrationManager struct {
 	lock          sync.RWMutex
 }
 
-var _ BackgroundManagerProcessI = &AttachmentMigrationManager{}
+var _ BackgroundManagerProcessI[map[string]any] = &AttachmentMigrationManager{}
 
 const MetaVersionValue = "4.0.0" // Meta version to set in syncInfo document upon completion of attachment migration for collection
 
-func NewAttachmentMigrationManager(database *DatabaseContext) *BackgroundManager {
+func NewAttachmentMigrationManager(database *DatabaseContext) *BackgroundManager[map[string]any] {
 	metadataStore := database.MetadataStore
 	metaKeys := database.MetadataKeys
-	return &BackgroundManager{
+	return &BackgroundManager[map[string]any]{
 		name: "attachment_migration",
 		Process: &AttachmentMigrationManager{
 			databaseCtx: database,

--- a/db/background_mgr_metadata_migration.go
+++ b/db/background_mgr_metadata_migration.go
@@ -34,15 +34,15 @@ type MetadataMigrationManager struct {
 
 const MetadataMigrationManagerName = "metadata_migration"
 
-var _ BackgroundManagerProcessI = &MetadataMigrationManager{}
+var _ BackgroundManagerProcessI[map[string]any] = &MetadataMigrationManager{}
 
 // errMetadataMigrationTerminated is the cancellation cause propagated to the run context when
 // the BackgroundManager terminator fires, so ops blocked on ctx (seq-counter retry loop, range
 // scan iteration) can distinguish an operator stop from a parent-context cancellation.
 var errMetadataMigrationTerminated = errors.New("metadata migration terminated by stop request")
 
-func NewMetadataMigrationManager(dbContext *DatabaseContext) *BackgroundManager {
-	return &BackgroundManager{
+func NewMetadataMigrationManager(dbContext *DatabaseContext) *BackgroundManager[map[string]any] {
+	return &BackgroundManager[map[string]any]{
 		name:    MetadataMigrationManagerName,
 		Process: &MetadataMigrationManager{dbContext: dbContext},
 		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -133,7 +133,7 @@ func NewResyncManagerDCP(db *DatabaseContext, distributed bool) *BackgroundManag
 	return b
 }
 
-// Init processes the options to start a resync process and sets them as struct memebers.
+// Init processes the options to start a resync process and sets them as struct members.
 func (r *ResyncManagerDCP) Init(ctx context.Context, options ResyncOptions, clusterStatus []byte) error {
 	r.setStartOptions(options)
 

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -45,7 +45,7 @@ type ResyncManagerDCP struct {
 	ResyncID                     string
 	VBUUIDs                      []uint64
 	ResyncedCollections          base.CollectionNames
-	startOptions                 map[string]any // options from the most recent Start call, persisted to meta for Resume
+	startOptions                 ResyncOptions // options from the most recent Start call, persisted to meta for Resume
 	resyncCollectionInfo
 	lock              sync.RWMutex
 	Distributed       bool
@@ -94,13 +94,20 @@ type resyncCollectionInfo struct {
 	hasAllCollections bool
 }
 
-var _ BackgroundManagerProcessI = &ResyncManagerDCP{}
+// ResyncOptions are used to initialize a resync process.
+type ResyncOptions struct {
+	Collections         base.CollectionNames `json:"collections,omitempty"`
+	Reset               bool                 `json:"reset,omitempty"`
+	RegenerateSequences bool                 `json:"regenerateSequences,omitempty"`
+}
+
+var _ BackgroundManagerProcessI[ResyncOptions] = &ResyncManagerDCP{}
 
 // NewResyncManagerDCP returns a new instance of ResyncManagerDCP wrapped in a BackgroundManager. If distributed is
 // true, the manager will be set up to run in a distributed manner across multiple nodes, otherwise it will run on a
 // single node.
-func NewResyncManagerDCP(db *DatabaseContext, distributed bool) *BackgroundManager {
-	b := &BackgroundManager{
+func NewResyncManagerDCP(db *DatabaseContext, distributed bool) *BackgroundManager[ResyncOptions] {
+	b := &BackgroundManager[ResyncOptions]{
 		name: "resync",
 		Process: &ResyncManagerDCP{
 			db:                db,
@@ -127,17 +134,13 @@ func NewResyncManagerDCP(db *DatabaseContext, distributed bool) *BackgroundManag
 }
 
 // Init processes the options to start a resync process and sets them as struct memebers.
-func (r *ResyncManagerDCP) Init(ctx context.Context, options map[string]any, clusterStatus []byte) error {
-	resyncCollections, ok := options["collections"].(base.CollectionNames)
-	if !ok {
-		return errors.New("collections option is required and must be of type base.CollectionNames")
-	}
+func (r *ResyncManagerDCP) Init(ctx context.Context, options ResyncOptions, clusterStatus []byte) error {
 	r.setStartOptions(options)
 
 	var collections DatabaseCollections
-	if len(resyncCollections) > 0 {
+	if len(options.Collections) > 0 {
 		var err error
-		collections, err = r.db.collections(resyncCollections)
+		collections, err = r.db.collections(options.Collections)
 		if err != nil {
 			return err
 		}
@@ -154,7 +157,7 @@ func (r *ResyncManagerDCP) Init(ctx context.Context, options map[string]any, clu
 	var statusDoc ResyncManagerStatusDocDCP
 	if clusterStatus == nil {
 		resetMsg = "no previous run found"
-	} else if resetOpt, _ := options["reset"].(bool); resetOpt {
+	} else if options.Reset {
 		resetMsg = "reset option requested"
 	} else if err := base.JSONUnmarshal(clusterStatus, &statusDoc); err != nil {
 		resetMsg = "failed to unmarshal cluster status"
@@ -216,7 +219,7 @@ func (r *ResyncManagerDCP) purgeCheckpoints(ctx context.Context, resyncID string
 }
 
 // setStartOptions stores the options used to start the current run so that Resume can reconstruct them.
-func (r *ResyncManagerDCP) setStartOptions(options map[string]any) {
+func (r *ResyncManagerDCP) setStartOptions(options ResyncOptions) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 	r.startOptions = options
@@ -230,12 +233,9 @@ func (r *ResyncManagerDCP) SetVBUUIDs(vbuuids []uint64) {
 }
 
 // Run starts a DCP feed to process documents for resync.
-func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, persistClusterStatusCallback updateStatusCallbackFunc, terminator *base.SafeTerminator) (err error) {
+func (r *ResyncManagerDCP) Run(ctx context.Context, options ResyncOptions, persistClusterStatusCallback updateStatusCallbackFunc, terminator *base.SafeTerminator) (err error) {
 	db := r.db
-	regenerateSequences, ok := options["regenerateSequences"].(bool)
-	if !ok {
-		return errors.New("regenerateSequences option is required and must be of type bool")
-	}
+	regenerateSequences := options.RegenerateSequences
 	ctx = context.WithoutCancel(ctx) // drop cancellation from parent context
 	ctx = base.CorrelationIDLogCtx(ctx, r.ResyncID)
 	ctx, cancelResync := context.WithCancelCause(ctx)
@@ -789,9 +789,9 @@ type resyncManagerCompletedVBuckets struct {
 }
 
 type ResyncManagerMeta struct {
-	VBUUIDs       []uint64       `json:"vbuuids"`
-	CollectionIDs []uint32       `json:"collection_ids,omitempty"`
-	Options       map[string]any `json:"options,omitempty"` // start options, persisted for Resume
+	VBUUIDs       []uint64      `json:"vbuuids"`
+	CollectionIDs []uint32      `json:"collection_ids,omitempty"`
+	Options       ResyncOptions `json:"options,omitempty"` // start options, persisted for Resume
 	resyncManagerCompletedVBuckets
 }
 

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -141,10 +141,9 @@ func TestResyncDCPInit(t *testing.T) {
 				db.ResyncManager.resetStatus()
 			}()
 
-			options := make(map[string]any)
-			options["collections"] = base.NewCollectionNames()
-			if testCase.forceReset {
-				options["reset"] = true
+			options := ResyncOptions{
+				Collections: base.NewCollectionNames(),
+				Reset:       testCase.forceReset,
 			}
 
 			var clusterData []byte
@@ -205,9 +204,8 @@ func TestResyncManagerDCPStopInMidWay(t *testing.T) {
 			})
 			defer db.Close(ctx)
 
-			options := map[string]any{
-				"regenerateSequences": false,
-				"collections":         base.NewCollectionNames(),
+			options := ResyncOptions{
+				Collections: base.NewCollectionNames(),
 			}
 
 			err := db.ResyncManager.Start(ctx, options)
@@ -251,9 +249,8 @@ func TestResyncManagerDCPStart(t *testing.T) {
 				scopeName := scopeAndCollectionName.ScopeName()
 				collectionName := scopeAndCollectionName.CollectionName()
 
-				options := map[string]any{
-					"regenerateSequences": false,
-					"collections":         base.NewCollectionNames(),
+				options := ResyncOptions{
+					Collections: base.NewCollectionNames(),
 				}
 				require.NoError(t, db.ResyncManager.Start(ctx, options))
 				stats := waitForResyncState(t, db, BackgroundProcessStateCompleted)
@@ -291,9 +288,8 @@ func TestResyncManagerDCPStart(t *testing.T) {
 				initialStats := getResyncStats(t, db)
 				log.Printf("initialStats: processed[%v] changed[%v]", initialStats.DocsProcessed, initialStats.DocsChanged)
 
-				options := map[string]any{
-					"regenerateSequences": false,
-					"collections":         base.NewCollectionNames(),
+				options := ResyncOptions{
+					Collections: base.NewCollectionNames(),
 				}
 
 				if testCase.Distributed {
@@ -347,9 +343,8 @@ func TestResyncManagerDCPRunTwice(t *testing.T) {
 			})
 			defer db.Close(ctx)
 
-			options := map[string]any{
-				"regenerateSequences": false,
-				"collections":         base.NewCollectionNames(),
+			options := ResyncOptions{
+				Collections: base.NewCollectionNames(),
 			}
 
 			err := db.ResyncManager.Start(ctx, options)
@@ -396,9 +391,8 @@ func TestResyncManagerDCPResumeStoppedProcess(t *testing.T) {
 			})
 			defer db.Close(ctx)
 
-			options := map[string]any{
-				"regenerateSequences": false,
-				"collections":         base.NewCollectionNames(),
+			options := ResyncOptions{
+				Collections: base.NewCollectionNames(),
 			}
 
 			err := db.ResyncManager.Start(ctx, options)
@@ -502,9 +496,8 @@ func TestResyncManagerDCPResumeStoppedProcessChangeCollections(t *testing.T) {
 				dbCollections[i] = col
 			}
 
-			options := map[string]any{
-				"regenerateSequences": false,
-				"collections":         base.NewCollectionNames(dbCollections[0].dataStore),
+			options := ResyncOptions{
+				Collections: base.NewCollectionNames(dbCollections[0].dataStore),
 			}
 
 			err := db.ResyncManager.Start(ctx, options)
@@ -530,7 +523,7 @@ func TestResyncManagerDCPResumeStoppedProcessChangeCollections(t *testing.T) {
 			firstDocsChanged := stats.DocsChanged
 
 			require.GreaterOrEqual(t, len(dbCollections), 2)
-			options["collections"] = db.collectionNames()
+			options.Collections = db.collectionNames()
 
 			// Resume process
 			err = db.ResyncManager.Start(ctx, options)
@@ -696,9 +689,8 @@ func runResync(t *testing.T, ctx context.Context, db *Database, collection *Data
 	initialStats := getResyncStats(t, db)
 	log.Printf("initialStats: processed[%v] changed[%v]", initialStats.DocsProcessed, initialStats.DocsChanged)
 
-	options := map[string]any{
-		"regenerateSequences": false,
-		"collections":         base.NewCollectionNames(),
+	options := ResyncOptions{
+		Collections: base.NewCollectionNames(),
 	}
 
 	require.NoError(t, db.ResyncManager.Start(ctx, options))
@@ -902,9 +894,8 @@ func TestResyncImportPartitionsPassthrough(t *testing.T) {
 	require.True(t, ok)
 	rs.Distributed = true
 
-	options := map[string]any{
-		"regenerateSequences": false,
-		"collections":         base.NewCollectionNames(),
+	options := ResyncOptions{
+		Collections: base.NewCollectionNames(),
 	}
 	require.NoError(t, db.ResyncManager.Start(ctx, options))
 	defer func() {
@@ -1112,9 +1103,9 @@ func TestResyncManagerDCPWritesV1SyncInfoAtCcv41(t *testing.T) {
 
 	dbc, _ := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 
-	options := map[string]any{
-		"regenerateSequences": true,
-		"collections":         base.NewCollectionNames(),
+	options := ResyncOptions{
+		Collections:         base.NewCollectionNames(),
+		RegenerateSequences: true,
 	}
 	require.NoError(t, db.ResyncManager.Start(ctx, options))
 	RequireBackgroundManagerState(t, db.ResyncManager, BackgroundProcessStateCompleted)
@@ -1132,32 +1123,22 @@ func TestResyncManagerOptionsStoredInMeta(t *testing.T) {
 	inputCollections := base.CollectionNames{"scope1": []string{"col1", "col2"}}
 
 	r := &ResyncManagerDCP{db: &DatabaseContext{}, completedvBuckets: newvBucketTracker()}
-	r.setStartOptions(map[string]any{
-		"regenerateSequences": false,
-		"collections":         inputCollections,
-		"reset":               true,
+	r.setStartOptions(ResyncOptions{
+		Collections: inputCollections,
+		Reset:       true,
 	})
 
 	_, metaBytes, err := r.GetProcessStatus(BackgroundManagerStatus{State: BackgroundProcessStateStopped}, nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, metaBytes)
 
-	// BackgroundManager.Resume reads "options" directly from the meta subdoc.
-	var metaDoc struct {
-		Options map[string]any `json:"options"`
-	}
+	// BackgroundManager.Resume reads "options" from the meta subdoc, deserialising into ResyncOptions.
+	var metaDoc ResyncManagerMeta
 	require.NoError(t, base.JSONUnmarshal(metaBytes, &metaDoc))
-	require.NotNil(t, metaDoc.Options)
 
-	require.Equal(t, false, metaDoc.Options["regenerateSequences"])
-	require.Equal(t, true, metaDoc.Options["reset"])
-
-	// collections round-trips through JSON as map[string]interface{}; re-marshal and unmarshal to recover the typed value.
-	collectionsRaw, err := base.JSONMarshal(metaDoc.Options["collections"])
-	require.NoError(t, err)
-	var recoveredCollections base.CollectionNames
-	require.NoError(t, base.JSONUnmarshal(collectionsRaw, &recoveredCollections))
-	require.Equal(t, inputCollections, recoveredCollections)
+	require.Equal(t, false, metaDoc.Options.RegenerateSequences)
+	require.Equal(t, true, metaDoc.Options.Reset)
+	require.Equal(t, inputCollections, metaDoc.Options.Collections)
 }
 
 // TestResyncDCPInitStoresOptionsInMeta verifies that Init stores the options it receives in the meta returned
@@ -1169,10 +1150,8 @@ func TestResyncDCPInitStoresOptionsInMeta(t *testing.T) {
 
 	// Use all collections by passing an empty CollectionNames — avoids hard-coding scope/collection names
 	// that might not match the test bucket configuration.
-	options := map[string]any{
-		"collections":         base.NewCollectionNames(),
-		"regenerateSequences": false,
-		"reset":               false,
+	options := ResyncOptions{
+		Collections: base.NewCollectionNames(),
 	}
 
 	require.NoError(t, db.ResyncManager.Process.Init(ctx, options, nil))
@@ -1183,9 +1162,85 @@ func TestResyncDCPInitStoresOptionsInMeta(t *testing.T) {
 
 	var metaDoc ResyncManagerMeta
 	require.NoError(t, base.JSONUnmarshal(metaBytes, &metaDoc))
-	require.NotNil(t, metaDoc.Options, "Init must call setStartOptions so that Resume can recover the options")
-	require.Equal(t, false, metaDoc.Options["regenerateSequences"])
-	require.Equal(t, false, metaDoc.Options["reset"])
+	// Verify Init stored the options so that Resume can recover them via the meta subdoc.
+	require.Equal(t, false, metaDoc.Options.RegenerateSequences)
+	require.Equal(t, false, metaDoc.Options.Reset)
+}
+
+// TestResyncManagerDCPResumeRoundTripsOptions verifies that ResyncOptions survive the full serialisation
+// round-trip performed by BackgroundManager.Resume: options are written to the cluster status document by
+// the first manager and then read back into a fresh ResyncManagerDCP via Resume, without ever being passed
+// to the second manager's Start call directly.
+//
+// The BackgroundManagers are constructed with multiNode=true (required for Resume) but with
+// ResyncManagerDCP.Distributed=false so the non-CBGT DCP path is used, which is compatible with Rosmar.
+func TestResyncManagerDCPResumeRoundTripsOptions(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
+
+	newMgr := func() *BackgroundManager[ResyncOptions] {
+		return &BackgroundManager[ResyncOptions]{
+			name: "resync",
+			Process: &ResyncManagerDCP{
+				db:                db.DatabaseContext,
+				completedvBuckets: newvBucketTracker(),
+				Distributed:       false,
+			},
+			clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
+				metadataStore: db.MetadataStore,
+				metaKeys:      db.MetadataKeys,
+				processSuffix: "resync",
+				multiNode:     true,
+			},
+			terminator: base.NewSafeTerminator(),
+		}
+	}
+
+	mgr1 := newMgr()
+	defer func() {
+		_ = mgr1.Stop(ctx)
+		mgr1.resetStatus()
+	}()
+
+	// Empty Collections means "all collections" (no per-collection lookup in Init).
+	// RegenerateSequences and Reset are both non-zero so a silent field drop would be caught.
+	inputOptions := ResyncOptions{
+		Collections:         base.NewCollectionNames(),
+		RegenerateSequences: true,
+		Reset:               true,
+	}
+
+	require.NoError(t, mgr1.Start(ctx, inputOptions))
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, BackgroundProcessStateRunning, mgr1.GetRunState())
+	}, 5*time.Second, 100*time.Millisecond)
+
+	// Flush options into the cluster status document before the second manager calls Resume.
+	require.NoError(t, mgr1.UpdateStatusClusterAware(ctx))
+
+	// A second manager sharing the same metadata store calls Resume: it must recover inputOptions from the
+	// status document without ever having been given them directly.
+	// Init is called synchronously inside Resume before Run is spawned, so startOptions is already set
+	// by the time Resume returns.
+	mgr2 := newMgr()
+	defer func() {
+		_ = mgr2.Stop(ctx)
+		mgr2.resetStatus()
+	}()
+
+	require.NoError(t, mgr2.Resume(ctx))
+
+	// Read startOptions from mgr2's process. The field is unexported but accessible within the package.
+	resync2 := mgr2.Process.(*ResyncManagerDCP)
+	resync2.lock.RLock()
+	got := resync2.startOptions
+	resync2.lock.RUnlock()
+
+	require.Equal(t, inputOptions.RegenerateSequences, got.RegenerateSequences)
+	require.Equal(t, inputOptions.Reset, got.Reset)
+	// Empty collections (meaning "all collections") marshals with omitempty and round-trips as nil;
+	// both nil and an empty map are semantically identical in ResyncManagerDCP.Init.
+	require.Empty(t, got.Collections)
 }
 
 // TestNewResyncManagerDCPUpdateDatabaseState verifies that NewResyncManagerDCP wires updateDatabaseState

--- a/db/background_mgr_test.go
+++ b/db/background_mgr_test.go
@@ -117,7 +117,7 @@ func TestBackgroundManagerModes(t *testing.T) {
 	for _, mode := range modes {
 		t.Run(mode.name, func(t *testing.T) {
 			process := &MockProcess{}
-			mgr := &BackgroundManager{
+			mgr := &BackgroundManager[map[string]any]{
 				name:                "test-mgr-" + mode.name,
 				clusterAwareOptions: mode.clusterAwareOptions,
 				Process:             process,
@@ -160,7 +160,7 @@ func TestBackgroundManagerMultiNodeTransitions(t *testing.T) {
 	}
 
 	process1 := &MockProcess{}
-	mgr1 := &BackgroundManager{
+	mgr1 := &BackgroundManager[map[string]any]{
 		name:                "mgr1",
 		clusterAwareOptions: options,
 		Process:             process1,
@@ -177,7 +177,7 @@ func TestBackgroundManagerMultiNodeTransitions(t *testing.T) {
 
 	// 3. Start mgr2 (should succeed because it's MultiNode)
 	process2 := &MockProcess{}
-	mgr2 := &BackgroundManager{
+	mgr2 := &BackgroundManager[map[string]any]{
 		name:                "mgr2",
 		clusterAwareOptions: options,
 		Process:             process2,
@@ -226,12 +226,12 @@ func TestBackgroundManagerMultiNodeSimultaneousTransitions(t *testing.T) {
 	}
 
 	numNodes := 5
-	managers := make([]*BackgroundManager, numNodes)
+	managers := make([]*BackgroundManager[map[string]any], numNodes)
 	processes := make([]*MockProcess, numNodes)
 
 	for i := 0; i < numNodes; i++ {
 		processes[i] = &MockProcess{}
-		managers[i] = &BackgroundManager{
+		managers[i] = &BackgroundManager[map[string]any]{
 			name:                fmt.Sprintf("mgr%d", i),
 			clusterAwareOptions: options,
 			Process:             processes[i],
@@ -290,7 +290,7 @@ func TestBackgroundManagerStartTimePreservedOnResume(t *testing.T) {
 	}
 
 	process1 := &MockProcess{}
-	mgr1 := &BackgroundManager{
+	mgr1 := &BackgroundManager[map[string]any]{
 		name:                "mgr1",
 		clusterAwareOptions: options,
 		Process:             process1,
@@ -315,7 +315,7 @@ func TestBackgroundManagerStartTimePreservedOnResume(t *testing.T) {
 	WaitForBackgroundManagerHeartbeatDocRemoval(t, mgr1)
 
 	process2 := &MockProcess{}
-	mgr2 := &BackgroundManager{
+	mgr2 := &BackgroundManager[map[string]any]{
 		name:                "mgr2",
 		clusterAwareOptions: options,
 		Process:             process2,
@@ -342,7 +342,7 @@ func TestBackgroundManagerMultiNodeStartTimePreserved(t *testing.T) {
 	}
 
 	process1 := &MockProcess{}
-	mgr1 := &BackgroundManager{
+	mgr1 := &BackgroundManager[map[string]any]{
 		name:                "mgr1",
 		clusterAwareOptions: options,
 		Process:             process1,
@@ -367,7 +367,7 @@ func TestBackgroundManagerMultiNodeStartTimePreserved(t *testing.T) {
 
 	// 2. Start mgr2 (MultiNode)
 	process2 := &MockProcess{}
-	mgr2 := &BackgroundManager{
+	mgr2 := &BackgroundManager[map[string]any]{
 		name:                "mgr2",
 		clusterAwareOptions: options,
 		Process:             process2,
@@ -516,7 +516,7 @@ func TestBackgroundManagerResume(t *testing.T) {
 	}
 
 	process := &ResumableMockProcess{}
-	mgr := &BackgroundManager{
+	mgr := &BackgroundManager[map[string]any]{
 		name:                "test-resume-mgr",
 		Process:             process,
 		clusterAwareOptions: clusterOpts,
@@ -533,7 +533,7 @@ func TestBackgroundManagerResume(t *testing.T) {
 
 	// While cluster state is running, a second manager sharing the same status document should join via Resume.
 	process2 := &ResumableMockProcess{}
-	mgr2 := &BackgroundManager{
+	mgr2 := &BackgroundManager[map[string]any]{
 		name:                "test-resume-mgr2",
 		Process:             process2,
 		clusterAwareOptions: clusterOpts,
@@ -559,7 +559,7 @@ func TestBackgroundManagerResumeNoDoc(t *testing.T) {
 	metadataStore := testBucket.DefaultDataStore(ctx)
 	metaKeys := base.NewMetadataKeys("test-resume-no-doc")
 
-	mgr := &BackgroundManager{
+	mgr := &BackgroundManager[map[string]any]{
 		name:    "test-resume-no-doc-mgr",
 		Process: &ResumableMockProcess{},
 		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
@@ -584,7 +584,7 @@ func TestBackgroundManagerResumeSingleNodeError(t *testing.T) {
 	metaKeys := base.NewMetadataKeys("test-resume-single-node")
 
 	process := &ResumableMockProcess{}
-	mgr := &BackgroundManager{
+	mgr := &BackgroundManager[map[string]any]{
 		name:    "test-resume-single-node-mgr",
 		Process: process,
 		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
@@ -610,7 +610,7 @@ func TestBackgroundManagerResumeWhileRunning(t *testing.T) {
 	metaKeys := base.NewMetadataKeys("test-resume-running")
 
 	process := &ResumableMockProcess{}
-	mgr := &BackgroundManager{
+	mgr := &BackgroundManager[map[string]any]{
 		name:    "test-resume-running-mgr",
 		Process: process,
 		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
@@ -652,7 +652,7 @@ func TestBackgroundManagerResumeWhenNotRunning(t *testing.T) {
 		multiNode:     true,
 	}
 
-	mgr := &BackgroundManager{
+	mgr := &BackgroundManager[map[string]any]{
 		name:                "test-resume-not-running-mgr",
 		Process:             &ResumableMockProcess{},
 		clusterAwareOptions: clusterOpts,
@@ -673,7 +673,7 @@ func TestBackgroundManagerResumeWhenNotRunning(t *testing.T) {
 	}, 5*time.Second, 100*time.Millisecond)
 
 	// Cluster state is now stopped; a second manager must not be able to Resume.
-	mgr2 := &BackgroundManager{
+	mgr2 := &BackgroundManager[map[string]any]{
 		name:                "test-resume-not-running-mgr2",
 		Process:             &ResumableMockProcess{},
 		clusterAwareOptions: clusterOpts,
@@ -690,7 +690,7 @@ func TestBackgroundManagerResumeWhenNotRunning(t *testing.T) {
 func TestBackgroundManagerResumeLocalModeError(t *testing.T) {
 	ctx := base.TestCtx(t)
 	process := &ResumableMockProcess{}
-	mgr := &BackgroundManager{
+	mgr := &BackgroundManager[map[string]any]{
 		name:       "test-resume-local-mgr",
 		Process:    process,
 		terminator: base.NewSafeTerminator(),
@@ -713,7 +713,7 @@ func TestBackgroundManagerUpdateDatabaseStateRunning(t *testing.T) {
 	var dbStateCalls []bool
 	var mu sync.Mutex
 
-	mgr := &BackgroundManager{
+	mgr := &BackgroundManager[map[string]any]{
 		name:    "test-update-db-state-running",
 		Process: &MockProcess{},
 		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
@@ -755,7 +755,7 @@ func TestBackgroundManagerUpdateDatabaseStateOnCompletion(t *testing.T) {
 
 	calledWithFalse := make(chan struct{}, 1)
 
-	mgr := &BackgroundManager{
+	mgr := &BackgroundManager[map[string]any]{
 		name:    "test-update-db-state-done",
 		Process: &MockProcess{},
 		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
@@ -803,7 +803,7 @@ func TestBackgroundManagerResumeCallsUpdateDatabaseStateWhenNotRunning(t *testin
 	var dbStateCalls []bool
 	var mu sync.Mutex
 
-	mgr := &BackgroundManager{
+	mgr := &BackgroundManager[map[string]any]{
 		name:    "test-resume-db-state-not-running",
 		Process: &ResumableMockProcess{},
 		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
@@ -851,7 +851,7 @@ func TestBackgroundManagerResumeCallsUpdateDatabaseStateWhenStopped(t *testing.T
 	}
 
 	// Start and then stop a manager so the cluster status doc shows Stopped.
-	starter := &BackgroundManager{
+	starter := &BackgroundManager[map[string]any]{
 		name:                "test-resume-db-state-stopped-starter",
 		Process:             &ResumableMockProcess{},
 		clusterAwareOptions: clusterOpts,
@@ -873,7 +873,7 @@ func TestBackgroundManagerResumeCallsUpdateDatabaseStateWhenStopped(t *testing.T
 	// A fresh manager observing the same (stopped) cluster state should call updateDatabaseState(false).
 	var dbStateCalls []bool
 	var mu sync.Mutex
-	observer := &BackgroundManager{
+	observer := &BackgroundManager[map[string]any]{
 		name:                "test-resume-db-state-stopped-observer",
 		Process:             &ResumableMockProcess{},
 		clusterAwareOptions: clusterOpts,
@@ -917,9 +917,9 @@ func (m *immediateCallbackProcess) Run(ctx context.Context, _ map[string]any, cb
 
 // newTestManagerWithStateDoc returns a multi-node BackgroundManager whose updateDatabaseState is wired
 // to a DatabaseStateMgr backed by the given metadata store.
-func newTestManagerWithStateDoc(metadataStore base.DataStore, metaKeys *base.MetadataKeys, suffix string, proc BackgroundManagerProcessI) (*BackgroundManager, *DatabaseStateMgr) {
+func newTestManagerWithStateDoc(metadataStore base.DataStore, metaKeys *base.MetadataKeys, suffix string, proc BackgroundManagerProcessI[map[string]any]) (*BackgroundManager[map[string]any], *DatabaseStateMgr) {
 	dbStateMgr := NewDatabaseStateMgr(metadataStore, metaKeys.DatabaseStateKey(), nil)
-	mgr := &BackgroundManager{
+	mgr := &BackgroundManager[map[string]any]{
 		name:    "test-" + suffix,
 		Process: proc,
 		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
@@ -1007,9 +1007,9 @@ func TestUpdateDatabaseStateConcurrentManagersSharedStateDoc(t *testing.T) {
 	dbStateMgr := NewDatabaseStateMgr(metadataStore, metaKeys.DatabaseStateKey(), nil)
 
 	const numNodes = 5
-	managers := make([]*BackgroundManager, numNodes)
+	managers := make([]*BackgroundManager[map[string]any], numNodes)
 	for i := range numNodes {
-		managers[i] = &BackgroundManager{
+		managers[i] = &BackgroundManager[map[string]any]{
 			name:    fmt.Sprintf("test-concurrent-shared-%d", i),
 			Process: &ResumableMockProcess{},
 			clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
@@ -1088,7 +1088,7 @@ func TestUpdateDatabaseStateResumeOverwritesRunningState(t *testing.T) {
 	// "not running" by stopping the cluster state doc before B calls Resume.
 	// In practice this can happen when B reads the status doc during a brief window between
 	// an old run completing and a new one starting.
-	mgrB := &BackgroundManager{
+	mgrB := &BackgroundManager[map[string]any]{
 		name:    "test-resume-overwrite-observer",
 		Process: &ResumableMockProcess{},
 		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
@@ -1188,7 +1188,7 @@ func TestBackgroundManagerResumeConcurrentWhileStopping(t *testing.T) {
 	startOptions := map[string]any{"key": "value"}
 
 	// mgr1 is the "originating" node that starts the process and then stops it.
-	mgr1 := &BackgroundManager{
+	mgr1 := &BackgroundManager[map[string]any]{
 		name:                "test-resume-race-mgr1",
 		Process:             &ResumableMockProcess{},
 		clusterAwareOptions: clusterOpts,
@@ -1205,9 +1205,9 @@ func TestBackgroundManagerResumeConcurrentWhileStopping(t *testing.T) {
 	const numResumeCallers = 10
 
 	// Build a fleet of managers that will all call Resume concurrently.
-	resumeManagers := make([]*BackgroundManager, numResumeCallers)
+	resumeManagers := make([]*BackgroundManager[map[string]any], numResumeCallers)
 	for i := range numResumeCallers {
-		resumeManagers[i] = &BackgroundManager{
+		resumeManagers[i] = &BackgroundManager[map[string]any]{
 			name:                fmt.Sprintf("test-resume-race-caller%d", i),
 			Process:             &ResumableMockProcess{},
 			clusterAwareOptions: clusterOpts,

--- a/db/background_mgr_tombstone_compaction.go
+++ b/db/background_mgr_tombstone_compaction.go
@@ -24,10 +24,10 @@ type TombstoneCompactionManager struct {
 	PurgedDocCount int64
 }
 
-var _ BackgroundManagerProcessI = &TombstoneCompactionManager{}
+var _ BackgroundManagerProcessI[map[string]any] = &TombstoneCompactionManager{}
 
-func NewTombstoneCompactionManager() *BackgroundManager {
-	return &BackgroundManager{
+func NewTombstoneCompactionManager() *BackgroundManager[map[string]any] {
+	return &BackgroundManager[map[string]any]{
 		name:       "tombstone_compaction",
 		Process:    &TombstoneCompactionManager{},
 		terminator: base.NewSafeTerminator(),

--- a/db/database.go
+++ b/db/database.go
@@ -128,12 +128,12 @@ type DatabaseContext struct {
 	Options                     DatabaseContextOptions // Database Context Options
 	AccessLock                  sync.RWMutex           // Allows DB offline to block until synchronous calls have completed
 	State                       uint32                 // The runtime state of the DB from a service perspective
-	ResyncManager               *BackgroundManager
-	TombstoneCompactionManager  *BackgroundManager
-	AttachmentCompactionManager *BackgroundManager
-	AttachmentMigrationManager  *BackgroundManager
-	AsyncIndexInitManager       *BackgroundManager
-	MetadataMigrationManager    *BackgroundManager
+	ResyncManager               *BackgroundManager[ResyncOptions]
+	TombstoneCompactionManager  *BackgroundManager[map[string]any]
+	AttachmentCompactionManager *BackgroundManager[map[string]any]
+	AttachmentMigrationManager  *BackgroundManager[map[string]any]
+	AsyncIndexInitManager       *BackgroundManager[map[string]any]
+	MetadataMigrationManager    *BackgroundManager[map[string]any]
 	OIDCProviders               auth.OIDCProviderMap // OIDC clients
 	LocalJWTProviders           auth.LocalJWTProviderMap
 	ServerUUID                  string // UUID of the server, if available
@@ -788,17 +788,31 @@ func (context *DatabaseContext) Close(ctx context.Context) {
 }
 
 // stopBackgroundManagers stops any running BackgroundManager.
-// Returns a list of BackgroundManager it signalled to stop
-func (dbCtx *DatabaseContext) stopBackgroundManagers(ctx context.Context) (stopped []*BackgroundManager) {
-	for _, manager := range []*BackgroundManager{
-		dbCtx.ResyncManager,
-		dbCtx.AttachmentCompactionManager,
-		dbCtx.TombstoneCompactionManager,
-		dbCtx.AsyncIndexInitManager,
-		dbCtx.AttachmentMigrationManager,
-		dbCtx.MetadataMigrationManager,
-	} {
-		if manager != nil && !isBackgroundManagerStopped(manager.GetRunState()) && manager.Stop(ctx) == nil {
+// Returns a list of StoppableBackgroundManager it signalled to stop.
+func (dbCtx *DatabaseContext) stopBackgroundManagers(ctx context.Context) (stopped []StoppableBackgroundManager) {
+	// Nil-check each typed pointer before adding to the interface slice to avoid the
+	// nil-pointer-wrapped-in-interface pitfall.
+	var managers []StoppableBackgroundManager
+	if dbCtx.ResyncManager != nil {
+		managers = append(managers, dbCtx.ResyncManager)
+	}
+	if dbCtx.AttachmentCompactionManager != nil {
+		managers = append(managers, dbCtx.AttachmentCompactionManager)
+	}
+	if dbCtx.TombstoneCompactionManager != nil {
+		managers = append(managers, dbCtx.TombstoneCompactionManager)
+	}
+	if dbCtx.AsyncIndexInitManager != nil {
+		managers = append(managers, dbCtx.AsyncIndexInitManager)
+	}
+	if dbCtx.AttachmentMigrationManager != nil {
+		managers = append(managers, dbCtx.AttachmentMigrationManager)
+	}
+	if dbCtx.MetadataMigrationManager != nil {
+		managers = append(managers, dbCtx.MetadataMigrationManager)
+	}
+	for _, manager := range managers {
+		if !isBackgroundManagerStopped(manager.GetRunState()) && manager.Stop(ctx) == nil {
 			stopped = append(stopped, manager)
 		}
 	}
@@ -806,7 +820,7 @@ func (dbCtx *DatabaseContext) stopBackgroundManagers(ctx context.Context) (stopp
 }
 
 // waitForBackgroundManagersToStop wait for given BackgroundManagers to stop within given time
-func waitForBackgroundManagersToStop(ctx context.Context, waitTimeMax time.Duration, bgManagers []*BackgroundManager) {
+func waitForBackgroundManagersToStop(ctx context.Context, waitTimeMax time.Duration, bgManagers []StoppableBackgroundManager) {
 	timeout := time.NewTicker(waitTimeMax)
 	defer timeout.Stop()
 	retryInterval := 1 * time.Millisecond

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -4356,39 +4356,37 @@ func Test_stopBackgroundManagers(t *testing.T) {
 	defer db.Close(ctx)
 
 	testCases := []struct {
-		resyncManager               *BackgroundManager
-		tombstoneCompactionManager  *BackgroundManager
-		attachmentCompactionManager *BackgroundManager
+		resyncManager               *BackgroundManager[ResyncOptions]
+		tombstoneCompactionManager  *BackgroundManager[map[string]any]
+		attachmentCompactionManager *BackgroundManager[map[string]any]
 		expected                    int
 	}{
 		{
 			expected: 0,
 		},
 		{
-			resyncManager: &BackgroundManager{
+			resyncManager: &BackgroundManager[ResyncOptions]{
 				name:    "test_resync",
-				Process: &testBackgroundProcess{isStoppable: true},
+				Process: &testBackgroundProcess[ResyncOptions]{isStoppable: true},
 			},
 			expected: 1,
 		},
 		{
-			resyncManager: &BackgroundManager{
+			resyncManager: &BackgroundManager[ResyncOptions]{
 				name:    "test_resync",
-				Process: &testBackgroundProcess{isStoppable: true},
+				Process: &testBackgroundProcess[ResyncOptions]{isStoppable: true},
 			},
-			tombstoneCompactionManager: &BackgroundManager{
+			tombstoneCompactionManager: &BackgroundManager[map[string]any]{
 				name:    "test_tombstone",
-				Process: &testBackgroundProcess{isStoppable: true},
+				Process: &testBackgroundProcess[map[string]any]{isStoppable: true},
 			},
-			attachmentCompactionManager: &BackgroundManager{
+			attachmentCompactionManager: &BackgroundManager[map[string]any]{
 				name:    "test_attachment",
-				Process: &testBackgroundProcess{isStoppable: true},
+				Process: &testBackgroundProcess[map[string]any]{isStoppable: true},
 			},
 			expected: 3,
 		},
 	}
-
-	emptyOptions := map[string]any{}
 
 	for i, testCase := range testCases {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
@@ -4396,15 +4394,15 @@ func Test_stopBackgroundManagers(t *testing.T) {
 			db.AttachmentCompactionManager = testCase.attachmentCompactionManager
 			db.TombstoneCompactionManager = testCase.tombstoneCompactionManager
 			if db.ResyncManager != nil {
-				err := db.ResyncManager.Start(ctx, emptyOptions)
+				err := db.ResyncManager.Start(ctx, ResyncOptions{})
 				assert.NoError(t, err)
 			}
 			if db.AttachmentCompactionManager != nil {
-				err := db.AttachmentCompactionManager.Start(ctx, emptyOptions)
+				err := db.AttachmentCompactionManager.Start(ctx, map[string]any{})
 				assert.NoError(t, err)
 			}
 			if db.TombstoneCompactionManager != nil {
-				err := db.TombstoneCompactionManager.Start(ctx, emptyOptions)
+				err := db.TombstoneCompactionManager.Start(ctx, map[string]any{})
 				assert.NoError(t, err)
 			}
 
@@ -4448,9 +4446,9 @@ func Test_waitForBackgroundManagersToStop(t *testing.T) {
 		waitTime = 1 * time.Second
 	}
 	t.Run("single unstoppable process", func(t *testing.T) {
-		bgMngr := &BackgroundManager{
+		bgMngr := &BackgroundManager[map[string]any]{
 			name:    "test_unstoppable_runner",
-			Process: &testBackgroundProcess{isStoppable: false},
+			Process: &testBackgroundProcess[map[string]any]{isStoppable: false},
 		}
 		ctx := base.TestCtx(t)
 		err := bgMngr.Start(ctx, map[string]any{})
@@ -4460,15 +4458,15 @@ func Test_waitForBackgroundManagersToStop(t *testing.T) {
 
 		startTime := time.Now()
 		deadline := waitTime
-		waitForBackgroundManagersToStop(ctx, deadline, []*BackgroundManager{bgMngr})
+		waitForBackgroundManagersToStop(ctx, deadline, []StoppableBackgroundManager{bgMngr})
 		assert.Greater(t, time.Since(startTime), deadline)
 		assert.Equal(t, BackgroundProcessStateStopping, bgMngr.GetRunState())
 	})
 
 	t.Run("single stoppable process", func(t *testing.T) {
-		bgMngr := &BackgroundManager{
+		bgMngr := &BackgroundManager[map[string]any]{
 			name:    "test_stoppable_runner",
-			Process: &testBackgroundProcess{isStoppable: true},
+			Process: &testBackgroundProcess[map[string]any]{isStoppable: true},
 		}
 		ctx := base.TestCtx(t)
 		err := bgMngr.Start(ctx, map[string]any{})
@@ -4478,15 +4476,15 @@ func Test_waitForBackgroundManagersToStop(t *testing.T) {
 
 		startTime := time.Now()
 		deadline := waitTime
-		waitForBackgroundManagersToStop(ctx, deadline, []*BackgroundManager{bgMngr})
+		waitForBackgroundManagersToStop(ctx, deadline, []StoppableBackgroundManager{bgMngr})
 		assert.Less(t, time.Since(startTime), deadline)
 		assert.Equal(t, BackgroundProcessStateStopped, bgMngr.GetRunState())
 	})
 
 	t.Run("one stoppable process and one unstoppable process", func(t *testing.T) {
-		stoppableBgMngr := &BackgroundManager{
+		stoppableBgMngr := &BackgroundManager[map[string]any]{
 			name:    "test_stoppable_runner",
-			Process: &testBackgroundProcess{isStoppable: true},
+			Process: &testBackgroundProcess[map[string]any]{isStoppable: true},
 		}
 		ctx := base.TestCtx(t)
 		err := stoppableBgMngr.Start(ctx, map[string]any{})
@@ -4494,9 +4492,9 @@ func Test_waitForBackgroundManagersToStop(t *testing.T) {
 		err = stoppableBgMngr.Stop(ctx)
 		require.NoError(t, err)
 
-		unstoppableBgMngr := &BackgroundManager{
+		unstoppableBgMngr := &BackgroundManager[map[string]any]{
 			name:    "test_unstoppable_runner",
-			Process: &testBackgroundProcess{isStoppable: false},
+			Process: &testBackgroundProcess[map[string]any]{isStoppable: false},
 		}
 
 		err = unstoppableBgMngr.Start(ctx, map[string]any{})
@@ -4506,7 +4504,7 @@ func Test_waitForBackgroundManagersToStop(t *testing.T) {
 
 		startTime := time.Now()
 		deadline := waitTime
-		waitForBackgroundManagersToStop(ctx, deadline, []*BackgroundManager{stoppableBgMngr, unstoppableBgMngr})
+		waitForBackgroundManagersToStop(ctx, deadline, []StoppableBackgroundManager{stoppableBgMngr, unstoppableBgMngr})
 		assert.Greater(t, time.Since(startTime), deadline)
 		assert.Equal(t, BackgroundProcessStateStopped, stoppableBgMngr.GetRunState())
 		assert.Equal(t, BackgroundProcessStateStopping, unstoppableBgMngr.GetRunState())
@@ -4514,17 +4512,17 @@ func Test_waitForBackgroundManagersToStop(t *testing.T) {
 }
 
 // Test BackgroundManagerProcessI which can be configured to stop or run forever
-var _ BackgroundManagerProcessI = &testBackgroundProcess{}
+var _ BackgroundManagerProcessI[map[string]any] = &testBackgroundProcess[map[string]any]{}
 
-type testBackgroundProcess struct {
+type testBackgroundProcess[O any] struct {
 	isStoppable bool
 }
 
-func (i *testBackgroundProcess) Init(ctx context.Context, options map[string]any, clusterStatus []byte) error {
+func (i *testBackgroundProcess[O]) Init(_ context.Context, _ O, _ []byte) error {
 	return nil
 }
 
-func (i *testBackgroundProcess) Run(ctx context.Context, options map[string]any, persistClusterStatusCallback updateStatusCallbackFunc, terminator *base.SafeTerminator) error {
+func (i *testBackgroundProcess[O]) Run(_ context.Context, _ O, _ updateStatusCallbackFunc, terminator *base.SafeTerminator) error {
 	<-terminator.Done()
 	if i.isStoppable {
 		return nil
@@ -4534,9 +4532,9 @@ func (i *testBackgroundProcess) Run(ctx context.Context, options map[string]any,
 	return nil
 }
 
-func (i *testBackgroundProcess) SetProcessStatus(context.Context, []byte, []byte) {}
+func (i *testBackgroundProcess[O]) SetProcessStatus(context.Context, []byte, []byte) {}
 
-func (i *testBackgroundProcess) GetProcessStatus(status BackgroundManagerStatus, _ []byte) ([]byte, []byte, error) {
+func (i *testBackgroundProcess[O]) GetProcessStatus(status BackgroundManagerStatus, _ []byte) ([]byte, []byte, error) {
 	statusJSON, err := base.JSONMarshal(status)
 	if err != nil {
 		return nil, nil, err
@@ -4545,7 +4543,7 @@ func (i *testBackgroundProcess) GetProcessStatus(status BackgroundManagerStatus,
 	return statusJSON, nil, nil
 }
 
-func (i *testBackgroundProcess) ResetStatus() {
+func (i *testBackgroundProcess[O]) ResetStatus() {
 }
 
 // Make sure that closing a database context after a mutation feed fails to start results does not panic

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -947,7 +947,7 @@ func MoveAttachmentXattrFromGlobalToSync(t *testing.T, dataStore base.DataStore,
 // After a background manager state transition to completed, stopped, error is followed by immediate removal of the
 // heartbeat document. When restarting a background manager, the state of the heartbeat document is checked, allowing
 // for a small race if you try to stop and immediately restart a background manager.
-func WaitForBackgroundManagerHeartbeatDocRemoval(t testing.TB, mgr *BackgroundManager) {
+func WaitForBackgroundManagerHeartbeatDocRemoval[O any](t testing.TB, mgr *BackgroundManager[O]) {
 	if mgr.mode() != backgroundManagerModeSingleNode {
 		return
 	}
@@ -961,7 +961,7 @@ func WaitForBackgroundManagerHeartbeatDocRemoval(t testing.TB, mgr *BackgroundMa
 }
 
 // RequireBackgroundManagerState waits for a BackgroundManager to reach a given state or fails test harness.
-func RequireBackgroundManagerState(t testing.TB, mgr *BackgroundManager, expState BackgroundProcessState) BackgroundManagerStatus {
+func RequireBackgroundManagerState[O any](t testing.TB, mgr *BackgroundManager[O], expState BackgroundProcessState) BackgroundManagerStatus {
 	waitTime := 10 * time.Second
 	if !base.UnitTestUrlIsWalrus() || base.IsRaceDetectorEnabled(t) || os.Getenv("CI") != "" {
 		// Increase wait time for CI tests against Couchbase Server, they can take longer to run.

--- a/rest/api.go
+++ b/rest/api.go
@@ -453,10 +453,10 @@ func (h *handler) handlePostResync() error {
 
 	if action == string(db.BackgroundProcessActionStart) {
 		if atomic.CompareAndSwapUint32(&h.db.State, db.DBOffline, db.DBResyncing) {
-			err := h.db.ResyncManager.Start(h.ctx(), map[string]any{
-				"regenerateSequences": regenerateSequences,
-				"collections":         resyncPostReqBody.Scope,
-				"reset":               reset,
+			err := h.db.ResyncManager.Start(h.ctx(), db.ResyncOptions{
+				RegenerateSequences: regenerateSequences,
+				Collections:         resyncPostReqBody.Scope,
+				Reset:               reset,
 			})
 			if err != nil {
 				return err


### PR DESCRIPTION
- Make options generic on BackgroundManager and BackgroundManagerProcessI. This keeps the existing code the same but allow changes for distributed resync. In the future, adopting typed options would be helpful.
- With typed options, ResyncOptions is used for serialization/deserialization and rest API access.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
