### PR TITLE
CBG-5426 drop duplicate lasterror field with separate locks

### DIFF
--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -513,6 +513,9 @@ func (b *BackgroundManager) setLastErrorMessage(msg string) {
 	b.statusLock.Lock()
 	defer b.statusLock.Unlock()
 	b.status.LastErrorMessage = msg
+	if msg != "" {
+		b.status.State = BackgroundProcessStateError
+	}
 }
 
 // Stop triggers a Stop of the background process. This will transition the state to BackgroundProcessStateStopping and
@@ -609,7 +612,6 @@ func (b *BackgroundManager) SetError(err error) {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 	b.setLastErrorMessage(err.Error())
-	b.setRunState(BackgroundProcessStateError)
 	b.Terminate()
 }
 

--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -64,7 +64,6 @@ type BackgroundManager struct {
 	status                                 BackgroundManagerStatus
 	statusLock                             sync.RWMutex
 	name                                   string
-	lastError                              error
 	terminator                             *base.SafeTerminator
 	backgroundManagerStatusUpdateWaitGroup sync.WaitGroup
 	clusterAwareOptions                    *ClusterAwareBackgroundManagerOptions
@@ -436,10 +435,6 @@ func (b *BackgroundManager) getStatusWithPrevious(previous []byte) ([]byte, []by
 		backgroundStatus.State = BackgroundProcessStateCompleted
 	}
 
-	if b.lastError != nil {
-		backgroundStatus.LastErrorMessage = b.lastError.Error()
-	}
-
 	return b.Process.GetProcessStatus(backgroundStatus, previous)
 }
 
@@ -509,16 +504,15 @@ func (b *BackgroundManager) resetStatus() {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
-	b.lastError = nil
-	b.clearLastErrorMessage()
+	b.setLastErrorMessage("")
 	b.Process.ResetStatus()
 }
 
 // setLastErrorMessage sets the last error message
-func (b *BackgroundManager) clearLastErrorMessage() {
+func (b *BackgroundManager) setLastErrorMessage(msg string) {
 	b.statusLock.Lock()
 	defer b.statusLock.Unlock()
-	b.status.LastErrorMessage = ""
+	b.status.LastErrorMessage = msg
 }
 
 // Stop triggers a Stop of the background process. This will transition the state to BackgroundProcessStateStopping and
@@ -614,8 +608,7 @@ func (b *BackgroundManager) setStartTime(startTime time.Time) {
 func (b *BackgroundManager) SetError(err error) {
 	b.lock.Lock()
 	defer b.lock.Unlock()
-
-	b.lastError = err
+	b.setLastErrorMessage(err.Error())
 	b.setRunState(BackgroundProcessStateError)
 	b.Terminate()
 }


### PR DESCRIPTION
CBG-5426 drop duplicate lasterror field with separate locks

`lastError` was behind `lock` and `status` fields are behind `statusLock`. Since `lastError` is not used separately from `lastErrorMessage`, just consolidate the fields.

When any of this code gets changed for any resync assertions, the race detector gets flagged.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
