### PR TITLE
CBG-5432: metadata migration steals co-located sibling DB metadata when the default metadataID DB migrates

### DIFF
--- a/db/background_mgr_metadata_migration.go
+++ b/db/background_mgr_metadata_migration.go
@@ -212,7 +212,7 @@ func (m *MetadataMigrationManager) Run(ctx context.Context, options map[string]a
 				var sibErr error
 				siblingMetadataIDs, sibErr = m.dbContext.SiblingMetadataIDFunc(runCtx)
 				if sibErr != nil {
-					return fmt.Errorf("[%s] Failed to get sibling MetadataIDs: %v", metadataMigrationLoggingID, sibErr)
+					return fmt.Errorf("[%s] failed to get sibling MetadataIDs: %w", metadataMigrationLoggingID, sibErr)
 				}
 			}
 

--- a/db/background_mgr_metadata_migration.go
+++ b/db/background_mgr_metadata_migration.go
@@ -202,8 +202,22 @@ func (m *MetadataMigrationManager) Run(ctx context.Context, options map[string]a
 				return nil
 			}
 
+			// Re-read the sibling metadataID list each pass rather than once before the loop:
+			// a sibling DB registered after the migration started must be recognised on the next
+			// pass so the (legacy default) migrating DB never migrates a newly-arrived sibling's
+			// inverted keys. The registry read is cheap next to the range scan, and there are at
+			// most maxPasses of them.
+			var siblingMetadataIDs []string
+			if m.dbContext.SiblingMetadataIDFunc != nil {
+				var sibErr error
+				siblingMetadataIDs, sibErr = m.dbContext.SiblingMetadataIDFunc(runCtx)
+				if sibErr != nil {
+					return fmt.Errorf("[%s] Failed to get sibling MetadataIDs: %v", metadataMigrationLoggingID, sibErr)
+				}
+			}
+
 			stats := &MigrationStats{}
-			remaining, err := MigrateMetadata(runCtx, ms, metadataID, dbSyncFunctionKeys, stats)
+			remaining, err := MigrateMetadata(runCtx, ms, metadataID, siblingMetadataIDs, dbSyncFunctionKeys, stats)
 			m.passes.Add(1)
 			m.docsProcessed.Add(stats.DocsMigrated.Load())
 			m.docsFailed.Add(stats.Errors.Load())

--- a/db/background_mgr_metadata_migration_test.go
+++ b/db/background_mgr_metadata_migration_test.go
@@ -265,6 +265,78 @@ func TestMetadataMigrationManagerErrorsOnUnclearableUnknownPrefix(t *testing.T) 
 	assert.NoError(t, err, "stuck unknown-prefix doc should still be on the fallback")
 }
 
+// TestMetadataMigrationManagerDCPCheckpointGroupIDCollisionCompletesEndToEnd is the
+// end-to-end counterpart to the low-level TestMigrateMetadataDcpCheckpointGroupIDCollisionKnownLimitation:
+//
+// Scenario: a default-metadataID DB (_default._default configured) whose own DCP checkpoint
+// embeds its config group ID "default" as the first body segment (`_sync:dcp_ck:default:<ver>`).
+// A pathological sibling DB whose metadataID is literally "default" is registered via
+// SiblingMetadataIDFunc, so the classifier subtracts that sibling and misclassifies the default
+// DB's own checkpoint as the sibling's.
+func TestMetadataMigrationManagerDCPCheckpointGroupIDCollisionCompletesEndToEnd(t *testing.T) {
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
+
+	primary, err := bucket.GetNamedDataStore(0)
+	require.NoError(t, err)
+	fallback := bucket.DefaultDataStore(ctx)
+	if _, ok := base.AsRangeScanStore(fallback); !ok {
+		t.Skipf("metadata migration requires KV range scan support on the fallback datastore")
+	}
+	ms := base.NewMetadataStore(primary, fallback)
+
+	metaKeys := base.NewMetadataKeys(base.DefaultMetadataID)
+	// The default DB's own DCP checkpoint embeds its config group ID as the first body
+	// segment: _sync:dcp_ck:default:1. "default" is the literal value of the rest package's
+	// PersistentConfigDefaultGroupID (not importable here without a cycle).
+	const defaultGroupID = "default"
+	ownCheckpoint := metaKeys.DCPCheckpointPrefix(defaultGroupID) + "1"
+	_, err = ms.Fallback().AddRaw(ctx, ownCheckpoint, 0, []byte(`{"seq":42}`))
+	require.NoError(t, err, "seed fallback %s", ownCheckpoint)
+
+	// KV range scans read from a per-vBucket snapshot view, so a scan issued immediately after
+	// the write can miss the just-seeded doc until the vBucket's scan view catches up. Wait for
+	// the seed to be visible to scan before starting, otherwise a first-pass miss would make the
+	// run complete trivially for the wrong reason.
+	base.RequireDocsVisibleToRangeScan(t, ms.Fallback(), []string{ownCheckpoint})
+
+	dbCtx := &DatabaseContext{
+		Name:                           "test",
+		terminator:                     make(chan bool),
+		MetadataStore:                  ms,
+		MetadataKeys:                   metaKeys,
+		Options:                        DatabaseContextOptions{MetadataID: base.DefaultMetadataID},
+		MetadataMigrationStatusUpdater: inMemoryMigrationStatusUpdater(),
+		// Pathological sibling whose metadataID == this default DB's DCP group ID ("default")
+		// triggers the documented collision in handleMigrationKey's isOursInverted exclusion.
+		SiblingMetadataIDFunc: func(context.Context) ([]string, error) {
+			return []string{defaultGroupID}, nil
+		},
+	}
+	dbCtx.MetadataMigrationManager = NewMetadataMigrationManager(dbCtx)
+
+	require.NoError(t, dbCtx.MetadataMigrationManager.Start(ctx, nil))
+	// The collision yields an out-of-scope (not unknown-prefix) classification, so the run
+	// still reaches Completed rather than the bounded-pass Errored give-up branch.
+	RequireBackgroundManagerState(t, dbCtx.MetadataMigrationManager, BackgroundProcessStateCompleted)
+
+	rawStatus, err := dbCtx.MetadataMigrationManager.GetStatus(ctx)
+	require.NoError(t, err)
+	var resp MigrationManagerResponse
+	require.NoError(t, base.JSONUnmarshal(rawStatus, &resp))
+	assert.Zero(t, resp.DocsProcessed, "known limitation: own checkpoint is NOT migrated under the group-id/sibling-id collision")
+	assert.Zero(t, resp.DocsFailed, "no per-doc errors: the collision is a classification outcome, not a move failure")
+	assert.Equal(t, int64(1), resp.DocsOutOfScope, "own checkpoint is (mis)classified out-of-scope, not unknown-prefix")
+
+	assert.True(t, ms.MigrationComplete(), "out-of-scope docs do not block completion - the run still flips MigrationComplete")
+
+	_, _, getErr := ms.Fallback().GetRaw(ctx, ownCheckpoint)
+	assert.NoError(t, getErr, "own checkpoint is stranded on the fallback under the known limitation")
+	_, _, getErr = ms.Primary().GetRaw(ctx, ownCheckpoint)
+	assert.True(t, base.IsDocNotFoundError(getErr), "own checkpoint did not reach primary")
+}
+
 // TestTryStartMetadataMigrationConfigNotApplied verifies that while the cluster has not yet
 // converged on the config, tryStartMetadataMigration reports done=false so the arm loop keeps
 // polling, and does not start the migration.

--- a/db/database.go
+++ b/db/database.go
@@ -160,9 +160,9 @@ type DatabaseContext struct {
 	// complete in the status doc. Triggers the bucket-level all-complete check + bootstrap copy
 	// + SetMigrationComplete on the cluster.
 	PostMetadataMigrationCompleteFunc func(ctx context.Context) error
-	// SiblingMetadataIDFunc will return metadataIDs of all sibling databases with the same bucket (excluding this databases).
-	// Used by metadata migration to recognise co-located sibling databases metadata documents to avoid migrating them and
-	// classify as out-of-scope.
+	// SiblingMetadataIDFunc returns metadataIDs of all sibling databases sharing the same bucket (excluding this database).
+	// Used by metadata migration to recognise co-located sibling databases' metadata documents, avoid migrating them, and
+	// classify them as out-of-scope.
 	SiblingMetadataIDFunc       func(ctx context.Context) ([]string, error)
 	ClusterCompatVersionFunc    func() *base.ClusterCompatVersion // Resolves the current cluster-wide minimum SG version, or nil if not yet known. Re-resolved at call time since CCV changes during rolling upgrades.
 	UserFunctionTimeout         time.Duration                     // Default timeout for N1QL & JavaScript queries. (Applies to REST and BLIP requests.)

--- a/db/database.go
+++ b/db/database.go
@@ -160,26 +160,30 @@ type DatabaseContext struct {
 	// complete in the status doc. Triggers the bucket-level all-complete check + bootstrap copy
 	// + SetMigrationComplete on the cluster.
 	PostMetadataMigrationCompleteFunc func(ctx context.Context) error
-	ClusterCompatVersionFunc          func() *base.ClusterCompatVersion // Resolves the current cluster-wide minimum SG version, or nil if not yet known. Re-resolved at call time since CCV changes during rolling upgrades.
-	UserFunctionTimeout               time.Duration                     // Default timeout for N1QL & JavaScript queries. (Applies to REST and BLIP requests.)
-	Scopes                            map[string]Scope                  // A map keyed by scope name containing a set of scopes/collections. Nil if running with only _default._default
-	CollectionByID                    map[uint32]*DatabaseCollection    // A map keyed by collection ID to Collection
-	CollectionNames                   map[string]map[string]struct{}    // Map of scope, collection names
-	MetadataKeys                      *base.MetadataKeys                // Factory to generate metadata document keys
-	RequireResync                     base.ScopeAndCollectionNames      // Collections requiring resync before database can go online
-	RequireAttachmentMigration        base.ScopeAndCollectionNames      // Collections that require the attachment migration background task to run against
-	CORS                              *auth.CORSConfig                  // CORS configuration
-	EnableMou                         bool                              // Write _mou xattr when performing metadata-only update.  Set based on bucket capability on connect
-	WasInitializedSynchronously       bool                              // true if the database was initialized synchronously
-	BroadcastSlowMode                 atomic.Bool                       // bool to indicate if a slower ticker value should be used to notify changes feeds of changes
-	DatabaseStartupError              *DatabaseError                    // Error that occurred during database online processes startup
-	CachedPurgeInterval               atomic.Pointer[time.Duration]     // If set, the cached value of the purge interval to avoid repeated lookups
-	CachedVersionPruningWindow        atomic.Pointer[time.Duration]     // If set, the cached value of the version pruning window to avoid repeated lookups
-	CachedCCVStartingCas              *base.VBucketCAS                  // If set, the cached value of the CCV starting CAS value to avoid repeated lookups
-	CachedCCVEnabled                  atomic.Bool                       // If set, the cached value of the CCV Enabled flag (this is not expected to transition from true->false, but could go false->true)
-	numVBuckets                       uint16                            // Number of vbuckets in the bucket
-	SameSiteCookieMode                http.SameSite
-	DBStateManager                    *DatabaseStateMgr // Manager used to manage the state of processes across nodes
+	// SiblingMetadataIDFunc will return metadataIDs of all sibling databases with the same bucket (excluding this databases).
+	// Used by metadata migration to recognise co-located sibling databases metadata documents to avoid migrating them and
+	// classify as out-of-scope.
+	SiblingMetadataIDFunc       func(ctx context.Context) ([]string, error)
+	ClusterCompatVersionFunc    func() *base.ClusterCompatVersion // Resolves the current cluster-wide minimum SG version, or nil if not yet known. Re-resolved at call time since CCV changes during rolling upgrades.
+	UserFunctionTimeout         time.Duration                     // Default timeout for N1QL & JavaScript queries. (Applies to REST and BLIP requests.)
+	Scopes                      map[string]Scope                  // A map keyed by scope name containing a set of scopes/collections. Nil if running with only _default._default
+	CollectionByID              map[uint32]*DatabaseCollection    // A map keyed by collection ID to Collection
+	CollectionNames             map[string]map[string]struct{}    // Map of scope, collection names
+	MetadataKeys                *base.MetadataKeys                // Factory to generate metadata document keys
+	RequireResync               base.ScopeAndCollectionNames      // Collections requiring resync before database can go online
+	RequireAttachmentMigration  base.ScopeAndCollectionNames      // Collections that require the attachment migration background task to run against
+	CORS                        *auth.CORSConfig                  // CORS configuration
+	EnableMou                   bool                              // Write _mou xattr when performing metadata-only update.  Set based on bucket capability on connect
+	WasInitializedSynchronously bool                              // true if the database was initialized synchronously
+	BroadcastSlowMode           atomic.Bool                       // bool to indicate if a slower ticker value should be used to notify changes feeds of changes
+	DatabaseStartupError        *DatabaseError                    // Error that occurred during database online processes startup
+	CachedPurgeInterval         atomic.Pointer[time.Duration]     // If set, the cached value of the purge interval to avoid repeated lookups
+	CachedVersionPruningWindow  atomic.Pointer[time.Duration]     // If set, the cached value of the version pruning window to avoid repeated lookups
+	CachedCCVStartingCas        *base.VBucketCAS                  // If set, the cached value of the CCV starting CAS value to avoid repeated lookups
+	CachedCCVEnabled            atomic.Bool                       // If set, the cached value of the CCV Enabled flag (this is not expected to transition from true->false, but could go false->true)
+	numVBuckets                 uint16                            // Number of vbuckets in the bucket
+	SameSiteCookieMode          http.SameSite
+	DBStateManager              *DatabaseStateMgr // Manager used to manage the state of processes across nodes
 
 	scopeName string // name of the single scope for the database
 }

--- a/db/metadata_migration.go
+++ b/db/metadata_migration.go
@@ -178,9 +178,9 @@ func syncFunctionKeysForDB(groupID string, collectionNames map[string]map[string
 // MetadataKeys prefix accessors so namespacing (the `m_<id>:` infix) is part of the prefix
 // match for namespaced metadataIDs. For the legacy `_default` metadataID, where each
 // inverted-form prefix (e.g. `_sync:user:`) overlaps with sibling DBs' inverted-form keys
-// (`_sync:user:<metaID>:…`), isOursInverted handles this case by doing a prefix match and for default metadata id db's
-// we will also check against sibling db's metadata ids fetched from registry doc — this keeps a legacy default
-// user literally named `m_alice` correctly classified as ours.
+// (`_sync:user:<metaID>:…`), isOursInverted handles this case by doing a prefix match, and for the default
+// metadataID DB it also checks the registry-supplied sibling metadataIDs — this keeps a legacy default user literally
+// named `m_alice` correctly classified as ours.
 //
 // Sync-function ("syncdata") docs are the exception to the metadataID-prefix scheme: they are
 // keyed by groupID + scope.collection, so ownership is decided by exact match against the

--- a/db/metadata_migration.go
+++ b/db/metadata_migration.go
@@ -41,7 +41,7 @@ type MigrationStats struct {
 // (DocsUnknownPrefix from this pass). The orchestrator drives this in a loop until remaining
 // reaches zero — a doc written underneath an in-flight scan can be missed on this pass but
 // will surface on the next one.
-func MigrateMetadata(ctx context.Context, ms *base.MetadataStore, metadataID string, dbSyncFunctionKeys map[string]struct{}, stats *MigrationStats) (remaining int, err error) {
+func MigrateMetadata(ctx context.Context, ms *base.MetadataStore, metadataID string, siblingMetadataIDs []string, dbSyncFunctionKeys map[string]struct{}, stats *MigrationStats) (remaining int, err error) {
 	if ms == nil {
 		return 0, errors.New("MigrateMetadata: nil MetadataStore")
 	}
@@ -74,7 +74,7 @@ func MigrateMetadata(ctx context.Context, ms *base.MetadataStore, metadataID str
 			return int(stats.DocsUnknownPrefix.Load()), ctxErr
 		}
 		stats.DocsScannedTotal.Add(1)
-		handleMigrationKey(ctx, ms, keys, metadataID, dbSyncFunctionKeys, item.ID, stats)
+		handleMigrationKey(ctx, ms, keys, metadataID, siblingMetadataIDs, dbSyncFunctionKeys, item.ID, stats)
 	}
 
 	// In-scope leftovers tell the orchestrator whether to schedule another pass. Out-of-
@@ -178,8 +178,8 @@ func syncFunctionKeysForDB(groupID string, collectionNames map[string]map[string
 // MetadataKeys prefix accessors so namespacing (the `m_<id>:` infix) is part of the prefix
 // match for namespaced metadataIDs. For the legacy `_default` metadataID, where each
 // inverted-form prefix (e.g. `_sync:user:`) overlaps with sibling DBs' inverted-form keys
-// (`_sync:user:m_<other>:…`), isOurs additionally excludes the *full* sibling shape
-// (`prefix + m_<X>:`, requiring a `:` after the namespace) — this keeps a legacy default
+// (`_sync:user:<metaID>:…`), isOursInverted handles this case by doing a prefix match and for default metadata id db's
+// we will also check against sibling db's metadata ids fetched from registry doc — this keeps a legacy default
 // user literally named `m_alice` correctly classified as ours.
 //
 // Sync-function ("syncdata") docs are the exception to the metadataID-prefix scheme: they are
@@ -190,24 +190,53 @@ func syncFunctionKeysForDB(groupID string, collectionNames map[string]map[string
 // Anything else that doesn't match a known family is split between out-of-scope (sibling-DB
 // standard form, bucket-level bootstrap docs, and `_sync:syncInfo` which the design plan keeps
 // in the source collection) and genuinely unknown.
-func handleMigrationKey(ctx context.Context, ms *base.MetadataStore, keys *base.MetadataKeys, metadataID string, dbSyncFunctionKeys map[string]struct{}, key string, stats *MigrationStats) {
-	// isOurs matches a prefix and excludes sibling-DB inverted-form keys. For namespaced
-	// metadataIDs the keys.XxxKeyPrefix() already encodes the unique `m_<id>:` segment
-	// so isSiblingInverted is structurally a no-op there. For the legacy default DB
-	// the discriminator is "starts with prefix+m_ AND has another colon" — that
-	// distinguishes `_sync:user:m_otherDB:alice` (sibling) from `_sync:user:m_alice`
-	// (our user whose username happens to start with `m_`).
+func handleMigrationKey(ctx context.Context, ms *base.MetadataStore, keys *base.MetadataKeys, metadataID string, siblingMetadataIDs []string, dbSyncFunctionKeys map[string]struct{}, key string, stats *MigrationStats) {
+	// Ownership of a fallback key is decided by two helpers, chosen per key family:
+	//
+	//   isOurs         — plain prefix match. Used for the non-inverted families
+	//                    (seq / unusedSeq / sgcfg / heartbeat / resync / state / replication
+	//                    status), whose keys are `_sync:[m_<id>:]<type>`. A sibling DB's keys
+	//                    carry a distinct `m_<id>:` infix, so they never share our prefix and
+	//                    no sibling check is needed.
+	//
+	//   isOursInverted — prefix match plus a sibling-DB exclusion. Used for the inverted
+	//                    families (user / role / useremail / session / dcp_ck), whose keys are
+	//                    `_sync:<type>:[<id>:]<body>`. For a namespaced migrating DB the prefix
+	//                    already embeds our `<id>:`, so a prefix match alone is unambiguous
+	//                    (early return). For the legacy default DB the prefix is bare
+	//                    (e.g. `_sync:user:`) and is therefore also a prefix of every sibling's
+	//                    `_sync:user:<id>:…` key, so we subtract the siblings: the key is a
+	//                    sibling's (not ours) iff its body begins with `<siblingID>:` for some
+	//                    metadataID in the registry-supplied siblingMetadataIDs.
+	//
+	// The sibling list comes from the gateway registry (ServerContext.SiblingMetadataIDFunc) and
+	// is authoritative — unlike the `m_`-shape heuristic this replaced, which never matched real
+	// inverted keys (formatInvertedMetadataKey embeds the bare metadataID, no `m_`) and so let
+	// the default DB migrate siblings' inverted docs.
+	//
+	// Accepted residual ambiguity (default DB only): a family whose own body can itself begin
+	// with `<siblingID>:` is indistinguishable from that sibling's key. useremail bodies are
+	// emails (the validator permits ':') and dcp_ck bodies begin with the config group id, so an
+	// own key colliding with a sibling metadataID is conservatively left out-of-scope rather than
+	// risk migrating a sibling's doc. Names are ':'-free (ValidatePrincipalName) and session IDs
+	// are hex, so user/role/session are not exposed.
 	isOurs := func(prefix string) bool {
-		if !strings.HasPrefix(key, prefix) {
+		return strings.HasPrefix(key, prefix)
+	}
+	isOursInverted := func(invertedPrefix string) bool {
+		if !strings.HasPrefix(key, invertedPrefix) {
 			return false
 		}
-		rest := key[len(prefix):]
-		if !strings.HasPrefix(rest, base.MetadataIdPrefix) {
-			return true
+		if metadataID != "" && metadataID != base.DefaultMetadataID {
+			return true // namespaced migrating DB: prefix already embeds our id, unambiguous
 		}
-		// starts with `m_` — sibling shape only if there's another `:` separating the
-		// metadataID from the rest of the key.
-		return !strings.Contains(rest[len(base.MetadataIdPrefix):], ":")
+		rest := key[len(invertedPrefix):]
+		for _, siblingID := range siblingMetadataIDs {
+			if strings.HasPrefix(rest, siblingID+":") {
+				return false
+			}
+		}
+		return true
 	}
 	// thisMetadataID is `_sync:m_<id>:` for namespaced metadataIDs — used to exclude OUR
 	// standard-form keys from the sibling-DB out-of-scope check. Empty for default mode
@@ -225,14 +254,14 @@ func handleMigrationKey(ctx context.Context, ms *base.MetadataStore, keys *base.
 	// matching sync docs for this database
 	case
 		isOurSyncFunctionDoc,
-		isOurs(keys.UserKeyPrefix()),
-		isOurs(keys.RoleKeyPrefix()),
-		isOurs(keys.UserEmailKey("")),
-		isOurs(keys.SessionKey("")),
+		isOursInverted(keys.UserKeyPrefix()),
+		isOursInverted(keys.RoleKeyPrefix()),
+		isOursInverted(keys.UserEmailKey("")),
+		isOursInverted(keys.SessionKey("")),
+		isOursInverted(keys.DCPCheckpointPrefix("")),
 		key == keys.DatabaseStateKey(),
 		isOurs(keys.ReplicationStatusKey("")),
 		isOurs(keys.SGCfgPrefix("")),
-		isOurs(keys.DCPCheckpointPrefix("")),
 		isOurs(keys.BackgroundProcessHeartbeatPrefix("")),
 		isOurs(keys.BackgroundProcessStatusPrefix("")),
 		isOurs(keys.ResyncHeartbeaterPrefix()),

--- a/db/metadata_migration_test.go
+++ b/db/metadata_migration_test.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/couchbase/cbgt"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -49,7 +50,7 @@ func TestMigrateMetadataEmptyFallback(t *testing.T) {
 	ms := newMigrationTestStore(t, bucket)
 	stats := &MigrationStats{}
 
-	remaining, err := MigrateMetadata(ctx, ms, "testEmpty", nil, stats)
+	remaining, err := MigrateMetadata(ctx, ms, "testEmpty", nil, nil, stats)
 	require.NoError(t, err)
 	assert.Equal(t, 0, remaining)
 	assert.Zero(t, stats.DocsScannedTotal.Load())
@@ -100,7 +101,7 @@ func TestMigrateMetadataUnknownPrefixCountedAsRemaining(t *testing.T) {
 	seedFallback(ctx, t, ms, unknownKey, []byte(`{"body":"unknown"}`))
 
 	stats := &MigrationStats{}
-	remaining, err := MigrateMetadata(ctx, ms, metadataID, nil, stats)
+	remaining, err := MigrateMetadata(ctx, ms, metadataID, nil, nil, stats)
 	require.NoError(t, err)
 	assert.Equal(t, 1, remaining, "unknown-prefix doc should be reported as remaining")
 	assert.Equal(t, int64(1), stats.DocsUnknownPrefix.Load())
@@ -125,7 +126,7 @@ func TestMigrateMetadataNamespacedExcludesSiblingDB(t *testing.T) {
 	seedFallback(ctx, t, ms, siblingKey, []byte(`{"heartbeat":"sibling"}`))
 
 	stats := &MigrationStats{}
-	_, err := MigrateMetadata(ctx, ms, "myDB", nil, stats)
+	_, err := MigrateMetadata(ctx, ms, "myDB", nil, nil, stats)
 	require.NoError(t, err)
 
 	assert.Equal(t, int64(1), stats.DocsOutOfScope.Load())
@@ -183,7 +184,7 @@ func TestMigrateMetadataMovesUserAndRoleDocs(t *testing.T) {
 	}
 
 	stats := &MigrationStats{}
-	remaining, err := MigrateMetadata(ctx, ms, metadataID, nil, stats)
+	remaining, err := MigrateMetadata(ctx, ms, metadataID, nil, nil, stats)
 	require.NoError(t, err)
 	assert.Equal(t, 0, remaining)
 	assert.Equal(t, int64(len(seeded)), stats.DocsMigrated.Load())
@@ -234,7 +235,7 @@ func TestMigrateMetadataMovesUserEmailAndSession(t *testing.T) {
 	base.RequireDocsVisibleToRangeScan(t, ms.Fallback(), []string{emailKey, sessionKey})
 
 	stats := &MigrationStats{}
-	remaining, err := MigrateMetadata(ctx, ms, metadataID, nil, stats)
+	remaining, err := MigrateMetadata(ctx, ms, metadataID, nil, nil, stats)
 	require.NoError(t, err)
 	assert.Equal(t, 0, remaining)
 	assert.Equal(t, int64(2), stats.DocsMigrated.Load(), "useremail and session should both be moved")
@@ -286,7 +287,7 @@ func TestMigrateMetadataUserDocPrimaryWinsOnConflict(t *testing.T) {
 	seedFallback(ctx, t, ms, key, stalerFallback)
 
 	stats := &MigrationStats{}
-	remaining, err := MigrateMetadata(ctx, ms, metadataID, nil, stats)
+	remaining, err := MigrateMetadata(ctx, ms, metadataID, nil, nil, stats)
 	require.NoError(t, err)
 	assert.Equal(t, 0, remaining)
 	assert.Equal(t, int64(1), stats.DocsMigrated.Load(), "already-exists short-circuit should count as migrated")
@@ -321,7 +322,7 @@ func TestMigrateMetadataLegacyDefaultUserAndRole(t *testing.T) {
 	}
 
 	stats := &MigrationStats{}
-	remaining, err := MigrateMetadata(ctx, ms, base.DefaultMetadataID, nil, stats)
+	remaining, err := MigrateMetadata(ctx, ms, base.DefaultMetadataID, nil, nil, stats)
 	require.NoError(t, err)
 	assert.Equal(t, 0, remaining)
 	assert.Equal(t, int64(len(seeded)), stats.DocsMigrated.Load())
@@ -356,7 +357,7 @@ func TestMigrateMetadataDefaultModeUnknownPreservedHeartbeatDeleted(t *testing.T
 	seedFallback(ctx, t, ms, heartbeatKey, []byte("nodeA"))
 
 	stats := &MigrationStats{}
-	remaining, err := MigrateMetadata(ctx, ms, base.DefaultMetadataID, nil, stats)
+	remaining, err := MigrateMetadata(ctx, ms, base.DefaultMetadataID, nil, nil, stats)
 	require.NoError(t, err)
 	assert.Equal(t, 1, remaining, "unknown-prefix doc must keep the migration in 'work remaining' state")
 	assert.Equal(t, int64(1), stats.DocsUnknownPrefix.Load(), "%q must be classified as unknown-prefix, not as a heartbeat", unknownKey)
@@ -392,7 +393,7 @@ func TestMigrateMetadataNamespacedHeartbeatWithGroupIDDeletedViaShapeMatch(t *te
 	seedFallback(ctx, t, ms, heartbeatKey, []byte("nodeA"))
 
 	stats := &MigrationStats{}
-	remaining, err := MigrateMetadata(ctx, ms, metadataID, nil, stats)
+	remaining, err := MigrateMetadata(ctx, ms, metadataID, nil, nil, stats)
 	require.NoError(t, err)
 	assert.Equal(t, 0, remaining, "groupID-suffixed heartbeat must not surface as unknown-prefix")
 	assert.Equal(t, int64(1), stats.DocsMigrated.Load(), "groupID-suffixed heartbeat doc should be deleted via the shape match")
@@ -418,7 +419,7 @@ func TestMigrateMetadataNamespacedHeartbeatDeletedViaShapeMatch(t *testing.T) {
 	seedFallback(ctx, t, ms, heartbeatKey, []byte("nodeA"))
 
 	stats := &MigrationStats{}
-	remaining, err := MigrateMetadata(ctx, ms, metadataID, nil, stats)
+	remaining, err := MigrateMetadata(ctx, ms, metadataID, nil, nil, stats)
 	require.NoError(t, err)
 	assert.Equal(t, 0, remaining)
 	assert.Equal(t, int64(1), stats.DocsMigrated.Load(), "namespaced heartbeat doc should be deleted via the shape match")
@@ -438,9 +439,9 @@ func TestMigrateMetadataNamespacedHeartbeatDeletedViaShapeMatch(t *testing.T) {
 func TestHandleMigrationKeyScoping(t *testing.T) {
 	ctx := base.TestCtx(t)
 
-	classify := func(metadataID, key string) *MigrationStats {
+	classify := func(metadataID string, siblingMetadataIDs []string, key string) *MigrationStats {
 		stats := &MigrationStats{}
-		handleMigrationKey(ctx, nil, base.NewMetadataKeys(metadataID), metadataID, nil, key, stats)
+		handleMigrationKey(ctx, nil, base.NewMetadataKeys(metadataID), metadataID, siblingMetadataIDs, nil, key, stats)
 		return stats
 	}
 
@@ -451,7 +452,7 @@ func TestHandleMigrationKeyScoping(t *testing.T) {
 			"_sync:m_otherDB:seq",
 			"_sync:m_otherDB:hb:groupA",
 		} {
-			s := classify("myDB", k)
+			s := classify("myDB", nil, k)
 			assert.Equal(t, int64(1), s.DocsOutOfScope.Load(), "%q should be out of scope for myDB", k)
 		}
 	})
@@ -461,7 +462,7 @@ func TestHandleMigrationKeyScoping(t *testing.T) {
 			"_sync:dbconfig:default",
 			"_sync:syncInfo",
 		} {
-			s := classify("myDB", k)
+			s := classify("myDB", nil, k)
 			assert.Equal(t, int64(1), s.DocsOutOfScope.Load(), "%q is a bucket-level doc — out of scope", k)
 		}
 	})
@@ -476,28 +477,248 @@ func TestHandleMigrationKeyScoping(t *testing.T) {
 			"_sync:somethingnew:foo",
 			"_sync:futurefeature",
 		} {
-			s := classify(base.DefaultMetadataID, k)
+			s := classify(base.DefaultMetadataID, nil, k)
 			assert.Equal(t, int64(1), s.DocsUnknownPrefix.Load(), "%q must be unknown-prefix, not classified as a heartbeat", k)
 			assert.Zero(t, s.DocsOutOfScope.Load(), "%q is in-scope (default mode owns `_sync:…`) so should not be out-of-scope", k)
 		}
 	})
 
 	// LegacySiblingInvertedFormOutOfScope pins the sibling-side of the corner-case fix:
-	// the inverted-form keys for a real sibling DB (with a trailing `:` after the
-	// metadataID) must still be classified out-of-scope when the local DB is in legacy
-	// default mode. The ours-side counterpart — a legacy default user literally named
-	// `m_alice` — is covered end-to-end by TestMigrateMetadataLegacyDefaultUserWithMPrefixUsername
-	// below (the dispatcher would call moveFallbackDoc on a real bucket for those).
+	// when the local DB is in legacy default mode, a co-located sibling's inverted-form
+	// keys must be classified out-of-scope. The classifier recognises them by matching
+	// the segment after the inverted prefix against the authoritative sibling-metadataID
+	// list from the registry (`<siblingID>:`) — there is no `m_` in inverted keys
+	// (`formatInvertedMetadataKey` omits it; see base/constants_syncdocs_test.go:75), so a
+	// real sibling "otherDB" produces `_sync:user:otherDB:alice`. Without the sibling list
+	// the default DB cannot tell these from its own keys, so the list must be supplied.
+	// The ours-side counterpart — a legacy default user literally named `m_alice` — is
+	// covered end-to-end by TestMigrateMetadataLegacyDefaultUserWithMPrefixUsername below.
 	t.Run("LegacySiblingInvertedFormOutOfScope", func(t *testing.T) {
 		for _, k := range []string{
-			"_sync:user:m_otherDB:alice",
-			"_sync:role:m_otherDB:admins",
-			"_sync:useremail:m_otherDB:alice@example.com",
-			"_sync:session:m_otherDB:tok1",
+			"_sync:user:otherDB:alice",
+			"_sync:role:otherDB:admins",
+			"_sync:useremail:otherDB:alice@example.com",
+			"_sync:session:otherDB:tok1",
 		} {
-			s := classify(base.DefaultMetadataID, k)
+			s := classify(base.DefaultMetadataID, []string{"otherDB"}, k)
 			assert.Equal(t, int64(1), s.DocsOutOfScope.Load(), "%q is a sibling-DB inverted-form key — must remain out-of-scope", k)
 		}
+	})
+}
+
+// migrationDisposition is the per-key routing decision handleMigrationKey makes for a
+// single fallback key. It is the unit of coverage for TestHandleMigrationKeyClassification.
+type migrationDisposition int
+
+const (
+	// dispMigrated: an in-scope metadata doc moved from fallback to primary (DocsMigrated++).
+	dispMigrated migrationDisposition = iota
+	// dispDeleted: a transient heartbeater doc removed from fallback, NOT copied to primary.
+	// deleteFallbackDoc also counts toward DocsMigrated, so the distinguishing assertion is
+	// "absent from primary" rather than the counter.
+	dispDeleted
+	// dispOutOfScope: a sibling-DB or bucket-level doc left on fallback (DocsOutOfScope++).
+	dispOutOfScope
+	// dispUnknown: an unrecognised `_sync:` key left on fallback (DocsUnknownPrefix++).
+	dispUnknown
+)
+
+// TestHandleMigrationKeyClassification is the exhaustive per-key routing matrix for
+// handleMigrationKey: every switch arm, for the legacy-default migrating DB (with and
+// without a sibling) and for a namespaced migrating DB (the inverse direction). It is the
+// unit-level guard for the sibling-DB misclassification fix — it asserts which collection
+// each key family is routed to, not the byte-fidelity of the move (datatype/TTL/body
+// equality live in the MigrateMetadata full-scan tests).
+//
+// Keys are built through the real base.MetadataKeys formatters rather than hardcoded, so a
+// future change to a key shape is reflected here automatically. The crux of the fix is the
+// inverted families (user/role/useremail/session/dcp_ck): for the default DB their prefix
+// is also a prefix of every sibling's inverted key, so the classifier must consult the
+// authoritative sibling-metadataID list to tell ours from theirs.
+func TestHandleMigrationKeyClassification(t *testing.T) {
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
+	ms := newMigrationTestStore(t, bucket)
+
+	existsOnPrimary := func(t *testing.T, key string) bool {
+		_, _, err := ms.Primary().GetRaw(ctx, key)
+		if base.IsDocNotFoundError(err) {
+			return false
+		}
+		require.NoError(t, err)
+		return true
+	}
+	fallbackHas := func(t *testing.T, key string) bool {
+		_, _, err := ms.Fallback().GetRaw(ctx, key)
+		if base.IsDocNotFoundError(err) {
+			return false
+		}
+		require.NoError(t, err)
+		return true
+	}
+
+	type keyCase struct {
+		name string
+		key  string
+		want migrationDisposition
+	}
+
+	// run executes one subtest per key under a fixed (migratingID, siblings, syncFnKeys)
+	// configuration. Keys destined to move/delete are seeded on the fallback first (an
+	// in-scope key with no fallback doc is a silent no-op in moveFallbackDoc).
+	run := func(t *testing.T, migratingID string, siblings []string, syncFnKeys map[string]struct{}, cases []keyCase) {
+		keys := base.NewMetadataKeys(migratingID)
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				if tc.want == dispMigrated || tc.want == dispDeleted {
+					_, err := ms.Fallback().AddRaw(ctx, tc.key, 0, []byte(`{"x":1}`))
+					require.NoError(t, err, "seed fallback %s", tc.key)
+				}
+				stats := &MigrationStats{}
+				handleMigrationKey(ctx, ms, keys, migratingID, siblings, syncFnKeys, tc.key, stats)
+
+				switch tc.want {
+				case dispMigrated:
+					assert.Equal(t, int64(1), stats.DocsMigrated.Load(), "%q should migrate", tc.key)
+					assert.Zero(t, stats.DocsOutOfScope.Load(), "%q must not be out-of-scope", tc.key)
+					assert.Zero(t, stats.DocsUnknownPrefix.Load(), "%q must not be unknown-prefix", tc.key)
+					assert.Zero(t, stats.Errors.Load(), "%q should move without error", tc.key)
+					assert.True(t, existsOnPrimary(t, tc.key), "%q should land on primary", tc.key)
+					assert.False(t, fallbackHas(t, tc.key), "%q fallback shadow should be removed", tc.key)
+				case dispDeleted:
+					assert.Equal(t, int64(1), stats.DocsMigrated.Load(), "%q delete is counted as migrated", tc.key)
+					assert.Zero(t, stats.DocsOutOfScope.Load(), "%q must not be out-of-scope", tc.key)
+					assert.Zero(t, stats.Errors.Load(), "%q should delete without error", tc.key)
+					assert.False(t, existsOnPrimary(t, tc.key), "transient heartbeater %q must NOT be copied to primary", tc.key)
+					assert.False(t, fallbackHas(t, tc.key), "%q should be removed from fallback", tc.key)
+				case dispOutOfScope:
+					assert.Equal(t, int64(1), stats.DocsOutOfScope.Load(), "%q should be out-of-scope", tc.key)
+					assert.Zero(t, stats.DocsMigrated.Load(), "%q must not migrate (data theft / loss)", tc.key)
+					assert.Zero(t, stats.DocsUnknownPrefix.Load(), "%q is recognised, not unknown", tc.key)
+				case dispUnknown:
+					assert.Equal(t, int64(1), stats.DocsUnknownPrefix.Load(), "%q should be unknown-prefix", tc.key)
+					assert.Zero(t, stats.DocsMigrated.Load(), "%q must not migrate", tc.key)
+					assert.Zero(t, stats.DocsOutOfScope.Load(), "%q must not be out-of-scope", tc.key)
+				}
+			})
+		}
+	}
+
+	def := base.NewMetadataKeys(base.DefaultMetadataID)
+	db2 := base.NewMetadataKeys("db2")
+
+	// Direction 1 — the legacy-default DB migrates while a namespaced sibling "db2" shares
+	// the bucket. This is the direction the bug manifested in: the default DB's bare inverted
+	// prefixes overlap every sibling's inverted key, so without the sibling list the default
+	// DB would steal db2's user/role/useremail/session/dcp_ck docs.
+	t.Run("DefaultDB_with_namespaced_sibling_db2", func(t *testing.T) {
+		run(t, base.DefaultMetadataID, []string{"db2"}, nil, []keyCase{
+			// inverted families — ours (no sibling-id segment after the prefix)
+			{"own user", def.UserKey("alice"), dispMigrated},
+			{"own role", def.RoleKey("admins"), dispMigrated},
+			{"own useremail", def.UserEmailKey("alice@example.com"), dispMigrated},
+			{"own session", def.SessionKey("sessAlice"), dispMigrated},
+			// own dcp_ck: group id "default" + version + vbno — colons in the body, but the
+			// first segment ("default") is not the sibling id "db2", so it stays ours. This is
+			// the case the naive "any colon ⇒ sibling" heuristic could not handle.
+			{"own dcp_ck (group default)", def.DCPCheckpointPrefix("default") + "1", dispMigrated},
+
+			// inverted families — sibling db2's keys (prefix + "db2:" + …) must stay put
+			{"sibling user", db2.UserKey("bob"), dispOutOfScope},
+			{"sibling role", db2.RoleKey("readers"), dispOutOfScope},
+			{"sibling useremail", db2.UserEmailKey("bob@example.com"), dispOutOfScope},
+			{"sibling session", db2.SessionKey("sessBob"), dispOutOfScope},
+			{"sibling dcp_ck", db2.DCPCheckpointPrefix("default") + "1", dispOutOfScope},
+
+			// non-inverted owned families (plain isOurs prefix match) — migrated
+			{"own unusedSeq (binary)", def.UnusedSeqKey(5), dispMigrated},
+			{"own unusedSeqRange (binary)", def.UnusedSeqRangeKey(5, 9), dispMigrated},
+			{"own database state", def.DatabaseStateKey(), dispMigrated},
+			{"own replication status", def.ReplicationStatusKey("repl1"), dispMigrated},
+			{"own sgcfg", def.SGCfgPrefix("") + "nodeDefs-known", dispMigrated},
+			{"own resync cfg", def.ResyncCfgPrefix() + cbgt.PLAN_PINDEXES_KEY, dispMigrated},
+			{"own background process status", def.BackgroundProcessStatusPrefix("resync"), dispMigrated},
+
+			// non-inverted sibling family (`_sync:m_db2:…`) — out-of-scope via SyncDocMetadataPrefix arm
+			{"sibling non-inverted seq", db2.SyncSeqKey(), dispOutOfScope},
+			{"sibling non-inverted unusedSeq", db2.UnusedSeqKey(7), dispOutOfScope},
+
+			// heartbeater — deleted, never moved
+			{"own heartbeater", def.HeartbeaterPrefix("") + "heartbeat_timeout:node1", dispDeleted},
+
+			// the seq counter is NEVER range-scan migrated (the orchestrator promotes it
+			// out-of-band) — out-of-scope even for the owning DB
+			{"own seq counter (not migrated)", def.SyncSeqKey(), dispOutOfScope},
+
+			// bucket-level docs — never migrated, never per-DB
+			{"registry", base.SGRegistryKey, dispOutOfScope},
+			{"syncInfo", base.SGSyncInfo, dispOutOfScope},
+			{"dbconfig", base.PersistentConfigPrefixWithoutGroupID + "default", dispOutOfScope},
+			{"unowned sync-function doc", base.SyncFunctionKeyWithoutGroupID + "_collection1", dispOutOfScope},
+
+			// genuinely unrecognised `_sync:` key — must surface as unknown, not be swallowed
+			{"unknown prefix", "_sync:somethingnew:foo", dispUnknown},
+		})
+	})
+
+	// Direction 2 (the inverse) — a namespaced DB "db2" migrates while the legacy-default DB
+	// is the sibling. isOursInverted early-returns true after the prefix check here (the
+	// `m_<id>`/`<id>:` segment already uniquely identifies db2), so the sibling list is not
+	// even consulted: behaviour is identical with or without it. This proves the direction
+	// that already worked is left untouched.
+	t.Run("NamespacedDB_db2_with_default_sibling", func(t *testing.T) {
+		run(t, "db2", []string{base.DefaultMetadataID}, nil, []keyCase{
+			// inverted families — ours
+			{"own user", db2.UserKey("bob"), dispMigrated},
+			{"own role", db2.RoleKey("readers"), dispMigrated},
+			{"own useremail", db2.UserEmailKey("bob@example.com"), dispMigrated},
+			{"own session", db2.SessionKey("sessBob2"), dispMigrated},
+			{"own dcp_ck", db2.DCPCheckpointPrefix("default") + "1:42", dispMigrated},
+
+			// the default sibling's inverted keys — out-of-scope (inverted-default arms)
+			{"default-sibling user", def.UserKey("alice"), dispOutOfScope},
+			{"default-sibling dcp_ck", def.DCPCheckpointPrefix("default") + "1", dispOutOfScope},
+
+			// non-inverted owned — migrated
+			{"own unusedSeq (binary)", db2.UnusedSeqKey(5), dispMigrated},
+			{"own database state", db2.DatabaseStateKey(), dispMigrated},
+
+			// a DIFFERENT sibling's non-inverted key — out-of-scope
+			{"otherDB non-inverted key", base.NewMetadataKeys("otherDB").SGCfgPrefix(""), dispOutOfScope},
+
+			// own heartbeater (namespaced shape `_sync:m_db2:hb:…heartbeat_timeout:`) — deleted
+			{"own heartbeater", db2.HeartbeaterPrefix("") + "heartbeat_timeout:node1", dispDeleted},
+
+			// own seq counter — out-of-scope (not range-scan migrated)
+			{"own seq counter (not migrated)", db2.SyncSeqKey(), dispOutOfScope},
+		})
+	})
+
+	// Direction 1 with NO sibling list — documents the contract that the registry list is
+	// load-bearing. Without it the default DB cannot distinguish a co-located sibling's
+	// inverted key from one of its own, so it claims the sibling key as in-scope. This is
+	// exactly why ServerContext must wire SiblingMetadataIDFunc (exercised end-to-end in the
+	// rest integration tests). If a future change makes nil-siblings safe, this flips —
+	// intentional tripwire.
+	t.Run("DefaultDB_no_sibling_list_claims_everything", func(t *testing.T) {
+		run(t, base.DefaultMetadataID, nil, nil, []keyCase{
+			{"own user still migrates", def.UserKey("carol"), dispMigrated},
+			{"own dcp_ck still migrates", def.DCPCheckpointPrefix("default") + "9", dispMigrated},
+			// WITHOUT the sibling list this sibling key is claimed as ours — the bug the fix
+			// closes only when SiblingMetadataIDFunc supplies "db2".
+			{"sibling user claimed (no list)", db2.UserKey("dave"), dispMigrated},
+		})
+	})
+
+	// Sync-function docs are not metadataID-namespaced — ownership is an exact match against
+	// the per-DB key set, not a prefix/registry decision. Cover both sides here.
+	t.Run("SyncFunctionDocOwnership", func(t *testing.T) {
+		ownedSyncFnKey := base.SyncFunctionKeyWithoutGroupID + ":scope1.collection1"
+		run(t, base.DefaultMetadataID, []string{"db2"}, map[string]struct{}{ownedSyncFnKey: {}}, []keyCase{
+			{"owned sync-function doc", ownedSyncFnKey, dispMigrated},
+			{"unowned sync-function doc", base.SyncFunctionKeyWithoutGroupID + ":scope1.collection2", dispOutOfScope},
+		})
 	})
 }
 
@@ -541,7 +762,7 @@ func TestMigrateMetadataUnusedSeqMoves(t *testing.T) {
 	base.RequireDocsVisibleToRangeScan(t, ms.Fallback(), []string{singletonKey, rangeKey})
 
 	stats := &MigrationStats{}
-	remaining, err := MigrateMetadata(ctx, ms, metadataID, nil, stats)
+	remaining, err := MigrateMetadata(ctx, ms, metadataID, nil, nil, stats)
 	require.NoError(t, err)
 	assert.Equal(t, 0, remaining, "unused-seq docs must clear in a single pass")
 	assert.Equal(t, int64(2), stats.DocsMigrated.Load())
@@ -572,7 +793,7 @@ func TestMigrateMetadataLegacyDefaultUserWithMPrefixUsername(t *testing.T) {
 	seedFallback(ctx, t, ms, mUserKey, body)
 
 	stats := &MigrationStats{}
-	remaining, err := MigrateMetadata(ctx, ms, base.DefaultMetadataID, nil, stats)
+	remaining, err := MigrateMetadata(ctx, ms, base.DefaultMetadataID, nil, nil, stats)
 	require.NoError(t, err)
 	assert.Equal(t, 0, remaining)
 	assert.Equal(t, int64(1), stats.DocsMigrated.Load(), "m_alice user in default mode must be migrated, not skipped as a sibling-DB shape")
@@ -615,4 +836,198 @@ func TestSyncFunctionKeysForDB(t *testing.T) {
 	require.Len(t, withGroup, 2)
 	assert.Contains(t, withGroup, base.CollectionSyncFunctionKeyWithoutGroupID+":myScope.collA:group1")
 	assert.Contains(t, withGroup, base.CollectionSyncFunctionKeyWithoutGroupID+":myScope.collB:group1")
+}
+
+// requireSiblingExclusionScan seeds the own + sibling docs on the fallback, runs a full
+// MigrateMetadata pass for migratingID with the given sibling list, and asserts the whole-run
+// outcome: every own doc was promoted to primary byte-identically and removed from the
+// fallback, every sibling doc stayed put on the fallback (and never reached primary), the
+// run is clean (remaining/unknown/errors all zero), and the counters match the seed split.
+func requireSiblingExclusionScan(ctx context.Context, t *testing.T, ms *base.MetadataStore, migratingID string, siblings []string, own, sibling map[string][]byte) {
+	t.Helper()
+	allKeys := make([]string, 0, len(own)+len(sibling))
+	for k, v := range own {
+		_, err := ms.Fallback().AddRaw(ctx, k, 0, v)
+		require.NoError(t, err, "seed own %s", k)
+		allKeys = append(allKeys, k)
+	}
+	for k, v := range sibling {
+		_, err := ms.Fallback().AddRaw(ctx, k, 0, v)
+		require.NoError(t, err, "seed sibling %s", k)
+		allKeys = append(allKeys, k)
+	}
+	base.RequireDocsVisibleToRangeScan(t, ms.Fallback(), allKeys)
+
+	stats := &MigrationStats{}
+	remaining, err := MigrateMetadata(ctx, ms, migratingID, siblings, nil, stats)
+	require.NoError(t, err)
+	assert.Equal(t, 0, remaining, "no in-scope doc should be left unclassified")
+	assert.Equal(t, int64(len(own)), stats.DocsMigrated.Load(), "all own docs should migrate")
+	assert.Equal(t, int64(len(sibling)), stats.DocsOutOfScope.Load(), "all sibling docs should be out-of-scope")
+	assert.Zero(t, stats.DocsUnknownPrefix.Load(), "no doc should be unknown-prefix (would stall the run)")
+	assert.Zero(t, stats.Errors.Load(), "no per-doc move errors")
+
+	for k, want := range own {
+		got, _, getErr := ms.Primary().GetRaw(ctx, k)
+		require.NoError(t, getErr, "primary should hold own %s", k)
+		assert.Equal(t, want, got, "primary body for own %s must match the seed", k)
+		_, _, getErr = ms.Fallback().GetRaw(ctx, k)
+		assert.True(t, base.IsDocNotFoundError(getErr), "fallback shadow for own %s should be gone", k)
+	}
+	for k, want := range sibling {
+		got, _, getErr := ms.Fallback().GetRaw(ctx, k)
+		require.NoError(t, getErr, "fallback should still hold sibling %s", k)
+		assert.Equal(t, want, got, "sibling fallback body for %s must be unchanged", k)
+		_, _, getErr = ms.Primary().GetRaw(ctx, k)
+		assert.True(t, base.IsDocNotFoundError(getErr), "sibling %s must NOT be promoted to primary", k)
+	}
+}
+
+// TestMigrateMetadataDefaultDBExcludesNamespacedSibling is the full-scan counterpart to the
+// classification matrix for Direction 1: the default metadataID DB migrates while a namespaced
+// sibling "db2" shares the fallback collection. Every one of the default DB's own metadata
+// families (inverted and non-inverted) is promoted to primary, and every one of db2's
+// co-located docs is left untouched on the fallback.
+func TestMigrateMetadataDefaultDBExcludesNamespacedSibling(t *testing.T) {
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
+	ms := newMigrationTestStore(t, bucket)
+
+	def := base.NewMetadataKeys(base.DefaultMetadataID)
+	db2 := base.NewMetadataKeys("db2")
+
+	own := map[string][]byte{
+		def.UserKey("alice"):                  []byte(`{"name":"alice"}`),
+		def.RoleKey("admins"):                 []byte(`{"name":"admins"}`),
+		def.UserEmailKey("alice@example.com"): []byte(`{"username":"alice"}`),
+		def.SessionKey("sessAlice"):           []byte(`{"session_id":"sessAlice"}`),
+		def.DCPCheckpointPrefix("") + "1":     []byte(`{"seq":42}`),
+		def.UnusedSeqKey(5):                   []byte(`{"unused":5}`),
+		def.DatabaseStateKey():                []byte(`{"state":"Online"}`),
+	}
+	sibling := map[string][]byte{
+		db2.UserKey("bob"):                  []byte(`{"name":"bob"}`),
+		db2.RoleKey("readers"):              []byte(`{"name":"readers"}`),
+		db2.UserEmailKey("bob@example.com"): []byte(`{"username":"bob"}`),
+		db2.SessionKey("sessBob"):           []byte(`{"session_id":"sessBob"}`),
+		db2.DCPCheckpointPrefix("") + "1":   []byte(`{"seq":7}`),
+		db2.SyncSeqKey():                    []byte(`{"seq":100}`),
+		db2.DatabaseStateKey():              []byte(`{"state":"Online"}`),
+	}
+
+	requireSiblingExclusionScan(ctx, t, ms, base.DefaultMetadataID, []string{"db2"}, own, sibling)
+}
+
+// TestMigrateMetadataNamespacedDBExcludesDefaultSibling is the inverse direction: a namespaced
+// DB "db2" migrates while default metadataID DB (plus an unrelated namespaced sibling
+// "otherDB") share the fallback. db2's own keys migrate; the default DB's inverted, dcp_ck,
+// non-inverted and seq-counter docs all stay, as does otherDB's standard-form key.
+func TestMigrateMetadataNamespacedDBExcludesDefaultSibling(t *testing.T) {
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
+	ms := newMigrationTestStore(t, bucket)
+
+	def := base.NewMetadataKeys(base.DefaultMetadataID)
+	db2 := base.NewMetadataKeys("db2")
+
+	own := map[string][]byte{
+		db2.UserKey("bob"):                  []byte(`{"name":"bob"}`),
+		db2.RoleKey("readers"):              []byte(`{"name":"readers"}`),
+		db2.UserEmailKey("bob@example.com"): []byte(`{"username":"bob"}`),
+		db2.SessionKey("sessBob"):           []byte(`{"session_id":"sessBob"}`),
+		db2.DCPCheckpointPrefix("") + "1":   []byte(`{"seq":7}`),
+		db2.UnusedSeqKey(5):                 []byte(`{"unused":5}`),
+		db2.DatabaseStateKey():              []byte(`{"state":"Online"}`),
+	}
+	sibling := map[string][]byte{
+		def.UserKey("alice"):                         []byte(`{"name":"alice"}`),
+		def.DCPCheckpointPrefix("") + "1":            []byte(`{"seq":42}`),
+		def.DatabaseStateKey():                       []byte(`{"state":"Online"}`),
+		def.SyncSeqKey():                             []byte(`{"seq":100}`),
+		base.NewMetadataKeys("otherDB").SyncSeqKey(): []byte(`{"seq":5}`),
+	}
+
+	requireSiblingExclusionScan(ctx, t, ms, "db2", []string{base.DefaultMetadataID}, own, sibling)
+}
+
+// TestMigrateMetadataDefaultDBExcludesNamespacedSiblingWhenUserIsNamedSiblingMetadataID tests when you name a user
+// on default metadataID db the same as a metadataID from a different db, the user is not misclassified
+// as a sibling key and left on fallback.
+func TestMigrateMetadataDefaultDBExcludesNamespacedSiblingWhenUserIsNamedSiblingMetadataID(t *testing.T) {
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
+	ms := newMigrationTestStore(t, bucket)
+
+	def := base.NewMetadataKeys(base.DefaultMetadataID)
+	db2 := base.NewMetadataKeys("db2")
+
+	own := map[string][]byte{
+		def.UserKey("db2"): []byte(`{"name":"alice"}`),
+	}
+	sibling := map[string][]byte{
+		db2.UserKey("bob"): []byte(`{"name":"bob"}`),
+	}
+
+	requireSiblingExclusionScan(ctx, t, ms, base.DefaultMetadataID, []string{"db2"}, own, sibling)
+}
+
+// TestMigrateMetadataNamespacedDBExcludesDefaultSiblingWithUserNamedSiblingMetadataID is the inverse of the above test:
+// a migration happening in the other direction
+func TestMigrateMetadataNamespacedDBExcludesDefaultSiblingWithUserNamedSiblingMetadataID(t *testing.T) {
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
+	ms := newMigrationTestStore(t, bucket)
+
+	def := base.NewMetadataKeys(base.DefaultMetadataID)
+	db2 := base.NewMetadataKeys("db2")
+
+	own := map[string][]byte{
+		db2.UserKey("bob"): []byte(`{"name":"bob"}`),
+	}
+	sibling := map[string][]byte{
+		def.UserKey("db2"): []byte(`{"name":"alice"}`),
+	}
+
+	requireSiblingExclusionScan(ctx, t, ms, "db2", []string{base.DefaultMetadataID}, own, sibling)
+}
+
+// TestMigrateMetadataDcpCheckpointGroupIDCollisionKnownLimitation pins the one documented
+// residual ambiguity of the registry-id approach. The default DB's own DCP checkpoint embeds
+// its config group ID as the first body segment (`_sync:dcp_ck:<groupID>:<ver>:<vb>`), and the
+// classifier excludes a key when that first segment matches a sibling metadataID. So a sibling
+// DB whose metadataID is literally equal to the default DB's DCP group ID ("default") makes the
+// default DB's own checkpoint look like that sibling's — and it is stranded on the fallback.
+//
+// This is a KNOWN, accepted limitation: calling a sibling db the same name as a groupID the default
+// metadataID db is using collides. The effect of this means the default DB's checkpoint is not migrated,
+// but we should self-heal by writing new checkpoints to the new primary.
+func TestMigrateMetadataDcpCheckpointGroupIDCollisionKnownLimitation(t *testing.T) {
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
+	ms := newMigrationTestStore(t, bucket)
+
+	def := base.NewMetadataKeys(base.DefaultMetadataID)
+	ownCheckpoint := def.DCPCheckpointPrefix("default") + "1" // _sync:dcp_ck:default:1
+	seedFallback(ctx, t, ms, ownCheckpoint, []byte(`{"seq":42}`))
+
+	stats := &MigrationStats{}
+	// Pathological sibling whose metadataID == this default DB's DCP group ID ("default").
+	remaining, err := MigrateMetadata(ctx, ms, base.DefaultMetadataID, []string{"default"}, nil, stats)
+	require.NoError(t, err)
+	assert.Equal(t, 0, remaining, "out-of-scope docs do not count as remaining, so the run still 'completes'")
+
+	// KNOWN LIMITATION: the default DB's own checkpoint is misclassified as the sibling's and
+	// left on the fallback rather than migrated.
+	assert.Zero(t, stats.DocsMigrated.Load(), "known limitation: own checkpoint is NOT migrated under the group-id/sibling-id collision")
+	assert.Equal(t, int64(1), stats.DocsOutOfScope.Load(), "own checkpoint is (mis)classified out-of-scope")
+
+	_, _, getErr := ms.Fallback().GetRaw(ctx, ownCheckpoint)
+	assert.NoError(t, getErr, "own checkpoint is stranded on the fallback under the known limitation")
+	_, _, getErr = ms.Primary().GetRaw(ctx, ownCheckpoint)
+	assert.True(t, base.IsDocNotFoundError(getErr), "own checkpoint did not reach primary")
 }

--- a/db/metadata_migration_test.go
+++ b/db/metadata_migration_test.go
@@ -484,15 +484,13 @@ func TestHandleMigrationKeyScoping(t *testing.T) {
 	})
 
 	// LegacySiblingInvertedFormOutOfScope pins the sibling-side of the corner-case fix:
-	// when the local DB is in legacy default mode, a co-located sibling's inverted-form
+	// when the local DB has default metadataID, a co-located sibling's inverted-form
 	// keys must be classified out-of-scope. The classifier recognises them by matching
 	// the segment after the inverted prefix against the authoritative sibling-metadataID
 	// list from the registry (`<siblingID>:`) — there is no `m_` in inverted keys
-	// (`formatInvertedMetadataKey` omits it; see base/constants_syncdocs_test.go:75), so a
-	// real sibling "otherDB" produces `_sync:user:otherDB:alice`. Without the sibling list
-	// the default DB cannot tell these from its own keys, so the list must be supplied.
-	// The ours-side counterpart — a legacy default user literally named `m_alice` — is
-	// covered end-to-end by TestMigrateMetadataLegacyDefaultUserWithMPrefixUsername below.
+	// (`formatInvertedMetadataKey` omits it, so a real sibling "otherDB" produces
+	// `_sync:user:otherDB:alice`. Without the sibling list the default DB cannot tell these from its own
+	// keys, so the list must be supplied.
 	t.Run("LegacySiblingInvertedFormOutOfScope", func(t *testing.T) {
 		for _, k := range []string{
 			"_sync:user:otherDB:alice",
@@ -524,17 +522,13 @@ const (
 )
 
 // TestHandleMigrationKeyClassification is the exhaustive per-key routing matrix for
-// handleMigrationKey: every switch arm, for the legacy-default migrating DB (with and
-// without a sibling) and for a namespaced migrating DB (the inverse direction). It is the
-// unit-level guard for the sibling-DB misclassification fix — it asserts which collection
+// handleMigrationKey: every switch arm, for the default metaID migrating DB (with and
+// without a sibling) and for a namespaced migrating DB (the inverse direction). It asserts which collection
 // each key family is routed to, not the byte-fidelity of the move (datatype/TTL/body
 // equality live in the MigrateMetadata full-scan tests).
 //
 // Keys are built through the real base.MetadataKeys formatters rather than hardcoded, so a
-// future change to a key shape is reflected here automatically. The crux of the fix is the
-// inverted families (user/role/useremail/session/dcp_ck): for the default DB their prefix
-// is also a prefix of every sibling's inverted key, so the classifier must consult the
-// authoritative sibling-metadataID list to tell ours from theirs.
+// future change to a key shape is reflected here automatically.
 func TestHandleMigrationKeyClassification(t *testing.T) {
 	ctx := base.TestCtx(t)
 	bucket := base.GetTestBucket(t)
@@ -609,9 +603,8 @@ func TestHandleMigrationKeyClassification(t *testing.T) {
 	db2 := base.NewMetadataKeys("db2")
 
 	// Direction 1 — the legacy-default DB migrates while a namespaced sibling "db2" shares
-	// the bucket. This is the direction the bug manifested in: the default DB's bare inverted
-	// prefixes overlap every sibling's inverted key, so without the sibling list the default
-	// DB would steal db2's user/role/useremail/session/dcp_ck docs.
+	// the bucket. The default DB's bare inverted prefixes overlap every sibling's inverted key,
+	// so without the sibling list the default DB would steal db2's user/role/useremail/session/dcp_ck docs.
 	t.Run("DefaultDB_with_namespaced_sibling_db2", func(t *testing.T) {
 		run(t, base.DefaultMetadataID, []string{"db2"}, nil, []keyCase{
 			// inverted families — ours (no sibling-id segment after the prefix)
@@ -619,7 +612,7 @@ func TestHandleMigrationKeyClassification(t *testing.T) {
 			{"own role", def.RoleKey("admins"), dispMigrated},
 			{"own useremail", def.UserEmailKey("alice@example.com"), dispMigrated},
 			{"own session", def.SessionKey("sessAlice"), dispMigrated},
-			// own dcp_ck: group id "default" + version + vbno — colons in the body, but the
+			// own dcp_ck: group id "default" + vbno — colons in the body, but the
 			// first segment ("default") is not the sibling id "db2", so it stays ours. This is
 			// the case the naive "any colon ⇒ sibling" heuristic could not handle.
 			{"own dcp_ck (group default)", def.DCPCheckpointPrefix("default") + "1", dispMigrated},
@@ -674,7 +667,7 @@ func TestHandleMigrationKeyClassification(t *testing.T) {
 			{"own role", db2.RoleKey("readers"), dispMigrated},
 			{"own useremail", db2.UserEmailKey("bob@example.com"), dispMigrated},
 			{"own session", db2.SessionKey("sessBob2"), dispMigrated},
-			{"own dcp_ck", db2.DCPCheckpointPrefix("default") + "1:42", dispMigrated},
+			{"own dcp_ck", db2.DCPCheckpointPrefix("default") + "1", dispMigrated},
 
 			// the default sibling's inverted keys — out-of-scope (inverted-default arms)
 			{"default-sibling user", def.UserKey("alice"), dispOutOfScope},
@@ -692,22 +685,6 @@ func TestHandleMigrationKeyClassification(t *testing.T) {
 
 			// own seq counter — out-of-scope (not range-scan migrated)
 			{"own seq counter (not migrated)", db2.SyncSeqKey(), dispOutOfScope},
-		})
-	})
-
-	// Direction 1 with NO sibling list — documents the contract that the registry list is
-	// load-bearing. Without it the default DB cannot distinguish a co-located sibling's
-	// inverted key from one of its own, so it claims the sibling key as in-scope. This is
-	// exactly why ServerContext must wire SiblingMetadataIDFunc (exercised end-to-end in the
-	// rest integration tests). If a future change makes nil-siblings safe, this flips —
-	// intentional tripwire.
-	t.Run("DefaultDB_no_sibling_list_claims_everything", func(t *testing.T) {
-		run(t, base.DefaultMetadataID, nil, nil, []keyCase{
-			{"own user still migrates", def.UserKey("carol"), dispMigrated},
-			{"own dcp_ck still migrates", def.DCPCheckpointPrefix("default") + "9", dispMigrated},
-			// WITHOUT the sibling list this sibling key is claimed as ours — the bug the fix
-			// closes only when SiblingMetadataIDFunc supplies "db2".
-			{"sibling user claimed (no list)", db2.UserKey("dave"), dispMigrated},
 		})
 	})
 

--- a/rest/metadatamigrationtest/metadata_migration_test.go
+++ b/rest/metadatamigrationtest/metadata_migration_test.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -538,6 +539,156 @@ func TestMetadataMigrationLegacyDefaultDBSiblingClassifiedOutOfScope(t *testing.
 	assert.NotContains(t, finalBody, `"status":"error"`,
 		"dbnamed's migration should not error — its own keys migrate and the sibling DB's "+
 			"out-of-scope keys are skipped. Final payload: %s", finalBody)
+}
+
+// TestMetadataMigrationConcurrentDefaultAndNamedDB migrates two databases that share one bucket -
+// a legacy default-metadataID DB on _default._default (unprefixed keys, e.g. `_sync:user:alice`)
+// and a namespaced DB on a named collection (m_<id>:-prefixed keys, e.g. `_sync:user:m_<id>:bob`) -
+// at the same time, each triggered through its own POST /{db}/_metadata_migration?action=start in
+// its own goroutine.
+//
+// Both migrations scan and drain the shared _default._default fallback concurrently.
+func TestMetadataMigrationConcurrentDefaultAndNamedDB(t *testing.T) {
+	base.TestRequiresCollections(t)
+
+	ctx := base.TestCtx(t)
+	tb := base.GetTestBucket(t)
+	defer tb.Close(ctx)
+
+	const namedCollection = "sg_test_0"
+	require.NoError(t, tb.CreateDataStore(ctx, base.ScopeAndCollectionName{Scope: base.DefaultScope, Collection: namedCollection}))
+	defer func() {
+		assert.NoError(t, tb.DropDataStore(ctx, base.ScopeAndCollectionName{Scope: base.DefaultScope, Collection: namedCollection}))
+	}()
+
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		CustomTestBucket: tb.NoCloseClone(),
+		PersistentConfig: true,
+	})
+	defer rt.Close()
+
+	// dbdefault: → metadataID="_default"
+	const dbDefaultName = "dbdefault"
+	dbDefaultCfg := rt.NewDbConfig()
+	dbDefaultCfg.UseSystemMobileMetadataCollection = base.Ptr(false)
+	dbDefaultCfg.Scopes = rest.ScopesConfig{
+		base.DefaultScope: rest.ScopeConfig{
+			Collections: rest.CollectionsConfig{base.DefaultCollection: {}},
+		},
+	}
+	rest.RequireStatus(t, rt.CreateDatabase(dbDefaultName, dbDefaultCfg), http.StatusCreated)
+	rest.RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/"+dbDefaultName+"/_user/alice",
+		`{"name":"alice","password":"letmein","admin_channels":["public"]}`), http.StatusCreated)
+	rest.RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/"+dbDefaultName+"/_role/admins",
+		`{"name":"admins","admin_channels":["public"]}`), http.StatusCreated)
+
+	// dbnamed: → namespaced metadataID
+	const dbNamedName = "dbnamed"
+	dbNamedCfg := rt.NewDbConfig()
+	dbNamedCfg.UseSystemMobileMetadataCollection = base.Ptr(false)
+	dbNamedCfg.Scopes = rest.ScopesConfig{
+		base.DefaultScope: rest.ScopeConfig{
+			Collections: rest.CollectionsConfig{namedCollection: {}},
+		},
+	}
+	rest.RequireStatus(t, rt.CreateDatabase(dbNamedName, dbNamedCfg), http.StatusCreated)
+	rest.RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/"+dbNamedName+"/_user/bob",
+		`{"name":"bob","password":"letmein","admin_channels":["public"]}`), http.StatusCreated)
+	rest.RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/"+dbNamedName+"/_role/readers",
+		`{"name":"readers","admin_channels":["public"]}`), http.StatusCreated)
+
+	// Confirm the topology matches the premise: distinct metadataIDs, the default one for dbdefault.
+	dbDefaultCtx, err := rt.ServerContext().GetDatabase(ctx, dbDefaultName)
+	require.NoError(t, err)
+	require.Equal(t, base.DefaultMetadataID, dbDefaultCtx.Options.MetadataID, "dbdefault must use the legacy default metadataID")
+	dbNamedCtx, err := rt.ServerContext().GetDatabase(ctx, dbNamedName)
+	require.NoError(t, err)
+	require.NotEqual(t, base.DefaultMetadataID, dbNamedCtx.Options.MetadataID, "dbnamed must have a non-default metadataID")
+	require.NotEmpty(t, dbNamedCtx.Options.MetadataID)
+
+	defaultDocKeys := []string{
+		base.DefaultMetadataKeys.UserKey("alice"),
+		base.DefaultMetadataKeys.RoleKey("admins"),
+	}
+	namedDocKeys := []string{
+		dbNamedCtx.MetadataKeys.UserKey("bob"),
+		dbNamedCtx.MetadataKeys.RoleKey("readers"),
+	}
+	allDocKeys := append(append([]string{}, defaultDocKeys...), namedDocKeys...)
+
+	fallback := tb.Bucket.DefaultDataStore(ctx)
+	for _, k := range allDocKeys {
+		exists, existsErr := fallback.Exists(ctx, k)
+		require.NoError(t, existsErr)
+		require.Truef(t, exists, "%q must exist in _default._default before migration", k)
+	}
+	base.RequireDocsVisibleToRangeScan(t, fallback, allDocKeys)
+
+	// Flip both DBs' opt-in
+	dbDefaultCfg.UseSystemMobileMetadataCollection = base.Ptr(true)
+	rest.RequireStatus(t, rt.UpsertDbConfig(dbDefaultName, dbDefaultCfg), http.StatusCreated)
+	dbNamedCfg.UseSystemMobileMetadataCollection = base.Ptr(true)
+	rest.RequireStatus(t, rt.UpsertDbConfig(dbNamedName, dbNamedCfg), http.StatusCreated)
+
+	// Flush this node's applied config versions so the manual starts pass the config-fully-applied gate.
+	rt.ServerContext().ForceClusterCompatRefresh(t, rt.Context())
+
+	// Kick both migrations off at the same time, each via its own admin endpoint POST in its own
+	// goroutine
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		resp := rt.SendAdminRequest(http.MethodPost, "/"+dbDefaultName+"/_metadata_migration?action=start", "")
+		rest.RequireStatus(t, resp, http.StatusOK)
+	}()
+	go func() {
+		defer wg.Done()
+		resp := rt.SendAdminRequest(http.MethodPost, "/"+dbNamedName+"/_metadata_migration?action=start", "")
+		rest.RequireStatus(t, resp, http.StatusOK)
+	}()
+	wg.Wait()
+
+	// Both per-DB managers must reach completed
+	defaultResp := rt.WaitForMetadataMigrationStatusForDB(db.BackgroundProcessStateCompleted, dbDefaultName)
+	namedResp := rt.WaitForMetadataMigrationStatusForDB(db.BackgroundProcessStateCompleted, dbNamedName)
+
+	assert.Zero(t, defaultResp.DocsFailed, "dbdefault migration must have no per-doc failures")
+	assert.Zero(t, namedResp.DocsFailed, "dbnamed migration must have no per-doc failures")
+	// Each DB migrates only its own principals (user + role) + other metadata documents; the other's are out-of-scope.
+	assert.GreaterOrEqual(t, defaultResp.DocsProcessed, int64(len(defaultDocKeys)), "dbdefault should migrate its own principals")
+	assert.GreaterOrEqual(t, namedResp.DocsProcessed, int64(len(namedDocKeys)), "dbnamed should migrate its own principals")
+
+	// Every principal moved to _system._mobile and left _default._default, regardless of owner.
+	systemDS, err := rt.Bucket().NamedDataStore(ctx, base.MobileSystemScopeAndCollectionName())
+	require.NoError(t, err)
+	for _, k := range allDocKeys {
+		onPrimary, existsErr := systemDS.Exists(ctx, k)
+		require.NoError(t, existsErr)
+		assert.Truef(t, onPrimary, "%q must be migrated to _system._mobile", k)
+		onFallback, existsErr := fallback.Exists(ctx, k)
+		require.NoError(t, existsErr)
+		assert.Falsef(t, onFallback, "%q must be removed from _default._default after migration", k)
+	}
+
+	// Both DBs' principals remain functional through their own admin APIs
+	rest.RequireStatus(t, rt.SendAdminRequest(http.MethodGet, "/"+dbDefaultName+"/_user/alice", ""), http.StatusOK)
+	rest.RequireStatus(t, rt.SendAdminRequest(http.MethodGet, "/"+dbNamedName+"/_user/bob", ""), http.StatusOK)
+
+	// check the bucket level doc for migration, assert that both db's are in completed state and bootstrap migration is done.
+	conn := rt.ServerContext().BootstrapContext.Connection
+	bucketName := rt.Bucket().GetName()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		status, _, statusErr := conn.GetMetadataMigrationStatus(ctx, bucketName)
+		require.NoError(c, statusErr)
+		require.NotNil(c, status)
+		for _, id := range []string{base.DefaultMetadataID, dbNamedCtx.Options.MetadataID} {
+			entry, ok := status.Databases[id]
+			require.Truef(c, ok, "status doc must have a per-DB entry for %q", id)
+			assert.Equalf(c, base.MigrationStateComplete, entry.State, "per-DB migration entry for %q should be complete", id)
+		}
+		assert.Equal(c, base.MigrationStateComplete, status.Bootstrap.State, "bucket bootstrap migration should be complete once both DBs finish")
+	}, 30*time.Second, 200*time.Millisecond)
 }
 
 // TestMetadataMigrationMovesOwnedSyncFunctionDocs verifies that a per-DB migration moves only

--- a/rest/metadatamigrationtest/metadata_migration_test.go
+++ b/rest/metadatamigrationtest/metadata_migration_test.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package metadatamigrationtest
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -1078,4 +1079,309 @@ func TestMetadataMigrationRESTStartRejectedBeforeConfigApplied(t *testing.T) {
 	// Manual REST start now succeeds.
 	resp = rtA.SendAdminRequest(http.MethodPost, "/db/_metadata_migration?action=start", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
+}
+
+// siblingMigrationKeys are the on-disk metadata keys produced by one database's principals,
+// used to assert post-migration placement (which collection each key ends up in).
+type siblingMigrationKeys struct {
+	user      string
+	userEmail string
+	role      string
+	session   string
+	dcpCk     string // versioned import checkpoint: DCPVersionedCheckpointPrefix(group, version)
+	dcpCkBg   string // non-versioned checkpoint as background processes write: DCPCheckpointPrefix(group)
+}
+
+func (k siblingMigrationKeys) all() []string {
+	return []string{k.user, k.userEmail, k.role, k.session, k.dcpCk, k.dcpCkBg}
+}
+
+// seedSiblingDBMetadata creates a user (with an email), a role and a session for dbName, then
+// seeds a DCP checkpoint doc on the fallback. It returns the resulting on-disk metadata keys,
+// built from the database's OWN MetadataKeys so they are correct for both the default
+// (unprefixed) and namespaced (`<id>:`) families. Together these cover all five inverted
+// families the sibling-exclusion fix scopes (user / useremail / role / session / dcp_ck).
+//
+// The DCP checkpoint is seeded directly rather than driven by a live import feed: real feed
+// checkpoint persistence is threshold/close-gated (see rest/importtest) and not deterministic
+// while the DB stays up for migration.
+func seedSiblingDBMetadata(t *testing.T, rt *rest.RestTester, fallback sgbucket.DataStore, dbName, user, role, email string) siblingMigrationKeys {
+	t.Helper()
+	ctx := rt.Context()
+
+	resp := rt.SendAdminRequest(http.MethodPut, "/"+dbName+"/_user/"+user,
+		fmt.Sprintf(`{"name":%q,"password":"letmein","email":%q,"admin_channels":["public"]}`, user, email))
+	rest.RequireStatus(t, resp, http.StatusCreated)
+
+	resp = rt.SendAdminRequest(http.MethodPut, "/"+dbName+"/_role/"+role,
+		fmt.Sprintf(`{"name":%q,"admin_channels":["public"]}`, role))
+	rest.RequireStatus(t, resp, http.StatusCreated)
+
+	resp = rt.SendAdminRequest(http.MethodPost, "/"+dbName+"/_session",
+		fmt.Sprintf(`{"name":%q,"ttl":86400}`, user))
+	rest.RequireStatus(t, resp, http.StatusOK)
+	var sess struct {
+		SessionID string `json:"session_id"`
+	}
+	require.NoError(t, base.JSONUnmarshal(resp.BodyBytes(), &sess))
+	require.NotEmpty(t, sess.SessionID, "admin session create must return a session_id")
+
+	dbCtx, err := rt.ServerContext().GetDatabase(ctx, dbName)
+	require.NoError(t, err)
+	keys := dbCtx.MetadataKeys
+
+	// Versioned import checkpoint (`_sync:dcp_ck:<group>:<version>:<vbno>`) — the import feed's shape.
+	checkpointKey := fmt.Sprintf("%s%d", keys.DCPVersionedCheckpointPrefix(dbCtx.Options.GroupID, dbCtx.Options.ImportVersion), 42)
+	_, err = fallback.AddRaw(ctx, checkpointKey, 0, []byte(`{"vbno":42}`))
+	require.NoError(t, err, "seed versioned dcp_ck %s", checkpointKey)
+
+	// Non-versioned checkpoint as background DCP processes (attachment compaction/migration,
+	// resync) write them: DCPCheckpointPrefix(group) with a process suffix, no version segment.
+	bgCheckpointKey := keys.DCPCheckpointPrefix(dbCtx.Options.GroupID) + ":sg:att_compaction:testcompact:mark:42"
+	_, err = fallback.AddRaw(ctx, bgCheckpointKey, 0, []byte(`{"vbno":42}`))
+	require.NoError(t, err, "seed background dcp_ck %s", bgCheckpointKey)
+
+	return siblingMigrationKeys{
+		user:      keys.UserKey(user),
+		userEmail: keys.UserEmailKey(email),
+		role:      keys.RoleKey(role),
+		session:   keys.SessionKey(sess.SessionID),
+		dcpCk:     checkpointKey,
+		dcpCkBg:   bgCheckpointKey,
+	}
+}
+
+func requireAllExist(t *testing.T, ctx context.Context, store sgbucket.DataStore, keys []string) {
+	t.Helper()
+	for _, key := range keys {
+		exists, err := store.Exists(ctx, key)
+		require.NoError(t, err, "checking %q in %s", key, store.GetName())
+		assert.True(t, exists, "expected key %q to exist in %s", key, store.GetName())
+	}
+}
+
+func requireNoneExist(t *testing.T, ctx context.Context, store sgbucket.DataStore, keys []string) {
+	t.Helper()
+	for _, key := range keys {
+		exists, err := store.Exists(ctx, key)
+		require.NoError(t, err, "checking %q in %s", key, store.GetName())
+		assert.False(t, exists, "key %q must NOT exist in %s", key, store.GetName())
+	}
+}
+
+// TestMetadataMigrationDefaultDBFirstThenNamedSiblingExclusion is the end-to-end guard for the
+// sibling-misclassification when a default metadataID DB and a namespaced sibling share one bucket,
+// and the DEFAULT DB migrates FIRST. With the registry-driven sibling list it must
+// migrate only its own docs and leave the sibling's on _default._default — verified online
+// through the admin API and the raw collections. Then the named DB migrates second and claims
+// its own, with the default DB's docs left untouched.
+func TestMetadataMigrationDefaultDBFirstThenNamedSiblingExclusion(t *testing.T) {
+	base.TestRequiresCollections(t)
+
+	ctx := base.TestCtx(t)
+	tb := base.GetTestBucket(t)
+	defer tb.Close(ctx)
+
+	const namedCollection = "sg_test_0"
+	require.NoError(t, tb.CreateDataStore(ctx, base.ScopeAndCollectionName{Scope: base.DefaultScope, Collection: namedCollection}))
+	defer func() {
+		assert.NoError(t, tb.DropDataStore(ctx, base.ScopeAndCollectionName{Scope: base.DefaultScope, Collection: namedCollection}))
+	}()
+
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		CustomTestBucket: tb.NoCloseClone(),
+		PersistentConfig: true,
+	})
+	defer rt.Close()
+
+	defaultDS := rt.Bucket().DefaultDataStore(ctx)
+	systemDS, err := rt.Bucket().NamedDataStore(ctx, base.MobileSystemScopeAndCollectionName())
+	require.NoError(t, err)
+
+	// dbdefault: only _default._default → metadataID "_default", unprefixed keys.
+	const dbDefaultName = "dbdefault"
+	dbDefaultCfg := rt.NewDbConfig()
+	dbDefaultCfg.UseSystemMobileMetadataCollection = base.Ptr(false)
+	dbDefaultCfg.Scopes = rest.ScopesConfig{
+		base.DefaultScope: rest.ScopeConfig{
+			Collections: rest.CollectionsConfig{base.DefaultCollection: {}},
+		},
+	}
+	rest.RequireStatus(t, rt.CreateDatabase(dbDefaultName, dbDefaultCfg), http.StatusCreated)
+
+	// dbnamed: only _default.sg_test_0 → namespaced metadataID. Legacy mode so its metadata
+	// colocates in _default._default alongside dbdefault's, reproducing the pre-migration state.
+	const dbNamedName = "dbnamed"
+	dbNamedCfg := rt.NewDbConfig()
+	dbNamedCfg.UseSystemMobileMetadataCollection = base.Ptr(false)
+	dbNamedCfg.Scopes = rest.ScopesConfig{
+		base.DefaultScope: rest.ScopeConfig{
+			Collections: rest.CollectionsConfig{namedCollection: {}},
+		},
+	}
+	rest.RequireStatus(t, rt.CreateDatabase(dbNamedName, dbNamedCfg), http.StatusCreated)
+
+	defaultKeys := seedSiblingDBMetadata(t, rt, defaultDS, dbDefaultName, "alice", "defaultadmins", "alice@example.com")
+	namedKeys := seedSiblingDBMetadata(t, rt, defaultDS, dbNamedName, "bob", "namedadmins", "bob@example.com")
+
+	// Sanity-check the topology the scenario depends on.
+	dbDefaultCtx, err := rt.ServerContext().GetDatabase(ctx, dbDefaultName)
+	require.NoError(t, err)
+	require.Equal(t, base.DefaultMetadataID, dbDefaultCtx.Options.MetadataID, "dbdefault must use the legacy default metadataID")
+	dbNamedCtx, err := rt.ServerContext().GetDatabase(ctx, dbNamedName)
+	require.NoError(t, err)
+	require.Equal(t, dbNamedName, dbNamedCtx.Options.MetadataID, "dbnamed must have a namespaced metadataID")
+
+	// Precondition: every key for both DBs starts on the shared fallback, none on _system._mobile.
+	requireAllExist(t, ctx, defaultDS, append(defaultKeys.all(), namedKeys.all()...))
+	requireNoneExist(t, ctx, systemDS, append(defaultKeys.all(), namedKeys.all()...))
+
+	// === migrate dbdefault FIRST ===
+	dbDefaultCfg.UseSystemMobileMetadataCollection = base.Ptr(true)
+	rest.RequireStatus(t, rt.UpsertDbConfig(dbDefaultName, dbDefaultCfg), http.StatusCreated)
+	rt.ServerContext().ForceClusterCompatRefresh(t, rt.Context())
+	resp := rt.SendAdminRequest(http.MethodPost, "/"+dbDefaultName+"/_metadata_migration?action=start", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	status := rt.WaitForMetadataMigrationStatusForDB(db.BackgroundProcessStateCompleted, dbDefaultName)
+	assert.Zero(t, status.DocsFailed, "dbdefault migration must not fail any docs")
+	assert.GreaterOrEqual(t, status.DocsOutOfScope, int64(len(namedKeys.all())),
+		"dbnamed's colocated docs must be classified out-of-scope (not migrated, not unknown-prefix)")
+
+	// dbdefault's own docs migrated to _system._mobile, gone from the fallback, readable online.
+	requireAllExist(t, ctx, systemDS, defaultKeys.all())
+	requireNoneExist(t, ctx, defaultDS, defaultKeys.all())
+	resp = rt.SendAdminRequest(http.MethodGet, "/"+dbDefaultName+"/_user/alice", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	assert.Contains(t, resp.Body.String(), `"name":"alice"`, "dbdefault's user must remain readable after its own migration")
+
+	// dbnamed's docs are untouched on the fallback, never reached _system._mobile,
+	// and remain readable through dbnamed's own admin API.
+	requireAllExist(t, ctx, defaultDS, namedKeys.all())
+	requireNoneExist(t, ctx, systemDS, namedKeys.all())
+	resp = rt.SendAdminRequest(http.MethodGet, "/"+dbNamedName+"/_user/bob", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	assert.Contains(t, resp.Body.String(), `"name":"bob"`, "dbnamed's user must be untouched by dbdefault's migration")
+
+	// === migrate dbnamed SECOND ===
+	dbNamedCfg.UseSystemMobileMetadataCollection = base.Ptr(true)
+	rest.RequireStatus(t, rt.UpsertDbConfig(dbNamedName, dbNamedCfg), http.StatusCreated)
+	rt.ServerContext().ForceClusterCompatRefresh(t, rt.Context())
+	resp = rt.SendAdminRequest(http.MethodPost, "/"+dbNamedName+"/_metadata_migration?action=start", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	status = rt.WaitForMetadataMigrationStatusForDB(db.BackgroundProcessStateCompleted, dbNamedName)
+	assert.Zero(t, status.DocsFailed, "dbnamed migration must not fail any docs")
+
+	// dbnamed's docs now migrated; dbdefault's docs remain on _system._mobile, untouched.
+	requireAllExist(t, ctx, systemDS, namedKeys.all())
+	requireNoneExist(t, ctx, defaultDS, namedKeys.all())
+	requireAllExist(t, ctx, systemDS, defaultKeys.all())
+	resp = rt.SendAdminRequest(http.MethodGet, "/"+dbNamedName+"/_user/bob", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	assert.Contains(t, resp.Body.String(), `"name":"bob"`)
+}
+
+// TestMetadataMigrationNamedDBFirstThenDefaultSiblingExclusion is the inverse migration order of
+// TestMetadataMigrationDefaultDBFirstThenNamedSiblingExclusion: the NAMESPACED DB migrates FIRST
+// and the default metadataID DB second. It proves order-independence and, critically, that the
+// second migration does not disturb the first DB's already-migrated metadata:
+//   - when dbnamed migrates first, it claims only its own docs and leaves dbdefault's on the
+//     fallback (the namespaced direction never consulted the sibling list, but its docs must
+//     still be not migrated);
+//   - when dbdefault migrates second, its own (now-only) fallback docs move to _system._mobile,
+//     and dbnamed's docs already sitting in _system._mobile are left untouched.
+func TestMetadataMigrationNamedDBFirstThenDefaultSiblingExclusion(t *testing.T) {
+	base.TestRequiresCollections(t)
+
+	ctx := base.TestCtx(t)
+	tb := base.GetTestBucket(t)
+	defer tb.Close(ctx)
+
+	const namedCollection = "sg_test_0"
+	require.NoError(t, tb.CreateDataStore(ctx, base.ScopeAndCollectionName{Scope: base.DefaultScope, Collection: namedCollection}))
+	defer func() {
+		assert.NoError(t, tb.DropDataStore(ctx, base.ScopeAndCollectionName{Scope: base.DefaultScope, Collection: namedCollection}))
+	}()
+
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		CustomTestBucket: tb.NoCloseClone(),
+		PersistentConfig: true,
+	})
+	defer rt.Close()
+
+	defaultDS := rt.Bucket().DefaultDataStore(ctx)
+	systemDS, err := rt.Bucket().NamedDataStore(ctx, base.MobileSystemScopeAndCollectionName())
+	require.NoError(t, err)
+
+	const dbDefaultName = "dbdefault"
+	dbDefaultCfg := rt.NewDbConfig()
+	dbDefaultCfg.UseSystemMobileMetadataCollection = base.Ptr(false)
+	dbDefaultCfg.Scopes = rest.ScopesConfig{
+		base.DefaultScope: rest.ScopeConfig{
+			Collections: rest.CollectionsConfig{base.DefaultCollection: {}},
+		},
+	}
+	rest.RequireStatus(t, rt.CreateDatabase(dbDefaultName, dbDefaultCfg), http.StatusCreated)
+
+	const dbNamedName = "dbnamed"
+	dbNamedCfg := rt.NewDbConfig()
+	dbNamedCfg.UseSystemMobileMetadataCollection = base.Ptr(false)
+	dbNamedCfg.Scopes = rest.ScopesConfig{
+		base.DefaultScope: rest.ScopeConfig{
+			Collections: rest.CollectionsConfig{namedCollection: {}},
+		},
+	}
+	rest.RequireStatus(t, rt.CreateDatabase(dbNamedName, dbNamedCfg), http.StatusCreated)
+
+	defaultKeys := seedSiblingDBMetadata(t, rt, defaultDS, dbDefaultName, "alice", "defaultadmins", "alice@example.com")
+	namedKeys := seedSiblingDBMetadata(t, rt, defaultDS, dbNamedName, "bob", "namedadmins", "bob@example.com")
+
+	dbDefaultCtx, err := rt.ServerContext().GetDatabase(ctx, dbDefaultName)
+	require.NoError(t, err)
+	require.Equal(t, base.DefaultMetadataID, dbDefaultCtx.Options.MetadataID, "dbdefault must use the legacy default metadataID")
+	dbNamedCtx, err := rt.ServerContext().GetDatabase(ctx, dbNamedName)
+	require.NoError(t, err)
+	require.Equal(t, dbNamedName, dbNamedCtx.Options.MetadataID, "dbnamed must have a namespaced metadataID")
+
+	requireAllExist(t, ctx, defaultDS, append(defaultKeys.all(), namedKeys.all()...))
+	requireNoneExist(t, ctx, systemDS, append(defaultKeys.all(), namedKeys.all()...))
+
+	// === migrate dbnamed FIRST ===
+	dbNamedCfg.UseSystemMobileMetadataCollection = base.Ptr(true)
+	rest.RequireStatus(t, rt.UpsertDbConfig(dbNamedName, dbNamedCfg), http.StatusCreated)
+	rt.ServerContext().ForceClusterCompatRefresh(t, rt.Context())
+	resp := rt.SendAdminRequest(http.MethodPost, "/"+dbNamedName+"/_metadata_migration?action=start", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	status := rt.WaitForMetadataMigrationStatusForDB(db.BackgroundProcessStateCompleted, dbNamedName)
+	assert.Zero(t, status.DocsFailed, "dbnamed migration must not fail any docs")
+	assert.GreaterOrEqual(t, status.DocsOutOfScope, int64(len(defaultKeys.all())),
+		"dbdefault's colocated docs must be classified out-of-scope during dbnamed's migration")
+
+	// dbnamed's own docs migrated; dbdefault's untouched on the fallback and readable.
+	requireAllExist(t, ctx, systemDS, namedKeys.all())
+	requireNoneExist(t, ctx, defaultDS, namedKeys.all())
+	requireAllExist(t, ctx, defaultDS, defaultKeys.all())
+	requireNoneExist(t, ctx, systemDS, defaultKeys.all())
+	resp = rt.SendAdminRequest(http.MethodGet, "/"+dbDefaultName+"/_user/alice", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	assert.Contains(t, resp.Body.String(), `"name":"alice"`, "dbdefault's user must be untouched by dbnamed's migration")
+
+	// === migrate dbdefault SECOND ===
+	dbDefaultCfg.UseSystemMobileMetadataCollection = base.Ptr(true)
+	rest.RequireStatus(t, rt.UpsertDbConfig(dbDefaultName, dbDefaultCfg), http.StatusCreated)
+	rt.ServerContext().ForceClusterCompatRefresh(t, rt.Context())
+	resp = rt.SendAdminRequest(http.MethodPost, "/"+dbDefaultName+"/_metadata_migration?action=start", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	status = rt.WaitForMetadataMigrationStatusForDB(db.BackgroundProcessStateCompleted, dbDefaultName)
+	assert.Zero(t, status.DocsFailed, "dbdefault migration must not fail any docs")
+
+	// dbdefault's docs now migrated; dbnamed's already-migrated docs remain in _system._mobile.
+	requireAllExist(t, ctx, systemDS, defaultKeys.all())
+	requireNoneExist(t, ctx, defaultDS, defaultKeys.all())
+	requireAllExist(t, ctx, systemDS, namedKeys.all())
+	resp = rt.SendAdminRequest(http.MethodGet, "/"+dbDefaultName+"/_user/alice", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	assert.Contains(t, resp.Body.String(), `"name":"alice"`)
+	resp = rt.SendAdminRequest(http.MethodGet, "/"+dbNamedName+"/_user/bob", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	assert.Contains(t, resp.Body.String(), `"name":"bob"`, "dbnamed must remain readable after dbdefault's later migration")
 }

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1077,6 +1077,16 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		dbcontext.PostMetadataMigrationCompleteFunc = func(ctx context.Context) error {
 			return sc.maybeCompleteBucketMetadataMigration(ctx, bucketName)
 		}
+		dbcontext.SiblingMetadataIDFunc = func(ctx context.Context) ([]string, error) {
+			registry, err := sc.BootstrapContext.getGatewayRegistry(ctx, bucketName)
+			if err != nil {
+				return nil, err
+			}
+			ids := registryMetadataIDs(registry)
+			return slices.DeleteFunc(ids, func(id string) bool {
+				return id == config.MetadataID
+			}), nil
+		}
 	}
 
 	if config.Unsupported != nil && config.Unsupported.ResyncPartitions != nil && *config.Unsupported.ResyncPartitions > dbcontext.NumVBuckets() {


### PR DESCRIPTION
CBG-5432

When two databases share a bucket and one is assigned default metadataID (metadataID _default, unprefixed keys), running metadata migration on the default DB incorrectly migrated the other database's inverted key metadata into `_system._mobile` instead of leaving it on the fallback (`_default._default`).

`handleMigrationKey` `isOurs` helper decided "mine vs a sibling's" by looking for an `m_` segment after the prefix. That assumption is wrong for the inverted key families (user, role, useremail, session, dcp_ck): `formatInvertedMetadataKey` embeds the bare `metadataID` with no `m_` (e.g. `_sync:user:db2:bob`). For the default DB the unprefixed inverted prefix (`_sync:user:`) is a prefix of every sibling's inverted key, so the `m_` guard never fired and the sibling's docs were classified as ours and migrated.

The fix was to pass the authoritative set of sibling metadataIDs from the gateway registry into the migration and use it to recognise co-located sibling metadata:
- New hook `DatabaseContext.SiblingMetadataIDFunc`, wired by `ServerContext` from the gateway registry (mirroring the existing `MetadataMigrationStatusUpdater` / `PostMetadataMigrationCompleteFunc` hooks), excluding the migrating DB's own metadataID.
- Classifier split in `handleMigrationKey`:
  - `isOurs` — plain prefix match, for non-inverted families (sibling keys carry a distinct `_sync:m_<id>:` infix, so no sibling check is needed).
  - `isOursInverted` — for the inverted families. A namespaced migrating DB returns immediately (its prefix already embeds its id); the legacy-default DB subtracts the registry siblings — a key is a sibling's if its body begins with `<siblingID>:`.
- Sibling list re-read each pass (not once up front), so a sibling DB registered mid-migration is recognised on the next pass rather than having its keys migrated by an in-flight default-DB migration.

**Accepted known limitations**
Two inverted families have a body that can itself begin with `<siblingID>:`, making an own-key indistinguishable from a sibling's only in a naming collision. In both I think the best approach is leave out-of-scope rather than risk stealing a sibling's doc, and the consequence is recoverable:
- dcp_ck — body begins with the config group id; a sibling whose metadataID equals the default DB's DCP group id strands the default DB's own checkpoint (recoverable via DCP re-stream). Pinned by `TestMigrateMetadataDcpCheckpointGroupIDCollisionKnownLimitation`

**Why a "colon in the body ⇒ sibling" heuristic isn't enough for dcp_ck**
It breaks for `dcp_ck`, because the default DB's own checkpoint key embeds the config group ID, import version, and vbucket number as colon-separated segments — its own body legitimately contains colons.

Possible keys:
default DB's own checkpoint:   _sync:dcp_ck:gregsGroupID:1:42
  → body after "_sync:dcp_ck:" = "gregsGroupID:1:42"   (group "gregsGroupID", import version 1, vbucket 42)

sibling db2's checkpoint:      _sync:dcp_ck:db2:gregsGroupID:1:42
  → body after "_sync:dcp_ck:" = "db2:gregsGroupID:1:42"

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/788/ (flake)
