### PR TITLE
mistake made using non existent bucket and was meant to use non exisent metadataID

### DIFF
--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -128,8 +128,8 @@ func TestIsPerDBMigrationInProgress(t *testing.T) {
 	})
 
 	// --- Subtest: status doc doesn't exist → not in progress ---
-	t.Run("missing status doc means not in progress", func(t *testing.T) {
-		requireDBMigrationNotInProgress(t, sc, ctx, "nonexistent-bucket", metadataID,
+	t.Run("missing meatdataID in doc means not in progress", func(t *testing.T) {
+		requireDBMigrationNotInProgress(t, sc, ctx, bucketName, "nonexistenbucket",
 			"missing status doc should not be treated as in_progress")
 	})
 }

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -127,8 +127,8 @@ func TestIsPerDBMigrationInProgress(t *testing.T) {
 			"completed migration should not be treated as in_progress")
 	})
 
-	// --- Subtest: status doc doesn't exist → not in progress ---
-	t.Run("missing meatdataID in doc means not in progress", func(t *testing.T) {
+	// --- Subtest: metadataID doesn't exist → not in progress ---
+	t.Run("missing metadataID in doc means not in progress", func(t *testing.T) {
 		requireDBMigrationNotInProgress(t, sc, ctx, bucketName, "nonexistent-metadata-id",
 			"missing status doc should not be treated as in_progress")
 	})

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -129,7 +129,7 @@ func TestIsPerDBMigrationInProgress(t *testing.T) {
 
 	// --- Subtest: status doc doesn't exist → not in progress ---
 	t.Run("missing meatdataID in doc means not in progress", func(t *testing.T) {
-		requireDBMigrationNotInProgress(t, sc, ctx, bucketName, "nonexistenbucket",
+		requireDBMigrationNotInProgress(t, sc, ctx, bucketName, "nonexistent-metadata-id",
 			"missing status doc should not be treated as in_progress")
 	})
 }


### PR DESCRIPTION

Mistake where meant to use a metadataID that doesn't exist in the status doc but used non existent bucket instead which fails on CBS in different way. 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/795/
