### PR TITLE
CBG-5198 add shell script & Jenkinsfile to run couchbase lite e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ tools/stats-definition-exporter/stats-definition-exporter
 .cbcache/
 
 planPIndexes/
+
+couchbase-lite-tests
+integration-test/e2e/.gitconfig.e2e

--- a/integration-test/e2e/Jenkinsfile
+++ b/integration-test/e2e/Jenkinsfile
@@ -1,0 +1,132 @@
+pipeline {
+    agent any
+    parameters {
+        choice(
+            name: 'BACKING_STORE',
+            choices: ['rosmar', 'cbs'],
+            description: 'Backing store to use'
+        )
+        choice(
+            name: 'TEST_DIRECTORY',
+            choices: ['tests/dev_e2e', 'tests/QE'],
+            description: 'Directory for tests'
+        )
+        string(
+            name: 'COUCHBASE_LITE_TESTS_COMMIT',
+            defaultValue: 'main',
+            description: 'Version of couchbase-lite-tests repo.'
+        )
+        activeChoiceHtml(
+            name: 'COUCHBASE_LITE_VERSION',
+            description: 'Version of Couchbase Lite C to build.',
+            choiceType: 'ET_FORMATTED_HTML',
+            omitValueField: true,
+            script: groovyScript(
+                script: [
+                    script: '''
+                        import jenkins.model.Jenkins
+                        def defaultVal = ""
+                        def errorMsg = ""
+                        try {
+                            def envVarsNodePropertyList = Jenkins.instance.globalNodeProperties.getAll(hudson.slaves.EnvironmentVariablesNodeProperty)
+                            if (envVarsNodePropertyList && envVarsNodePropertyList[0]) {
+                                defaultVal = envVarsNodePropertyList[0].envVars.get("DEFAULT_COUCHBASE_LITE_VERSION") ?: ""
+                            }
+                        } catch (Throwable t) {
+                            errorMsg = "Exception retrieving default: " + t.toString().replace("'", "&apos;").replace("<", "&lt;").replace(">", "&gt;")
+                        }
+                        defaultVal = defaultVal.replace("'", "&apos;").replace("<", "&lt;").replace(">", "&gt;")
+                        def html = "<input name='value' value='" + defaultVal + "' class='setting-input' type='text'>"
+                        if (errorMsg) {
+                            html += "<div class='description' style='color: #d9534f; margin-top: 5px;'>" + errorMsg + "</div>"
+                        }
+                        return html
+                    ''',
+                    sandbox: false
+                ],
+                fallbackScript: [
+                    script: '''
+                        return "<input name='value' value='' class='setting-input' type='text' placeholder='Enter COUCHBASE_LITE_VERSION...'>" +
+                               "<div class='description' style='color: #d9534f; margin-top: 5px;'>Error: Script approval required or execution failed. Check Jenkins script approvals if this is not populated. Please enter the version manually.</div>"
+                    ''',
+                    sandbox: false
+                ]
+            )
+        )
+        activeChoiceHtml(
+            name: 'COUCHBASE_SERVER_VERSION',
+            description: 'Version of Couchbase Server',
+            choiceType: 'ET_FORMATTED_HTML',
+            omitValueField: true,
+            script: groovyScript(
+                script: [
+                    script: '''
+                        import jenkins.model.Jenkins
+                        def defaultVal = ""
+                        def errorMsg = ""
+                        try {
+                            def envVarsNodePropertyList = Jenkins.instance.globalNodeProperties.getAll(hudson.slaves.EnvironmentVariablesNodeProperty)
+                            if (envVarsNodePropertyList && envVarsNodePropertyList[0]) {
+                                defaultVal = envVarsNodePropertyList[0].envVars.get("DEFAULT_COUCHBASE_SERVER_VERSION") ?: ""
+                            }
+                        } catch (Throwable t) {
+                            errorMsg = "Exception retrieving default: " + t.toString().replace("'", "&apos;").replace("<", "&lt;").replace(">", "&gt;")
+                        }
+                        defaultVal = defaultVal.replace("'", "&apos;").replace("<", "&lt;").replace(">", "&gt;")
+                        def html = "<input name='value' value='" + defaultVal + "' class='setting-input' type='text'>"
+                        if (errorMsg) {
+                            html += "<div class='description' style='color: #d9534f; margin-top: 5px;'>" + errorMsg + "</div>"
+                        }
+                        return html
+                    ''',
+                    sandbox: false
+                ],
+                fallbackScript: [
+                    script: '''
+                        return "<input name='value' value='' class='setting-input' type='text' placeholder='Enter COUCHBASE_SERVER_VERSION...'>" +
+                               "<div class='description' style='color: #d9534f; margin-top: 5px;'>Error: Script approval required or execution failed. Check Jenkins script approvals if this is not populated. Please enter the version manually.</div>"
+                    ''',
+                    sandbox: false
+                ]
+            )
+        )
+        string(
+            name: 'PYTEST_EXTRA_ARGS',
+            defaultValue: '',
+            description: 'Add additional args to pytest run, such is -k <test name> or -x'
+        )
+        string(
+            name: 'SG_COMMIT',
+            defaultValue: 'main',
+            description: 'Revision of Sync Gateway to build.'
+        )
+    }
+    stages {
+        stage('Checkout Scm') {
+            steps {
+                cleanWs()
+                git(
+                    url: 'git@github.com:couchbase/sync_gateway.git',
+                    branch: "${params.SG_COMMIT}",
+                    credentialsId: 'CB_SG_Robot_Github_SSH_Key'
+                )
+            }
+        }
+        stage('Run E2E Tests') {
+            steps {
+                sshagent(credentials: ['CB_SG_Robot_Github_SSH_Key']) {
+                    sh '/bin/bash ./integration-test/e2e/run_e2e_tests.sh'
+                }
+            }
+        }
+    }
+    post {
+        always {
+            archiveArtifacts artifacts: 'couchbase-lite-tests/environment/local/sync_gateway.log', followSymlinks: false
+            junit allowEmptyResults: true, testResults: 'couchbase-lite-tests/tests/**/junit*.xml'
+        }
+        cleanup {
+            cleanWs(disableDeferredWipeout: true)
+        }
+    }
+}

--- a/integration-test/e2e/Jenkinsfile
+++ b/integration-test/e2e/Jenkinsfile
@@ -1,5 +1,8 @@
 pipeline {
     agent any
+    options {
+        skipDefaultCheckout()
+    }
     parameters {
         choice(
             name: 'BACKING_STORE',
@@ -104,7 +107,7 @@ pipeline {
     stages {
         stage('Checkout Scm') {
             steps {
-                cleanWs()
+                cleanWs(disableDeferredWipeout: false)
                 git(
                     url: 'git@github.com:couchbase/sync_gateway.git',
                     branch: "${params.SG_COMMIT}",

--- a/integration-test/e2e/run_e2e_tests.sh
+++ b/integration-test/e2e/run_e2e_tests.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Copyright 2026-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
+# Run Couchbase Lite C e2e tests against rosmar or Couchbase Server.
+set -eux -o pipefail
+
+# Resolve the script and repository directories
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_DIR="$( dirname "$( dirname "${SCRIPT_DIR}" )" )"
+
+# Check for required environment variables
+: "${BACKING_STORE:?BACKING_STORE must be set}"
+: "${COUCHBASE_LITE_TESTS_COMMIT:?COUCHBASE_LITE_TESTS_COMMIT must be set}"
+: "${COUCHBASE_LITE_VERSION:?COUCHBASE_LITE_VERSION must be set}"
+: "${TEST_DIRECTORY:?TEST_DIRECTORY must be set}"
+
+# Validate BACKING_STORE
+if [[ "$BACKING_STORE" != "rosmar" && "$BACKING_STORE" != "cbs" ]]; then
+    echo "Error: BACKING_STORE must be 'rosmar' or 'cbs', found: $BACKING_STORE"
+    exit 1
+fi
+
+if [[ "$BACKING_STORE" == "cbs" ]]; then
+    : "${COUCHBASE_SERVER_VERSION:?COUCHBASE_SERVER_VERSION must be set when BACKING_STORE=cbs}"
+    "${REPO_DIR}/integration-test/start_server.sh" "${COUCHBASE_SERVER_VERSION}"
+fi
+
+export GIT_CONFIG_GLOBAL="${SCRIPT_DIR}/.gitconfig.e2e"
+export GOPRIVATE="github.com/couchbaselabs/go-fleecedelta"
+git config --global url.git@github.com:couchbaselabs/go-fleecedelta.insteadOf https://github.com/couchbaselabs/go-fleecedelta
+
+# Clean up any existing clone to make local re-runs idempotent
+rm -rf couchbase-lite-tests
+
+git clone --recurse-submodules https://github.com/couchbaselabs/couchbase-lite-tests.git
+cd couchbase-lite-tests
+git checkout --detach "${COUCHBASE_LITE_TESTS_COMMIT}"
+git submodule sync --recursive
+git submodule update --init --recursive --force
+
+uv run -- ./environment/local/start_local.py --build-testserver "${COUCHBASE_LITE_VERSION}"
+uv run -- ./environment/local/build_sync_gateway.py --repo-path "${REPO_DIR}"
+uv run -- ./environment/local/run_sync_gateway.py --start --server "${BACKING_STORE}"
+# shellcheck disable=SC2086
+uv run pytest --config "./environment/local/${BACKING_STORE}_config.json" --junitxml="${TEST_DIRECTORY}/junit_report.xml" -o junit_logging=all -o junit_log_passing_tests=false "./${TEST_DIRECTORY}" ${PYTEST_EXTRA_ARGS:-}


### PR DESCRIPTION
CBG-5198 add shell script to run couchbase lite e2e tests

This can get invoked by Jenkins or by a user.

This can be invoked in https://jenkins.sgwdev.com/job/Couchbase%20Lite%20E2E/ and this script runs on linux or mac.

The Jenkinsfile stores the information needed to run a pipeline. The versions of DEFAULT_COUCHBASE_LITE_VERSION and DEFAULT _COUCHBASE_SERVER_VERSION are stored as environment variables https://jenkins.sgwdev.com/manage/configure - we could probably share this server version with integration test runs and weekly runs. This uses active choice plugin to fill in the default value from this value. I tried to think of other ways to separate the version number from the jenkinsfile so this doesn't need to be backported to each branch and this was the best idea I had.
