### PR TITLE
resync: Allow BackgroundManager.Stop to be called always

### DIFF
--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -49,8 +49,8 @@ type ResyncManagerDCP struct {
 	resyncCollectionInfo
 	lock              sync.RWMutex
 	Distributed       bool
-	dcpDoneChan       chan error      // mark when the DCP feed is completed
-	completedvBuckets *vBucketTracker // tracks the number of completed vBuckets for the local
+	dcpDoneChan       atomic.Pointer[chan error] // mark when the DCP feed is completed; nil if Run() has not been called
+	completedvBuckets *vBucketTracker            // tracks the number of completed vBuckets for the local
 }
 
 // vBucketTracker tracks completed vBuckets in a thread safe way. It is used to determine when all vBuckets have
@@ -350,7 +350,8 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 		sort.Strings(collectionNamesByScope[scopeName])
 		resyncDestKey = base.DestKey(db.Name, scopeName, collectionNamesByScope[scopeName], base.ShardedDCPFeedTypeResync)
 
-		r.dcpDoneChan = make(chan error)
+		dcpDoneChan := make(chan error)
+		r.dcpDoneChan.Store(&dcpDoneChan)
 		checkPointPrefix := GetResyncDCPCheckpointPrefix(db, r.ResyncID, true)
 		endSeqNos, err := base.GetHighSeqNos(ctx, db.Bucket)
 		if err != nil {
@@ -444,15 +445,16 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 			base.WarnfCtx(ctx, "Failed to create resync DCP client! %v", err)
 			return err
 		}
-		r.dcpDoneChan, err = dcpClient.Start()
+		dcpDoneChan, err := dcpClient.Start()
 		if err != nil {
 			base.WarnfCtx(ctx, "Failed to start resync DCP feed! %v", err)
 			_ = dcpClient.Close()
 			return err
 		}
+		r.dcpDoneChan.Store(&dcpDoneChan)
 		dcpClientClose.append(func() error {
 			_ = dcpClient.Close()
-			err := <-r.dcpDoneChan
+			err := <-*r.dcpDoneChan.Load()
 			return err
 		})
 
@@ -461,7 +463,7 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 		r.SetVBUUIDs(base.GetVBUUIDs(dcpClient.GetMetadata()))
 	}
 	select {
-	case <-r.dcpDoneChan:
+	case <-*r.dcpDoneChan.Load():
 		base.InfofCtx(ctx, base.KeyAll, "Finished running resync. %d/%d docs changed", r.DocsChanged(), r.DocsProcessed())
 		err := dcpClientClose.shutdown()
 		if err != nil {
@@ -762,7 +764,9 @@ func (r *ResyncManagerDCP) markVBucketsCompleted(ctx context.Context, vbNos iter
 		r.completedvBuckets.m[vbNo] = struct{}{}
 	}
 	if len(r.completedvBuckets.m) == int(totalVbuckets) {
-		close(r.dcpDoneChan)
+		if chPtr := r.dcpDoneChan.Load(); chPtr != nil {
+			close(*chPtr)
+		}
 	}
 }
 

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -1092,6 +1092,59 @@ func TestResyncManagerDCPCompletedVBucketsStatus(t *testing.T) {
 	})
 }
 
+// TestResyncManagerDCPStopOnNonRunningNode exercises the scenario where two SG nodes share the
+// same distributed resync metadata: node 1 runs the resync to completion while node 2 (which
+// never ran) calls Stop unconditionally — simulating DatabaseContext.Close.
+//
+// In production, DBStateManager polling on node 2 calls Resume when it detects ResyncRunning=true;
+// Resume calls start which sets state=Running. DatabaseContext.Close then calls Stop. Stop sees
+// state=Running, calls stopProcess → UpdateStatusClusterAware → SetProcessStatus → markVBucketsCompleted.
+// The completed status doc (all vBuckets) causes markVBucketsCompleted to close dcpDoneChan, but
+// dcpDoneChan is nil because Run() was never called on node 2 → panic.
+func TestResyncManagerDCPStopOnNonRunningNode(t *testing.T) {
+	if !base.IsEnterpriseEdition() {
+		t.Skip("Distributed resync requires EE")
+	}
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("Distributed resync not supported for rosmar")
+	}
+	AllowDistributedResync(t)
+	db, ctx := setupTestDBForResyncWithDocs(t, testDBForResyncOptions{
+		docsToCreate:                 10,
+		updateSyncFuncAfterDocsAdded: true,
+		distributed:                  true,
+	})
+	defer db.Close(ctx)
+
+	options := map[string]any{
+		"regenerateSequences": false,
+		"collections":         base.NewCollectionNames(),
+	}
+
+	// Node 1 runs the resync and completes (writes all vBuckets to the cluster status doc).
+	require.NoError(t, db.ResyncManager.Start(ctx, options))
+	waitForResyncState(t, db, BackgroundProcessStateCompleted)
+
+	// Simulate a second SG node (node 2) that shares the same metadata store but never ran
+	// the resync. In production, DBStateManager polling calls Resume which puts the manager
+	// into Running state; DatabaseContext.Close then calls Stop unconditionally.
+	node2 := NewResyncManagerDCP(db.DatabaseContext, true)
+	_, err := node2.GetStatus(ctx)
+	require.NoError(t, err)
+
+	// Without this, markStop returns errBackgroundManagerProcessAlreadyStopped for state ""
+	// and the stopProcess/UpdateStatusClusterAware path is never reached.
+	node2.statusLock.Lock()
+	node2.status.State = BackgroundProcessStateRunning
+	node2.statusLock.Unlock()
+
+	// Stop must not panic. Previously it would: Stop → stopProcess → UpdateStatusClusterAware →
+	// SetProcessStatus → markVBucketsCompleted → close(nil dcpDoneChan).
+	assert.NotPanics(t, func() {
+		require.NoError(t, node2.Stop(ctx))
+	})
+}
+
 // TestResyncManagerDCPWritesV1SyncInfoAtCcv41 verifies the end-to-end wiring from
 // DatabaseContext.ClusterCompatVersion through ResyncManagerDCP.Run into
 // base.SetSyncInfoMetadataID — when ccv>=4.1 the syncInfo doc is written with the V1


### PR DESCRIPTION
Found in `TestResyncCrossNode`, the state of resync can be not running on node2 which means that `dcpDoneChan` is not synchronized. While this test "technically" reproduces the issue, I think I'd prefer to remove it because I think it is unrealistic. I am leaving it for the reviewer to understand what is going on, or to run and observe the panic.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
