### PR TITLE
CBG-5438: make AttachmentMigrationManager.CollectionIDs race proof

### DIFF
--- a/db/background_mgr_attachment_migration.go
+++ b/db/background_mgr_attachment_migration.go
@@ -166,7 +166,7 @@ func (a *AttachmentMigrationManager) Run(ctx context.Context, options map[string
 
 	// check for mismatch in collection id's between current collections on the db and prev run
 
-	err = a.resetDCPMetadataIfNeeded(ctx, db, dcpOptions.CheckpointPrefix, currCollectionIDs)
+	err = a.resetDCPMetadataIfNeeded(ctx, db, currCollectionIDs)
 	if err != nil {
 		return err
 	}
@@ -340,28 +340,24 @@ func (a *AttachmentMigrationManager) purgeCheckpoints(ctx context.Context, db *D
 	)
 }
 
+// matchingCollectionIDs returns true if the collectionIDs passed in are the same as the collectionIDs configured
+func (a *AttachmentMigrationManager) matchingCollectionIDs(collectionIDs []uint32) bool {
+	a.lock.RLock()
+	defer a.lock.RUnlock()
+	rhs := slices.Clone(a.CollectionIDs)
+	slices.Sort(rhs)
+	lhs := slices.Clone(collectionIDs)
+	slices.Sort(lhs)
+	return slices.Compare(rhs, lhs) == 0
+}
+
 // resetDCPMetadataIfNeeded will check for mismatch between current collectionIDs and collectionIDs on previous run
-func (a *AttachmentMigrationManager) resetDCPMetadataIfNeeded(ctx context.Context, database *DatabaseContext, metadataKeyPrefix string, collectionIDs []uint32) error {
-	// if we are on our first run, no collections will be defined on the manager yet
-	if len(a.CollectionIDs) == 0 {
+func (a *AttachmentMigrationManager) resetDCPMetadataIfNeeded(ctx context.Context, database *DatabaseContext, collectionIDs []uint32) error {
+	if a.matchingCollectionIDs(collectionIDs) {
 		return nil
 	}
-	if len(a.CollectionIDs) != len(collectionIDs) {
-		base.InfofCtx(ctx, base.KeyDCP, "Purging invalid checkpoints for background task run %s", a.MigrationID)
-		err := a.purgeCheckpoints(ctx, database, a.MigrationID)
-		if err != nil {
-			return err
-		}
-		return nil
-	}
-	slices.Sort(collectionIDs)
-	slices.Sort(a.CollectionIDs)
-	purgeNeeded := slices.Compare(collectionIDs, a.CollectionIDs)
-	if purgeNeeded != 0 {
-		base.InfofCtx(ctx, base.KeyDCP, "Purging invalid checkpoints for background task run %s", a.MigrationID)
-		return a.purgeCheckpoints(ctx, database, a.MigrationID)
-	}
-	return nil
+	base.InfofCtx(ctx, base.KeyDCP, "Purging invalid checkpoints for background task run %s", a.MigrationID)
+	return a.purgeCheckpoints(ctx, database, a.MigrationID)
 }
 
 // getCollectionsForAttachmentMigration will get all datastores.

--- a/db/background_mgr_attachment_migration.go
+++ b/db/background_mgr_attachment_migration.go
@@ -340,15 +340,22 @@ func (a *AttachmentMigrationManager) purgeCheckpoints(ctx context.Context, db *D
 	)
 }
 
+// getCollectionIDs returns a copy of the sorted collection IDs that are being processed in the current migration run.
+func (a *AttachmentMigrationManager) getCollectionIDs() []uint32 {
+	a.lock.RLock()
+	defer a.lock.RUnlock()
+	c := slices.Clone(a.CollectionIDs)
+	slices.Sort(c)
+	return c
+}
+
 // matchingCollectionIDs returns true if the collectionIDs passed in are the same as the collectionIDs configured
 func (a *AttachmentMigrationManager) matchingCollectionIDs(collectionIDs []uint32) bool {
 	a.lock.RLock()
 	defer a.lock.RUnlock()
-	rhs := slices.Clone(a.CollectionIDs)
-	slices.Sort(rhs)
 	lhs := slices.Clone(collectionIDs)
 	slices.Sort(lhs)
-	return slices.Compare(rhs, lhs) == 0
+	return slices.Compare(a.getCollectionIDs(), lhs) == 0
 }
 
 // resetDCPMetadataIfNeeded will check for mismatch between current collectionIDs and collectionIDs on previous run


### PR DESCRIPTION
CBG-5438: make AttachmentMigrationManager.CollectionIDs race proof

`AttachmentMigration.CollectionIDs` can be read from `GetProcessStatus` and set simultaneously in `resetDCPMetadataIfNeeded`, make sure setting it is done under a lock.
- pre-sort the collection IDs.
- write a comparison function to determine if the collection IDs match under a lock.
- remove unused argument to `resetDCPMetadataIfNeeded`

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
