### PR TITLE
CBG-5430: add system collection to purgeWithDCPFeed

### DIFF
--- a/base/cluster_n1ql.go
+++ b/base/cluster_n1ql.go
@@ -75,6 +75,16 @@ func (cl *ClusterOnlyN1QLStore) GetName() string {
 	return cl.bucketName
 }
 
+// ScopeName returns the scope name for the N1QLStore.
+func (cl *ClusterOnlyN1QLStore) ScopeName() string {
+	return cl.scopeName
+}
+
+// CollectionName returns the collection name for the N1QLStore.
+func (cl *ClusterOnlyN1QLStore) CollectionName() string {
+	return cl.collectionName
+}
+
 func (cl *ClusterOnlyN1QLStore) BucketName() string {
 	return cl.bucketName
 }

--- a/base/collection.go
+++ b/base/collection.go
@@ -451,7 +451,7 @@ func (b *GocbV2Bucket) Flush(ctx context.Context) error {
 // BucketItemCount first tries to retrieve an accurate bucket count via N1QL,
 // but falls back to the REST API if that cannot be done (when there's no index to count all items in a bucket)
 func (b *GocbV2Bucket) BucketItemCount(ctx context.Context) (itemCount int, err error) {
-	dataStoreNames, err := b.ListDataStores(ctx)
+	dataStoreNames, err := GetAllDataStores(ctx, b)
 	if err != nil {
 		return 0, err
 	}

--- a/base/collection.go
+++ b/base/collection.go
@@ -451,20 +451,13 @@ func (b *GocbV2Bucket) Flush(ctx context.Context) error {
 // BucketItemCount first tries to retrieve an accurate bucket count via N1QL,
 // but falls back to the REST API if that cannot be done (when there's no index to count all items in a bucket)
 func (b *GocbV2Bucket) BucketItemCount(ctx context.Context) (itemCount int, err error) {
-	dataStoreNames, err := GetAllDataStores(ctx, b)
+	n1qlStores, err := GetAllN1QLStores(ctx, b)
 	if err != nil {
 		return 0, err
 	}
 
-	for _, dsn := range dataStoreNames {
-		ds, err := b.NamedDataStore(ctx, dsn)
-		if err != nil {
-			return 0, err
-		}
-		ns, ok := AsN1QLStore(ds)
-		if !ok {
-			return 0, fmt.Errorf("DataStore %v %T is not a N1QLStore", ds.GetName(), ds)
-		}
+	for _, ns := range n1qlStores {
+		ctx := DataStoreLogCtx(ctx, ns)
 		itemCount, err = QueryBucketItemCount(ctx, ns)
 		if err == nil {
 			return itemCount, nil

--- a/base/collection_common.go
+++ b/base/collection_common.go
@@ -41,12 +41,21 @@ func MobileSystemScopeAndCollectionName() ScopeAndCollectionName {
 // (_system._mobile). ListDataStores intentionally omits the system scope so that callers don't
 // accidentally iterate over system collections; use this instead in paths that must account for
 // Sync Gateway's metadata in the system collection (e.g. purging documents, dropping indexes).
-func GetAllDataStores(ctx context.Context, bucket Bucket) ([]sgbucket.DataStoreName, error) {
-	dataStores, err := bucket.ListDataStores(ctx)
+func GetAllDataStores(ctx context.Context, bucket Bucket) ([]DataStore, error) {
+	dataStoreNames, err := bucket.ListDataStores(ctx)
 	if err != nil {
 		return nil, err
 	}
-	dataStores = append(dataStores, MobileSystemScopeAndCollectionName())
+	dataStoreNames = append(dataStoreNames, MobileSystemScopeAndCollectionName())
+
+	dataStores := make([]DataStore, 0, len(dataStoreNames))
+	for _, name := range dataStoreNames {
+		ds, err := bucket.NamedDataStore(ctx, name)
+		if err != nil {
+			return nil, err
+		}
+		dataStores = append(dataStores, ds)
+	}
 	return dataStores, nil
 }
 

--- a/base/collection_common.go
+++ b/base/collection_common.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package base
 
 import (
+	"context"
 	"errors"
 	"maps"
 	"slices"
@@ -34,6 +35,19 @@ func DefaultScopeAndCollectionName() ScopeAndCollectionName {
 
 func MobileSystemScopeAndCollectionName() ScopeAndCollectionName {
 	return ScopeAndCollectionName{Scope: SystemScope, Collection: SystemCollectionMobile}
+}
+
+// GetAllDataStores returns all data stores in the bucket, including the mobile system collection
+// (_system._mobile). ListDataStores intentionally omits the system scope so that callers don't
+// accidentally iterate over system collections; use this instead in paths that must account for
+// Sync Gateway's metadata in the system collection (e.g. purging documents, dropping indexes).
+func GetAllDataStores(ctx context.Context, bucket Bucket) ([]sgbucket.DataStoreName, error) {
+	dataStores, err := bucket.ListDataStores(ctx)
+	if err != nil {
+		return nil, err
+	}
+	dataStores = append(dataStores, MobileSystemScopeAndCollectionName())
+	return dataStores, nil
 }
 
 func NewScopeAndCollectionName(scope, collection string) ScopeAndCollectionName {

--- a/base/collection_n1ql.go
+++ b/base/collection_n1ql.go
@@ -34,11 +34,11 @@ func IsDefaultCollection(scope, collection string) bool {
 	return collection == DefaultCollection && scope == DefaultScope
 }
 
-// IsMobileCollection returns true if the scope and collection are the mobile system collection
-// (_system._mobile).
-func IsMobileCollection(scope, collection string) bool {
+// IsMobileSystemCollection returns true datastore name is the
+// mobile system collection (_system._mobile).
+func IsMobileSystemCollection(dsn sgbucket.DataStoreName) bool {
 	// check collection first to early exit non-mobile collection
-	return collection == SystemCollectionMobile && scope == SystemScope
+	return dsn.CollectionName() == SystemCollectionMobile && dsn.ScopeName() == SystemScope
 }
 
 // EscapedKeyspace returns the escaped fully-qualified identifier for the keyspace (e.g. `bucket`.`scope`.`collection`)

--- a/base/collection_n1ql.go
+++ b/base/collection_n1ql.go
@@ -34,6 +34,13 @@ func IsDefaultCollection(scope, collection string) bool {
 	return collection == DefaultCollection && scope == DefaultScope
 }
 
+// IsMobileCollection returns true if the scope and collection are the mobile system collection
+// (_system._mobile).
+func IsMobileCollection(scope, collection string) bool {
+	// check collection first to early exit non-mobile collection
+	return collection == SystemCollectionMobile && scope == SystemScope
+}
+
 // EscapedKeyspace returns the escaped fully-qualified identifier for the keyspace (e.g. `bucket`.`scope`.`collection`)
 func (c *Collection) EscapedKeyspace() string {
 	if !c.IsSupported(sgbucket.BucketStoreFeatureCollections) {

--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -51,6 +51,8 @@ const (
 // N1QLStore defines the set of operations Sync Gateway uses to manage and interact with N1QL
 type N1QLStore interface {
 	GetName() string
+	ScopeName() string
+	CollectionName() string
 	BuildDeferredIndexes(ctx context.Context, indexSet []string) error
 	CreateIndex(ctx context.Context, indexName string, expression string, filterExpression string, options *N1qlIndexOptions) error
 	CreateIndexIfNotExists(ctx context.Context, indexName string, expression string, filterExpression string, options *N1qlIndexOptions) error
@@ -379,6 +381,23 @@ func DropIndex(ctx context.Context, store N1QLStore, indexName string) error {
 	}
 
 	return err
+}
+
+// GetAllN1QLStores returns all N1QL stores in the bucket, including the mobile system collection
+// (_system._mobile).
+func GetAllN1QLStores(ctx context.Context, bucket Bucket) ([]N1QLStore, error) {
+	dataStores, err := GetAllDataStores(ctx, bucket)
+	if err != nil {
+		return nil, err
+	}
+
+	n1qlStores := make([]N1QLStore, 0, len(dataStores))
+	for _, ds := range dataStores {
+		if ns, ok := AsN1QLStore(ds); ok {
+			n1qlStores = append(n1qlStores, ns)
+		}
+	}
+	return n1qlStores, nil
 }
 
 // AsN1QLStore tries to return the given DataStore as a N1QLStore.

--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -395,7 +395,7 @@ func GetAllN1QLStores(ctx context.Context, bucket Bucket) ([]N1QLStore, error) {
 	for _, ds := range dataStores {
 		ns, ok := AsN1QLStore(ds)
 		if !ok {
-			return nil, RedactErrorf("%s.%s.%s is not a N1QLStore is of type %T", ds.GetName(), ds.ScopeName(), ds.CollectionName(), ds)
+			return nil, RedactErrorf("%s.%s.%s is not a N1QLStore is of type %T", MD(ds.GetName()), MD(ds.ScopeName()), MD(ds.CollectionName()), ds)
 		}
 		n1qlStores = append(n1qlStores, ns)
 	}

--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -393,9 +393,11 @@ func GetAllN1QLStores(ctx context.Context, bucket Bucket) ([]N1QLStore, error) {
 
 	n1qlStores := make([]N1QLStore, 0, len(dataStores))
 	for _, ds := range dataStores {
-		if ns, ok := AsN1QLStore(ds); ok {
-			n1qlStores = append(n1qlStores, ns)
+		ns, ok := AsN1QLStore(ds)
+		if !ok {
+			return nil, RedactErrorf("%s.%s.%s is not a N1QLStore is of type %T", ds.GetName(), ds.ScopeName(), ds.CollectionName(), ds)
 		}
+		n1qlStores = append(n1qlStores, ns)
 	}
 	return n1qlStores, nil
 }

--- a/base/leaky_datastore.go
+++ b/base/leaky_datastore.go
@@ -73,10 +73,12 @@ func (lds *LeakyDataStore) GetName() string {
 	return lds.dataStore.GetName()
 }
 
+// ScopeName returns the scope name for the DataStore.
 func (lds *LeakyDataStore) ScopeName() string {
 	return lds.dataStore.ScopeName()
 }
 
+// CollectionName returns the collection name for the DataStore.
 func (lds *LeakyDataStore) CollectionName() string {
 	return lds.dataStore.CollectionName()
 }

--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -16,6 +16,8 @@ import (
 	"math/rand"
 	"strconv"
 	"testing"
+
+	sgbucket "github.com/couchbase/sg-bucket"
 )
 
 // LogContextKey is used to key a LogContext value
@@ -258,6 +260,14 @@ func KeyspaceLogCtx(parent context.Context, bucketName, scopeName, collectionNam
 	newCtx.Bucket = bucketName
 	newCtx.Collection = collectionName
 	newCtx.Scope = scopeName
+	return LogContextWith(parent, &newCtx)
+}
+
+// DataStoreLogCtx extends the parent context with a scope and collection from a DataStoreName.
+func DataStoreLogCtx(parent context.Context, dataStoreName sgbucket.DataStoreName) context.Context {
+	newCtx := getLogCtx(parent)
+	newCtx.Collection = dataStoreName.CollectionName()
+	newCtx.Scope = dataStoreName.ScopeName()
 	return LogContextWith(parent, &newCtx)
 }
 

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -969,6 +969,18 @@ func GetNonDefaultDatastoreNames(t testing.TB, bucket Bucket) []sgbucket.DataSto
 	return nonDefaultDataStoreNames
 }
 
+// DropAllBucketIndexes removes all indexes from all N1QL stores in the bucket.
+func DropAllBucketIndexes(t testing.TB, tb *TestBucket) {
+	ctx := TestCtx(t)
+	n1qlStores, err := GetAllN1QLStores(ctx, tb)
+	require.NoError(t, err)
+
+	for _, ns := range n1qlStores {
+		dropErr := DropAllIndexes(ctx, ns)
+		require.NoError(t, dropErr)
+	}
+}
+
 // TestClusterSpec returns the cluster spec for the test bucket pool.
 func TestClusterSpec(t *testing.T) CouchbaseClusterSpec {
 	return GTestBucketPool.clusterSpec

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -198,6 +198,15 @@ func purgeWithDCPFeed(ctx context.Context, bucket base.Bucket, tbp *base.TestBuc
 		collections[collection.GetCollectionID()] = collection
 
 	}
+	// add system cope and collection to we also purge metadata from the system collection to avoid
+	// interference between test runs
+	mobileCollectionName := base.MobileSystemScopeAndCollectionName()
+	collectionNames.Add(mobileCollectionName)
+	systemDS, err := bucket.NamedDataStore(ctx, mobileCollectionName)
+	if err != nil {
+		return err
+	}
+	collections[systemDS.GetCollectionID()] = systemDS
 
 	purgeCallback := func(event sgbucket.FeedEvent) bool {
 		processedDocCount.Add(1)

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -191,13 +191,9 @@ func purgeWithDCPFeed(ctx context.Context, bucket base.Bucket, tbp *base.TestBuc
 	}
 	collections := make(map[uint32]sgbucket.DataStore, len(dataStores))
 	collectionNames := base.NewCollectionNameSet()
-	for _, dataStoreName := range dataStores {
-		collection, err := bucket.NamedDataStore(ctx, dataStoreName)
-		if err != nil {
-			return err
-		}
-		collectionNames.Add(dataStoreName)
-		collections[collection.GetCollectionID()] = collection
+	for _, dataStore := range dataStores {
+		collectionNames.Add(dataStore)
+		collections[dataStore.GetCollectionID()] = dataStore
 	}
 
 	purgeCallback := func(event sgbucket.FeedEvent) bool {
@@ -322,20 +318,13 @@ var deleteDocsAndIndexesBucketReadier base.TBPBucketReadierFunc = func(ctx conte
 		return err
 	}
 	// Include the mobile system collection so its indexes are dropped too.
-	dataStores, err := base.GetAllDataStores(ctx, b)
+	n1qlStores, err := base.GetAllN1QLStores(ctx, b)
 	if err != nil {
 		return err
 	}
-	for _, dataStoreName := range dataStores {
-		dataStore, err := b.NamedDataStore(ctx, dataStoreName)
-		if err != nil {
-			return err
-		}
-		n1qlStore, ok := base.AsN1QLStore(dataStore)
-		if !ok {
-			return errors.New("attempting to empty indexes with non-N1QL store")
-		}
-		tbp.Logf(ctx, "dropping existing bucket indexes %s.%s.%s", b.GetName(), dataStore.ScopeName(), dataStore.CollectionName())
+	for _, n1qlStore := range n1qlStores {
+		ctx := base.DataStoreLogCtx(ctx, n1qlStore)
+		tbp.Logf(ctx, "dropping existing bucket indexes %s", n1qlStore.GetName())
 		if err := base.DropAllIndexes(ctx, n1qlStore); err != nil {
 			tbp.Logf(ctx, "Failed to drop bucket indexes: %v", err)
 			return err
@@ -362,13 +351,8 @@ var viewsAndGSIBucketInit base.TBPBucketInitFunc = func(ctx context.Context, b b
 		return err
 	}
 
-	for _, dataStoreName := range dataStores {
-		ctx := base.KeyspaceLogCtx(ctx, b.GetName(), dataStoreName.ScopeName(), dataStoreName.CollectionName())
-		isSystemCollection := base.IsMobileCollection(dataStoreName.ScopeName(), dataStoreName.CollectionName())
-		dataStore, err := b.NamedDataStore(ctx, dataStoreName)
-		if err != nil {
-			return err
-		}
+	for _, dataStore := range dataStores {
+		ctx := base.DataStoreLogCtx(ctx, dataStore)
 
 		// Views
 		if skipGSI || base.TestsDisableGSI() {
@@ -399,7 +383,7 @@ var viewsAndGSIBucketInit base.TBPBucketInitFunc = func(ctx context.Context, b b
 			NumPartitions:              DefaultNumIndexPartitions,
 		}
 		switch {
-		case isSystemCollection:
+		case base.IsMobileSystemCollection(dataStore):
 			options.MetadataIndexes = IndexesMetadataOnly
 		case base.IsDefaultCollection(dataStore.ScopeName(), dataStore.CollectionName()):
 			options.MetadataIndexes = IndexesAll
@@ -1139,7 +1123,7 @@ func InitializeDualMetadataStoreIndexes(t *testing.T, ctx context.Context, metad
 	if !ok {
 		return fmt.Errorf("primary datastore (%T) is not an N1QL store; cannot initialize dual metadata store indexes", metadataStore.Primary())
 	}
-	primaryCtx := base.CollectionLogCtx(ctx, metadataStore.Primary().ScopeName(), metadataStore.Primary().CollectionName())
+	primaryCtx := base.DataStoreLogCtx(ctx, metadataStore.Primary())
 	primaryOptions.MetadataIndexes = IndexesMetadataOnly // primary store only needs metadata indexes (no other data can be stored here)
 	if err := InitializeIndexes(primaryCtx, primaryN1QL, primaryOptions); err != nil {
 		return fmt.Errorf("initializing indexes on primary metadata store: %w", err)
@@ -1149,7 +1133,7 @@ func InitializeDualMetadataStoreIndexes(t *testing.T, ctx context.Context, metad
 	if !ok {
 		return fmt.Errorf("fallback datastore (%T) is not an N1QL store; cannot initialize dual metadata store indexes", metadataStore.Fallback())
 	}
-	fallbackCtx := base.CollectionLogCtx(ctx, metadataStore.Fallback().ScopeName(), metadataStore.Fallback().CollectionName())
+	fallbackCtx := base.DataStoreLogCtx(ctx, metadataStore.Fallback())
 	if err := InitializeIndexes(fallbackCtx, fallbackN1QL, options); err != nil {
 		return fmt.Errorf("initializing indexes on fallback metadata store: %w", err)
 	}

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -183,7 +183,9 @@ func purgeWithDCPFeed(ctx context.Context, bucket base.Bucket, tbp *base.TestBuc
 
 	var purgeErrors *base.MultiError
 
-	dataStores, err := bucket.ListDataStores(ctx)
+	// Include the mobile system collection so we also purge Sync Gateway metadata from it, avoiding
+	// interference between test runs.
+	dataStores, err := base.GetAllDataStores(ctx, bucket)
 	if err != nil {
 		return err
 	}
@@ -196,17 +198,7 @@ func purgeWithDCPFeed(ctx context.Context, bucket base.Bucket, tbp *base.TestBuc
 		}
 		collectionNames.Add(dataStoreName)
 		collections[collection.GetCollectionID()] = collection
-
 	}
-	// add system cope and collection to we also purge metadata from the system collection to avoid
-	// interference between test runs
-	mobileCollectionName := base.MobileSystemScopeAndCollectionName()
-	collectionNames.Add(mobileCollectionName)
-	systemDS, err := bucket.NamedDataStore(ctx, mobileCollectionName)
-	if err != nil {
-		return err
-	}
-	collections[systemDS.GetCollectionID()] = systemDS
 
 	purgeCallback := func(event sgbucket.FeedEvent) bool {
 		processedDocCount.Add(1)
@@ -329,7 +321,8 @@ var deleteDocsAndIndexesBucketReadier base.TBPBucketReadierFunc = func(ctx conte
 	if err != nil {
 		return err
 	}
-	dataStores, err := b.ListDataStores(ctx)
+	// Include the mobile system collection so its indexes are dropped too.
+	dataStores, err := base.GetAllDataStores(ctx, b)
 	if err != nil {
 		return err
 	}
@@ -362,36 +355,16 @@ var viewsAndGSIBucketInit base.TBPBucketInitFunc = func(ctx context.Context, b b
 
 	tbp.Logf(ctx, "Starting bucket init function")
 
-	if !skipGSI {
-		mobileSystemDataStore, err := b.NamedDataStore(ctx, base.MobileSystemScopeAndCollectionName())
-		if err != nil {
-			return err
-		}
-		systemCollectionInitOptions := InitializeIndexOptions{
-			UseXattrs:                  true,
-			NumReplicas:                0,
-			WaitForIndexesOnlineOption: base.WaitForIndexesDefault,
-			LegacySyncDocsIndex:        false,
-			MetadataIndexes:            IndexesMetadataOnly,
-			NumPartitions:              DefaultNumIndexPartitions,
-		}
-		systemN1QLStore, ok := base.AsN1QLStore(mobileSystemDataStore)
-		if !ok {
-			return fmt.Errorf("bucket %T was not a N1QL store", b)
-		}
-
-		if err := InitializeIndexes(ctx, systemN1QLStore, systemCollectionInitOptions); err != nil {
-			return err
-		}
-	}
-
-	dataStores, err := b.ListDataStores(ctx)
+	// Include the mobile system collection so its indexes are dropped and recreated alongside the
+	// other collections, rather than being left with stale indexes between bucket reuses.
+	dataStores, err := base.GetAllDataStores(ctx, b)
 	if err != nil {
 		return err
 	}
 
 	for _, dataStoreName := range dataStores {
 		ctx := base.KeyspaceLogCtx(ctx, b.GetName(), dataStoreName.ScopeName(), dataStoreName.CollectionName())
+		isSystemCollection := base.IsMobileCollection(dataStoreName.ScopeName(), dataStoreName.CollectionName())
 		dataStore, err := b.NamedDataStore(ctx, dataStoreName)
 		if err != nil {
 			return err
@@ -425,7 +398,10 @@ var viewsAndGSIBucketInit base.TBPBucketInitFunc = func(ctx context.Context, b b
 			MetadataIndexes:            IndexesWithoutMetadata,
 			NumPartitions:              DefaultNumIndexPartitions,
 		}
-		if base.IsDefaultCollection(dataStore.ScopeName(), dataStore.CollectionName()) {
+		switch {
+		case isSystemCollection:
+			options.MetadataIndexes = IndexesMetadataOnly
+		case base.IsDefaultCollection(dataStore.ScopeName(), dataStore.CollectionName()):
 			options.MetadataIndexes = IndexesAll
 		}
 		if err := InitializeIndexes(ctx, n1qlStore, options); err != nil {

--- a/rest/database_init_manager_test.go
+++ b/rest/database_init_manager_test.go
@@ -45,7 +45,7 @@ func TestDatabaseInitManager(t *testing.T) {
 	require.NoError(t, dbConfig.setup(ctx, dbName, sc.Config.Bootstrap, nil, nil, false))
 
 	// Drop indexes
-	dropAllNonPrimaryIndexes(t, tb.GetSingleDataStore())
+	base.DropAllBucketIndexes(t, tb)
 
 	// Async index creation
 	doneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex)
@@ -76,7 +76,7 @@ func TestDatabaseInitConfigChangeSameCollections(t *testing.T) {
 	tb := base.GetTestBucket(t)
 	defer tb.Close(ctx)
 	// Drop all test indexes so we can test InitializeDatabase
-	DropAllTestIndexes(t, tb)
+	base.DropAllBucketIndexes(t, tb)
 
 	// Set up collection names and ScopesConfig for testing
 	scopesConfig := GetCollectionsConfig(t, tb, 3)
@@ -163,7 +163,7 @@ func TestDatabaseInitConfigChangeDifferentCollections(t *testing.T) {
 	defer tb.Close(ctx)
 
 	// Drop all test indexes so we can test InitializeDatabase
-	DropAllTestIndexes(t, tb)
+	base.DropAllBucketIndexes(t, tb)
 
 	// Set up collection names and ScopesConfig for testing
 	scopesConfig := GetCollectionsConfig(t, tb, 3)
@@ -250,7 +250,7 @@ func TestDatabaseInitConcurrentDatabasesSameBucket(t *testing.T) {
 	defer tb.Close(ctx)
 
 	// Drop all test indexes so we can test InitializeDatabase
-	DropAllTestIndexes(t, tb)
+	base.DropAllBucketIndexes(t, tb)
 
 	// Set up collection names and ScopesConfig for testing
 	scopesConfig := GetCollectionsConfig(t, tb, 3)
@@ -336,14 +336,14 @@ func TestDatabaseInitConcurrentDatabasesDifferentBuckets(t *testing.T) {
 	defer tb1.Close(ctx)
 
 	// Drop all test indexes so we can test InitializeDatabase
-	DropAllTestIndexes(t, tb1)
+	base.DropAllBucketIndexes(t, tb1)
 
 	// Get two test buckets for bootstrap testing, and drop indexes created by bucket pool readier
 	tb2 := base.GetTestBucket(t)
 	defer tb2.Close(ctx)
 
 	// Drop all test indexes so we can test InitializeDatabase
-	DropAllTestIndexes(t, tb2)
+	base.DropAllBucketIndexes(t, tb2)
 
 	// Set up collection names and ScopesConfig for testing - use same collections for both buckets
 	scopesConfig := GetCollectionsConfig(t, tb1, 3)
@@ -433,7 +433,7 @@ func TestDatabaseInitTeardownTiming(t *testing.T) {
 	defer tb.Close(ctx)
 
 	// Drop all test indexes so we can test InitializeDatabase
-	DropAllTestIndexes(t, tb)
+	base.DropAllBucketIndexes(t, tb)
 
 	// Set up collection names and ScopesConfig for testing
 	scopesConfig := GetCollectionsConfig(t, tb, 3)

--- a/rest/indextest/index_test.go
+++ b/rest/indextest/index_test.go
@@ -26,13 +26,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func requireNoIndexes(t *testing.T, dataStore base.DataStore) {
-	collection, err := base.AsCollection(dataStore)
-	require.NoError(t, err)
-	indexNames, err := collection.GetIndexes()
+func requireNoIndexes(t *testing.T, n1qlStore base.N1QLStore) {
+	indexNames, err := n1qlStore.GetIndexes()
 	require.NoError(t, err)
 	require.Len(t, indexNames, 0)
-
 }
 
 func TestSyncGatewayStartupIndexes(t *testing.T) {
@@ -41,13 +38,11 @@ func TestSyncGatewayStartupIndexes(t *testing.T) {
 	defer bucket.Close(ctx)
 
 	// Assert there are no indexes on the datastores, to test server startup
-	dsNames, err := base.GetAllDataStores(ctx, bucket)
+	n1qlStores, err := base.GetAllN1QLStores(ctx, bucket)
 	require.NoError(t, err)
-	for _, dsName := range dsNames {
-		dataStore, err := bucket.NamedDataStore(ctx, dsName)
-		require.NoError(t, err)
+	for _, ns := range n1qlStores {
 		if !base.TestsDisableGSI() {
-			requireNoIndexes(t, dataStore)
+			requireNoIndexes(t, ns)
 		}
 	}
 
@@ -279,7 +274,7 @@ func TestAsyncInitWithResync(t *testing.T) {
 	resp = rest.BootstrapAdminRequest(t, sc, http.MethodDelete, "/"+dbName+"/", "")
 	resp.RequireStatus(http.StatusOK)
 
-	rest.DropAllTestIndexesIncludingPrimary(t, tb)
+	base.DropAllBucketIndexes(t, tb)
 
 	// Set testing callbacks for async initialization
 	collectionCount := int64(0)

--- a/rest/indextest/index_test.go
+++ b/rest/indextest/index_test.go
@@ -41,7 +41,7 @@ func TestSyncGatewayStartupIndexes(t *testing.T) {
 	defer bucket.Close(ctx)
 
 	// Assert there are no indexes on the datastores, to test server startup
-	dsNames, err := bucket.ListDataStores(ctx)
+	dsNames, err := base.GetAllDataStores(ctx, bucket)
 	require.NoError(t, err)
 	for _, dsName := range dsNames {
 		dataStore, err := bucket.NamedDataStore(ctx, dsName)

--- a/rest/indextest/index_test.go
+++ b/rest/indextest/index_test.go
@@ -86,7 +86,7 @@ func TestSyncGatewayStartupIndexes(t *testing.T) {
 		rest.RequireStatus(t, response, http.StatusOK)
 
 		var responseUsers []string
-		err = json.Unmarshal(response.Body.Bytes(), &responseUsers)
+		err := json.Unmarshal(response.Body.Bytes(), &responseUsers)
 		require.NoError(t, err)
 		require.Equal(t, users, responseUsers)
 	})
@@ -103,7 +103,7 @@ func TestSyncGatewayStartupIndexes(t *testing.T) {
 		rest.RequireStatus(t, response, http.StatusOK)
 
 		var responseRoles []string
-		err = json.Unmarshal(response.Body.Bytes(), &responseRoles)
+		err := json.Unmarshal(response.Body.Bytes(), &responseRoles)
 		require.NoError(t, err)
 		require.Equal(t, roles, responseRoles)
 	})

--- a/rest/indextest/index_test.go
+++ b/rest/indextest/index_test.go
@@ -26,25 +26,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func requireNoIndexes(t *testing.T, n1qlStore base.N1QLStore) {
-	indexNames, err := n1qlStore.GetIndexes()
-	require.NoError(t, err)
-	require.Len(t, indexNames, 0)
-}
-
 func TestSyncGatewayStartupIndexes(t *testing.T) {
 	ctx := base.TestCtx(t)
 	bucket := base.GetTestBucket(t)
 	defer bucket.Close(ctx)
-
-	// Assert there are no indexes on the datastores, to test server startup
-	n1qlStores, err := base.GetAllN1QLStores(ctx, bucket)
-	require.NoError(t, err)
-	for _, ns := range n1qlStores {
-		if !base.TestsDisableGSI() {
-			requireNoIndexes(t, ns)
-		}
-	}
 
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
 		CustomTestBucket: bucket.NoCloseClone(),

--- a/rest/indextest/resync_test.go
+++ b/rest/indextest/resync_test.go
@@ -44,7 +44,7 @@ func TestResyncWithoutIndexes(t *testing.T) {
 	rt.WaitForDBInitializationCompleted(dbName)
 
 	if !base.TestsDisableGSI() {
-		rest.DropAllTestIndexesIncludingPrimary(t, rt.TestBucket)
+		base.DropAllBucketIndexes(t, rt.TestBucket)
 	}
 
 	rest.RequireStatus(t, rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_resync?action=start", ""), http.StatusOK)

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2610,36 +2610,6 @@ func stringPtrOrNil(s string) *string {
 	return base.Ptr(s)
 }
 
-func DropAllTestIndexes(t *testing.T, tb *base.TestBucket) {
-	dropAllNonPrimaryIndexes(t, tb.GetMetadataStore())
-
-	dsNames := tb.GetNonDefaultDatastoreNames()
-	for i := range dsNames {
-		ds, err := tb.GetNamedDataStore(i)
-		require.NoError(t, err)
-		dropAllNonPrimaryIndexes(t, ds)
-	}
-}
-
-func DropAllTestIndexesIncludingPrimary(t *testing.T, tb *base.TestBucket) {
-
-	ctx := base.TestCtx(t)
-	n1qlStore, ok := base.AsN1QLStore(tb.GetMetadataStore())
-	require.True(t, ok)
-	dropErr := base.DropAllIndexes(ctx, n1qlStore)
-	require.NoError(t, dropErr)
-
-	dsNames := tb.GetNonDefaultDatastoreNames()
-	for i := range dsNames {
-		ds, err := tb.GetNamedDataStore(i)
-		require.NoError(t, err)
-		n1qlStore, ok := base.AsN1QLStore(ds)
-		require.True(t, ok)
-		dropErr := base.DropAllIndexes(ctx, n1qlStore)
-		require.NoError(t, dropErr)
-	}
-}
-
 func (sc *ServerContext) RequireInvalidDatabaseConfigNames(t *testing.T, expectedDbNames []string) {
 	sc.invalidDatabaseConfigTracking.m.RLock()
 	defer sc.invalidDatabaseConfigTracking.m.RUnlock()
@@ -2679,18 +2649,6 @@ func (sc *ServerContext) AllInvalidDatabaseNames(_ *testing.T) []string {
 		dbs = append(dbs, db)
 	}
 	return dbs
-}
-
-// Calls DropAllIndexes to remove all indexes, then restores the primary index for TestBucketPool readier requirements
-func dropAllNonPrimaryIndexes(t *testing.T, dataStore base.DataStore) {
-
-	n1qlStore, ok := base.AsN1QLStore(dataStore)
-	require.True(t, ok)
-	ctx := base.TestCtx(t)
-	dropErr := base.DropAllIndexes(ctx, n1qlStore)
-	require.NoError(t, dropErr)
-	err := n1qlStore.CreatePrimaryIndex(ctx, base.PrimaryIndexName, nil)
-	require.NoError(t, err, "Unable to recreate primary index")
 }
 
 // RequireBucketSpecificCredentials skips tests if bucket specific credentials are required


### PR DESCRIPTION
CBG-5430

We don't currently add the mobile system collection to the DCP feed for purging docs in between test runs. Decided to add this in `purgeWithDCPFeed` function instead of having `ListDataStores` return the system collection given we want to avid people accidentally using the system collection as a viable datastore (should be internal metadata use only)

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/761/ (run 100 times)
- [ ] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/762/ (full integration run)
