### PR TITLE
CBG-5442: sync function documents are not handled by migration process

### DIFF
--- a/db/background_mgr_metadata_migration.go
+++ b/db/background_mgr_metadata_migration.go
@@ -190,6 +190,10 @@ func (m *MetadataMigrationManager) Run(ctx context.Context, options map[string]a
 		//
 		// Each pass scans the fallback DataStore, and remaining are in-scope docs we didn't move on this pass
 		const maxPasses = 16
+		// Sync-function ("syncdata") docs are keyed by groupID + scope.collection rather than
+		// metadataID, so precompute this DB's owned set from its configured collections for the
+		// key handler to match against.
+		dbSyncFunctionKeys := syncFunctionKeysForDB(m.dbContext.Options.GroupID, m.dbContext.CollectionNames)
 		for pass := 0; ; pass++ {
 			if terminator.IsClosed() {
 				// Mid-run stop: leave the per-DB entry in in_progress so the next manager
@@ -199,7 +203,7 @@ func (m *MetadataMigrationManager) Run(ctx context.Context, options map[string]a
 			}
 
 			stats := &MigrationStats{}
-			remaining, err := MigrateMetadata(runCtx, ms, metadataID, stats)
+			remaining, err := MigrateMetadata(runCtx, ms, metadataID, dbSyncFunctionKeys, stats)
 			m.passes.Add(1)
 			m.docsProcessed.Add(stats.DocsMigrated.Load())
 			m.docsFailed.Add(stats.Errors.Load())

--- a/db/metadata_migration.go
+++ b/db/metadata_migration.go
@@ -41,7 +41,7 @@ type MigrationStats struct {
 // (DocsUnknownPrefix from this pass). The orchestrator drives this in a loop until remaining
 // reaches zero — a doc written underneath an in-flight scan can be missed on this pass but
 // will surface on the next one.
-func MigrateMetadata(ctx context.Context, ms *base.MetadataStore, metadataID string, stats *MigrationStats) (remaining int, err error) {
+func MigrateMetadata(ctx context.Context, ms *base.MetadataStore, metadataID string, dbSyncFunctionKeys map[string]struct{}, stats *MigrationStats) (remaining int, err error) {
 	if ms == nil {
 		return 0, errors.New("MigrateMetadata: nil MetadataStore")
 	}
@@ -74,7 +74,7 @@ func MigrateMetadata(ctx context.Context, ms *base.MetadataStore, metadataID str
 			return int(stats.DocsUnknownPrefix.Load()), ctxErr
 		}
 		stats.DocsScannedTotal.Add(1)
-		handleMigrationKey(ctx, ms, keys, metadataID, item.ID, stats)
+		handleMigrationKey(ctx, ms, keys, metadataID, dbSyncFunctionKeys, item.ID, stats)
 	}
 
 	// In-scope leftovers tell the orchestrator whether to schedule another pass. Out-of-
@@ -156,6 +156,23 @@ func migrateSeqCounter(ctx context.Context, ms *base.MetadataStore, seqKey strin
 	return nil
 }
 
+// syncFunctionKeysForDB returns the set of sync-function ("syncdata") metadata doc keys owned
+// by this database — one per configured collection. Unlike the rest of SG's metadata, these
+// docs are NOT namespaced by metadataID (see base.CollectionSyncFunctionKeyWithGroupID): they
+// are keyed by groupID + scope.collection, so handleMigrationKey's metadataID-prefix matching
+// (isOurs) can't classify them. Precomputing the exact owned-key set from the DB's configured
+// collections lets us decide ownership by exact match, distinguishing our _sync:syncdata
+// docs from a sibling DB's.
+func syncFunctionKeysForDB(groupID string, collectionNames map[string]map[string]struct{}) map[string]struct{} {
+	out := make(map[string]struct{})
+	for scopeName, colls := range collectionNames {
+		for collName := range colls {
+			out[base.CollectionSyncFunctionKeyWithGroupID(groupID, scopeName, collName)] = struct{}{}
+		}
+	}
+	return out
+}
+
 // handleMigrationKey is the per-key dispatcher. It owns both the in-scope/out-of-scope
 // decision and the per-family policy. The switch cases use the database's own
 // MetadataKeys prefix accessors so namespacing (the `m_<id>:` infix) is part of the prefix
@@ -165,10 +182,15 @@ func migrateSeqCounter(ctx context.Context, ms *base.MetadataStore, seqKey strin
 // (`prefix + m_<X>:`, requiring a `:` after the namespace) — this keeps a legacy default
 // user literally named `m_alice` correctly classified as ours.
 //
-// Anything that doesn't match a known family is split between out-of-scope (sibling-DB
-// standard form, bucket-level bootstrap docs, `_sync:syncdata*` and `_sync:syncInfo`
-// which the design plan keeps in the source collection) and genuinely unknown.
-func handleMigrationKey(ctx context.Context, ms *base.MetadataStore, keys *base.MetadataKeys, metadataID, key string, stats *MigrationStats) {
+// Sync-function ("syncdata") docs are the exception to the metadataID-prefix scheme: they are
+// keyed by groupID + scope.collection, so ownership is decided by exact match against the
+// precomputed dbSyncFunctionKeys set rather than by isOurs. Our collections' syncdata docs are
+// migrated; any other `_sync:syncdata*` key belongs to a sibling DB and is out-of-scope.
+//
+// Anything else that doesn't match a known family is split between out-of-scope (sibling-DB
+// standard form, bucket-level bootstrap docs, and `_sync:syncInfo` which the design plan keeps
+// in the source collection) and genuinely unknown.
+func handleMigrationKey(ctx context.Context, ms *base.MetadataStore, keys *base.MetadataKeys, metadataID string, dbSyncFunctionKeys map[string]struct{}, key string, stats *MigrationStats) {
 	// isOurs matches a prefix and excludes sibling-DB inverted-form keys. For namespaced
 	// metadataIDs the keys.XxxKeyPrefix() already encodes the unique `m_<id>:` segment
 	// so isSiblingInverted is structurally a no-op there. For the legacy default DB
@@ -195,9 +217,14 @@ func handleMigrationKey(ctx context.Context, ms *base.MetadataStore, keys *base.
 		thisMetadataID = base.SyncDocMetadataPrefix + metadataID + ":"
 	}
 
+	// Sync-function docs aren't metadataID-namespaced, so isOurs can't classify them — ownership
+	// is an exact match against the keys precomputed from this DB's configured collections.
+	_, isOurSyncFunctionDoc := dbSyncFunctionKeys[key]
+
 	switch {
 	// matching sync docs for this database
 	case
+		isOurSyncFunctionDoc,
 		isOurs(keys.UserKeyPrefix()),
 		isOurs(keys.RoleKeyPrefix()),
 		isOurs(keys.UserEmailKey("")),
@@ -234,6 +261,11 @@ func handleMigrationKey(ctx context.Context, ms *base.MetadataStore, keys *base.
 		key == base.SyncDocPrefix+"seq",
 		key == base.SGRegistryKey,
 		key == base.SGSyncInfo,
+		// sync-function docs not in our owned set belong to a sibling DB (different
+		// collection, or same collection under another groupID) — left on the source
+		// collection. SyncFunctionKeyWithoutGroupID (`_sync:syncdata`) is also a prefix of
+		// the collection form (`_sync:syncdata_collection:…`), so this covers both shapes.
+		strings.HasPrefix(key, base.SyncFunctionKeyWithoutGroupID),
 		strings.HasPrefix(key, base.PersistentConfigPrefixWithoutGroupID):
 		stats.DocsOutOfScope.Add(1)
 

--- a/db/metadata_migration_test.go
+++ b/db/metadata_migration_test.go
@@ -49,7 +49,7 @@ func TestMigrateMetadataEmptyFallback(t *testing.T) {
 	ms := newMigrationTestStore(t, bucket)
 	stats := &MigrationStats{}
 
-	remaining, err := MigrateMetadata(ctx, ms, "testEmpty", stats)
+	remaining, err := MigrateMetadata(ctx, ms, "testEmpty", nil, stats)
 	require.NoError(t, err)
 	assert.Equal(t, 0, remaining)
 	assert.Zero(t, stats.DocsScannedTotal.Load())
@@ -100,7 +100,7 @@ func TestMigrateMetadataUnknownPrefixCountedAsRemaining(t *testing.T) {
 	seedFallback(ctx, t, ms, unknownKey, []byte(`{"body":"unknown"}`))
 
 	stats := &MigrationStats{}
-	remaining, err := MigrateMetadata(ctx, ms, metadataID, stats)
+	remaining, err := MigrateMetadata(ctx, ms, metadataID, nil, stats)
 	require.NoError(t, err)
 	assert.Equal(t, 1, remaining, "unknown-prefix doc should be reported as remaining")
 	assert.Equal(t, int64(1), stats.DocsUnknownPrefix.Load())
@@ -125,7 +125,7 @@ func TestMigrateMetadataNamespacedExcludesSiblingDB(t *testing.T) {
 	seedFallback(ctx, t, ms, siblingKey, []byte(`{"heartbeat":"sibling"}`))
 
 	stats := &MigrationStats{}
-	_, err := MigrateMetadata(ctx, ms, "myDB", stats)
+	_, err := MigrateMetadata(ctx, ms, "myDB", nil, stats)
 	require.NoError(t, err)
 
 	assert.Equal(t, int64(1), stats.DocsOutOfScope.Load())
@@ -183,7 +183,7 @@ func TestMigrateMetadataMovesUserAndRoleDocs(t *testing.T) {
 	}
 
 	stats := &MigrationStats{}
-	remaining, err := MigrateMetadata(ctx, ms, metadataID, stats)
+	remaining, err := MigrateMetadata(ctx, ms, metadataID, nil, stats)
 	require.NoError(t, err)
 	assert.Equal(t, 0, remaining)
 	assert.Equal(t, int64(len(seeded)), stats.DocsMigrated.Load())
@@ -234,7 +234,7 @@ func TestMigrateMetadataMovesUserEmailAndSession(t *testing.T) {
 	base.RequireDocsVisibleToRangeScan(t, ms.Fallback(), []string{emailKey, sessionKey})
 
 	stats := &MigrationStats{}
-	remaining, err := MigrateMetadata(ctx, ms, metadataID, stats)
+	remaining, err := MigrateMetadata(ctx, ms, metadataID, nil, stats)
 	require.NoError(t, err)
 	assert.Equal(t, 0, remaining)
 	assert.Equal(t, int64(2), stats.DocsMigrated.Load(), "useremail and session should both be moved")
@@ -286,7 +286,7 @@ func TestMigrateMetadataUserDocPrimaryWinsOnConflict(t *testing.T) {
 	seedFallback(ctx, t, ms, key, stalerFallback)
 
 	stats := &MigrationStats{}
-	remaining, err := MigrateMetadata(ctx, ms, metadataID, stats)
+	remaining, err := MigrateMetadata(ctx, ms, metadataID, nil, stats)
 	require.NoError(t, err)
 	assert.Equal(t, 0, remaining)
 	assert.Equal(t, int64(1), stats.DocsMigrated.Load(), "already-exists short-circuit should count as migrated")
@@ -321,7 +321,7 @@ func TestMigrateMetadataLegacyDefaultUserAndRole(t *testing.T) {
 	}
 
 	stats := &MigrationStats{}
-	remaining, err := MigrateMetadata(ctx, ms, base.DefaultMetadataID, stats)
+	remaining, err := MigrateMetadata(ctx, ms, base.DefaultMetadataID, nil, stats)
 	require.NoError(t, err)
 	assert.Equal(t, 0, remaining)
 	assert.Equal(t, int64(len(seeded)), stats.DocsMigrated.Load())
@@ -356,7 +356,7 @@ func TestMigrateMetadataDefaultModeUnknownPreservedHeartbeatDeleted(t *testing.T
 	seedFallback(ctx, t, ms, heartbeatKey, []byte("nodeA"))
 
 	stats := &MigrationStats{}
-	remaining, err := MigrateMetadata(ctx, ms, base.DefaultMetadataID, stats)
+	remaining, err := MigrateMetadata(ctx, ms, base.DefaultMetadataID, nil, stats)
 	require.NoError(t, err)
 	assert.Equal(t, 1, remaining, "unknown-prefix doc must keep the migration in 'work remaining' state")
 	assert.Equal(t, int64(1), stats.DocsUnknownPrefix.Load(), "%q must be classified as unknown-prefix, not as a heartbeat", unknownKey)
@@ -392,7 +392,7 @@ func TestMigrateMetadataNamespacedHeartbeatWithGroupIDDeletedViaShapeMatch(t *te
 	seedFallback(ctx, t, ms, heartbeatKey, []byte("nodeA"))
 
 	stats := &MigrationStats{}
-	remaining, err := MigrateMetadata(ctx, ms, metadataID, stats)
+	remaining, err := MigrateMetadata(ctx, ms, metadataID, nil, stats)
 	require.NoError(t, err)
 	assert.Equal(t, 0, remaining, "groupID-suffixed heartbeat must not surface as unknown-prefix")
 	assert.Equal(t, int64(1), stats.DocsMigrated.Load(), "groupID-suffixed heartbeat doc should be deleted via the shape match")
@@ -418,7 +418,7 @@ func TestMigrateMetadataNamespacedHeartbeatDeletedViaShapeMatch(t *testing.T) {
 	seedFallback(ctx, t, ms, heartbeatKey, []byte("nodeA"))
 
 	stats := &MigrationStats{}
-	remaining, err := MigrateMetadata(ctx, ms, metadataID, stats)
+	remaining, err := MigrateMetadata(ctx, ms, metadataID, nil, stats)
 	require.NoError(t, err)
 	assert.Equal(t, 0, remaining)
 	assert.Equal(t, int64(1), stats.DocsMigrated.Load(), "namespaced heartbeat doc should be deleted via the shape match")
@@ -440,7 +440,7 @@ func TestHandleMigrationKeyScoping(t *testing.T) {
 
 	classify := func(metadataID, key string) *MigrationStats {
 		stats := &MigrationStats{}
-		handleMigrationKey(ctx, nil, base.NewMetadataKeys(metadataID), metadataID, key, stats)
+		handleMigrationKey(ctx, nil, base.NewMetadataKeys(metadataID), metadataID, nil, key, stats)
 		return stats
 	}
 
@@ -541,7 +541,7 @@ func TestMigrateMetadataUnusedSeqMoves(t *testing.T) {
 	base.RequireDocsVisibleToRangeScan(t, ms.Fallback(), []string{singletonKey, rangeKey})
 
 	stats := &MigrationStats{}
-	remaining, err := MigrateMetadata(ctx, ms, metadataID, stats)
+	remaining, err := MigrateMetadata(ctx, ms, metadataID, nil, stats)
 	require.NoError(t, err)
 	assert.Equal(t, 0, remaining, "unused-seq docs must clear in a single pass")
 	assert.Equal(t, int64(2), stats.DocsMigrated.Load())
@@ -572,7 +572,7 @@ func TestMigrateMetadataLegacyDefaultUserWithMPrefixUsername(t *testing.T) {
 	seedFallback(ctx, t, ms, mUserKey, body)
 
 	stats := &MigrationStats{}
-	remaining, err := MigrateMetadata(ctx, ms, base.DefaultMetadataID, stats)
+	remaining, err := MigrateMetadata(ctx, ms, base.DefaultMetadataID, nil, stats)
 	require.NoError(t, err)
 	assert.Equal(t, 0, remaining)
 	assert.Equal(t, int64(1), stats.DocsMigrated.Load(), "m_alice user in default mode must be migrated, not skipped as a sibling-DB shape")
@@ -582,4 +582,37 @@ func TestMigrateMetadataLegacyDefaultUserWithMPrefixUsername(t *testing.T) {
 	assert.Equal(t, body, got)
 	_, _, getErr = ms.Fallback().GetRaw(ctx, mUserKey)
 	assert.True(t, base.IsDocNotFoundError(getErr))
+}
+
+// TestSyncFunctionKeysForDB verifies the owned sync-function key set is built per configured
+// collection, using the legacy `_sync:syncdata` shape for the default collection and the
+// `_sync:syncdata_collection:scope.collection` shape for named collections, with groupID
+// applied to both.
+func TestSyncFunctionKeysForDB(t *testing.T) {
+	collections := map[string]map[string]struct{}{
+		base.DefaultScope: {base.DefaultCollection: {}},
+	}
+
+	// default collection
+	noGroup := syncFunctionKeysForDB("", collections)
+	require.Len(t, noGroup, 1)
+	assert.Contains(t, noGroup, base.SyncFunctionKeyWithoutGroupID)
+
+	withGroup := syncFunctionKeysForDB("group1", collections)
+	require.Len(t, withGroup, 1)
+	assert.Contains(t, withGroup, base.SyncFunctionKeyWithoutGroupID+":group1")
+
+	// named collection
+	collections = map[string]map[string]struct{}{
+		"myScope": {"collA": {}, "collB": {}},
+	}
+	noGroup = syncFunctionKeysForDB("", collections)
+	require.Len(t, noGroup, 2)
+	assert.Contains(t, noGroup, base.CollectionSyncFunctionKeyWithoutGroupID+":myScope.collA")
+	assert.Contains(t, noGroup, base.CollectionSyncFunctionKeyWithoutGroupID+":myScope.collB")
+
+	withGroup = syncFunctionKeysForDB("group1", collections)
+	require.Len(t, withGroup, 2)
+	assert.Contains(t, withGroup, base.CollectionSyncFunctionKeyWithoutGroupID+":myScope.collA:group1")
+	assert.Contains(t, withGroup, base.CollectionSyncFunctionKeyWithoutGroupID+":myScope.collB:group1")
 }

--- a/rest/metadatamigrationtest/metadata_migration_test.go
+++ b/rest/metadatamigrationtest/metadata_migration_test.go
@@ -555,9 +555,10 @@ func TestMetadataMigrationMovesOwnedSyncFunctionDocs(t *testing.T) {
 	tb := base.GetTestBucket(t)
 	defer tb.Close(ctx)
 
-	stores := tb.GetNonDefaultDatastoreNames()
-	require.GreaterOrEqual(t, len(stores), 2, "test needs two named collections in the same scope")
-	coll0, coll1 := stores[0], stores[1]
+	dataStore1, err := tb.GetNamedDataStore(0)
+	require.NoError(t, err)
+	dataStore2, err := tb.GetNamedDataStore(1)
+	require.NoError(t, err)
 
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
 		CustomTestBucket: tb.NoCloseClone(),
@@ -583,8 +584,8 @@ func TestMetadataMigrationMovesOwnedSyncFunctionDocs(t *testing.T) {
 		return cfg
 	}
 
-	rest.RequireStatus(t, rt.CreateDatabase("db0", dbConfigForCollection(coll0)), http.StatusCreated)
-	rest.RequireStatus(t, rt.CreateDatabase("db1", dbConfigForCollection(coll1)), http.StatusCreated)
+	rest.RequireStatus(t, rt.CreateDatabase("db0", dbConfigForCollection(dataStore1)), http.StatusCreated)
+	rest.RequireStatus(t, rt.CreateDatabase("db1", dbConfigForCollection(dataStore2)), http.StatusCreated)
 
 	db0Ctx, err := rt.ServerContext().GetDatabase(ctx, "db0")
 	require.NoError(t, err)
@@ -592,8 +593,8 @@ func TestMetadataMigrationMovesOwnedSyncFunctionDocs(t *testing.T) {
 	require.NoError(t, err)
 
 	// syncdata docs are keyed by groupID + scope.collection, not metadataID.
-	syncFnKey0 := base.CollectionSyncFunctionKeyWithGroupID(db0Ctx.Options.GroupID, coll0.ScopeName(), coll0.CollectionName())
-	syncFnKey1 := base.CollectionSyncFunctionKeyWithGroupID(db1Ctx.Options.GroupID, coll1.ScopeName(), coll1.CollectionName())
+	syncFnKey0 := base.CollectionSyncFunctionKeyWithGroupID(db0Ctx.Options.GroupID, dataStore1.ScopeName(), dataStore1.CollectionName())
+	syncFnKey1 := base.CollectionSyncFunctionKeyWithGroupID(db1Ctx.Options.GroupID, dataStore2.ScopeName(), dataStore2.CollectionName())
 	require.NotEqual(t, syncFnKey0, syncFnKey1, "the two collections must produce distinct syncdata keys")
 
 	fallback := tb.Bucket.DefaultDataStore(ctx)
@@ -606,8 +607,7 @@ func TestMetadataMigrationMovesOwnedSyncFunctionDocs(t *testing.T) {
 		require.True(t, exists, "syncdata doc %q must exist in _default._default before migration", k)
 	}
 
-	// migrateDB flips a DB's opt-in, seeds its seq counter so the new-DB fast path doesn't
-	// auto-complete the migration, and drives the migration to completion via the admin API.
+	// migrateDB flips a DB's opt-in, drives the migration to completion via the admin API.
 	migrateDB := func(dbName string, dbCtx *db.DatabaseContext, cfg rest.DbConfig, ownedKey string) *base.MetadataStore {
 
 		cfg.UseSystemMobileMetadataCollection = base.Ptr(true)
@@ -630,7 +630,7 @@ func TestMetadataMigrationMovesOwnedSyncFunctionDocs(t *testing.T) {
 	}
 
 	// Migrate db0. Its syncdata doc moves to primary; db1's must stay on fallback.
-	ms0 := migrateDB("db0", db0Ctx, dbConfigForCollection(coll0), syncFnKey0)
+	ms0 := migrateDB("db0", db0Ctx, dbConfigForCollection(dataStore1), syncFnKey0)
 
 	primaryHas0, err := ms0.Primary().Exists(ctx, syncFnKey0)
 	require.NoError(t, err)
@@ -647,7 +647,7 @@ func TestMetadataMigrationMovesOwnedSyncFunctionDocs(t *testing.T) {
 	assert.True(t, fallbackHas1, "db1's syncdata doc must remain on _default._default after db0's migration")
 
 	// Migrate db1. Its syncdata doc now moves too, leaving both on primary.
-	ms1 := migrateDB("db1", db1Ctx, dbConfigForCollection(coll1), syncFnKey1)
+	ms1 := migrateDB("db1", db1Ctx, dbConfigForCollection(dataStore2), syncFnKey1)
 
 	primaryHas1, err = ms1.Primary().Exists(ctx, syncFnKey1)
 	require.NoError(t, err)

--- a/rest/metadatamigrationtest/metadata_migration_test.go
+++ b/rest/metadatamigrationtest/metadata_migration_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbase/sync_gateway/rest"
@@ -535,6 +536,179 @@ func TestMetadataMigrationLegacyDefaultDBSiblingClassifiedOutOfScope(t *testing.
 	assert.NotContains(t, finalBody, `"status":"error"`,
 		"dbnamed's migration should not error — its own keys migrate and the sibling DB's "+
 			"out-of-scope keys are skipped. Final payload: %s", finalBody)
+}
+
+// TestMetadataMigrationMovesOwnedSyncFunctionDocs verifies that a per-DB migration moves only
+// this database's sync-function ("syncdata") doc and leaves a sibling DB's untouched. Unlike the
+// rest of SG's metadata these docs are keyed by groupID + scope.collection rather than metadataID
+// (see base.CollectionSyncFunctionKeyWithGroupID), so the dispatcher classifies them via the
+// per-DB owned-collection set rather than the metadataID-prefix isOurs check.
+//
+// Two databases share one scope, each owning a different collection. db0's migration must move
+// db0's syncdata doc to _system._mobile and leave db1's on _default._default. Migrating db1 then
+// moves the second doc, leaving both on primary.
+func TestMetadataMigrationMovesOwnedSyncFunctionDocs(t *testing.T) {
+	base.TestRequiresCollections(t)
+	base.RequireNumTestDataStores(t, 2)
+
+	ctx := base.TestCtx(t)
+	tb := base.GetTestBucket(t)
+	defer tb.Close(ctx)
+
+	stores := tb.GetNonDefaultDatastoreNames()
+	require.GreaterOrEqual(t, len(stores), 2, "test needs two named collections in the same scope")
+	coll0, coll1 := stores[0], stores[1]
+
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		CustomTestBucket: tb.NoCloseClone(),
+		PersistentConfig: true,
+	})
+	defer rt.Close()
+
+	const syncFn = `function(doc){channel(doc.channels);}`
+
+	// dbConfigForCollection builds a single-collection DB config in legacy mode (opt-in=false)
+	// with an explicit sync function, so the syncdata doc is written to _default._default at
+	// creation — the pre-migration shape we want to exercise.
+	dbConfigForCollection := func(coll sgbucket.DataStoreName) rest.DbConfig {
+		cfg := rt.NewDbConfig()
+		cfg.UseSystemMobileMetadataCollection = base.Ptr(false)
+		cfg.Scopes = rest.ScopesConfig{
+			coll.ScopeName(): rest.ScopeConfig{
+				Collections: rest.CollectionsConfig{
+					coll.CollectionName(): {SyncFn: base.Ptr(syncFn)},
+				},
+			},
+		}
+		return cfg
+	}
+
+	rest.RequireStatus(t, rt.CreateDatabase("db0", dbConfigForCollection(coll0)), http.StatusCreated)
+	rest.RequireStatus(t, rt.CreateDatabase("db1", dbConfigForCollection(coll1)), http.StatusCreated)
+
+	db0Ctx, err := rt.ServerContext().GetDatabase(ctx, "db0")
+	require.NoError(t, err)
+	db1Ctx, err := rt.ServerContext().GetDatabase(ctx, "db1")
+	require.NoError(t, err)
+
+	// syncdata docs are keyed by groupID + scope.collection, not metadataID.
+	syncFnKey0 := base.CollectionSyncFunctionKeyWithGroupID(db0Ctx.Options.GroupID, coll0.ScopeName(), coll0.CollectionName())
+	syncFnKey1 := base.CollectionSyncFunctionKeyWithGroupID(db1Ctx.Options.GroupID, coll1.ScopeName(), coll1.CollectionName())
+	require.NotEqual(t, syncFnKey0, syncFnKey1, "the two collections must produce distinct syncdata keys")
+
+	fallback := tb.Bucket.DefaultDataStore(ctx)
+
+	// Both syncdata docs land in _default._default in legacy mode — the precondition for the
+	// migration to have anything to move.
+	for _, k := range []string{syncFnKey0, syncFnKey1} {
+		exists, err := fallback.Exists(ctx, k)
+		require.NoError(t, err)
+		require.True(t, exists, "syncdata doc %q must exist in _default._default before migration", k)
+	}
+
+	// migrateDB flips a DB's opt-in, seeds its seq counter so the new-DB fast path doesn't
+	// auto-complete the migration, and drives the migration to completion via the admin API.
+	migrateDB := func(dbName string, dbCtx *db.DatabaseContext, cfg rest.DbConfig, ownedKey string) *base.MetadataStore {
+
+		cfg.UseSystemMobileMetadataCollection = base.Ptr(true)
+		rest.RequireStatus(t, rt.UpsertDbConfig(dbName, cfg), http.StatusCreated)
+
+		// Make sure the owned syncdata doc is visible to the range scan before we start, so the
+		// first pass can't miss it and complete with nothing migrated.
+		base.RequireDocsVisibleToRangeScan(t, fallback, []string{ownedKey})
+
+		rt.ServerContext().ForceClusterCompatRefresh(t, ctx)
+		resp := rt.SendAdminRequest(http.MethodPost, "/"+dbName+"/_metadata_migration?action=start", "")
+		rest.RequireStatus(t, resp, http.StatusOK)
+		rt.WaitForMetadataMigrationStatusForDB(db.BackgroundProcessStateCompleted, dbName)
+
+		reloaded, err := rt.ServerContext().GetDatabase(ctx, dbName)
+		require.NoError(t, err)
+		ms, ok := reloaded.MetadataStore.(*base.MetadataStore)
+		require.True(t, ok, "%s MetadataStore must be the dual-collection wrapper after opt-in", dbName)
+		return ms
+	}
+
+	// Migrate db0. Its syncdata doc moves to primary; db1's must stay on fallback.
+	ms0 := migrateDB("db0", db0Ctx, dbConfigForCollection(coll0), syncFnKey0)
+
+	primaryHas0, err := ms0.Primary().Exists(ctx, syncFnKey0)
+	require.NoError(t, err)
+	assert.True(t, primaryHas0, "db0's syncdata doc must be migrated to _system._mobile")
+	fallbackHas0, err := fallback.Exists(ctx, syncFnKey0)
+	require.NoError(t, err)
+	assert.False(t, fallbackHas0, "db0's syncdata doc must be removed from _default._default after its migration")
+
+	primaryHas1, err := ms0.Primary().Exists(ctx, syncFnKey1)
+	require.NoError(t, err)
+	assert.False(t, primaryHas1, "db1's syncdata doc must NOT be migrated by db0's run")
+	fallbackHas1, err := fallback.Exists(ctx, syncFnKey1)
+	require.NoError(t, err)
+	assert.True(t, fallbackHas1, "db1's syncdata doc must remain on _default._default after db0's migration")
+
+	// Migrate db1. Its syncdata doc now moves too, leaving both on primary.
+	ms1 := migrateDB("db1", db1Ctx, dbConfigForCollection(coll1), syncFnKey1)
+
+	primaryHas1, err = ms1.Primary().Exists(ctx, syncFnKey1)
+	require.NoError(t, err)
+	assert.True(t, primaryHas1, "db1's syncdata doc must be migrated to _system._mobile after its own migration")
+	fallbackHas1, err = fallback.Exists(ctx, syncFnKey1)
+	require.NoError(t, err)
+	assert.False(t, fallbackHas1, "db1's syncdata doc must be removed from _default._default after its migration")
+}
+
+// TestMoveSyncDataDocumentForDefaultDB verifies that the sync function document for the default database is moved
+// from the fallback collection to the primary collection when opting in to the system metadata collection.
+func TestMoveSyncDataDocumentForDefaultDB(t *testing.T) {
+	ctx := base.TestCtx(t)
+	tb := base.GetTestBucket(t)
+	defer tb.Close(ctx)
+
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		CustomTestBucket: tb.NoCloseClone(),
+		PersistentConfig: true,
+	})
+	defer rt.Close()
+
+	dbConfig := rt.NewDbConfig()
+	dbConfig.UseSystemMobileMetadataCollection = base.Ptr(false)
+	dbConfig.Scopes = rest.ScopesConfig{
+		base.DefaultScope: rest.ScopeConfig{
+			Collections: rest.CollectionsConfig{
+				base.DefaultCollection: {SyncFn: base.Ptr(`function(doc){channel(doc.channels);}`)},
+			},
+		},
+	}
+	resp := rt.CreateDatabase("db", dbConfig)
+	rest.RequireStatus(t, resp, http.StatusCreated)
+
+	fallback := tb.Bucket.DefaultDataStore(ctx)
+
+	syncFnKey := base.CollectionSyncFunctionKeyWithGroupID(rt.ServerContext().Config.Bootstrap.ConfigGroupID, base.DefaultScope, base.DefaultCollection)
+	// assert we find sync data doc on fallback before migration
+	exists, err := fallback.Exists(ctx, syncFnKey)
+	require.NoError(t, err)
+	require.True(t, exists, "syncdata doc must exist in _default._default before migration")
+
+	// Flip the opt-in and migrate.
+	dbConfig.UseSystemMobileMetadataCollection = base.Ptr(true)
+	rest.RequireStatus(t, rt.UpsertDbConfig("db", dbConfig), http.StatusCreated)
+
+	rt.ServerContext().ForceClusterCompatRefresh(t, ctx)
+	resp = rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_metadata_migration?action=start", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	rt.WaitForMetadataMigrationStatus(db.BackgroundProcessStateCompleted)
+
+	// assert the sync data doc is migrated to primary and removed from fallback
+	dbCtx := rt.GetDatabase()
+	ms, ok := dbCtx.MetadataStore.(*base.MetadataStore)
+	require.True(t, ok, "MetadataStore must be the dual-collection wrapper after opt-in")
+	primaryHasSyncData, err := ms.Primary().Exists(ctx, syncFnKey)
+	require.NoError(t, err)
+	assert.True(t, primaryHasSyncData, "syncdata doc must be migrated to _system._mobile")
+	fallbackHasSyncData, err := fallback.Exists(ctx, syncFnKey)
+	require.NoError(t, err)
+	assert.False(t, fallbackHasSyncData, "syncdata doc must be removed from _default._default after migration")
 }
 
 // TestMetadataMigrationOptInRejectedWithViews verifies the DbConfig.validateVersion guard:

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -452,6 +452,10 @@ func (rt *RestTester) WaitForMetadataMigrationStatus(status db.BackgroundProcess
 	return rt.waitForMetadataMigrationStatus(status, "{{.db}}")
 }
 
+func (rt *RestTester) WaitForMetadataMigrationStatusForDB(status db.BackgroundProcessState, dbName string) db.MigrationManagerResponse {
+	return rt.waitForMetadataMigrationStatus(status, dbName)
+}
+
 func (rt *RestTester) waitForMetadataMigrationStatus(status db.BackgroundProcessState, dbName string) db.MigrationManagerResponse {
 	timeout := 10 * time.Second
 	pollInterval := 10 * time.Millisecond


### PR DESCRIPTION
CBG-5442

Pass down map of sync function keys for the db migration is running on. This is easier to handle inside `handleMigrationKey` because sync data docs do not follow the same metadata key format as other metadata documnet keys. 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/782/ (flake fixed in diff PR)
