### PR TITLE
CBG-5424: check migration status before determining whether to set migration as complete

### DIFF
--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -1191,3 +1191,10 @@ func (db *DatabaseContext) RestartChangeListener(t testing.TB, flushCache bool) 
 func (db *DatabaseContext) FlushChannelCache(t testing.TB) {
 	db.RestartChangeListener(t, true)
 }
+
+// MigrateSeqCounterForTest exposes the unexported migrateSeqCounter for cross-package tests.
+func MigrateSeqCounterForTest(t testing.TB, ctx context.Context, ms *base.MetadataStore, seqKey string) {
+	t.Helper()
+	stats := &MigrationStats{}
+	require.NoError(t, migrateSeqCounter(ctx, ms, seqKey, stats))
+}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -818,15 +818,19 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		fallbackStore := bucket.DefaultDataStore(ctx)
 		metaStore := base.NewMetadataStore(primaryMetadataStore, fallbackStore)
 		if !probeLegacyPerDBMetadata(ctx, fallbackStore, config.MetadataID) {
-			metaStore.SetMigrationComplete()
-			// Same SetMigrationComplete action covers two distinct cases — log them
-			// separately so operators don't see "new-database fast path" against a DB
-			// that just finished migrating.
-			primarySeqKey := base.NewMetadataKeys(config.MetadataID).SyncSeqKey()
-			if primaryHasSeq, _ := primaryMetadataStore.Exists(ctx, primarySeqKey); primaryHasSeq {
-				base.InfofCtx(ctx, base.KeyConfig, "db:%s primary metadata present and no legacy data in _default._default — marking per-DB MetadataStore wrapper migration-complete", base.MD(dbName))
+			if sc.isPerDBMigrationInProgress(ctx, spec.BucketName, config.MetadataID) {
+				base.InfofCtx(ctx, base.KeyConfig, "db:%s no legacy _sync:seq in _default._default but per-DB migration is in_progress on another node — keeping dual-read mode until migration completes", base.MD(dbName))
 			} else {
-				base.InfofCtx(ctx, base.KeyConfig, "db:%s no legacy metadata in _default._default — marking per-DB MetadataStore wrapper migration-complete (new-database fast path)", base.MD(dbName))
+				metaStore.SetMigrationComplete()
+				// Same SetMigrationComplete action covers two distinct cases — log them
+				// separately so operators don't see "new-database fast path" against a DB
+				// that just finished migrating.
+				primarySeqKey := base.NewMetadataKeys(config.MetadataID).SyncSeqKey()
+				if primaryHasSeq, _ := primaryMetadataStore.Exists(ctx, primarySeqKey); primaryHasSeq {
+					base.InfofCtx(ctx, base.KeyConfig, "db:%s primary metadata present and no legacy data in _default._default — marking per-DB MetadataStore wrapper migration-complete", base.MD(dbName))
+				} else {
+					base.InfofCtx(ctx, base.KeyConfig, "db:%s no legacy metadata in _default._default — marking per-DB MetadataStore wrapper migration-complete (new-database fast path)", base.MD(dbName))
+				}
 			}
 		}
 		contextOptions.MetadataStore = metaStore
@@ -2389,6 +2393,33 @@ func probeLegacyPerDBMetadata(ctx context.Context, fallback base.DataStore, meta
 		return true
 	}
 	return exists
+}
+
+// isPerDBMigrationInProgress checks the bucket-level metadata-migration status doc for the
+// given metadataID and reports whether its per-DB entry is in_progress. This guards against a
+// race where another node's migration has already moved the _sync:seq counter to primary
+// (causing probeLegacyPerDBMetadata to return false) but has not yet finished migrating all
+// per-DB metadata (users, roles, sessions). Without this check the joining node would
+// incorrectly call SetMigrationComplete, causing reads to skip the fallback and miss
+// not-yet-migrated docs.
+//
+// Returns false (safe to mark complete) when the status doc is absent, the per-DB entry does
+// not exist, the entry is in any state other than in_progress, or the bootstrap connection is
+// unavailable. All of these mean either no migration has been attempted or it has already
+// finished.
+func (sc *ServerContext) isPerDBMigrationInProgress(ctx context.Context, bucketName, metadataID string) bool {
+	if sc.BootstrapContext == nil || sc.BootstrapContext.Connection == nil {
+		return false
+	}
+	status, _, err := sc.BootstrapContext.Connection.GetMetadataMigrationStatus(ctx, bucketName)
+	if err != nil {
+		return false
+	}
+	entry, ok := status.Databases[metadataID]
+	if !ok || entry == nil {
+		return false
+	}
+	return entry.State == base.MigrationStateInProgress
 }
 
 // maybeCompleteBucketMetadataMigration is invoked after each per-DB migration reports complete.

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -2414,7 +2414,7 @@ func (sc *ServerContext) isPerDBMigrationInProgress(ctx context.Context, bucketN
 	}
 	status, _, err := sc.BootstrapContext.Connection.GetMetadataMigrationStatus(ctx, bucketName)
 	if err != nil {
-		if errors.Is(err, base.ErrNotFound) {
+		if base.IsDocNotFoundError(err) {
 			// only treat not found as "no migration" if the bucket-level status doc is missing — if the doc is present
 			// but unreadable for some reason (transient failure network/timeout), it's safer to assume a migration is
 			// in progress than to risk a false negative and prematurely disable fallback reads
@@ -2425,6 +2425,7 @@ func (sc *ServerContext) isPerDBMigrationInProgress(ctx context.Context, bucketN
 	}
 	entry, ok := status.Databases[metadataID]
 	if !ok || entry == nil {
+		base.DebugfCtx(ctx, base.KeyConfig, "No entry for metadataID %q in bucket %q metadata-migration status doc — treating as no migration in progress (expected for a new database with no legacy metadata to migrate)", base.MD(metadataID), base.MD(bucketName))
 		return false
 	}
 	return entry.State == base.MigrationStateInProgress

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -2406,14 +2406,22 @@ func probeLegacyPerDBMetadata(ctx context.Context, fallback base.DataStore, meta
 // Returns false (safe to mark complete) when the status doc is absent, the per-DB entry does
 // not exist, the entry is in any state other than in_progress, or the bootstrap connection is
 // unavailable. All of these mean either no migration has been attempted or it has already
-// finished.
+// finished. If status doc cannot be read it is safer to assume a migration is in progress than to
+// risk a false negative and prematurely disable fallback reads.
 func (sc *ServerContext) isPerDBMigrationInProgress(ctx context.Context, bucketName, metadataID string) bool {
 	if sc.BootstrapContext == nil || sc.BootstrapContext.Connection == nil {
 		return false
 	}
 	status, _, err := sc.BootstrapContext.Connection.GetMetadataMigrationStatus(ctx, bucketName)
 	if err != nil {
-		return false
+		if errors.Is(err, base.ErrNotFound) {
+			// only treat not found as "no migration" if the bucket-level status doc is missing — if the doc is present
+			// but unreadable for some reason (transient failure network/timeout), it's safer to assume a migration is
+			// in progress than to risk a false negative and prematurely disable fallback reads
+			return false
+		}
+		base.WarnfCtx(ctx, "Unable to read %s on bucket %q while checking per-DB migration status: %v — assuming migration in progress to avoid prematurely disabling fallback reads", base.MD(base.MetadataMigrationStatusDocID), base.MD(bucketName), err)
+		return true
 	}
 	entry, ok := status.Databases[metadataID]
 	if !ok || entry == nil {

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -10,6 +10,7 @@ package rest
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -72,7 +73,7 @@ func TestIsPerDBMigrationInProgress(t *testing.T) {
 
 	// --- Subtest: no per-DB entry → not in progress ---
 	t.Run("no entry means not in progress", func(t *testing.T) {
-		assert.False(t, sc.isPerDBMigrationInProgress(ctx, bucketName, metadataID),
+		requireDBMigrationNotInProgress(t, sc, ctx, bucketName, metadataID,
 			"missing per-DB entry should not be treated as in_progress")
 	})
 
@@ -84,7 +85,7 @@ func TestIsPerDBMigrationInProgress(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("in_progress entry detected", func(t *testing.T) {
-		assert.True(t, sc.isPerDBMigrationInProgress(ctx, bucketName, metadataID),
+		requireDBMigrationInProgress(t, sc, ctx, bucketName, metadataID,
 			"in_progress per-DB entry must be detected")
 	})
 
@@ -100,8 +101,8 @@ func TestIsPerDBMigrationInProgress(t *testing.T) {
 		hasLegacy := probeLegacyPerDBMetadata(ctx, fallback, metadataID)
 		require.False(t, hasLegacy, "probe returns false — seq was migrated")
 
-		inProgress := sc.isPerDBMigrationInProgress(ctx, bucketName, metadataID)
-		require.True(t, inProgress, "status doc shows in_progress — guard must fire")
+		requireDBMigrationInProgress(t, sc, ctx, bucketName, metadataID,
+			"status doc shows in_progress — guard must fire")
 
 		// Node B does NOT call SetMigrationComplete — the fix keeps dual-read mode.
 		for k, want := range legacyDocs {
@@ -122,15 +123,31 @@ func TestIsPerDBMigrationInProgress(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("complete entry means not in progress", func(t *testing.T) {
-		assert.False(t, sc.isPerDBMigrationInProgress(ctx, bucketName, metadataID),
+		requireDBMigrationNotInProgress(t, sc, ctx, bucketName, metadataID,
 			"completed migration should not be treated as in_progress")
 	})
 
 	// --- Subtest: status doc doesn't exist → not in progress ---
 	t.Run("missing status doc means not in progress", func(t *testing.T) {
-		assert.False(t, sc.isPerDBMigrationInProgress(ctx, "nonexistent-bucket", metadataID),
+		requireDBMigrationNotInProgress(t, sc, ctx, "nonexistent-bucket", metadataID,
 			"missing status doc should not be treated as in_progress")
 	})
+}
+
+// requireDBMigrationInProgress asserts that isPerDBMigrationInProgress reports true, logging the
+// bucketName and metadataID under test if the assertion fails.
+func requireDBMigrationInProgress(t *testing.T, sc *ServerContext, ctx context.Context, bucketName, metadataID, msg string) {
+	t.Helper()
+	require.True(t, sc.isPerDBMigrationInProgress(ctx, bucketName, metadataID),
+		"%s (bucketName=%q, metadataID=%q)", msg, bucketName, metadataID)
+}
+
+// requireDBMigrationNotInProgress asserts that isPerDBMigrationInProgress reports false, logging the
+// bucketName and metadataID under test if the assertion fails.
+func requireDBMigrationNotInProgress(t *testing.T, sc *ServerContext, ctx context.Context, bucketName, metadataID, msg string) {
+	t.Helper()
+	require.False(t, sc.isPerDBMigrationInProgress(ctx, bucketName, metadataID),
+		"%s (bucketName=%q, metadataID=%q)", msg, bucketName, metadataID)
 }
 
 func TestRecordGoroutineHighwaterMark(t *testing.T) {

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -44,9 +44,9 @@ func TestIsPerDBMigrationInProgress(t *testing.T) {
 	tb := base.GetTestBucket(t)
 	defer tb.Close(ctx)
 
-	primary, err := tb.GetNamedDataStore(0)
+	primary, err := rt.Bucket().NamedDataStore(ctx, base.ScopeAndCollectionName{Scope: base.SystemScope, Collection: base.SystemCollectionMobile})
 	require.NoError(t, err)
-	fallback := tb.DefaultDataStore(ctx)
+	fallback := rt.Bucket().DefaultDataStore(ctx)
 
 	const metadataID = "test-in-progress-guard"
 	metaKeys := base.NewMetadataKeys(metadataID)

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -31,6 +31,108 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestIsPerDBMigrationInProgress verifies the guard that prevents a joining node from marking
+// its MetadataStore wrapper migration-complete while another node's migration is still running.
+func TestIsPerDBMigrationInProgress(t *testing.T) {
+	rt := NewRestTesterPersistentConfigNoDB(t)
+	defer rt.Close()
+
+	ctx := rt.Context()
+	sc := rt.ServerContext()
+	conn := sc.BootstrapContext.Connection
+
+	tb := base.GetTestBucket(t)
+	defer tb.Close(ctx)
+
+	primary, err := tb.GetNamedDataStore(0)
+	require.NoError(t, err)
+	fallback := tb.DefaultDataStore(ctx)
+
+	const metadataID = "test-in-progress-guard"
+	metaKeys := base.NewMetadataKeys(metadataID)
+	seqKey := metaKeys.SyncSeqKey()
+	bucketName := tb.GetName()
+
+	// Seed legacy metadata on fallback.
+	_, err = fallback.Incr(ctx, seqKey, 0, 42, 0)
+	require.NoError(t, err)
+	legacyDocs := map[string][]byte{
+		metaKeys.UserKey("alice"):      []byte(`{"name":"alice"}`),
+		metaKeys.RoleKey("admin"):      []byte(`{"name":"admin"}`),
+		metaKeys.SessionKey("sess123"): []byte(`{"session_id":"sess123"}`),
+	}
+	for k, v := range legacyDocs {
+		_, err := fallback.AddRaw(ctx, k, 0, v)
+		require.NoError(t, err)
+	}
+
+	// Stamp the initial (empty) migration status doc.
+	_, err = conn.InsertMetadataMigrationStatus(ctx, bucketName, base.NewMetadataMigrationStatus())
+	require.NoError(t, err)
+
+	// --- Subtest: no per-DB entry → not in progress ---
+	t.Run("no entry means not in progress", func(t *testing.T) {
+		assert.False(t, sc.isPerDBMigrationInProgress(ctx, bucketName, metadataID),
+			"missing per-DB entry should not be treated as in_progress")
+	})
+
+	// --- Subtest: per-DB entry is in_progress → guard fires ---
+	_, err = conn.UpdateMetadataMigrationStatus(ctx, bucketName, func(s *base.MetadataMigrationStatus) error {
+		s.Databases[metadataID] = &base.DatabaseMigrationStatus{State: base.MigrationStateInProgress}
+		return nil
+	})
+	require.NoError(t, err)
+
+	t.Run("in_progress entry detected", func(t *testing.T) {
+		assert.True(t, sc.isPerDBMigrationInProgress(ctx, bucketName, metadataID),
+			"in_progress per-DB entry must be detected")
+	})
+
+	// --- Subtest: full race scenario with the fix ---
+	// Migrate the seq counter (Node A's first step) and verify the guard keeps
+	// dual-read mode so fallback docs remain accessible.
+	nodeAStore := base.NewMetadataStore(primary, fallback)
+	db.MigrateSeqCounterForTest(t, ctx, nodeAStore, seqKey)
+
+	t.Run("race scenario with fix applied", func(t *testing.T) {
+		nodeBStore := base.NewMetadataStore(primary, fallback)
+
+		hasLegacy := probeLegacyPerDBMetadata(ctx, fallback, metadataID)
+		require.False(t, hasLegacy, "probe returns false — seq was migrated")
+
+		inProgress := sc.isPerDBMigrationInProgress(ctx, bucketName, metadataID)
+		require.True(t, inProgress, "status doc shows in_progress — guard must fire")
+
+		// Node B does NOT call SetMigrationComplete — the fix keeps dual-read mode.
+		for k, want := range legacyDocs {
+			got, _, getErr := nodeBStore.GetRaw(ctx, k)
+			require.NoError(t, getErr, "with fix: wrapper must still find %s on fallback", k)
+			assert.Equal(t, want, got)
+		}
+
+		assert.False(t, nodeBStore.MigrationComplete(),
+			"wrapper must NOT be marked migration-complete while another node is mid-migration")
+	})
+
+	// --- Subtest: per-DB entry is complete → safe to mark complete ---
+	_, err = conn.UpdateMetadataMigrationStatus(ctx, bucketName, func(s *base.MetadataMigrationStatus) error {
+		s.Databases[metadataID] = &base.DatabaseMigrationStatus{State: base.MigrationStateComplete}
+		return nil
+	})
+	require.NoError(t, err)
+
+	t.Run("complete entry means not in progress", func(t *testing.T) {
+		assert.False(t, sc.isPerDBMigrationInProgress(ctx, bucketName, metadataID),
+			"completed migration should not be treated as in_progress")
+	})
+
+	// --- Subtest: status doc doesn't exist → not in progress ---
+	t.Run("missing status doc means not in progress", func(t *testing.T) {
+		assert.False(t, sc.isPerDBMigrationInProgress(ctx, "nonexistent-bucket", metadataID),
+			"missing status doc should not be treated as in_progress")
+	})
+}
+
 func TestRecordGoroutineHighwaterMark(t *testing.T) {
 
 	// Reset this to 0


### PR DESCRIPTION

CBG-5424

We check for `isPerDBMigrationInProgress` which will return false if no migration is there for the db or if its not in progress. We stamp migration status at start of Run on background manager so its stafe that if any migration is in place we will find an entry for this db on the status document. 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/767/
