### PR TITLE
CBG-5418 Improve resync processed and changed stats when running across multiple nodes

### DIFF
--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -44,6 +44,7 @@ type ResyncManagerDCP struct {
 	docsTargeted                 atomic.Uint64 // number of documents targeted for resync, computed once at the start of a new run
 	ResyncID                     string
 	VBUUIDs                      []uint64
+	EndSeqNos                    []uint64 // EndSeqNos for resync, stored as a slice to optimize persistence in status doc
 	ResyncedCollections          base.CollectionNames
 	startOptions                 ResyncOptions // options from the most recent Start call, persisted to meta for Resume
 	resyncCollectionInfo
@@ -191,6 +192,15 @@ func (r *ResyncManagerDCP) Init(ctx context.Context, options ResyncOptions, clus
 	r.db.DbStats.Database().ResyncDocsTargeted.Set(int64(docsTargeted))
 
 	r.ResyncID = newID.String()
+
+	if r.Distributed {
+		endSeqNosMap, err := base.GetHighSeqNos(ctx, r.db.Bucket)
+		if err != nil {
+			return err
+		}
+		r.setEndSeqNosFromMap(endSeqNosMap)
+	}
+
 	base.InfofCtx(ctx, base.KeyAll, "Running new resync process with ID: %q - %s", r.ResyncID, resetMsg)
 	return nil
 }
@@ -237,6 +247,7 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options ResyncOptions, persi
 	db := r.db
 	regenerateSequences := options.RegenerateSequences
 	ctx = context.WithoutCancel(ctx) // drop cancellation from parent context
+	ctx = db.AddDatabaseLogContext(ctx)
 	ctx = base.CorrelationIDLogCtx(ctx, r.ResyncID)
 	ctx, cancelResync := context.WithCancelCause(ctx)
 	defer func() {
@@ -353,10 +364,6 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options ResyncOptions, persi
 
 		r.dcpDoneChan = make(chan error)
 		checkPointPrefix := GetResyncDCPCheckpointPrefix(db, r.ResyncID, true)
-		endSeqNos, err := base.GetHighSeqNos(ctx, db.Bucket)
-		if err != nil {
-			return err
-		}
 
 		resyncDestFunc := func(janitorRollback func()) (cbgt.Dest, error) {
 			resyncDest, err := base.NewDCPDest(
@@ -367,7 +374,7 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options ResyncOptions, persi
 					MaxVbNo:            db.numVBuckets,
 					PersistCheckpoints: true,
 					CheckpointPrefix:   checkPointPrefix,
-					EndSeqNos:          endSeqNos,
+					EndSeqNos:          r.endSeqNosMap(),
 				},
 			)
 			if err != nil {
@@ -425,7 +432,7 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options ResyncOptions, persi
 			IndexName:              indexName,
 			Datastore:              db.MetadataStore,
 			FeedType:               base.ShardedDCPFeedTypeResync,
-			EndSeqNos:              endSeqNos,
+			EndSeqNos:              r.endSeqNosMap(),
 			UnregisterFeedCallback: r.getUnregisterFeedFunc(ctx, db.numVBuckets),
 		}
 		resyncCbgtContext, err := base.StartShardedDCPFeed(ctx, opts)
@@ -575,15 +582,33 @@ func (r *ResyncManagerDCP) ResetStatus() {
 
 // initializeFromPreviousStatus restores the in-memory state of the manager from a previously persisted status
 // document so that a resumed run starts with the correct accumulated counts.
+// Does not set local stats (*Local) from persisted stats (cluster-wide).  These start again from zero on resume,
+// and follow the standard status update process to aggregate those with the previously persisted stats.
 func (r *ResyncManagerDCP) initializeFromPreviousStatus(statusDoc ResyncManagerStatusDocDCP) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 	r.ResyncID = statusDoc.ResyncID
-	r.docsChangedLocal.Store(statusDoc.DocsChanged)
-	r.docsProcessedLocal.Store(statusDoc.DocsProcessed)
-	r.docsErroredLocal.Store(statusDoc.DocsErrored)
+	r.EndSeqNos = statusDoc.EndSeqNos
 	r.docsTargeted.Store(statusDoc.DocsTargeted)
 	r.db.DbStats.Database().ResyncDocsTargeted.Set(int64(statusDoc.DocsTargeted))
+}
+
+// makeEndSeqNosMap converts a slice of end sequence numbers by vBucket to a map
+func (r *ResyncManagerDCP) endSeqNosMap() map[uint16]uint64 {
+	endSeqNoMap := make(map[uint16]uint64, len(r.EndSeqNos))
+	for vb, endSeq := range r.EndSeqNos {
+		endSeqNoMap[uint16(vb)] = endSeq
+	}
+	return endSeqNoMap
+}
+
+// makeEndSeqNosSlice converts a map of end sequence numbers by vBucket to a slice, filling in any missing vBuckets with 0
+func (r *ResyncManagerDCP) setEndSeqNosFromMap(endSeqMap map[uint16]uint64) {
+	r.EndSeqNos = make([]uint64, r.db.numVBuckets)
+	for vb := uint16(0); vb < r.db.numVBuckets; vb++ {
+		r.EndSeqNos[vb] = endSeqMap[vb]
+	}
+
 }
 
 // setCollectionStatus sets the active collections being resynced.
@@ -689,6 +714,7 @@ func (r *ResyncManagerDCP) GetProcessStatus(status BackgroundManagerStatus, prev
 		VBUUIDs:       r.VBUUIDs,
 		CollectionIDs: r.collectionIDs,
 		Options:       r.startOptions,
+		EndSeqNos:     r.EndSeqNos,
 	}
 
 	prevVBuckets, err := getCompletedVBucketsFromMeta(previousStatus)
@@ -792,6 +818,7 @@ type resyncManagerCompletedVBuckets struct {
 type ResyncManagerMeta struct {
 	VBUUIDs       []uint64      `json:"vbuuids"`
 	CollectionIDs []uint32      `json:"collection_ids,omitempty"`
+	EndSeqNos     []uint64      `json:"end_seq_nos"`       // end seq nos, persisted for Resume
 	Options       ResyncOptions `json:"options,omitempty"` // start options, persisted for Resume
 	resyncManagerCompletedVBuckets
 }

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -589,6 +589,11 @@ func (r *ResyncManagerDCP) initializeFromPreviousStatus(statusDoc ResyncManagerS
 	defer r.lock.Unlock()
 	r.ResyncID = statusDoc.ResyncID
 	r.EndSeqNos = statusDoc.EndSeqNos
+	if !r.Distributed {
+		r.docsChangedLocal.Store(statusDoc.DocsChanged)
+		r.docsProcessedLocal.Store(statusDoc.DocsProcessed)
+		r.docsErroredLocal.Store(statusDoc.DocsErrored)
+	}
 	r.docsTargeted.Store(statusDoc.DocsTargeted)
 	r.db.DbStats.Database().ResyncDocsTargeted.Set(int64(statusDoc.DocsTargeted))
 }

--- a/rest/adminapitest/resync_test.go
+++ b/rest/adminapitest/resync_test.go
@@ -512,7 +512,7 @@ func TestDistributedResync(t *testing.T) {
 	rt2 := rest.NewRestTester(t, rt2Config)
 	defer rt2.Close()
 
-	// Verify the db exists on rt2
+	// wait for db to be online on rt1
 	rt1.WaitForDBState(db.RunStateString[db.DBOnline])
 
 	// Wait for database polling on rt2 to detect the database created by rt1
@@ -562,7 +562,7 @@ function sync(doc, oldDoc){
 
 	log.Printf("rt2 resync status (changed/processed): %v/%v", rt2ResyncStatus.DocsChanged, rt2ResyncStatus.DocsProcessed)
 	assert.Equal(t, int64(numDocs), rt2ResyncStatus.DocsChanged)
-	assert.LessOrEqual(t, int64(numDocs), rt1ResyncStatus.DocsProcessed)
+	assert.LessOrEqual(t, int64(numDocs), rt2ResyncStatus.DocsProcessed)
 
 	log.Printf("rt1 stats - resync num changed: %v", rt1.GetDatabase().DbStats.Database().ResyncNumChanged.Value())
 	log.Printf("rt2 stats - resync num changed: %v", rt2.GetDatabase().DbStats.Database().ResyncNumChanged.Value())

--- a/rest/adminapitest/resync_test.go
+++ b/rest/adminapitest/resync_test.go
@@ -557,16 +557,16 @@ function sync(doc, oldDoc){
 	log.Printf("rt2 sync function count: %v", rt2.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
 
 	log.Printf("rt1 resync status (changed/processed): %v/%v", rt1ResyncStatus.DocsChanged, rt1ResyncStatus.DocsProcessed)
-	assert.Equal(t, numDocs, rt1ResyncStatus.DocsChanged)
-	assert.GreaterOrEqual(t, numDocs, rt1ResyncStatus.DocsProcessed)
+	assert.Equal(t, int64(numDocs), rt1ResyncStatus.DocsChanged)
+	assert.LessOrEqual(t, int64(numDocs), rt1ResyncStatus.DocsProcessed)
 
 	log.Printf("rt2 resync status (changed/processed): %v/%v", rt2ResyncStatus.DocsChanged, rt2ResyncStatus.DocsProcessed)
-	assert.Equal(t, numDocs, rt2ResyncStatus.DocsChanged)
-	assert.GreaterOrEqual(t, numDocs, rt1ResyncStatus.DocsProcessed)
+	assert.Equal(t, int64(numDocs), rt2ResyncStatus.DocsChanged)
+	assert.LessOrEqual(t, int64(numDocs), rt1ResyncStatus.DocsProcessed)
 
 	log.Printf("rt1 stats - resync num changed: %v", rt1.GetDatabase().DbStats.Database().ResyncNumChanged.Value())
 	log.Printf("rt2 stats - resync num changed: %v", rt2.GetDatabase().DbStats.Database().ResyncNumChanged.Value())
-	assert.Equal(t, numDocs, rt1.GetDatabase().DbStats.Database().ResyncNumChanged.Value()+rt2.GetDatabase().DbStats.Database().ResyncNumChanged.Value())
+	assert.Equal(t, int64(numDocs), rt1.GetDatabase().DbStats.Database().ResyncNumChanged.Value()+rt2.GetDatabase().DbStats.Database().ResyncNumChanged.Value())
 
 	log.Printf("rt1 stats - resync num processed: %v", rt1.GetDatabase().DbStats.Database().ResyncNumProcessed.Value())
 	log.Printf("rt2 stats - resync num processed: %v", rt2.GetDatabase().DbStats.Database().ResyncNumProcessed.Value())

--- a/rest/adminapitest/resync_test.go
+++ b/rest/adminapitest/resync_test.go
@@ -11,8 +11,10 @@ package adminapitest
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/couchbase/gocbcore/v10"
 	"github.com/couchbase/sync_gateway/base"
@@ -482,4 +484,91 @@ func TestResyncPartitionsMaximumValidation(t *testing.T) {
 	resp := rt.CreateDatabase("db1", dbConfig)
 	rest.RequireStatus(t, resp, http.StatusInternalServerError)
 	assert.Contains(t, resp.Body.String(), "resync_partitions must be between 1 and")
+}
+
+// TestDistributedResync is a long-running dev-time test used to validate cbgt rebalance behavior during resync.
+// It creates two rest testers with the same bucket and config group, and triggers a resync on one node while the database is offline.
+// The test then validates that the resync completes successfully on both nodes, and logs the number of documents processed/changed on each node to verify that work is being distributed.
+// Usage notes: even with 100K docs, the test may intermittently complete resync on just rt1.  Putting a breakpoint in ResyncManagerDCP.Run and pausing for a few seconds
+// is typically sufficient to ensure rebalance happens without further increasing the number of docs.
+func TestDistributedResync(t *testing.T) {
+
+	t.Skip("Long-running dev-time test used to test multi-node cbgt rebalance during resync")
+
+	// Create first rest tester with persistent config
+	rt1 := rest.NewRestTesterPersistentConfig(t)
+	defer rt1.Close()
+
+	// Create second RT targeting the same bucket, with matching groupID and config polling enabled
+	rt2Config := &rest.RestTesterConfig{
+		GroupID: &rt1.ServerContext().Config.Bootstrap.ConfigGroupID,
+		MutateStartupConfig: func(config *rest.StartupConfig) {
+			// enable config polling
+			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(50 * time.Millisecond)
+		},
+		CustomTestBucket: rt1.TestBucket.NoCloseClone(),
+		PersistentConfig: true,
+	}
+	rt2 := rest.NewRestTester(t, rt2Config)
+	defer rt2.Close()
+
+	// Verify the db exists on rt2
+	rt1.WaitForDBState(db.RunStateString[db.DBOnline])
+
+	// Wait for database polling on rt2 to detect the database created by rt1
+	//  (can't use rt2.WaitForDBState as it includes a require for database existence)
+	err := rt2.WaitForCondition(func() bool {
+		return len(rt2.ServerContext().AllDatabases()) > 0
+	})
+	require.NoError(t, err)
+
+	rt2.WaitForDBState(db.RunStateString[db.DBOnline])
+
+	// create documents in DB to ensure resync takes long enough for cbgt rebalance to occur
+	numDocs := 100000
+	for i := range numDocs {
+		rt1.CreateTestDoc(fmt.Sprintf("doc%v", i))
+	}
+
+	rt1.TakeDbOffline()
+
+	// wait until the db status is offline for both rts
+	rt1.WaitForDBState(db.RunStateString[db.DBOffline])
+	rt2.WaitForDBState(db.RunStateString[db.DBOffline])
+
+	// update sync function to have resync process the doc
+	syncFn := `
+function sync(doc, oldDoc){
+	channel("resync_channel");
+}`
+	resp := rt1.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/_config/sync", syncFn)
+	rest.RequireStatus(t, resp, http.StatusOK)
+
+	// Start resync on rt1
+	response := rt1.SendAdminRequest("POST", "/db/_resync?action=start", "")
+	rest.RequireStatus(t, response, http.StatusOK)
+
+	// Wait for completed on both nodes
+	rt1ResyncStatus := rt1.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
+
+	rt2ResyncStatus := rt2.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
+
+	log.Printf("rt1 sync function count: %v", rt1.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
+	log.Printf("rt2 sync function count: %v", rt2.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
+
+	log.Printf("rt1 resync status (changed/processed): %v/%v", rt1ResyncStatus.DocsChanged, rt1ResyncStatus.DocsProcessed)
+	assert.Equal(t, numDocs, rt1ResyncStatus.DocsChanged)
+	assert.GreaterOrEqual(t, numDocs, rt1ResyncStatus.DocsProcessed)
+
+	log.Printf("rt2 resync status (changed/processed): %v/%v", rt2ResyncStatus.DocsChanged, rt2ResyncStatus.DocsProcessed)
+	assert.Equal(t, numDocs, rt2ResyncStatus.DocsChanged)
+	assert.GreaterOrEqual(t, numDocs, rt1ResyncStatus.DocsProcessed)
+
+	log.Printf("rt1 stats - resync num changed: %v", rt1.GetDatabase().DbStats.Database().ResyncNumChanged.Value())
+	log.Printf("rt2 stats - resync num changed: %v", rt2.GetDatabase().DbStats.Database().ResyncNumChanged.Value())
+	assert.Equal(t, numDocs, rt1.GetDatabase().DbStats.Database().ResyncNumChanged.Value()+rt2.GetDatabase().DbStats.Database().ResyncNumChanged.Value())
+
+	log.Printf("rt1 stats - resync num processed: %v", rt1.GetDatabase().DbStats.Database().ResyncNumProcessed.Value())
+	log.Printf("rt2 stats - resync num processed: %v", rt2.GetDatabase().DbStats.Database().ResyncNumProcessed.Value())
+
 }


### PR DESCRIPTION
CBG-5418

Resync docs changed stat was incorrect (too high) because local stats (single node) were being initialized to the aggregate stats (all nodes) when a node was added to resync. Value should now be accurate.

Resync docs processed stat was incorrect (too high) because the endSeqNo for the resync was being recomputed (based on the bucket's highSeqNos) whenever a node joined resync.  The endseqnos for a given resync are now computed on first Run, stored with the resync metadata in the status document, and reloaded from there in a resume scenario.  This stat may still be greater than the number of docs in the bucket due to DCP rollback during cbgt rebalance, but testing showed a significant improvement (reduced docs processed overestimates from ~30-40% to ~1-2% on a 100K doc dataset)

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/789/
