### PR TITLE
CBG-5431: Update go version 1.26.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ env:
   ACTIONS_CHECKOUT_VERSION: &actions_checkout_version actions/checkout@v6
   ACTIONS_SETUP_GO_VERSION: &actions_setup_go_version actions/setup-go@v6
   ACTIONS_RUFF_VERSION: &actions_ruff_version astral-sh/ruff-action@v4.0.0
-  GO_VERSION: &go_version 1.26.3
+  GO_VERSION: &go_version 1.26.4
   GOTESTSUM_VERSION: 1.13.0
   GO_TEST_ANNOTATIONS_VERSION: &go_test_annotations_version guyarb/golang-test-annotations@v0.9.0
 

--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -47,7 +47,7 @@ jobs:
       # build sync gateway since the executable is needed for service installation
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.26.3
+          go-version: 1.26.4
       - name: "Build Sync Gateway"
         run: mkdir -p ./bin && go build -o ./bin ./...
       - name: "Run test scripts"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/couchbase/sync_gateway
 
-go 1.26.3
+go 1.26.4
 
 require (
 	dario.cat/mergo v1.0.0

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -611,7 +611,7 @@
             "trigger_blackduck": true
         },
         "manifest/3.2.xml": {
-            "go_version": "1.25.10",
+            "go_version": "1.25.11",
             "interval": 120,
             "production": true,
             "release": "3.2.8",
@@ -729,7 +729,7 @@
             "trigger_blackduck": true
         },
         "manifest/3.3.xml": {
-            "go_version": "1.25.10",
+            "go_version": "1.25.11",
             "interval": 120,
             "production": true,
             "release": "3.3.6",
@@ -838,7 +838,7 @@
             "trigger_blackduck": true
         },
         "manifest/4.0.xml": {
-            "go_version": "1.25.10",
+            "go_version": "1.25.11",
             "interval": 120,
             "production": true,
             "release": "4.0.6",
@@ -938,7 +938,7 @@
         },
 
         "manifest/default.xml": {
-            "go_version": "1.26.3",
+            "go_version": "1.26.4",
             "interval": 30,
             "production": true,
             "release": "4.1.0",


### PR DESCRIPTION
CBG-5431

Describe your PR here...
- Update go version 1.26.4

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
