### PR TITLE
Skip flaky tests for distributed resync until investigation

### DIFF
--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -298,7 +298,8 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options ResyncOptions, persi
 		db.DbStats.Database().ResyncNumProcessed.Add(1)
 		databaseCollection, ok := db.CollectionByID[event.CollectionID]
 		if !ok {
-			base.AssertfCtx(ctx, "Received DCP event for collection ID %d, but no collection found with that ID, skipping document %q", event.CollectionID, base.UD(docID))
+			// turn to AssertfCtx in CBG-5440
+			base.WarnfCtx(ctx, "Received DCP event for collection ID %d, but no collection found with that ID, skipping document %q", event.CollectionID, base.UD(docID))
 			return false
 		}
 		databaseCollection.collectionStats.ResyncNumProcessed.Add(1)

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -354,6 +354,9 @@ func TestResyncManagerDCPRunTwice(t *testing.T) {
 }
 
 func TestResyncManagerDCPResumeStoppedProcess(t *testing.T) {
+	if !base.UnitTestUrlIsWalrus() && base.IsEnterpriseEdition() {
+		t.Skip("CBG-5441 skip test which flakes for distributed resync")
+	}
 	docsToCreate := 5000
 	// rosmar runs too quickly, increase doc count
 	if base.UnitTestUrlIsWalrus() {


### PR DESCRIPTION
Skip flaky tests for distributed resync until further investigation in tagged tickets.