### PR TITLE
CBG-5418 drop previous resync stats on restart

### DIFF
--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -57,13 +57,16 @@ var errBackgroundManagerProcessAlreadyStopped = base.HTTPErrorf(http.StatusServi
 type backgroundManagerUpdateClusterStatusMode int
 
 const (
-	// backgroundManagerReportInconsistentStatus returns errBackgroundManagerStatusNotRunning
-	// when the cluster doc shows a terminal state but the local state is running. Used by the polling loop to
-	// detect that another node has stopped or completed the process.
-	backgroundManagerReportInconsistentStatus backgroundManagerUpdateClusterStatusMode = iota
-	// backgroundManagerOverwriteInconsistentStatus writes the current local status to the
-	// cluster doc unconditionally. Used when starting or finalising a run where we own the state transition.
-	backgroundManagerOverwriteInconsistentStatus
+	// backgroundManagerStatusUpdate returns errBackgroundManagerStatusNotRunning
+	// when the cluster doc shows a terminal state but the local state is running. Used by the polling loop and
+	// periodic status updates to detect that another node has stopped or completed the process.
+	backgroundManagerStatusUpdate backgroundManagerUpdateClusterStatusMode = iota
+	// backgroundManagerStatusStart writes the current local status to the cluster doc unconditionally
+	// and does not pass the previous status when updating local status. Used when starting a new run.
+	backgroundManagerStatusStart
+	// backgroundManagerStatusResume writes the current local status to the cluster doc unconditionally
+	// and passes the previous status when updating local status. Used when resuming an existing run.
+	backgroundManagerStatusResume
 )
 
 type BackgroundProcessAction string
@@ -205,7 +208,7 @@ func (b *BackgroundManager[O]) Resume(ctx context.Context) error {
 		return fmt.Errorf("failed to unmarshal meta for background process %q: %w", b.name, err)
 	}
 
-	return b.start(ctx, doc.Meta.Options, raw)
+	return b.start(ctx, doc.Meta.Options, raw, true)
 }
 
 func (b *BackgroundManager[O]) Start(ctx context.Context, options O) error {
@@ -217,10 +220,10 @@ func (b *BackgroundManager[O]) Start(ctx context.Context, options O) error {
 			return pkgerrors.Wrap(err, "Failed to get current process status")
 		}
 	}
-	return b.start(ctx, options, processClusterStatus)
+	return b.start(ctx, options, processClusterStatus, false)
 }
 
-func (b *BackgroundManager[O]) start(ctx context.Context, options O, processClusterStatus []byte) error {
+func (b *BackgroundManager[O]) start(ctx context.Context, options O, processClusterStatus []byte, isResume bool) error {
 	if b.mode() != backgroundManagerModeMultiNode && b.updateDatabaseState != nil {
 		return fmt.Errorf("updateDatabaseState should only be set for multi-node background managers")
 	}
@@ -313,8 +316,11 @@ func (b *BackgroundManager[O]) start(ctx context.Context, options O, processClus
 	if b.mode() != backgroundManagerModeLocal {
 		var err error
 		if b.mode() == backgroundManagerModeMultiNode {
-			// when starting a background process, allow overwriting any previous state (completed, error, stopped, stopping)
-			err = b.updateMultiNodeClusterAwareStatus(ctx, backgroundManagerOverwriteInconsistentStatus)
+			mode := backgroundManagerStatusStart
+			if isResume {
+				mode = backgroundManagerStatusResume
+			}
+			err = b.updateMultiNodeClusterAwareStatus(ctx, mode)
 		} else {
 			err = b.UpdateSingleNodeClusterAwareStatus(ctx)
 		}
@@ -655,7 +661,7 @@ func (b *BackgroundManager[O]) UpdateStatusClusterAware(ctx context.Context) err
 	case backgroundManagerModeSingleNode:
 		return b.UpdateSingleNodeClusterAwareStatus(ctx)
 	case backgroundManagerModeMultiNode:
-		return b.updateMultiNodeClusterAwareStatus(ctx, backgroundManagerReportInconsistentStatus)
+		return b.updateMultiNodeClusterAwareStatus(ctx, backgroundManagerStatusUpdate)
 	case backgroundManagerModeLocal:
 		return nil
 	default:
@@ -691,16 +697,21 @@ func (b *BackgroundManager[O]) UpdateSingleNodeClusterAwareStatus(ctx context.Co
 }
 
 // updateMultiNodeClusterAwareStatus updates the cluster status document with the current local status.
-// When mode is backgroundManagerReportInconsistentStatus and the cluster doc shows a terminal
+// When mode is backgroundManagerStatusUpdate and the cluster doc shows a terminal
 // state while the local state is running, it returns errBackgroundManagerStatusNotRunning without
-// writing. When mode is backgroundManagerOverwriteInconsistentStatus the write always proceeds.
+// writing. When mode is backgroundManagerStatusStart or backgroundManagerStatusResume the write always proceeds.
 func (b *BackgroundManager[O]) updateMultiNodeClusterAwareStatus(ctx context.Context, mode backgroundManagerUpdateClusterStatusMode) error {
 	docID := b.clusterAwareOptions.StatusDocID()
 	var previousStatus []byte
 	var newStatus []byte
 	_, err := b.clusterAwareOptions.metadataStore.Update(ctx, docID, 0, func(current []byte) ([]byte, *uint32, bool, error) {
-		previousStatus = current
-		status, metadata, err := b.getStatusWithPrevious(current)
+		// In the case of starting a run (backgroundManagerStatusStart), don't send the previous status to
+		// BackgroundManagerProcessI so as to not process previous stats.
+		// For status updates and resuming runs, we do pass the previous status so we can merge/preserve existing stats.
+		if mode == backgroundManagerStatusUpdate || mode == backgroundManagerStatusResume {
+			previousStatus = current
+		}
+		status, metadata, err := b.getStatusWithPrevious(previousStatus)
 		if err != nil {
 			return nil, nil, false, err
 		}
@@ -711,7 +722,7 @@ func (b *BackgroundManager[O]) updateMultiNodeClusterAwareStatus(ctx context.Con
 			}
 			// If the local status is running, but another node stopped or errored, do not serialize status and report
 			// not running so that caller can terminate the background manager on this node
-			if mode == backgroundManagerReportInconsistentStatus {
+			if mode == backgroundManagerStatusUpdate {
 				if status, ok := output["status"]; ok {
 					bucketState, err := unmarshalBackgroundProcessState(status)
 					if err != nil {
@@ -791,7 +802,7 @@ func (b *BackgroundManager[O]) startPollingMultiNodeStatus(ctx context.Context, 
 	for {
 		select {
 		case <-ticker.C:
-			err := b.updateMultiNodeClusterAwareStatus(ctx, backgroundManagerReportInconsistentStatus)
+			err := b.updateMultiNodeClusterAwareStatus(ctx, backgroundManagerStatusUpdate)
 			if err != nil {
 				if errors.Is(err, errBackgroundManagerStatusNotRunning) {
 					b.stopProcess(ctx)

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -300,11 +300,8 @@ func TestResyncManagerDCPStart(t *testing.T) {
 		assert.GreaterOrEqual(t, cs.ResyncNumProcessed.Value(), int64(docsToCreate))
 		assert.Equal(t, int64(docsToCreate), cs.ResyncNumChanged.Value())
 
-		if !db.useShardedDCP() {
-			// CBG-5418: debug flake of why distributed resync sometimes processes more documents than expected
-			deltaOk := assert.InDelta(t, int64(docsToCreate), db.DbStats.Database().SyncFunctionCount.Value(), 2)
-			assert.True(t, deltaOk, "DCP stream has processed some documents more than once than allowed delta. Try rerunning the test.")
-		}
+		deltaOk := assert.InDelta(t, int64(docsToCreate), db.DbStats.Database().SyncFunctionCount.Value(), 2)
+		assert.True(t, deltaOk, "DCP stream has processed some documents more than once than allowed delta. Try rerunning the test.")
 	})
 }
 
@@ -616,16 +613,13 @@ function sync(doc, oldDoc){
 	channel("resync_channel_again");
 }`
 
-	if !db.useShardedDCP() {
-		// CBG-5418: debug distributed resync processing more documents than expected
-		resyncStats = runResync(t, ctx, db, collection, syncFn)
-		assert.GreaterOrEqual(t, resyncStats.DocsProcessed, int64(2))
+	resyncStats = runResync(t, ctx, db, collection, syncFn)
+	assert.GreaterOrEqual(t, resyncStats.DocsProcessed, int64(2))
 
-		assert.Equal(t, int64(2), resyncStats.DocsChanged)
+	assert.Equal(t, int64(2), resyncStats.DocsChanged)
 
-		assert.GreaterOrEqual(t, db.DbStats.Database().ResyncNumProcessed.Value(), int64(4))
-		assert.Equal(t, int64(4), db.DbStats.Database().ResyncNumChanged.Value())
-	}
+	assert.GreaterOrEqual(t, db.DbStats.Database().ResyncNumProcessed.Value(), int64(4))
+	assert.Equal(t, int64(4), db.DbStats.Database().ResyncNumChanged.Value())
 
 	syncData, mou, cas = getSyncAndMou(t, collection, "sgWrite")
 	require.NotNil(t, syncData)

--- a/db/background_mgr_test.go
+++ b/db/background_mgr_test.go
@@ -1311,3 +1311,80 @@ func TestBackgroundManagerStartAfterCompletedSucceeds(t *testing.T) {
 	err := mgr.Start(ctx, nil)
 	require.NoError(t, err)
 }
+
+type statsMockProcess struct {
+	MockProcess
+	lastPreviousStatus []byte
+	previousStatusLock sync.Mutex
+}
+
+func (s *statsMockProcess) GetProcessStatus(status BackgroundManagerStatus, previousStatus []byte) ([]byte, []byte, error) {
+	s.previousStatusLock.Lock()
+	s.lastPreviousStatus = previousStatus
+	s.previousStatusLock.Unlock()
+	return s.MockProcess.GetProcessStatus(status, previousStatus)
+}
+
+func (s *statsMockProcess) LastPreviousStatus() []byte {
+	s.previousStatusLock.Lock()
+	defer s.previousStatusLock.Unlock()
+	return s.lastPreviousStatus
+}
+
+// TestBackgroundManagerResumePreservesPreviousStatus verifies that when a multi-node manager Resume()s,
+// it preserves and passes the previous cluster status to the process GetProcessStatus call,
+// allowing it to merge/preserve stats.
+func TestBackgroundManagerResumePreservesPreviousStatus(t *testing.T) {
+	testBucket := base.GetTestBucket(t)
+	ctx := base.TestCtx(t)
+	defer testBucket.Close(ctx)
+	metadataStore := testBucket.DefaultDataStore(ctx)
+	metaKeys := base.NewMetadataKeys("test-resume-preserve-status")
+
+	clusterOpts := &ClusterAwareBackgroundManagerOptions{
+		metadataStore: metadataStore,
+		metaKeys:      metaKeys,
+		processSuffix: "resume-preserve-status",
+		multiNode:     true,
+	}
+
+	process1 := &statsMockProcess{}
+	mgr1 := &BackgroundManager[map[string]any]{
+		name:                "test-resume-mgr1",
+		Process:             process1,
+		clusterAwareOptions: clusterOpts,
+		terminator:          base.NewSafeTerminator(),
+	}
+
+	require.NoError(t, mgr1.Start(ctx, nil))
+	RequireBackgroundManagerState(t, mgr1, BackgroundProcessStateRunning)
+
+	// Ensure the running status is written to the cluster.
+	require.NoError(t, mgr1.UpdateStatusClusterAware(ctx))
+
+	process2 := &statsMockProcess{}
+	mgr2 := &BackgroundManager[map[string]any]{
+		name:                "test-resume-mgr2",
+		Process:             process2,
+		clusterAwareOptions: clusterOpts,
+		terminator:          base.NewSafeTerminator(),
+	}
+
+	require.NoError(t, mgr2.Resume(ctx))
+	RequireBackgroundManagerState(t, mgr2, BackgroundProcessStateRunning)
+
+	// Assert that process2 received the previous status in its GetProcessStatus call,
+	// which is required to avoid dropping stats on resume.
+	require.NotEmpty(t, process2.LastPreviousStatus(), "expected previous status to be passed to GetProcessStatus on resume")
+
+	// Ensure we can unmarshal it to verify it actually contains the status.
+	var clusterStatus struct {
+		Status BackgroundManagerStatus `json:"status"`
+	}
+	err := json.Unmarshal(process2.LastPreviousStatus(), &clusterStatus)
+	require.NoError(t, err)
+	require.Equal(t, BackgroundProcessStateRunning, clusterStatus.Status.State)
+
+	require.NoError(t, mgr1.Stop(ctx))
+	require.NoError(t, mgr2.Stop(ctx))
+}

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -877,10 +877,7 @@ func TestResyncUsingDCPStreamForNamedCollection(t *testing.T) {
 	rest.RequireStatus(t, resp, http.StatusOK)
 	resyncManagerStatus := rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
 
-	if base.UnitTestUrlIsWalrus() || !base.IsEnterpriseEdition() {
-		// CBG-5418: debug distributed resync processing more documents than expected
-		assert.Equal(t, 10, int(resyncManagerStatus.DocsChanged))
-	}
+	assert.Equal(t, 10, int(resyncManagerStatus.DocsChanged))
 
 	rest.RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/{{.keyspace1}}/_config/sync", `function(doc){channel("B")}`), http.StatusOK)
 	rest.RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/{{.keyspace2}}/_config/sync", `function(doc){channel("B")}`), http.StatusOK)
@@ -890,10 +887,7 @@ func TestResyncUsingDCPStreamForNamedCollection(t *testing.T) {
 	rest.RequireStatus(t, resp, http.StatusOK)
 	resyncManagerStatus = rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
 
-	if base.UnitTestUrlIsWalrus() || !base.IsEnterpriseEdition() {
-		// CBG-5418: debug distributed resync processing more documents than expected
-		assert.Equal(t, 20, int(resyncManagerStatus.DocsChanged))
-	}
+	assert.Equal(t, 20, int(resyncManagerStatus.DocsChanged))
 }
 
 func TestResyncErrorScenariosUsingDCPStream(t *testing.T) {


### PR DESCRIPTION
CBG-5418 drop previous resync stats on restart

When transiting for the initial start (not resume), don't pass the previous stats into `GetProcessStatus` so that the stats reset on a node start.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/772/ (failing tests are due to not stop not stopping very quickly in jenkins sometime, these tests were run in a tight loop)
