### PR TITLE
CBG-5414: Create indexes in mobile collection only if mobile collections is enabled

### DIFF
--- a/rest/database_init_manager.go
+++ b/rest/database_init_manager.go
@@ -230,7 +230,6 @@ func buildCollectionIndexData(startup *StartupConfig, config *DatabaseConfig, de
 	useSystemMetadataCollection := resolveUseSystemMetadataCollection(startup, &config.DbConfig)
 	if len(config.Scopes) == 0 {
 		if useSystemMetadataCollection {
-			//if config.UseSystemMobileMetadataCollection != nil && *config.UseSystemMobileMetadataCollection {
 			return CollectionInitData{base.DefaultScopeAndCollectionName(): db.IndexesAll, base.MobileSystemScopeAndCollectionName(): db.IndexesMetadataOnly}
 		} else {
 			return CollectionInitData{base.DefaultScopeAndCollectionName(): db.IndexesAll}
@@ -259,7 +258,6 @@ func buildCollectionIndexData(startup *StartupConfig, config *DatabaseConfig, de
 		collectionInitData[base.DefaultScopeAndCollectionName()] = defaultScopeAndCollectionMetadataIndexes
 	}
 	if useSystemMetadataCollection {
-		//if config.UseSystemMobileMetadataCollection != nil && *config.UseSystemMobileMetadataCollection {
 		collectionInitData[base.MobileSystemScopeAndCollectionName()] = db.IndexesMetadataOnly
 	}
 

--- a/rest/database_init_manager.go
+++ b/rest/database_init_manager.go
@@ -66,7 +66,7 @@ func (m *DatabaseInitManager) InitializeDatabaseWithStatusCallback(ctx context.C
 		base.MD(dbConfig.Name))
 	dbInitWorker, ok := m.workers[dbConfig.Name]
 
-	collectionSet := buildCollectionIndexData(dbConfig, defaultCollectionExists)
+	collectionSet := buildCollectionIndexData(startupConfig, dbConfig, defaultCollectionExists)
 	if ok {
 		// If worker exists for the database and the collection sets match, add watcher to the existing worker
 		if dbInitWorker.collectionsEqual(collectionSet) {
@@ -226,9 +226,11 @@ func (m *DatabaseInitManager) cancelWorkers() {
 // customer may drop it once migration completes, at which point those indexes are vestigial and attempting to
 // build them on the missing collection would retry until the op times out and fail initialization. When
 // _default is gone (and not itself a configured data collection) it is omitted from the index set.
-func buildCollectionIndexData(config *DatabaseConfig, defaultCollectionExists bool) CollectionInitData {
+func buildCollectionIndexData(startup *StartupConfig, config *DatabaseConfig, defaultCollectionExists bool) CollectionInitData {
+	useSystemMetadataCollection := resolveUseSystemMetadataCollection(startup, &config.DbConfig)
 	if len(config.Scopes) == 0 {
-		if config.UseSystemMobileMetadataCollection != nil && *config.UseSystemMobileMetadataCollection {
+		if useSystemMetadataCollection {
+			//if config.UseSystemMobileMetadataCollection != nil && *config.UseSystemMobileMetadataCollection {
 			return CollectionInitData{base.DefaultScopeAndCollectionName(): db.IndexesAll, base.MobileSystemScopeAndCollectionName(): db.IndexesMetadataOnly}
 		} else {
 			return CollectionInitData{base.DefaultScopeAndCollectionName(): db.IndexesAll}
@@ -256,7 +258,8 @@ func buildCollectionIndexData(config *DatabaseConfig, defaultCollectionExists bo
 	if defaultCollectionExists || defaultIsConfiguredCollection {
 		collectionInitData[base.DefaultScopeAndCollectionName()] = defaultScopeAndCollectionMetadataIndexes
 	}
-	if config.UseSystemMobileMetadataCollection != nil && *config.UseSystemMobileMetadataCollection {
+	if useSystemMetadataCollection {
+		//if config.UseSystemMobileMetadataCollection != nil && *config.UseSystemMobileMetadataCollection {
 		collectionInitData[base.MobileSystemScopeAndCollectionName()] = db.IndexesMetadataOnly
 	}
 

--- a/rest/database_init_manager.go
+++ b/rest/database_init_manager.go
@@ -228,8 +228,11 @@ func (m *DatabaseInitManager) cancelWorkers() {
 // _default is gone (and not itself a configured data collection) it is omitted from the index set.
 func buildCollectionIndexData(config *DatabaseConfig, defaultCollectionExists bool) CollectionInitData {
 	if len(config.Scopes) == 0 {
-		// todo: only init these mobile collection indexes when required?
-		return CollectionInitData{base.DefaultScopeAndCollectionName(): db.IndexesAll, base.MobileSystemScopeAndCollectionName(): db.IndexesMetadataOnly}
+		if config.UseSystemMobileMetadataCollection != nil && *config.UseSystemMobileMetadataCollection {
+			return CollectionInitData{base.DefaultScopeAndCollectionName(): db.IndexesAll, base.MobileSystemScopeAndCollectionName(): db.IndexesMetadataOnly}
+		} else {
+			return CollectionInitData{base.DefaultScopeAndCollectionName(): db.IndexesAll}
+		}
 	}
 
 	defaultScopeAndCollectionMetadataIndexes := db.IndexesMetadataOnly
@@ -253,8 +256,9 @@ func buildCollectionIndexData(config *DatabaseConfig, defaultCollectionExists bo
 	if defaultCollectionExists || defaultIsConfiguredCollection {
 		collectionInitData[base.DefaultScopeAndCollectionName()] = defaultScopeAndCollectionMetadataIndexes
 	}
-	// todo: only init these indexes when required?
-	collectionInitData[base.MobileSystemScopeAndCollectionName()] = db.IndexesMetadataOnly
+	if config.UseSystemMobileMetadataCollection != nil && *config.UseSystemMobileMetadataCollection {
+		collectionInitData[base.MobileSystemScopeAndCollectionName()] = db.IndexesMetadataOnly
+	}
 
 	return collectionInitData
 }

--- a/rest/database_init_manager_test.go
+++ b/rest/database_init_manager_test.go
@@ -518,7 +518,20 @@ func TestBuildCollectionIndexData(t *testing.T) {
 		want                    CollectionInitData
 	}{
 		{
-			name: "implicit default collection",
+			name: "implicit default collection with mobile collection enabled",
+			config: &DatabaseConfig{
+				DbConfig: DbConfig{
+					Scopes:                            nil,
+					UseSystemMobileMetadataCollection: base.Ptr(true),
+				},
+			},
+			want: CollectionInitData{
+				base.DefaultScopeAndCollectionName():      db.IndexesAll,
+				base.MobileSystemScopeAndCollectionName(): db.IndexesMetadataOnly,
+			},
+		},
+		{
+			name: "implicit default collection with mobile collection disabled",
 			config: &DatabaseConfig{
 				DbConfig: DbConfig{
 					Scopes: nil,
@@ -526,15 +539,15 @@ func TestBuildCollectionIndexData(t *testing.T) {
 			},
 			defaultCollectionExists: true,
 			want: CollectionInitData{
-				base.DefaultScopeAndCollectionName():      db.IndexesAll,
-				base.MobileSystemScopeAndCollectionName(): db.IndexesMetadataOnly,
+				base.DefaultScopeAndCollectionName(): db.IndexesAll,
 			},
 		},
 		{
-			name: "explicit default collection",
+			name: "explicit default collection with mobile collection enabled",
 			config: &DatabaseConfig{
 				DbConfig: DbConfig{
-					Scopes: makeScopesConfig(base.DefaultScope, []string{base.DefaultCollection}),
+					Scopes:                            makeScopesConfig(base.DefaultScope, []string{base.DefaultCollection}),
+					UseSystemMobileMetadataCollection: base.Ptr(true),
 				},
 			},
 			defaultCollectionExists: true,
@@ -544,10 +557,22 @@ func TestBuildCollectionIndexData(t *testing.T) {
 			},
 		},
 		{
-			name: "one named collection",
+			name: "explicit default collection with mobile collection disabled",
 			config: &DatabaseConfig{
 				DbConfig: DbConfig{
-					Scopes: makeScopesConfig("scope1", []string{"collection1"}),
+					Scopes: makeScopesConfig(base.DefaultScope, []string{base.DefaultCollection}),
+				},
+			},
+			want: CollectionInitData{
+				base.DefaultScopeAndCollectionName(): db.IndexesAll,
+			},
+		},
+		{
+			name: "one named collection with mobile collection enabled",
+			config: &DatabaseConfig{
+				DbConfig: DbConfig{
+					Scopes:                            makeScopesConfig("scope1", []string{"collection1"}),
+					UseSystemMobileMetadataCollection: base.Ptr(true),
 				},
 			},
 			defaultCollectionExists: true,
@@ -558,7 +583,33 @@ func TestBuildCollectionIndexData(t *testing.T) {
 			},
 		},
 		{
-			name: "one named and explicit default collection",
+			name: "one named collection with mobile collection disabled",
+			config: &DatabaseConfig{
+				DbConfig: DbConfig{
+					Scopes: makeScopesConfig("scope1", []string{"collection1"}),
+				},
+			},
+			want: CollectionInitData{
+				base.DefaultScopeAndCollectionName():                    db.IndexesMetadataOnly,
+				base.NewScopeAndCollectionName("scope1", "collection1"): db.IndexesWithoutMetadata,
+			},
+		},
+		{
+			name: "one named and explicit default collection with mobile collection enabled",
+			config: &DatabaseConfig{
+				DbConfig: DbConfig{
+					Scopes:                            makeScopesConfig(base.DefaultScope, []string{base.DefaultCollection, "collection1"}),
+					UseSystemMobileMetadataCollection: base.Ptr(true),
+				},
+			},
+			want: CollectionInitData{
+				base.DefaultScopeAndCollectionName():                             db.IndexesAll,
+				base.MobileSystemScopeAndCollectionName():                        db.IndexesMetadataOnly,
+				base.NewScopeAndCollectionName(base.DefaultScope, "collection1"): db.IndexesWithoutMetadata,
+			},
+		},
+		{
+			name: "one named and explicit default collection with mobile collection disabled",
 			config: &DatabaseConfig{
 				DbConfig: DbConfig{
 					Scopes: makeScopesConfig(base.DefaultScope, []string{base.DefaultCollection, "collection1"}),
@@ -567,7 +618,6 @@ func TestBuildCollectionIndexData(t *testing.T) {
 			defaultCollectionExists: true,
 			want: CollectionInitData{
 				base.DefaultScopeAndCollectionName():                             db.IndexesAll,
-				base.MobileSystemScopeAndCollectionName():                        db.IndexesMetadataOnly,
 				base.NewScopeAndCollectionName(base.DefaultScope, "collection1"): db.IndexesWithoutMetadata,
 			},
 		},

--- a/rest/database_init_manager_test.go
+++ b/rest/database_init_manager_test.go
@@ -109,6 +109,7 @@ func TestDatabaseInitConfigChangeSameCollections(t *testing.T) {
 
 	dbName := "dbName"
 	dbConfig := makeDbConfig(tb.GetName(), dbName, collection1and2ScopesConfig)
+	dbConfig.UseSystemMobileMetadataCollection = base.Ptr(true)
 	require.NoError(t, dbConfig.setup(ctx, dbName, sc.Config.Bootstrap, nil, nil, false))
 
 	// Start first async index creation, blocks after first collection
@@ -199,6 +200,7 @@ func TestDatabaseInitConfigChangeDifferentCollections(t *testing.T) {
 	dbName := "dbName"
 	dbConfig := makeDbConfig(tb.GetName(), dbName, collection1and2ScopesConfig)
 	require.NoError(t, dbConfig.setup(ctx, dbName, sc.Config.Bootstrap, nil, nil, false))
+	dbConfig.UseSystemMobileMetadataCollection = base.Ptr(true)
 
 	// Start first async index creation, should block after first collection
 	doneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true)
@@ -210,6 +212,7 @@ func TestDatabaseInitConfigChangeDifferentCollections(t *testing.T) {
 	// Make a call to initialize database for the same db name, different collections
 	modifiedDbConfig := makeDbConfig(tb.GetName(), dbName, collection1and3ScopesConfig)
 	require.NoError(t, modifiedDbConfig.setup(ctx, dbName, sc.Config.Bootstrap, nil, nil, false))
+	modifiedDbConfig.UseSystemMobileMetadataCollection = base.Ptr(true)
 	modifiedDoneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, modifiedDbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true)
 	require.NoError(t, err)
 
@@ -286,10 +289,12 @@ func TestDatabaseInitConcurrentDatabasesSameBucket(t *testing.T) {
 	db1Name := "db1Name"
 	db1Config := makeDbConfig(tb.GetName(), db1Name, collection1and2ScopesConfig)
 	require.NoError(t, db1Config.setup(ctx, db1Name, sc.Config.Bootstrap, nil, nil, false))
+	db1Config.UseSystemMobileMetadataCollection = base.Ptr(true)
 
 	db2Name := "db2Name"
 	db2Config := makeDbConfig(tb.GetName(), db2Name, collection3ScopesConfig)
 	require.NoError(t, db2Config.setup(ctx, db2Name, sc.Config.Bootstrap, nil, nil, false))
+	db2Config.UseSystemMobileMetadataCollection = base.Ptr(true)
 
 	// Start first async index creation, should block after first collection
 	doneChan1, err := initMgr.InitializeDatabase(ctx, sc.Config, db1Config.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true)
@@ -381,10 +386,12 @@ func TestDatabaseInitConcurrentDatabasesDifferentBuckets(t *testing.T) {
 	db1Name := "db1Name"
 	db1Config := makeDbConfig(tb1.GetName(), db1Name, collection1and2ScopesConfig)
 	require.NoError(t, db1Config.setup(ctx, db1Name, sc.Config.Bootstrap, nil, nil, false))
+	db1Config.UseSystemMobileMetadataCollection = base.Ptr(true)
 
 	db2Name := "db2Name"
 	db2Config := makeDbConfig(tb2.GetName(), db2Name, collection1and2ScopesConfig)
 	require.NoError(t, db2Config.setup(ctx, db2Name, sc.Config.Bootstrap, nil, nil, false))
+	db2Config.UseSystemMobileMetadataCollection = base.Ptr(true)
 
 	// Start first async index creation, should block after first collection
 	doneChan1, err := initMgr.InitializeDatabase(ctx, sc.Config, db1Config.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true)
@@ -456,6 +463,7 @@ func TestDatabaseInitTeardownTiming(t *testing.T) {
 	dbName := "dbName"
 	dbConfig := makeDbConfig(tb.GetName(), dbName, collection1and2ScopesConfig)
 	require.NoError(t, dbConfig.setup(ctx, dbName, sc.Config.Bootstrap, nil, nil, false))
+	dbConfig.UseSystemMobileMetadataCollection = base.Ptr(true)
 
 	wg := &sync.WaitGroup{}
 	wg.Add(1)

--- a/rest/database_init_manager_test.go
+++ b/rest/database_init_manager_test.go
@@ -662,6 +662,19 @@ func TestBuildCollectionIndexData(t *testing.T) {
 				base.NewScopeAndCollectionName("scope1", "collection1"): db.IndexesWithoutMetadata,
 			},
 		},
+		{
+			name: "explicit default collection, migration complete, mobile enabled",
+			config: &DatabaseConfig{DbConfig: DbConfig{
+				Scopes:                            makeScopesConfig(base.DefaultScope, []string{base.DefaultCollection, "collection1"}),
+				UseSystemMobileMetadataCollection: base.Ptr(true),
+			}},
+			metadataMigrationComplete: true,
+			want: CollectionInitData{
+				base.DefaultScopeAndCollectionName():                             db.IndexesAll,
+				base.MobileSystemScopeAndCollectionName():                        db.IndexesMetadataOnly,
+				base.NewScopeAndCollectionName(base.DefaultScope, "collection1"): db.IndexesWithoutMetadata,
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/rest/database_init_manager_test.go
+++ b/rest/database_init_manager_test.go
@@ -511,20 +511,22 @@ func waitForWorkerDone(t *testing.T, manager *DatabaseInitManager, dbName string
 }
 
 func TestBuildCollectionIndexData(t *testing.T) {
+	bootstrapEnabled := &StartupConfig{Bootstrap: BootstrapConfig{UseSystemMetadataCollection: base.Ptr(true)}}
+	bootstrapDisabled := &StartupConfig{Bootstrap: BootstrapConfig{UseSystemMetadataCollection: base.Ptr(false)}}
+
 	tests := []struct {
 		name                    string
 		config                  *DatabaseConfig
 		defaultCollectionExists bool
 		want                    CollectionInitData
 	}{
+		// Scope variations — verifies index sets are computed correctly per collection layout.
+		// Uses per-DB opt-in to show the full output including mobile collection.
 		{
-			name: "implicit default collection with mobile collection enabled",
-			config: &DatabaseConfig{
-				DbConfig: DbConfig{
-					Scopes:                            nil,
-					UseSystemMobileMetadataCollection: base.Ptr(true),
-				},
-			},
+			name: "implicit default collection",
+			config: &DatabaseConfig{DbConfig: DbConfig{
+				UseSystemMobileMetadataCollection: base.Ptr(true),
+			}},
 			want: CollectionInitData{
 				base.DefaultScopeAndCollectionName():      db.IndexesAll,
 				base.MobileSystemScopeAndCollectionName(): db.IndexesMetadataOnly,
@@ -583,29 +585,25 @@ func TestBuildCollectionIndexData(t *testing.T) {
 			},
 		},
 		{
-			name: "one named collection with mobile collection disabled",
-			config: &DatabaseConfig{
-				DbConfig: DbConfig{
-					Scopes: makeScopesConfig("scope1", []string{"collection1"}),
-				},
-			},
-			want: CollectionInitData{
-				base.DefaultScopeAndCollectionName():                    db.IndexesMetadataOnly,
-				base.NewScopeAndCollectionName("scope1", "collection1"): db.IndexesWithoutMetadata,
-			},
-		},
-		{
-			name: "one named and explicit default collection with mobile collection enabled",
-			config: &DatabaseConfig{
-				DbConfig: DbConfig{
-					Scopes:                            makeScopesConfig(base.DefaultScope, []string{base.DefaultCollection, "collection1"}),
-					UseSystemMobileMetadataCollection: base.Ptr(true),
-				},
-			},
+			name: "one named and explicit default collection",
+			config: &DatabaseConfig{DbConfig: DbConfig{
+				Scopes:                            makeScopesConfig(base.DefaultScope, []string{base.DefaultCollection, "collection1"}),
+				UseSystemMobileMetadataCollection: base.Ptr(true),
+			}},
 			want: CollectionInitData{
 				base.DefaultScopeAndCollectionName():                             db.IndexesAll,
 				base.MobileSystemScopeAndCollectionName():                        db.IndexesMetadataOnly,
 				base.NewScopeAndCollectionName(base.DefaultScope, "collection1"): db.IndexesWithoutMetadata,
+			},
+		},
+		// Flag interaction cases — verifies resolveUseSystemMetadataCollection precedence.
+		// Uses implicit default collection as a representative scope.
+		{
+			name:   "per-DB enabled, no startup config",
+			config: &DatabaseConfig{DbConfig: DbConfig{UseSystemMobileMetadataCollection: base.Ptr(true)}},
+			want: CollectionInitData{
+				base.DefaultScopeAndCollectionName():      db.IndexesAll,
+				base.MobileSystemScopeAndCollectionName(): db.IndexesMetadataOnly,
 			},
 		},
 		{
@@ -617,8 +615,36 @@ func TestBuildCollectionIndexData(t *testing.T) {
 			},
 			defaultCollectionExists: true,
 			want: CollectionInitData{
-				base.DefaultScopeAndCollectionName():                             db.IndexesAll,
-				base.NewScopeAndCollectionName(base.DefaultScope, "collection1"): db.IndexesWithoutMetadata,
+				base.DefaultScopeAndCollectionName():      db.IndexesAll,
+				base.MobileSystemScopeAndCollectionName(): db.IndexesMetadataOnly,
+			},
+		},
+		{
+			// per-DB false falls through to the cluster flag, which is true
+			name:          "bootstrap enabled, per-DB explicitly disabled",
+			startupConfig: bootstrapEnabled,
+			config:        &DatabaseConfig{DbConfig: DbConfig{UseSystemMobileMetadataCollection: base.Ptr(false)}},
+			want: CollectionInitData{
+				base.DefaultScopeAndCollectionName():      db.IndexesAll,
+				base.MobileSystemScopeAndCollectionName(): db.IndexesMetadataOnly,
+			},
+		},
+		{
+			name:          "bootstrap disabled, per-DB unset",
+			startupConfig: bootstrapDisabled,
+			config:        &DatabaseConfig{},
+			want: CollectionInitData{
+				base.DefaultScopeAndCollectionName(): db.IndexesAll,
+			},
+		},
+		{
+			// per-DB true always wins, regardless of cluster flag
+			name:          "bootstrap disabled, per-DB explicitly enabled",
+			startupConfig: bootstrapDisabled,
+			config:        &DatabaseConfig{DbConfig: DbConfig{UseSystemMobileMetadataCollection: base.Ptr(true)}},
+			want: CollectionInitData{
+				base.DefaultScopeAndCollectionName():      db.IndexesAll,
+				base.MobileSystemScopeAndCollectionName(): db.IndexesMetadataOnly,
 			},
 		},
 		{

--- a/rest/database_init_manager_test.go
+++ b/rest/database_init_manager_test.go
@@ -519,6 +519,7 @@ func TestBuildCollectionIndexData(t *testing.T) {
 		config                  *DatabaseConfig
 		defaultCollectionExists bool
 		want                    CollectionInitData
+		startupConfig           *StartupConfig
 	}{
 		// Scope variations — verifies index sets are computed correctly per collection layout.
 		// Uses per-DB opt-in to show the full output including mobile collection.
@@ -615,8 +616,8 @@ func TestBuildCollectionIndexData(t *testing.T) {
 			},
 			defaultCollectionExists: true,
 			want: CollectionInitData{
-				base.DefaultScopeAndCollectionName():      db.IndexesAll,
-				base.MobileSystemScopeAndCollectionName(): db.IndexesMetadataOnly,
+				base.DefaultScopeAndCollectionName():                             db.IndexesAll,
+				base.NewScopeAndCollectionName(base.DefaultScope, "collection1"): db.IndexesWithoutMetadata,
 			},
 		},
 		{
@@ -653,7 +654,8 @@ func TestBuildCollectionIndexData(t *testing.T) {
 			name: "named collection with _default dropped",
 			config: &DatabaseConfig{
 				DbConfig: DbConfig{
-					Scopes: makeScopesConfig("scope1", []string{"collection1"}),
+					Scopes:                            makeScopesConfig("scope1", []string{"collection1"}),
+					UseSystemMobileMetadataCollection: base.Ptr(true),
 				},
 			},
 			defaultCollectionExists: false,
@@ -662,23 +664,10 @@ func TestBuildCollectionIndexData(t *testing.T) {
 				base.NewScopeAndCollectionName("scope1", "collection1"): db.IndexesWithoutMetadata,
 			},
 		},
-		{
-			name: "explicit default collection, migration complete, mobile enabled",
-			config: &DatabaseConfig{DbConfig: DbConfig{
-				Scopes:                            makeScopesConfig(base.DefaultScope, []string{base.DefaultCollection, "collection1"}),
-				UseSystemMobileMetadataCollection: base.Ptr(true),
-			}},
-			metadataMigrationComplete: true,
-			want: CollectionInitData{
-				base.DefaultScopeAndCollectionName():                             db.IndexesAll,
-				base.MobileSystemScopeAndCollectionName():                        db.IndexesMetadataOnly,
-				base.NewScopeAndCollectionName(base.DefaultScope, "collection1"): db.IndexesWithoutMetadata,
-			},
-		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actual := buildCollectionIndexData(test.config, test.defaultCollectionExists)
+			actual := buildCollectionIndexData(test.startupConfig, test.config, test.defaultCollectionExists)
 			assert.Equalf(t, test.want, actual, "buildCollectionIndexData(%v, %v)", test.config, test.defaultCollectionExists)
 		})
 	}

--- a/rest/database_init_manager_test.go
+++ b/rest/database_init_manager_test.go
@@ -676,7 +676,7 @@ func TestBuildCollectionIndexData(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			actual := buildCollectionIndexData(test.startupConfig, test.config, test.defaultCollectionExists)
-			assert.Equalf(t, test.want, actual, "buildCollectionIndexData(%v, %v)", test.config, test.defaultCollectionExists)
+			assert.Equalf(t, test.want, actual, "buildCollectionIndexData(startup=%v, config=%v, defaultCollectionExists=%v)", test.startupConfig, test.config, test.defaultCollectionExists)
 		})
 	}
 }

--- a/rest/indextest/index_test.go
+++ b/rest/indextest/index_test.go
@@ -372,6 +372,7 @@ func TestAsyncOnlineOffline(t *testing.T) {
 
 	dbConfig := makeDbConfig(t, tb, syncFunc, importFilter)
 	dbConfig.StartOffline = base.Ptr(true)
+	dbConfig.UseSystemMobileMetadataCollection = base.Ptr(true)
 	dbConfigPayload, err := json.Marshal(dbConfig)
 	require.NoError(t, err)
 	dbName := "db"
@@ -502,6 +503,7 @@ func TestAsyncCreateThenDelete(t *testing.T) {
 
 	dbConfig := makeDbConfig(t, tb, syncFunc, importFilter)
 	dbConfig.StartOffline = base.Ptr(true)
+	dbConfig.UseSystemMobileMetadataCollection = base.Ptr(true)
 	dbConfigPayload, err := json.Marshal(dbConfig)
 	require.NoError(t, err)
 	dbName := "db"


### PR DESCRIPTION
CBG-5414

Describe your PR here...
- Create indexes in mobile collections only when mobile collections is enabled
- add test coverage for the same.

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/790/
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/793/
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/843/
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/844/
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/846/