### PR TITLE
CBG-5461: Support dropping _default._default after metadata migration, and make bootstrap migration-completion per-bucket

### DIFF
--- a/base/bootstrap.go
+++ b/base/bootstrap.go
@@ -478,6 +478,14 @@ func (cc *CouchbaseCluster) probeRegistryLocation(b *gocb.Bucket) (target bucket
 	if sysErr == nil && existsInSystem {
 		return bucketTargetSystemMobile, true, nil
 	}
+	// A bucket marked migration-complete has no legacy registry in _default._default to find — and
+	// _default may have been dropped (system-collection-only deployment / post-migration cleanup).
+	// Skip the _default probe so we never issue a KV op against a missing collection, which would
+	// retry KV_COLLECTION_OUTDATED to the op timeout. ensureBucketBootstrapTargetCached sets this
+	// flag (via the _default-existence check) before any caller reaches this point.
+	if cc.bucketBootstrapMigrationComplete(b.Name()) {
+		return 0, false, nil
+	}
 	defaultCol := b.DefaultCollection()
 	existsInDefault, defErr := cc.configPersistence.keyExists(defaultCol, SGRegistryKey)
 	if defErr != nil {
@@ -844,15 +852,7 @@ func (cc *CouchbaseCluster) GetMetadataMigrationStatus(ctx context.Context, buck
 		return nil, 0, err
 	}
 	defer teardown()
-	return cc.readMetadataMigrationStatus(b)
-}
 
-// readMetadataMigrationStatus reads and decodes the status doc from _system._mobile using an
-// already-resolved bucket handle. Split out from GetMetadataMigrationStatus so callers that already
-// hold a *gocb.Bucket — notably ensureBucketBootstrapTargetCached, which runs under
-// cachedBucketConnections.lock inside getBucket — can read it without re-entering getBucket. Re-entry
-// would re-acquire that non-reentrant lock on the same goroutine and deadlock.
-func (cc *CouchbaseCluster) readMetadataMigrationStatus(b *gocb.Bucket) (*MetadataMigrationStatus, uint64, error) {
 	res, err := cc.systemMobileCollection(b).Get(MetadataMigrationStatusDocID, &gocb.GetOptions{Transcoder: NewSGJSONTranscoder()})
 	if err != nil {
 		if IsDocNotFoundError(err) {
@@ -1058,21 +1058,23 @@ func (cc *CouchbaseCluster) getBucket(ctx context.Context, bucketName string) (b
 // SetBucketBootstrapTargetHint) can still claim system._mobile; metadataCollections will fall
 // back to the connection-wide flag in the meantime. Best-effort: probe errors are swallowed.
 //
-// When the registry is found in _system._mobile (target=systemMobile), the bucket has been
-// bootstrap-migrated, so we also read its migration status doc and, if bootstrap.state=complete,
-// mark the bucket migration-complete. This disables the _default._default fallback for this bucket
-// from its very first bootstrap read — covering both cluster-level and per-DB opt-in (the status
-// doc is the source of truth regardless of opt-in source) and avoiding a fallback read against a
-// _default that may have been dropped post-migration. The status read is safe here because the
-// registry's presence in _system._mobile proves that collection exists; legacy (_default-target)
-// buckets are never probed for the status doc, so their absent _system._mobile is never touched.
-//
-// The status read uses readMetadataMigrationStatus(b) on the handle we already hold rather than
-// GetMetadataMigrationStatus, which would re-enter getBucket. This function runs under
-// cachedBucketConnections.lock (held by the getBucket call above us), and re-entering getBucket
-// would re-acquire that non-reentrant lock on the same goroutine and deadlock.
+// Before probing, it checks whether _default._default exists (via the collection manifest, not a
+// KV op). If _default is absent — a system-collection-only deployment provisioned without it, or a
+// post-migration cleanup — there is no fallback collection and no legacy registry could live there,
+// so we resolve the bucket to _system._mobile and mark it migration-complete. That disables the
+// _default fallback for this bucket from its first bootstrap read, so reads never route to the
+// missing collection (which would retry KV_COLLECTION_OUTDATED to the op timeout). Marking complete
+// also makes probeRegistryLocation skip its own _default keyExists for callers that invoke it
+// directly (SetBucketBootstrapTargetHint).
 func (cc *CouchbaseCluster) ensureBucketBootstrapTargetCached(b *gocb.Bucket) {
 	if _, cached := cc.bucketBootstrapTargets.Load(b.Name()); cached {
+		return
+	}
+	// Manifest check (not a KV op) so an absent _default is reported promptly instead of hanging.
+	// On any error, fall through to the normal probe — no worse than prior behaviour.
+	if exists, existsErr := defaultCollectionExists(b); existsErr == nil && !exists {
+		cc.bucketBootstrapTargets.LoadOrStore(b.Name(), bucketTargetSystemMobile)
+		cc.SetMigrationComplete(b.Name())
 		return
 	}
 	target, found, err := cc.probeRegistryLocation(b)
@@ -1080,18 +1082,28 @@ func (cc *CouchbaseCluster) ensureBucketBootstrapTargetCached(b *gocb.Bucket) {
 		return
 	}
 	cc.bucketBootstrapTargets.LoadOrStore(b.Name(), target)
-	if target != bucketTargetSystemMobile {
-		return
+}
+
+// defaultCollectionExists reports whether _default._default is present in the bucket's collection
+// manifest. It queries the collections manager (GetAllScopes) rather than issuing a KV op, so a
+// dropped _default is reported promptly from the authoritative manifest instead of triggering the
+// KV client's KV_COLLECTION_OUTDATED retry loop (which blocks for the full op timeout).
+func defaultCollectionExists(b *gocb.Bucket) (bool, error) {
+	scopes, err := b.Collections().GetAllScopes(nil)
+	if err != nil {
+		return false, err
 	}
-	status, _, statusErr := cc.readMetadataMigrationStatus(b)
-	if statusErr != nil {
-		// ErrNotFound (no status doc yet) or a transient read error — leave the bucket
-		// not-complete so reads keep the fallback. Best-effort convergence, not correctness.
-		return
+	for _, scope := range scopes {
+		if scope.Name != DefaultScope {
+			continue
+		}
+		for _, collection := range scope.Collections {
+			if collection.Name == DefaultCollection {
+				return true, nil
+			}
+		}
 	}
-	if status.Bootstrap.State == MigrationStateComplete {
-		cc.SetMigrationComplete(b.Name())
-	}
+	return false, nil
 }
 
 func (cc *CouchbaseCluster) GetClusterConnectionForBucket(ctx context.Context, bucketName string) (connection *gocb.Cluster, teardownFn func(), err error) {

--- a/base/bootstrap.go
+++ b/base/bootstrap.go
@@ -16,7 +16,6 @@ import (
 	"reflect"
 	"sort"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"dario.cat/mergo"
@@ -49,9 +48,10 @@ type BootstrapConnection interface {
 	// GetRawDocument retrieves the document with the specified key from the bucket's default collection as raw bytes.
 	// Returns exists=false if key is not found, returns error for any other error.
 	GetRawDocument(ctx context.Context, bucket, docID string) (value []byte, exists bool, err error)
-	// SetMigrationComplete signals that bootstrap-metadata migration to _system._mobile has finished;
-	// subsequent reads stop falling back to _default._default. No-op when useSystemMetadataCollection is false.
-	SetMigrationComplete()
+	// SetMigrationComplete signals that bootstrap-metadata migration to _system._mobile has finished
+	// for the given bucket; subsequent bootstrap reads for that bucket stop falling back to
+	// _default._default. Per-bucket so completing one bucket never disables another's fallback.
+	SetMigrationComplete(bucketName string)
 	// GetMetadataMigrationStatus reads the bucket-level metadata-migration status doc directly from
 	// _system._mobile (never via the dual-collection wrapper). Returns ErrNotFound when the doc has
 	// not yet been stamped on this bucket.
@@ -116,12 +116,18 @@ type CouchbaseCluster struct {
 	cachedConnectionLock        sync.Mutex              // mutex for access to cachedBucketConnections
 	configPersistence           ConfigPersistence       // ConfigPersistence mode
 	useSystemMetadataCollection bool                    // When true, bootstrap metadata is stored in _system._mobile, with read-fallback to _default._default during migration
-	migrationComplete           atomic.Bool             // When set, fallback reads are skipped even if useSystemMetadataCollection is true
 	// bucketBootstrapTargets caches the resolved bootstrap-doc location for each bucket.
 	// Resolved lazily on first interaction (or eagerly via SetBucketBootstrapTargetHint).
 	// Absence of an entry means "fall back to the connection-wide flag."
 	bucketBootstrapTargets SyncMap[string, bucketBootstrapTarget]
-	useGOCBFastFailRetry   bool // When true, readiness checks fail fast instead of using the best-effort retry strategy
+	// bucketsBootstrapMigrationComplete records, per bucket, that the bootstrap metadata migration
+	// has finished (status doc bootstrap.state=complete). When set for a bucket, its bootstrap reads
+	// skip the _default._default fallback. This is per-bucket, and the source of opt-in doesn't matter — it is
+	// driven by the persisted status doc, not the bootstrap-level use_system_metadata_collection flag — so a
+	// database that opted in only at the per-DB level still disables its fallback after migration,
+	// and completing one bucket's migration never disables another bucket's fallback.
+	bucketsBootstrapMigrationComplete SyncMap[string, bool]
+	useGOCBFastFailRetry              bool // When true, readiness checks fail fast instead of using the best-effort retry strategy
 }
 
 // bucketBootstrapTarget records where bootstrap docs (registry, dbconfig, cbgt cfg) live for a
@@ -399,7 +405,7 @@ func (cc *CouchbaseCluster) metadataCollections(b *gocb.Bucket) (primary, fallba
 		return b.DefaultCollection(), nil
 	}
 	primary = b.Scope(SystemScope).Collection(SystemCollectionMobile)
-	if cc.migrationComplete.Load() {
+	if cc.bucketBootstrapMigrationComplete(b.Name()) {
 		return primary, nil
 	}
 	return primary, b.DefaultCollection()
@@ -489,14 +495,25 @@ func (cc *CouchbaseCluster) shouldFallback(err error, fallback *gocb.Collection)
 	return fallback != nil && IsDocNotFoundError(err)
 }
 
-// SetMigrationComplete marks bootstrap-metadata migration as finished; subsequent reads stop
-// falling back to _default._default. Safe to call concurrently with in-flight operations.
-func (cc *CouchbaseCluster) SetMigrationComplete() {
-	cc.migrationComplete.Store(true)
+// SetMigrationComplete marks bootstrap-metadata migration as finished for the given bucket;
+// subsequent bootstrap reads for that bucket stop falling back to _default._default. Per-bucket so
+// completing one bucket never disables another's fallback. Safe to call concurrently with in-flight
+// operations.
+func (cc *CouchbaseCluster) SetMigrationComplete(bucketName string) {
+	cc.bucketsBootstrapMigrationComplete.Store(bucketName, true)
+}
+
+// bucketBootstrapMigrationComplete reports whether bootstrap-metadata migration has been marked
+// complete for the given bucket. Absence of an entry means not-complete, so reads keep the
+// _default._default fallback.
+func (cc *CouchbaseCluster) bucketBootstrapMigrationComplete(bucketName string) bool {
+	complete, _ := cc.bucketsBootstrapMigrationComplete.Load(bucketName)
+	return complete
 }
 
 // RefreshBucketBootstrapTarget reads the bucket's metadata-migration status doc; if bootstrap.state
-// is complete it updates the per-bucket cache to _system._mobile via noteBucketFallbackHit. ErrNotFound
+// is complete it updates the per-bucket cache to _system._mobile via noteBucketFallbackHit and marks
+// the bucket migration-complete so reads stop falling back to _default._default. ErrNotFound
 // (no migration ever started here) and any other transient error are returned to the caller for
 // telemetry but never escalate — this is best-effort cache convergence, not a correctness path.
 func (cc *CouchbaseCluster) RefreshBucketBootstrapTarget(ctx context.Context, bucket string) error {
@@ -509,6 +526,7 @@ func (cc *CouchbaseCluster) RefreshBucketBootstrapTarget(ctx context.Context, bu
 	}
 	if status.Bootstrap.State == MigrationStateComplete {
 		cc.noteBucketFallbackHit(bucket)
+		cc.SetMigrationComplete(bucket)
 	}
 	return nil
 }
@@ -826,7 +844,15 @@ func (cc *CouchbaseCluster) GetMetadataMigrationStatus(ctx context.Context, buck
 		return nil, 0, err
 	}
 	defer teardown()
+	return cc.readMetadataMigrationStatus(b)
+}
 
+// readMetadataMigrationStatus reads and decodes the status doc from _system._mobile using an
+// already-resolved bucket handle. Split out from GetMetadataMigrationStatus so callers that already
+// hold a *gocb.Bucket — notably ensureBucketBootstrapTargetCached, which runs under
+// cachedBucketConnections.lock inside getBucket — can read it without re-entering getBucket. Re-entry
+// would re-acquire that non-reentrant lock on the same goroutine and deadlock.
+func (cc *CouchbaseCluster) readMetadataMigrationStatus(b *gocb.Bucket) (*MetadataMigrationStatus, uint64, error) {
 	res, err := cc.systemMobileCollection(b).Get(MetadataMigrationStatusDocID, &gocb.GetOptions{Transcoder: NewSGJSONTranscoder()})
 	if err != nil {
 		if IsDocNotFoundError(err) {
@@ -1031,6 +1057,20 @@ func (cc *CouchbaseCluster) getBucket(ctx context.Context, bucketName string) (b
 // When no registry exists yet the decision is left uncached so a subsequent per-DB opt-in (via
 // SetBucketBootstrapTargetHint) can still claim system._mobile; metadataCollections will fall
 // back to the connection-wide flag in the meantime. Best-effort: probe errors are swallowed.
+//
+// When the registry is found in _system._mobile (target=systemMobile), the bucket has been
+// bootstrap-migrated, so we also read its migration status doc and, if bootstrap.state=complete,
+// mark the bucket migration-complete. This disables the _default._default fallback for this bucket
+// from its very first bootstrap read — covering both cluster-level and per-DB opt-in (the status
+// doc is the source of truth regardless of opt-in source) and avoiding a fallback read against a
+// _default that may have been dropped post-migration. The status read is safe here because the
+// registry's presence in _system._mobile proves that collection exists; legacy (_default-target)
+// buckets are never probed for the status doc, so their absent _system._mobile is never touched.
+//
+// The status read uses readMetadataMigrationStatus(b) on the handle we already hold rather than
+// GetMetadataMigrationStatus, which would re-enter getBucket. This function runs under
+// cachedBucketConnections.lock (held by the getBucket call above us), and re-entering getBucket
+// would re-acquire that non-reentrant lock on the same goroutine and deadlock.
 func (cc *CouchbaseCluster) ensureBucketBootstrapTargetCached(b *gocb.Bucket) {
 	if _, cached := cc.bucketBootstrapTargets.Load(b.Name()); cached {
 		return
@@ -1040,6 +1080,18 @@ func (cc *CouchbaseCluster) ensureBucketBootstrapTargetCached(b *gocb.Bucket) {
 		return
 	}
 	cc.bucketBootstrapTargets.LoadOrStore(b.Name(), target)
+	if target != bucketTargetSystemMobile {
+		return
+	}
+	status, _, statusErr := cc.readMetadataMigrationStatus(b)
+	if statusErr != nil {
+		// ErrNotFound (no status doc yet) or a transient read error — leave the bucket
+		// not-complete so reads keep the fallback. Best-effort convergence, not correctness.
+		return
+	}
+	if status.Bootstrap.State == MigrationStateComplete {
+		cc.SetMigrationComplete(b.Name())
+	}
 }
 
 func (cc *CouchbaseCluster) GetClusterConnectionForBucket(ctx context.Context, bucketName string) (connection *gocb.Cluster, teardownFn func(), err error) {

--- a/base/bootstrap_test.go
+++ b/base/bootstrap_test.go
@@ -402,6 +402,164 @@ func newCouchbaseBootstrapDualFixture(t *testing.T, useXattrs bool) bootstrapDua
 	}
 }
 
+// bootstrapTwoBucketFixture pairs one dual-collection BootstrapConnection with two buckets, plus
+// helpers to seed a legacy (fallback-only) bootstrap doc into either. Used to prove that completing
+// bootstrap migration on one bucket does not disable the _default._default read-fallback for the
+// other.
+type bootstrapTwoBucketFixture struct {
+	Cluster BootstrapConnection
+	BucketA string
+	BucketB string
+	// SeedLegacy writes a config-shaped doc into the named bucket's fallback (_default._default).
+	SeedLegacy func(t *testing.T, bucketName, docID string, value bootstrapTestCfg)
+	// CleanupDoc removes docID from the named bucket's fallback. Idempotent.
+	CleanupDoc func(t *testing.T, bucketName, docID string)
+}
+
+// newBootstrapTwoBucketDualFixture builds a two-bucket dual-collection fixture for the active
+// backing store. useXattrs selects the bootstrap-config persistence mode on Couchbase Server (see
+// newBootstrapDualTestFixture); it is ignored on Rosmar.
+func newBootstrapTwoBucketDualFixture(t *testing.T, useXattrs bool) bootstrapTwoBucketFixture {
+	t.Helper()
+	if UnitTestUrlIsWalrus() {
+		return newRosmarBootstrapTwoBucketDualFixture(t)
+	}
+	return newCouchbaseBootstrapTwoBucketDualFixture(t, useXattrs)
+}
+
+func newRosmarBootstrapTwoBucketDualFixture(t *testing.T) bootstrapTwoBucketFixture {
+	t.Helper()
+	ctx := TestCtx(t)
+	tbA := GetTestBucket(t)
+	t.Cleanup(func() { tbA.Close(ctx) })
+	tbB := GetTestBucket(t)
+	t.Cleanup(func() { tbB.Close(ctx) })
+
+	cluster, err := NewRosmarCluster(UnitTestUrl(), true)
+	require.NoError(t, err)
+	t.Cleanup(cluster.Close)
+
+	defaultDS := make(map[string]DataStore, 2)
+	for _, tb := range []*TestBucket{tbA, tbB} {
+		ds, err := tb.Bucket.NamedDataStore(ctx, DefaultScopeAndCollectionName())
+		require.NoError(t, err)
+		defaultDS[tb.GetName()] = ds
+	}
+
+	return bootstrapTwoBucketFixture{
+		Cluster: cluster,
+		BucketA: tbA.GetName(),
+		BucketB: tbB.GetName(),
+		SeedLegacy: func(t *testing.T, bucketName, docID string, value bootstrapTestCfg) {
+			t.Helper()
+			_, err := defaultDS[bucketName].WriteCas(TestCtx(t), docID, 0, 0, value, 0)
+			require.NoError(t, err)
+		},
+		CleanupDoc: func(t *testing.T, bucketName, docID string) {
+			t.Helper()
+			_, _ = defaultDS[bucketName].Remove(TestCtx(t), docID, 0)
+		},
+	}
+}
+
+func newCouchbaseBootstrapTwoBucketDualFixture(t *testing.T, useXattrs bool) bootstrapTwoBucketFixture {
+	t.Helper()
+	ctx := TestCtx(t)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, int32(GTestBucketPool.numBuckets), GTestBucketPool.stats.TotalBucketInitCount.Load())
+	}, 2*time.Minute, 5*time.Millisecond)
+
+	cluster, err := NewCouchbaseCluster(ctx, TestClusterSpec(t), false, nil, useXattrs, true, CachedClusterConnections)
+	require.NoError(t, err)
+	t.Cleanup(cluster.Close)
+
+	// Claim two clean buckets from the test pool rather than enumerating arbitrary cluster buckets
+	// via GetConfigBuckets. A pooled bucket is flushed between tests, so it carries no leftover
+	// _sync:registry or migration-status docs. An arbitrary cluster bucket might have been left
+	// bootstrap-migration-complete by a prior tenant; getBucket below (via
+	// ensureBucketBootstrapTargetCached) would then latch it as migration-complete, disabling the
+	// _default fallback before this test seeds anything and breaking its first sanity assertion.
+	tbA := GetTestBucket(t)
+	t.Cleanup(func() { tbA.Close(ctx) })
+	tbB := GetTestBucket(t)
+	t.Cleanup(func() { tbB.Close(ctx) })
+
+	gocbBuckets := make(map[string]*gocb.Bucket, 2)
+	for _, tb := range []*TestBucket{tbA, tbB} {
+		name := tb.GetName()
+		b, teardown, err := cluster.getBucket(ctx, name)
+		require.NoError(t, err)
+		t.Cleanup(teardown)
+		gocbBuckets[name] = b
+	}
+
+	return bootstrapTwoBucketFixture{
+		Cluster: cluster,
+		BucketA: tbA.GetName(),
+		BucketB: tbB.GetName(),
+		SeedLegacy: func(t *testing.T, bucketName, docID string, value bootstrapTestCfg) {
+			t.Helper()
+			seedLegacyBootstrapDoc(t, gocbBuckets[bucketName], docID, value, useXattrs)
+		},
+		CleanupDoc: func(t *testing.T, bucketName, docID string) {
+			t.Helper()
+			_, _ = gocbBuckets[bucketName].DefaultCollection().Remove(docID, nil)
+		},
+	}
+}
+
+// TestBootstrapMigrationCompleteIsPerBucket is a regression test for the connection-wide
+// SetMigrationComplete: completing bootstrap migration on one bucket must not disable the
+// _default._default read-fallback for a different bucket that has not migrated.
+func TestBootstrapMigrationCompleteIsPerBucket(t *testing.T) {
+	RequireNumTestBuckets(t, 2)
+	forEachBootstrapXattrMode(t, func(t *testing.T, useXattrs bool) {
+		f := newBootstrapTwoBucketDualFixture(t, useXattrs)
+		ctx := TestCtx(t)
+		docID := SyncDocPrefix + "per-bucket-migration-complete"
+
+		// Both buckets start un-migrated: their config doc lives only in the _default fallback.
+		t.Cleanup(func() {
+			f.CleanupDoc(t, f.BucketA, docID)
+			f.CleanupDoc(t, f.BucketB, docID)
+		})
+		f.SeedLegacy(t, f.BucketA, docID, bootstrapTestCfg{Foo: "bucketA"})
+		f.SeedLegacy(t, f.BucketB, docID, bootstrapTestCfg{Foo: "bucketB"})
+
+		// Sanity: both buckets resolve their doc via the fallback before any completion.
+		var loaded bootstrapTestCfg
+		_, err := f.Cluster.GetMetadataDocument(ctx, f.BucketA, docID, &loaded)
+		require.NoError(t, err)
+		require.Equal(t, "bucketA", loaded.Foo)
+		_, err = f.Cluster.GetMetadataDocument(ctx, f.BucketB, docID, &loaded)
+		require.NoError(t, err)
+		require.Equal(t, "bucketB", loaded.Foo)
+
+		// Complete bootstrap migration on bucket A only.
+		f.Cluster.SetMigrationComplete(f.BucketA)
+
+		// Bucket A's fallback is now disabled: its fallback-only doc is no longer visible. This
+		// confirms the completion flag actually took effect for A.
+		_, err = f.Cluster.GetMetadataDocument(ctx, f.BucketA, docID, &loaded)
+		require.Error(t, err)
+		require.True(t, IsDocNotFoundError(err), "bucket A fallback must be disabled after its migration completes, got: %v", err)
+
+		// THE REGRESSION CHECK: bucket B has NOT migrated, so its fallback must still be active and
+		// its doc still readable. With the old connection-wide flag this read returned not-found.
+		loaded = bootstrapTestCfg{}
+		_, err = f.Cluster.GetMetadataDocument(ctx, f.BucketB, docID, &loaded)
+		require.NoError(t, err, "completing bucket A's migration must not disable bucket B's fallback")
+		require.Equal(t, "bucketB", loaded.Foo)
+
+		// Completing bucket B disables its fallback too — confirming the flag is genuinely per-bucket
+		// in both directions, not a one-off.
+		f.Cluster.SetMigrationComplete(f.BucketB)
+		_, err = f.Cluster.GetMetadataDocument(ctx, f.BucketB, docID, &loaded)
+		require.Error(t, err)
+		require.True(t, IsDocNotFoundError(err), "bucket B fallback must be disabled after its own migration completes, got: %v", err)
+	})
+}
+
 // forEachBootstrapXattrMode runs body once with useXattrs=false and once with useXattrs=true,
 // each as a t.Run subtest. The useXattrs=true subtest is skipped on Rosmar — its bootstrap
 // path doesn't support xattr-mode persistence, so the variant has no meaningful coverage

--- a/base/rosmar_cluster.go
+++ b/base/rosmar_cluster.go
@@ -183,18 +183,6 @@ func (c *RosmarCluster) metadataDataStores(ctx context.Context, bucketName strin
 	if _, alreadyCached := c.bucketBootstrapTargets.Load(bucketName); !alreadyCached {
 		if target, found := c.probeRegistryLocation(ctx, systemCol, defaultCol); found {
 			c.bucketBootstrapTargets.LoadOrStore(bucketName, target)
-			// Registry in _system._mobile means this bucket has been bootstrap-migrated. Read its
-			// status doc and, if bootstrap.state=complete, mark the bucket migration-complete so its
-			// reads skip the _default._default fallback — covering cluster-level and per-DB opt-in
-			// alike. Mirrors CouchbaseCluster.ensureBucketBootstrapTargetCached. Read from the
-			// already-open systemCol handle rather than GetMetadataMigrationStatus, which would
-			// re-open the bucket while we already hold a handle to it.
-			if target == bucketTargetSystemMobile {
-				status := &MetadataMigrationStatus{}
-				if _, getErr := systemCol.Get(ctx, MetadataMigrationStatusDocID, status); getErr == nil && status.Bootstrap.State == MigrationStateComplete {
-					c.SetMigrationComplete(bucketName)
-				}
-			}
 		}
 	}
 	if c.bucketBootstrapMigrationComplete(bucketName) {

--- a/base/rosmar_cluster.go
+++ b/base/rosmar_cluster.go
@@ -16,7 +16,6 @@ import (
 	"os"
 	"runtime"
 	"strings"
-	"sync/atomic"
 
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbaselabs/rosmar"
@@ -28,11 +27,13 @@ var _ BootstrapConnection = &RosmarCluster{}
 type RosmarCluster struct {
 	serverURL                   string
 	bucketDirectory             string
-	useSystemMetadataCollection bool        // When true, bootstrap metadata is stored in _system._mobile, with read-fallback to _default._default during migration
-	migrationComplete           atomic.Bool // When set, fallback reads are skipped even if useSystemMetadataCollection is true
+	useSystemMetadataCollection bool // When true, bootstrap metadata is stored in _system._mobile, with read-fallback to _default._default during migration
 	// bucketBootstrapTargets caches the resolved bootstrap-doc target for each bucket.
 	// Mirrors CouchbaseCluster.bucketBootstrapTargets — see that comment for the decision tree.
 	bucketBootstrapTargets SyncMap[string, bucketBootstrapTarget]
+	// bucketsBootstrapMigrationComplete records per-bucket bootstrap-migration completion.
+	// Mirrors CouchbaseCluster.bucketsBootstrapMigrationComplete — see that comment.
+	bucketsBootstrapMigrationComplete SyncMap[string, bool]
 }
 
 // NewRosmarCluster creates a from a given URL. useSystemMetadataCollection mirrors
@@ -182,9 +183,21 @@ func (c *RosmarCluster) metadataDataStores(ctx context.Context, bucketName strin
 	if _, alreadyCached := c.bucketBootstrapTargets.Load(bucketName); !alreadyCached {
 		if target, found := c.probeRegistryLocation(ctx, systemCol, defaultCol); found {
 			c.bucketBootstrapTargets.LoadOrStore(bucketName, target)
+			// Registry in _system._mobile means this bucket has been bootstrap-migrated. Read its
+			// status doc and, if bootstrap.state=complete, mark the bucket migration-complete so its
+			// reads skip the _default._default fallback — covering cluster-level and per-DB opt-in
+			// alike. Mirrors CouchbaseCluster.ensureBucketBootstrapTargetCached. Read from the
+			// already-open systemCol handle rather than GetMetadataMigrationStatus, which would
+			// re-open the bucket while we already hold a handle to it.
+			if target == bucketTargetSystemMobile {
+				status := &MetadataMigrationStatus{}
+				if _, getErr := systemCol.Get(ctx, MetadataMigrationStatusDocID, status); getErr == nil && status.Bootstrap.State == MigrationStateComplete {
+					c.SetMigrationComplete(bucketName)
+				}
+			}
 		}
 	}
-	if c.migrationComplete.Load() {
+	if c.bucketBootstrapMigrationComplete(bucketName) {
 		return systemCol, nil, closer, nil
 	}
 	return systemCol, defaultCol, closer, nil
@@ -263,14 +276,25 @@ func (c *RosmarCluster) shouldFallback(err error, fallback *rosmar.Collection) b
 	return fallback != nil && IsDocNotFoundError(err)
 }
 
-// SetMigrationComplete marks bootstrap-metadata migration as finished; subsequent reads stop
-// falling back to _default._default. Safe to call concurrently with in-flight operations.
-func (c *RosmarCluster) SetMigrationComplete() {
-	c.migrationComplete.Store(true)
+// SetMigrationComplete marks bootstrap-metadata migration as finished for the given bucket;
+// subsequent bootstrap reads for that bucket stop falling back to _default._default. Per-bucket so
+// completing one bucket never disables another's fallback. Safe to call concurrently with in-flight
+// operations.
+func (c *RosmarCluster) SetMigrationComplete(bucketName string) {
+	c.bucketsBootstrapMigrationComplete.Store(bucketName, true)
+}
+
+// bucketBootstrapMigrationComplete reports whether bootstrap-metadata migration has been marked
+// complete for the given bucket. Absence of an entry means not-complete, so reads keep the
+// _default._default fallback.
+func (c *RosmarCluster) bucketBootstrapMigrationComplete(bucketName string) bool {
+	complete, _ := c.bucketsBootstrapMigrationComplete.Load(bucketName)
+	return complete
 }
 
 // RefreshBucketBootstrapTarget reads the bucket's metadata-migration status doc; if bootstrap.state
-// is complete it updates the per-bucket cache to _system._mobile via noteBucketFallbackHit. ErrNotFound
+// is complete it updates the per-bucket cache to _system._mobile via noteBucketFallbackHit and marks
+// the bucket migration-complete so reads stop falling back to _default._default. ErrNotFound
 // (no migration ever started here) and any other transient error are returned to the caller for
 // telemetry but never escalate — this is best-effort cache convergence, not a correctness path.
 func (c *RosmarCluster) RefreshBucketBootstrapTarget(ctx context.Context, bucket string) error {
@@ -280,6 +304,7 @@ func (c *RosmarCluster) RefreshBucketBootstrapTarget(ctx context.Context, bucket
 	}
 	if status.Bootstrap.State == MigrationStateComplete {
 		c.noteBucketFallbackHit(bucket)
+		c.SetMigrationComplete(bucket)
 	}
 	return nil
 }

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -87,15 +87,19 @@ func (listener *changeListener) OnDocChanged(event sgbucket.FeedEvent, docType D
 }
 
 // cachingFeedCollections returns the set of (scope, collection) pairs that the caching DCP
-// feed must subscribe to. When metadataStore is a *base.MetadataStore (active during the
-// metadata migration window), both its primary (_system._mobile) and fallback
-// (_default._default) datastores are included so that _sync:* mutations are observed
-// regardless of which collection currently holds the doc.
+// feed must subscribe to. When metadataStore is a *base.MetadataStore whose migration is still
+// in flight, both its primary (_system._mobile) and fallback (_default._default) datastores are
+// included so that _sync:* mutations are observed regardless of which collection currently holds
+// the doc. Once migration is complete, metadata lives solely on primary, so the fallback is
+// omitted — it would otherwise be redundant, and a customer who has dropped _default._default
+// post-migration would fail the DCP feed Start with "collection _default not found".
 func cachingFeedCollections(metadataStore base.DataStore, scopes map[string]Scope) base.CollectionNameSet {
 	collectionNames := base.NewCollectionNameSet()
 	if ms, ok := metadataStore.(*base.MetadataStore); ok {
 		collectionNames.Add(ms.Primary())
-		collectionNames.Add(ms.Fallback())
+		if !ms.MigrationComplete() {
+			collectionNames.Add(ms.Fallback())
+		}
 	} else {
 		collectionNames.Add(metadataStore)
 	}

--- a/db/change_listener_dual_metadata_test.go
+++ b/db/change_listener_dual_metadata_test.go
@@ -38,6 +38,30 @@ func TestCachingFeedCollections_DualMetadataStore(t *testing.T) {
 	assert.Contains(t, got[base.DefaultScope], base.DefaultCollection)
 }
 
+// TestCachingFeedCollectionsDualMetadataStoreMigrationComplete verifies that once the dual
+// metadata store reports migration complete, the caching feed subscribes only to the primary
+// (_system._mobile) and omits the fallback (_default._default). This prevents the DCP feed Start
+// from failing when a customer has dropped _default._default after migration completed.
+func TestCachingFeedCollectionsDualMetadataStoreMigrationComplete(t *testing.T) {
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
+
+	primary := bucket.GetMobileSystemDataStore() // skips if backing store does not support system collections
+	fallback := bucket.DefaultDataStore(ctx)
+	ms := base.NewMetadataStore(primary, fallback)
+	ms.SetMigrationComplete()
+
+	got := cachingFeedCollections(ms, nil)
+
+	require.Contains(t, got, base.SystemScope, "expected %s scope to be present", base.SystemScope)
+	assert.Contains(t, got[base.SystemScope], base.SystemCollectionMobile)
+
+	// The fallback (_default._default) must not be subscribed at all once migration is complete, so
+	// the _default scope must be absent from the result entirely.
+	assert.NotContains(t, got, base.DefaultScope, "fallback _default._default must not be subscribed after migration completes")
+}
+
 // TestCachingFeedCollections_SingleMetadataStore verifies that when the metadata store is a
 // plain DataStore (not the dual wrapper), the caching feed subscribes only to that store's
 // collection — preserving the pre-CBG-5223 behaviour.

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -496,7 +496,16 @@ func (h *handler) handlePostIndexInit() error {
 	if req.SeparatePrincipalIndexes != nil {
 		useLegacySyncDocsIndex = !(*req.SeparatePrincipalIndexes)
 	}
-	done, err := h.server.DatabaseInitManager.InitializeDatabaseWithStatusCallback(h.ctx(), h.server.initialStartupConfig, &newDbConfig, statusCallback, useLegacySyncDocsIndex)
+	// Skip metadata index initialization on _default._default if it has been dropped (e.g. after a
+	// completed metadata migration) — building indexes on a missing collection would retry until the
+	// op times out. Default to attempting init on _default if existence can't be determined.
+	defaultCollectionPresent := true
+	if exists, existsErr := defaultCollectionExists(h.ctx(), h.db.Bucket); existsErr != nil {
+		base.WarnfCtx(h.ctx(), "db:%s unable to determine whether _default._default exists while reinitializing indexes: %v — will attempt index init on _default", base.MD(h.db.Name), existsErr)
+	} else {
+		defaultCollectionPresent = exists
+	}
+	done, err := h.server.DatabaseInitManager.InitializeDatabaseWithStatusCallback(h.ctx(), h.server.initialStartupConfig, &newDbConfig, statusCallback, useLegacySyncDocsIndex, defaultCollectionPresent)
 	if err != nil {
 		return err
 	}

--- a/rest/database_init_manager.go
+++ b/rest/database_init_manager.go
@@ -56,7 +56,7 @@ type InitializeIndexesFunc func(context.Context, base.N1QLStore, db.InitializeIn
 // indexes required for each collection.
 type CollectionInitData map[base.ScopeAndCollectionName]db.CollectionIndexesType
 
-func (m *DatabaseInitManager) InitializeDatabaseWithStatusCallback(ctx context.Context, startupConfig *StartupConfig, dbConfig *DatabaseConfig, statusCallback CollectionCallbackFunc, useLegacySyncDocsIndex bool) (doneChan chan error, err error) {
+func (m *DatabaseInitManager) InitializeDatabaseWithStatusCallback(ctx context.Context, startupConfig *StartupConfig, dbConfig *DatabaseConfig, statusCallback CollectionCallbackFunc, useLegacySyncDocsIndex bool, defaultCollectionExists bool) (doneChan chan error, err error) {
 	m.workersLock.Lock()
 	defer m.workersLock.Unlock()
 	if m.workers == nil {
@@ -66,7 +66,7 @@ func (m *DatabaseInitManager) InitializeDatabaseWithStatusCallback(ctx context.C
 		base.MD(dbConfig.Name))
 	dbInitWorker, ok := m.workers[dbConfig.Name]
 
-	collectionSet := buildCollectionIndexData(dbConfig)
+	collectionSet := buildCollectionIndexData(dbConfig, defaultCollectionExists)
 	if ok {
 		// If worker exists for the database and the collection sets match, add watcher to the existing worker
 		if dbInitWorker.collectionsEqual(collectionSet) {
@@ -152,8 +152,8 @@ func (m *DatabaseInitManager) InitializeDatabaseWithStatusCallback(ctx context.C
 
 // InitializeDatabase will establish a new cluster connection using the provided server config.  Establishes a new
 // cluster-only N1QLStore based on the startup config to perform initialization.
-func (m *DatabaseInitManager) InitializeDatabase(ctx context.Context, startupConfig *StartupConfig, dbConfig *DatabaseConfig, useLegacySyncDocsIndex bool) (doneChan chan error, err error) {
-	return m.InitializeDatabaseWithStatusCallback(ctx, startupConfig, dbConfig, nil, useLegacySyncDocsIndex)
+func (m *DatabaseInitManager) InitializeDatabase(ctx context.Context, startupConfig *StartupConfig, dbConfig *DatabaseConfig, useLegacySyncDocsIndex bool, defaultCollectionExists bool) (doneChan chan error, err error) {
+	return m.InitializeDatabaseWithStatusCallback(ctx, startupConfig, dbConfig, nil, useLegacySyncDocsIndex, defaultCollectionExists)
 }
 
 func (m *DatabaseInitManager) HasActiveInitialization(dbName string) bool {
@@ -221,14 +221,19 @@ func (m *DatabaseInitManager) cancelWorkers() {
 }
 
 // buildCollectionIndexData determines the set of indexes required for each collection in the config, including
-// the metadata collection
-func buildCollectionIndexData(config *DatabaseConfig) CollectionInitData {
+// the metadata collection. defaultCollectionExists reports whether _default._default physically exists in the
+// bucket: _default carries metadata indexes that support dual-read principal queries during migration, but a
+// customer may drop it once migration completes, at which point those indexes are vestigial and attempting to
+// build them on the missing collection would retry until the op times out and fail initialization. When
+// _default is gone (and not itself a configured data collection) it is omitted from the index set.
+func buildCollectionIndexData(config *DatabaseConfig, defaultCollectionExists bool) CollectionInitData {
 	if len(config.Scopes) == 0 {
 		// todo: only init these mobile collection indexes when required?
 		return CollectionInitData{base.DefaultScopeAndCollectionName(): db.IndexesAll, base.MobileSystemScopeAndCollectionName(): db.IndexesMetadataOnly}
 	}
 
 	defaultScopeAndCollectionMetadataIndexes := db.IndexesMetadataOnly
+	defaultIsConfiguredCollection := false
 
 	collectionInitData := make(CollectionInitData)
 	for scopeName, scopeConfig := range config.Scopes {
@@ -236,13 +241,18 @@ func buildCollectionIndexData(config *DatabaseConfig) CollectionInitData {
 			scName := base.ScopeAndCollectionName{Scope: scopeName, Collection: collectionName}
 			if scName.IsDefault() {
 				defaultScopeAndCollectionMetadataIndexes = db.IndexesAll
+				defaultIsConfiguredCollection = true
 				continue
 			}
 			collectionInitData[scName] = db.IndexesWithoutMetadata
 		}
 	}
 
-	collectionInitData[base.DefaultScopeAndCollectionName()] = defaultScopeAndCollectionMetadataIndexes
+	// Include _default for metadata indexes only when it actually exists. If _default is itself a
+	// configured data collection it necessarily exists, so it is always included in that case.
+	if defaultCollectionExists || defaultIsConfiguredCollection {
+		collectionInitData[base.DefaultScopeAndCollectionName()] = defaultScopeAndCollectionMetadataIndexes
+	}
 	// todo: only init these indexes when required?
 	collectionInitData[base.MobileSystemScopeAndCollectionName()] = db.IndexesMetadataOnly
 

--- a/rest/database_init_manager_test.go
+++ b/rest/database_init_manager_test.go
@@ -48,7 +48,7 @@ func TestDatabaseInitManager(t *testing.T) {
 	base.DropAllBucketIndexes(t, tb)
 
 	// Async index creation
-	doneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex)
+	doneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true)
 	require.NoError(t, err)
 
 	select {
@@ -112,14 +112,14 @@ func TestDatabaseInitConfigChangeSameCollections(t *testing.T) {
 	require.NoError(t, dbConfig.setup(ctx, dbName, sc.Config.Bootstrap, nil, nil, false))
 
 	// Start first async index creation, blocks after first collection
-	doneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex)
+	doneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true)
 	require.NoError(t, err)
 
 	// Wait for first collection to be initialized
 	WaitForChannel(t, singleCollectionInitChannel, "first collection init")
 
 	// Make a duplicate call to initialize database, should reuse the existing agent
-	duplicateDoneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex)
+	duplicateDoneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true)
 	require.NoError(t, err)
 
 	// Unblock collection callback to process all remaining collections
@@ -136,7 +136,7 @@ func TestDatabaseInitConfigChangeSameCollections(t *testing.T) {
 	waitForWorkerDone(t, initMgr, "dbName")
 
 	// Rerun init, should start a new worker for the database and re-verify init for each collection
-	rerunDoneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex)
+	rerunDoneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true)
 	require.NoError(t, err)
 	WaitForChannel(t, rerunDoneChan, "repeated init done chan")
 	totalCount = atomic.LoadInt64(&collectionCount)
@@ -201,7 +201,7 @@ func TestDatabaseInitConfigChangeDifferentCollections(t *testing.T) {
 	require.NoError(t, dbConfig.setup(ctx, dbName, sc.Config.Bootstrap, nil, nil, false))
 
 	// Start first async index creation, should block after first collection
-	doneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex)
+	doneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true)
 	require.NoError(t, err)
 
 	// Wait for first collection to be initialized
@@ -210,7 +210,7 @@ func TestDatabaseInitConfigChangeDifferentCollections(t *testing.T) {
 	// Make a call to initialize database for the same db name, different collections
 	modifiedDbConfig := makeDbConfig(tb.GetName(), dbName, collection1and3ScopesConfig)
 	require.NoError(t, modifiedDbConfig.setup(ctx, dbName, sc.Config.Bootstrap, nil, nil, false))
-	modifiedDoneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, modifiedDbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex)
+	modifiedDoneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, modifiedDbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true)
 	require.NoError(t, err)
 
 	// Unblock the first InitializeDatabase, should cancel
@@ -292,14 +292,14 @@ func TestDatabaseInitConcurrentDatabasesSameBucket(t *testing.T) {
 	require.NoError(t, db2Config.setup(ctx, db2Name, sc.Config.Bootstrap, nil, nil, false))
 
 	// Start first async index creation, should block after first collection
-	doneChan1, err := initMgr.InitializeDatabase(ctx, sc.Config, db1Config.ToDatabaseConfig(), testUseLegacySyncDocsIndex)
+	doneChan1, err := initMgr.InitializeDatabase(ctx, sc.Config, db1Config.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true)
 	require.NoError(t, err)
 
 	// Wait for first collection to be initialized
 	WaitForChannel(t, firstCollectionInitChannel, "first collection init")
 
 	// Start second async index creation for db2 while first is still running
-	doneChan2, err := initMgr.InitializeDatabase(ctx, sc.Config, db2Config.ToDatabaseConfig(), testUseLegacySyncDocsIndex)
+	doneChan2, err := initMgr.InitializeDatabase(ctx, sc.Config, db2Config.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true)
 	require.NoError(t, err)
 
 	// Unblock the first InitializeDatabase, should cancel
@@ -387,14 +387,14 @@ func TestDatabaseInitConcurrentDatabasesDifferentBuckets(t *testing.T) {
 	require.NoError(t, db2Config.setup(ctx, db2Name, sc.Config.Bootstrap, nil, nil, false))
 
 	// Start first async index creation, should block after first collection
-	doneChan1, err := initMgr.InitializeDatabase(ctx, sc.Config, db1Config.ToDatabaseConfig(), testUseLegacySyncDocsIndex)
+	doneChan1, err := initMgr.InitializeDatabase(ctx, sc.Config, db1Config.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true)
 	require.NoError(t, err)
 
 	// Wait for first collection to be initialized
 	WaitForChannel(t, firstCollectionInitChannel, "first collection init")
 
 	// Start second async index creation for db2 while first is still running
-	doneChan2, err := initMgr.InitializeDatabase(ctx, sc.Config, db2Config.ToDatabaseConfig(), testUseLegacySyncDocsIndex)
+	doneChan2, err := initMgr.InitializeDatabase(ctx, sc.Config, db2Config.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true)
 	require.NoError(t, err)
 
 	// Unblock the first InitializeDatabase, should cancel
@@ -465,14 +465,14 @@ func TestDatabaseInitTeardownTiming(t *testing.T) {
 		if databaseCompleteCount.Add(1) == 1 {
 			defer wg.Done()
 			log.Printf("invoking InitializeDatabase again during teardown")
-			doneChan2, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex)
+			doneChan2, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true)
 			require.NoError(t, err)
 			WaitForChannel(t, doneChan2, "done chan 2")
 		}
 	}
 
 	// Start first async index creation, should block after first collection
-	doneChan1, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex)
+	doneChan1, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true)
 	require.NoError(t, err)
 
 	WaitForChannel(t, doneChan1, "done chan 1")
@@ -512,9 +512,10 @@ func waitForWorkerDone(t *testing.T, manager *DatabaseInitManager, dbName string
 
 func TestBuildCollectionIndexData(t *testing.T) {
 	tests := []struct {
-		name   string
-		config *DatabaseConfig
-		want   CollectionInitData
+		name                    string
+		config                  *DatabaseConfig
+		defaultCollectionExists bool
+		want                    CollectionInitData
 	}{
 		{
 			name: "implicit default collection",
@@ -523,6 +524,7 @@ func TestBuildCollectionIndexData(t *testing.T) {
 					Scopes: nil,
 				},
 			},
+			defaultCollectionExists: true,
 			want: CollectionInitData{
 				base.DefaultScopeAndCollectionName():      db.IndexesAll,
 				base.MobileSystemScopeAndCollectionName(): db.IndexesMetadataOnly,
@@ -535,6 +537,7 @@ func TestBuildCollectionIndexData(t *testing.T) {
 					Scopes: makeScopesConfig(base.DefaultScope, []string{base.DefaultCollection}),
 				},
 			},
+			defaultCollectionExists: true,
 			want: CollectionInitData{
 				base.DefaultScopeAndCollectionName():      db.IndexesAll,
 				base.MobileSystemScopeAndCollectionName(): db.IndexesMetadataOnly,
@@ -547,6 +550,7 @@ func TestBuildCollectionIndexData(t *testing.T) {
 					Scopes: makeScopesConfig("scope1", []string{"collection1"}),
 				},
 			},
+			defaultCollectionExists: true,
 			want: CollectionInitData{
 				base.DefaultScopeAndCollectionName():                    db.IndexesMetadataOnly,
 				base.MobileSystemScopeAndCollectionName():               db.IndexesMetadataOnly,
@@ -560,17 +564,33 @@ func TestBuildCollectionIndexData(t *testing.T) {
 					Scopes: makeScopesConfig(base.DefaultScope, []string{base.DefaultCollection, "collection1"}),
 				},
 			},
+			defaultCollectionExists: true,
 			want: CollectionInitData{
 				base.DefaultScopeAndCollectionName():                             db.IndexesAll,
 				base.MobileSystemScopeAndCollectionName():                        db.IndexesMetadataOnly,
 				base.NewScopeAndCollectionName(base.DefaultScope, "collection1"): db.IndexesWithoutMetadata,
 			},
 		},
+		{
+			// _default dropped after migration (e.g. system metadata collection in use): metadata
+			// indexes must not be targeted at the now-missing _default._default collection.
+			name: "named collection with _default dropped",
+			config: &DatabaseConfig{
+				DbConfig: DbConfig{
+					Scopes: makeScopesConfig("scope1", []string{"collection1"}),
+				},
+			},
+			defaultCollectionExists: false,
+			want: CollectionInitData{
+				base.MobileSystemScopeAndCollectionName():               db.IndexesMetadataOnly,
+				base.NewScopeAndCollectionName("scope1", "collection1"): db.IndexesWithoutMetadata,
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actual := buildCollectionIndexData(test.config)
-			assert.Equalf(t, test.want, actual, "buildCollectionIndexData(%v)", test.config)
+			actual := buildCollectionIndexData(test.config, test.defaultCollectionExists)
+			assert.Equalf(t, test.want, actual, "buildCollectionIndexData(%v, %v)", test.config, test.defaultCollectionExists)
 		})
 	}
 }

--- a/rest/defaultcollectiondroptest/default_collection_drop_test.go
+++ b/rest/defaultcollectiondroptest/default_collection_drop_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2026-Present Couchbase, Inc.
+
+Use of this software is governed by the Business Source License included in
+the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+file, in accordance with the Business Source License, use of this software will
+be governed by the Apache License, Version 2.0, included in the file
+licenses/APL2.txt.
+*/
+
+package defaultcollectiondroptest
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
+	"github.com/couchbase/sync_gateway/rest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDatabaseSurvivesDefaultCollectionDropAfterMetadataMigration exercises the theory that once a
+// database has fully migrated its metadata into _system._mobile, the _default collection is no
+// longer required and can be dropped without preventing the database from coming back online.
+//
+// The flow mirrors a production upgrade:
+//
+//  1. Create a database whose documents with use_system_metadata_collection=false.
+//     In this mode the database's metadata (users, roles,
+//     sync-function doc, sequence counters, registry, etc.) lands in _default._default.
+//  2. Write a few users so there is real metadata sitting in _default._default.
+//  3. Opt the database into the system metadata collection and drive the migration to completion,
+//     waiting for BOTH the per-DB status and the bucket-wide bootstrap status to report complete.
+//     After this, all metadata has moved to _system._mobile and _default._default should be unused.
+//  4. Drop the _default collection.
+//  5. Force a full database reload (via a benign config update) so the DatabaseContext is torn down
+//     and rebuilt, reopening its metadata store and collections from scratch.
+//  6. Assert the database comes back Online and still services requests (principals readable, a doc
+//     round-trips through the named collection).
+//
+// This can only run against Couchbase Server: rosmar refuses to drop _default
+func TestDatabaseSurvivesDefaultCollectionDropAfterMetadataMigration(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("requires Couchbase Server: rosmar cannot drop the _default collection, and this scenario only matters on CBS")
+	}
+	base.TestRequiresCollections(t)
+
+	ctx := base.TestCtx(t)
+	tb := base.GetTestBucket(t)
+	defer tb.Close(ctx)
+
+	// The database's documents live in a named collection (sg_test_0.sg_test_0), NOT in
+	// _default._default. That is the precondition for dropping _default safely: only legacy
+	// metadata — never user documents — is colocated there before migration.
+	namedDataStore, err := tb.GetNamedDataStore(0)
+	require.NoError(t, err)
+	namedCollection := base.ScopeAndCollectionName{Scope: namedDataStore.ScopeName(), Collection: namedDataStore.CollectionName()}
+
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		CustomTestBucket: tb.NoCloseClone(),
+		PersistentConfig: true,
+	})
+	defer rt.Close()
+
+	const dbName = "db"
+
+	// 1. Legacy mode: opt-in disabled, so metadata is written to _default._default.
+	dbConfig := rt.NewDbConfig()
+	dbConfig.UseSystemMobileMetadataCollection = base.Ptr(false)
+	dbConfig.Scopes = rest.ScopesConfig{
+		namedCollection.ScopeName(): rest.ScopeConfig{
+			Collections: rest.CollectionsConfig{
+				namedCollection.CollectionName(): {},
+			},
+		},
+	}
+	rest.RequireStatus(t, rt.CreateDatabase(dbName, dbConfig), http.StatusCreated)
+
+	// 2. Write a few users. In legacy mode these `_sync:user:...` docs land in _default._default.
+	for _, user := range []string{"alice", "bob", "carol"} {
+		resp := rt.SendAdminRequest(http.MethodPut, "/"+dbName+"/_user/"+user,
+			fmt.Sprintf(`{"name":%q,"password":"letmein123","admin_channels":["*"]}`, user))
+		rest.RequireStatus(t, resp, http.StatusCreated)
+	}
+
+	// Confirm the legacy metadata really is in _default._default — otherwise the rest of the test
+	// (drop _default, expect survival) would be meaningless.
+	dbCtx, err := rt.ServerContext().GetDatabase(ctx, dbName)
+	require.NoError(t, err)
+	fallback := tb.Bucket.DefaultDataStore(ctx)
+	aliceKey := dbCtx.MetadataKeys.UserKey("alice")
+	exists, err := fallback.Exists(ctx, aliceKey)
+	require.NoError(t, err)
+	require.Truef(t, exists, "user key %q must exist in _default._default before migration", aliceKey)
+
+	// 3a. Opt into the system metadata collection. This rebuilds the MetadataStore as the
+	// dual-collection wrapper (primary=_system._mobile, fallback=_default._default).
+	dbConfig.UseSystemMobileMetadataCollection = base.Ptr(true)
+	rest.RequireStatus(t, rt.UpsertDbConfig(dbName, dbConfig), http.StatusCreated)
+
+	// 3b. Drive the migration. The manual start gates on config-fully-applied, so flush this node's
+	// applied config version first, then kick off and wait for the per-DB status to report complete.
+	rt.ServerContext().ForceClusterCompatRefresh(t, ctx)
+	rest.RequireStatus(t, rt.SendAdminRequest(http.MethodPost, "/"+dbName+"/_metadata_migration?action=start", ""), http.StatusOK)
+	migStatus := rt.WaitForMetadataMigrationStatusForDB(db.BackgroundProcessStateCompleted, dbName)
+	assert.Zero(t, migStatus.DocsFailed, "migration must complete with no per-doc failures")
+
+	// 3c. Wait for the bucket-WIDE bootstrap migration to complete. Bootstrap only flips to complete
+	// once every per-DB entry is complete (here, our single DB), covering the bucket-global docs
+	// (_sync:registry, _sync:dbconfig:*, cbgt cfg). This is the "wait for migration to finish for the
+	// whole bucket" step.
+	rt.WaitForBucketMetadataMigrationComplete(rt.Bucket().GetName())
+
+	// Sanity: the migrated metadata now lives on _system._mobile and is gone from _default._default.
+	systemDS, err := rt.Bucket().NamedDataStore(ctx, base.MobileSystemScopeAndCollectionName())
+	require.NoError(t, err)
+	onPrimary, err := systemDS.Exists(ctx, aliceKey)
+	require.NoError(t, err)
+	require.True(t, onPrimary, "user key must be on _system._mobile after migration")
+	onFallback, err := fallback.Exists(ctx, aliceKey)
+	require.NoError(t, err)
+	require.False(t, onFallback, "user key must be removed from _default._default after migration")
+
+	// 4. Drop _default. IRREVERSIBLE — this is what poisons the bucket and forces this test into its
+	// own package. After this point the bucket must never be reused by another test.
+	require.NoError(t, tb.DropDataStore(ctx, base.ScopeAndCollectionName{Scope: base.DefaultScope, Collection: base.DefaultCollection}),
+		"dropping _default should succeed on Couchbase Server")
+
+	// 5. Force a full database reload by pushing a benign config change (bump revs_limit). The opt-in
+	// must stay true (it is irreversible). A config update reloads the DatabaseContext, tearing down
+	// and rebuilding the metadata store and collection connections — this is where any lingering
+	// dependency on the now-dropped _default collection would surface.
+	dbConfig.RevsLimit = base.Ptr(uint32(100))
+	rest.RequireStatus(t, rt.UpsertDbConfig(dbName, dbConfig), http.StatusCreated)
+
+	// 6a. The database must come back Online.
+	rt.WaitForDatabaseState(dbName, "Online")
+
+	// Guard against a flaky-fast reload: ensure the reload actually took effect.
+	require.Eventually(t, func() bool {
+		reloaded, getErr := rt.ServerContext().GetDatabase(ctx, dbName)
+		return getErr == nil && reloaded.RevsLimit == 100
+	}, 10*time.Second, 100*time.Millisecond, "config reload (revs_limit bump) should have been applied")
+
+	// 6b. Principals must still be readable — these reads go through the migrated _system._mobile
+	// metadata store, not the dropped _default collection.
+	for _, user := range []string{"alice", "bob", "carol"} {
+		resp := rt.SendAdminRequest(http.MethodGet, "/"+dbName+"/_user/"+user, "")
+		rest.RequireStatus(t, resp, http.StatusOK)
+		assert.Contains(t, resp.Body.String(), fmt.Sprintf(`"name":%q`, user))
+	}
+
+	// 6c. End-to-end document round-trip through the named collection: the data path must be fully
+	// functional with _default gone.
+	keyspace := fmt.Sprintf("%s.%s.%s", dbName, namedCollection.ScopeName(), namedCollection.CollectionName())
+	resp := rt.SendAdminRequest(http.MethodPut, "/"+keyspace+"/doc1", `{"channels":["*"],"value":"hello"}`)
+	rest.RequireStatus(t, resp, http.StatusCreated)
+	resp = rt.SendAdminRequest(http.MethodGet, "/"+keyspace+"/doc1", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	assert.Contains(t, resp.Body.String(), `"value":"hello"`)
+}

--- a/rest/defaultcollectiondroptest/default_collection_drop_test.go
+++ b/rest/defaultcollectiondroptest/default_collection_drop_test.go
@@ -54,8 +54,7 @@ func TestDatabaseSurvivesDefaultCollectionDropAfterMetadataMigration(t *testing.
 	defer tb.Close(ctx)
 
 	// The database's documents live in a named collection (sg_test_0.sg_test_0), NOT in
-	// _default._default. That is the precondition for dropping _default safely: only legacy
-	// metadata — never user documents — is colocated there before migration.
+	// _default._default.
 	namedDataStore, err := tb.GetNamedDataStore(0)
 	require.NoError(t, err)
 	namedCollection := base.ScopeAndCollectionName{Scope: namedDataStore.ScopeName(), Collection: namedDataStore.CollectionName()}
@@ -125,15 +124,12 @@ func TestDatabaseSurvivesDefaultCollectionDropAfterMetadataMigration(t *testing.
 	require.NoError(t, err)
 	require.False(t, onFallback, "user key must be removed from _default._default after migration")
 
-	// 4. Drop _default. IRREVERSIBLE — this is what poisons the bucket and forces this test into its
-	// own package. After this point the bucket must never be reused by another test.
+	// 4. Drop _default.
 	require.NoError(t, tb.DropDataStore(ctx, base.ScopeAndCollectionName{Scope: base.DefaultScope, Collection: base.DefaultCollection}),
 		"dropping _default should succeed on Couchbase Server")
 
 	// 5. Force a full database reload by pushing a benign config change (bump revs_limit). The opt-in
-	// must stay true (it is irreversible). A config update reloads the DatabaseContext, tearing down
-	// and rebuilding the metadata store and collection connections — this is where any lingering
-	// dependency on the now-dropped _default collection would surface.
+	// must stay true (it is irreversible).
 	dbConfig.RevsLimit = base.Ptr(uint32(100))
 	rest.RequireStatus(t, rt.UpsertDbConfig(dbName, dbConfig), http.StatusCreated)
 

--- a/rest/defaultcollectiondroptest/main_test.go
+++ b/rest/defaultcollectiondroptest/main_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2026-Present Couchbase, Inc.
+
+Use of this software is governed by the Business Source License included in
+the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+file, in accordance with the Business Source License, use of this software will
+be governed by the Apache License, Version 2.0, included in the file
+licenses/APL2.txt.
+*/
+
+// Package defaultcollectiondroptest is deliberately its own package. The single test it
+// contains DROPS the _default collection. A dropped-_default bucket returned to a shared TestBucketPool would
+// break every sibling test that relies on _default existing, so this destructive test is
+// isolated in a package whose pool only ever services this one test.
+package defaultcollectiondroptest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
+)
+
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 8192}
+	db.TestBucketPoolWithIndexes(ctx, m, tbpOptions)
+}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -807,6 +807,12 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	//     via base.MetadataStore. For a brand-new database with no legacy metadata in
 	//     _default._default the wrapper is immediately marked MigrationComplete so reads go
 	//     straight to the primary collection — no per-DB migration arming.
+	// defaultCollectionPresent tracks whether _default._default physically exists in the bucket. It
+	// drives two decisions: whether the per-DB MetadataStore wrapper needs _default as a read-fallback,
+	// and whether index initialization should build metadata indexes on _default. Defaults to true so
+	// legacy (non-opted-in) DBs — where _default is the metadata store and always exists — and the
+	// "couldn't determine existence" case both preserve existing behavior.
+	defaultCollectionPresent := true
 	if resolveUseSystemMetadataCollection(sc.Config, &config.DbConfig) {
 		primaryMetadataStore, err := bucket.NamedDataStore(ctx, base.MobileSystemScopeAndCollectionName())
 		if err != nil {
@@ -817,7 +823,19 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		}
 		fallbackStore := bucket.DefaultDataStore(ctx)
 		metaStore := base.NewMetadataStore(primaryMetadataStore, fallbackStore)
-		if !probeLegacyPerDBMetadata(ctx, fallbackStore, config.MetadataID) {
+		// It's possible that the legacy _default._default collection has been dropped by a customer,
+		// in which case we can mark the per-DB MetadataStore wrapper as MigrationComplete and skip
+		// dual-read mode. If it exists, probe for legacy _sync:seq to determine whether we need to keep
+		// dual-read mode active.
+		defaultExists, defaultErr := defaultCollectionExists(ctx, bucket)
+		switch {
+		case defaultErr != nil:
+			base.WarnfCtx(ctx, "db:%s unable to determine whether _default._default exists while resolving metadata fallback: %v — keeping dual-read mode", base.MD(dbName), defaultErr)
+		case !defaultExists:
+			defaultCollectionPresent = false
+			metaStore.SetMigrationComplete()
+			base.InfofCtx(ctx, base.KeyConfig, "db:%s _default._default does not exist — marking per-DB MetadataStore wrapper migration-complete (no legacy fallback collection to read from)", base.MD(dbName))
+		case !probeLegacyPerDBMetadata(ctx, fallbackStore, config.MetadataID):
 			if sc.isPerDBMigrationInProgress(ctx, spec.BucketName, config.MetadataID) {
 				base.InfofCtx(ctx, base.KeyConfig, "db:%s no legacy _sync:seq in _default._default but per-DB migration is in_progress on another node — keeping dual-read mode until migration completes", base.MD(dbName))
 			} else {
@@ -943,7 +961,13 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		primaryIndexStore, fallbackIndexStore := contextOptions.MetadataStore, base.DataStore(nil)
 		if dual, isDual := contextOptions.MetadataStore.(*base.MetadataStore); isDual {
 			primaryIndexStore = dual.Primary()
-			fallbackIndexStore = dual.Fallback()
+			// Only consult the fallback for syncDocs-vs-principal index-style inference while
+			// migration is still in flight. Once complete, primary is authoritative; the fallback
+			// (_default._default) may even have been dropped, in which case querying it is wasteful
+			// and noisy (ShouldUseLegacySyncDocsIndex tolerates the error but still fires the query).
+			if !dual.MigrationComplete() {
+				fallbackIndexStore = dual.Fallback()
+			}
 		}
 		metadataStore, ok := base.AsN1QLStore(primaryIndexStore)
 		if !ok {
@@ -966,8 +990,10 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		// If database has been requested to start offline, or there's an active async initialization, use async initialization
 		isAsync = startOffline || sc.DatabaseInitManager.HasActiveInitialization(dbName)
 
-		// Initialize indexes using DatabaseInitManager.
-		dbInitDoneChan, err = sc.DatabaseInitManager.InitializeDatabase(ctx, sc.Config, &config, contextOptions.UseLegacySyncDocsIndex)
+		// Initialize indexes using DatabaseInitManager. defaultCollectionPresent prevents building
+		// metadata indexes on _default._default when it has been dropped post-migration — otherwise
+		// the index create retries until it times out and fails db initialization.
+		dbInitDoneChan, err = sc.DatabaseInitManager.InitializeDatabase(ctx, sc.Config, &config, contextOptions.UseLegacySyncDocsIndex, defaultCollectionPresent)
 		if err != nil {
 			if options.loadFromBucket {
 				sc._handleInvalidDatabaseConfig(ctx, spec.BucketName, config, db.NewDatabaseError(db.DatabaseInitializationIndexError))
@@ -2306,6 +2332,29 @@ func (sc *ServerContext) initializeBootstrapConnection(ctx context.Context) erro
 		base.InfofCtx(ctx, base.KeyConfig, "Unable to migrate v3.0 config to registry - will not be migrated: %v", err)
 	}
 
+	// Stamp the bucket-level metadata-migration status doc into _system._mobile on every bucket
+	// this SG can see. The doc is the source-of-truth for "is migration running / done" — by being
+	// born in the destination collection it never needs migration itself, and a missing doc is
+	// treated as "no migration ever started" by the rest of the pipeline.
+	//
+	// For a bucket whose migration previously completed, stampMetadataMigrationStatusDocs also marks
+	// that bucket migration-complete on this process's connection, which stops bootstrap reads from
+	// falling back to _default._default. (The same per-bucket disable also happens lazily inside
+	// getBucket via ensureBucketBootstrapTargetCached on the first read of each migrated bucket, so a
+	// dropped _default is never the target of a fallback read — otherwise such a read retries on
+	// KV_COLLECTION_OUTDATED until the op times out, ~10s each, hanging startup and config polling.)
+	//
+	// Ordering: this runs AFTER migrateV30Configs so a genuinely-legacy (non-migrated) bucket keeps
+	// its _default fallback while its v3.0 config doc — which lives in _default — is migrated; and
+	// BEFORE fetchAndLoadConfigs so the status doc exists before any database config is loaded. The
+	// stamp only reads the registry/status doc from _system._mobile (never _default for a migrated
+	// bucket) and its writes are idempotent, so it is safe to run here.
+	if base.ValDefault(sc.Config.Bootstrap.UseSystemMetadataCollection, DefaultUseSystemMetadataCollection) {
+		if err := sc.stampMetadataMigrationStatusDocs(ctx); err != nil {
+			base.WarnfCtx(ctx, "Failed to stamp metadata-migration status docs at bootstrap: %v", err)
+		}
+	}
+
 	// Initialize the cluster compat manager before loading configs so that database loads
 	// triggered by fetchAndLoadConfigs can lazily register this node in the buckets they use.
 	sc.ClusterCompat = &clusterCompatManager{sc: sc}
@@ -2314,16 +2363,6 @@ func (sc *ServerContext) initializeBootstrapConnection(ctx context.Context) erro
 	count, err := sc.fetchAndLoadConfigs(ctx, true)
 	if err != nil {
 		return err
-	}
-
-	// Stamp the bucket-level metadata-migration status doc into _system._mobile on every
-	// bucket this SG can see. The doc is the source-of-truth for "is migration running / done"
-	// — by being born in the destination collection it never needs migration itself, and a
-	// missing doc is treated as "no migration ever started" by the rest of the pipeline.
-	if base.ValDefault(sc.Config.Bootstrap.UseSystemMetadataCollection, DefaultUseSystemMetadataCollection) {
-		if err := sc.stampMetadataMigrationStatusDocs(ctx); err != nil {
-			base.WarnfCtx(ctx, "Failed to stamp metadata-migration status docs at bootstrap: %v", err)
-		}
 	}
 
 	if count > 0 {
@@ -2400,6 +2439,25 @@ func probeLegacyPerDBMetadata(ctx context.Context, fallback base.DataStore, meta
 		return true
 	}
 	return exists
+}
+
+// defaultCollectionExists reports whether _default._default is present in the bucket's current
+// collection manifest. It queries the collections manager (management API, via ListDataStores)
+// rather than issuing a KV op against the collection, so a dropped _default is reported promptly
+// from the authoritative ns_server manifest instead of triggering the KV client's
+// KV_COLLECTION_OUTDATED retry loop (which blocks for the full op timeout and surfaces as an
+// unambiguous timeout rather than a clean not-found).
+func defaultCollectionExists(ctx context.Context, bucket base.Bucket) (bool, error) {
+	dataStores, err := bucket.ListDataStores(ctx)
+	if err != nil {
+		return false, err
+	}
+	for _, name := range dataStores {
+		if base.IsDefaultCollection(name.ScopeName(), name.CollectionName()) {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // isPerDBMigrationInProgress checks the bucket-level metadata-migration status doc for the
@@ -2508,7 +2566,7 @@ func (sc *ServerContext) maybeCompleteBucketMetadataMigration(ctx context.Contex
 		return fmt.Errorf("record bootstrap-migration completion on bucket %q: %w", bucketName, err)
 	}
 
-	sc.BootstrapContext.Connection.SetMigrationComplete()
+	sc.BootstrapContext.Connection.SetMigrationComplete(bucketName)
 	if wonRace {
 		base.InfofCtx(ctx, base.KeyConfig, "Bucket %q metadata migration: bootstrap copy complete, fallback reads disabled", base.MD(bucketName))
 	} else {
@@ -2591,9 +2649,10 @@ func bootstrapDocKeysToMigrate(ctx context.Context, registry *GatewayRegistry) [
 
 // stampMetadataMigrationStatusDocs ensures the bucket-level metadata-migration status doc exists
 // in _system._mobile on every bucket visible to this SG. If a doc is found with bootstrap.state
-// already complete (a previous SG instance finished the bucket migration) we immediately invoke
-// SetMigrationComplete on the cluster so this fresh process doesn't pay the fallback-read cost
-// for the lifetime of the connection.
+// already complete (a previous SG instance finished the bucket migration) we mark that bucket
+// migration-complete on the connection so this fresh process doesn't pay the fallback-read cost
+// for that bucket. Completion is tracked per-bucket, so a completed bucket disables its own
+// fallback regardless of other buckets' state.
 //
 // Idempotent across SG nodes — concurrent stamp attempts surface ErrAlreadyExists which we treat
 // as success. Caller has verified that the cluster-level use_system_metadata_collection flag is enabled.
@@ -2602,13 +2661,6 @@ func (sc *ServerContext) stampMetadataMigrationStatusDocs(ctx context.Context) e
 	if err != nil {
 		return fmt.Errorf("list buckets for status-doc stamp: %w", err)
 	}
-	// SetMigrationComplete is connection-scoped, not per-bucket. Until per-bucket migration
-	// state can be tracked on the BootstrapConnection itself, only flip the flag once every
-	// bucket-with-SG-state reports bootstrap.state=complete — otherwise an unfinished bucket
-	// would lose its legacy fallback. Empty buckets (no SG registry presence) are excluded
-	// since they can never drive the migration to completion themselves.
-	sgBucketsSeen := 0
-	sgBucketsComplete := 0
 	for _, bucket := range buckets {
 		_, err := sc.BootstrapContext.Connection.InsertMetadataMigrationStatus(ctx, bucket, base.NewMetadataMigrationStatus())
 		switch {
@@ -2621,17 +2673,14 @@ func (sc *ServerContext) stampMetadataMigrationStatusDocs(ctx context.Context) e
 			continue
 		}
 
-		// If this bucket has already finished the bootstrap migration in a prior SG lifecycle,
-		// the cluster object on this process still has migrationComplete=false (it's per-process
-		// state, not bucket-persisted). Re-apply that signal so fallback reads stay disabled
-		// from this process's first KV op.
-		// Skip buckets with no SG registry presence — they don't participate in migration
-		// and would otherwise pin the cluster in dual-read mode forever.
+		// If this bucket already finished bootstrap migration in a prior SG lifecycle, mark it
+		// complete on this process's connection so its bootstrap reads skip the _default fallback
+		// from the first KV op. Per-bucket: completing one bucket never disables another's fallback.
+		// Skip buckets with no SG registry presence — they don't participate in migration.
 		registry, regErr := sc.BootstrapContext.getGatewayRegistry(ctx, bucket)
 		if regErr != nil || len(registryMetadataIDs(registry)) == 0 {
 			continue
 		}
-		sgBucketsSeen++
 
 		status, _, statusErr := sc.BootstrapContext.Connection.GetMetadataMigrationStatus(ctx, bucket)
 		if statusErr != nil {
@@ -2639,12 +2688,9 @@ func (sc *ServerContext) stampMetadataMigrationStatusDocs(ctx context.Context) e
 			continue
 		}
 		if status.Bootstrap.State == base.MigrationStateComplete {
-			sgBucketsComplete++
+			sc.BootstrapContext.Connection.SetMigrationComplete(bucket)
+			base.InfofCtx(ctx, base.KeyConfig, "Bucket %q metadata migration previously completed — disabling bootstrap fallback reads for this bucket", base.MD(bucket))
 		}
-	}
-	if sgBucketsSeen > 0 && sgBucketsComplete == sgBucketsSeen {
-		sc.BootstrapContext.Connection.SetMigrationComplete()
-		base.InfofCtx(ctx, base.KeyConfig, "Bucket metadata migration previously completed on all visible buckets — disabling bootstrap fallback reads for this process")
 	}
 	return nil
 }

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1111,8 +1111,12 @@ func (rt *RestTester) WaitForBucketMetadataMigrationComplete(bucketName string) 
 	conn := rt.ServerContext().BootstrapContext.Connection
 	require.EventuallyWithT(rt.TB(), func(c *assert.CollectT) {
 		status, _, err := conn.GetMetadataMigrationStatus(ctx, bucketName)
-		require.NoError(c, err)
-		require.NotNil(c, status)
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, status) {
+			return
+		}
 		assert.Equal(c, base.MigrationStateComplete, status.Bootstrap.State, "bucket bootstrap migration should be complete")
 	}, timeout, pollInterval)
 }

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1094,6 +1094,29 @@ func (rt *RestTester) WaitForDatabaseState(dbName string, targetState string) {
 	}, 10*time.Second, 100*time.Millisecond)
 }
 
+// WaitForBucketMetadataMigrationComplete polls the bucket-wide metadata migration status doc until
+// its bootstrap migration reports complete. Bootstrap only transitions to complete once every per-DB
+// entry is complete, so this is the signal that metadata migration has finished for the ENTIRE bucket
+// (including bucket-global docs such as _sync:registry, _sync:dbconfig:* and cbgt cfg) rather than for
+// a single database.
+func (rt *RestTester) WaitForBucketMetadataMigrationComplete(bucketName string) {
+	timeout := 10 * time.Second
+	pollInterval := 100 * time.Millisecond
+	if !base.UnitTestUrlIsWalrus() || base.IsRaceDetectorEnabled(rt.TB()) || os.Getenv("CI") != "" {
+		timeout = 60 * time.Second
+		pollInterval = 500 * time.Millisecond
+	}
+
+	ctx := base.TestCtx(rt.TB())
+	conn := rt.ServerContext().BootstrapContext.Connection
+	require.EventuallyWithT(rt.TB(), func(c *assert.CollectT) {
+		status, _, err := conn.GetMetadataMigrationStatus(ctx, bucketName)
+		require.NoError(c, err)
+		require.NotNil(c, status)
+		assert.Equal(c, base.MigrationStateComplete, status.Bootstrap.State, "bucket bootstrap migration should be complete")
+	}, timeout, pollInterval)
+}
+
 func (rt *RestTester) SendAdminRequestWithHeaders(method, resource string, body string, headers map[string]string) *TestResponse {
 	request := Request(method, rt.mustTemplateResource(resource), body)
 	for k, v := range headers {


### PR DESCRIPTION

CBG-5461

Once a database opts into the system metadata collection (`use_system_metadata_collection`) and its metadata migrates to `_system._mobile`, the `_default._default` collection is no longer needed and an operator may drop it. Several code paths still assumed `_default` was always present and would fail — or hang for ~10s on `KV_COLLECTION_OUTDATED` — when it was gone. This branch makes Sync Gateway tolerate a dropped `_default` across the metadata-store, index-init, caching-feed, and bootstrap-connection layers.

While fixing the bootstrap layer it also corrects a pre-existing cross-bucket correctness bug: bootstrap migration-completion was tracked with a single connection-wide flag, so completing migration on one bucket disabled the _default read-fallback for every bucket on the connection.

Metadata store (rest/server_context.go)
- Added `defaultCollectionExists` (manifest-based via `ListDataStores`, not a KV op, so it can't hang on a dropped collection).
- When opted-in and _default is absent, mark the dual `MetadataStore` wrapper migration-complete so reads go to `_system._mobile` only instead of falling back to a missing collection.

Index initialisation (rest/database_init_manager.go, rest/server_context.go, rest/admin_api.go)
- `buildCollectionIndexData` now takes `defaultCollectionExists` and omits `_default` from the metadata-index set when it's gone (unless `_default` is itself a configured data collection). Prevents the init worker from retrying index creation against a missing collection until the op times out.
- Index-style inventory inspection skips the `_default` fallback once migration is complete.
- This definitely overlaps a but with a different ticket not to create indexes on `_mobile/_default` if not needed. Its possible my changes in index init manger can be torn out in favour for this changes

Caching DCP feed (db/change_listener.go)
- `cachingFeedCollections` only subscribes to the `_default` fallback while `!MigrationComplete()`. Post-migration (or after a drop) the feed subscribes to `_system._mobile` only, fixing a collection `_default` not found failure on feed start.

Bootstrap connection — per-bucket migration completion (base/bootstrap.go, base/rosmar_cluster.go)
- Replaced the connection-wide `migrationComplete` atomic.Bool with a per-bucket `bucketsBootstrapMigrationComplete` map.
- `BootstrapConnection.SetMigrationComplete()` → `SetMigrationComplete(bucketName string)`; `metadataCollections` gates the `_default` fallback per-bucket. Completing one bucket's migration no longer disables another bucket's fallback.
- Piggy backing off of the above:
  - New `defaultCollectionExists(b)` helper (manifest-based, can't hang).
  - `ensureBucketBootstrapTargetCached` checks it first; when `_default` is absent it caches the bucket's target as `_system._mobile` and marks it migration-complete, so all bootstrap reads route to `_system._mobile` only.
  - `probeRegistryLocation` skips its _default keyExists once the bucket is marked complete (covers the direct `SetBucketBootstrapTargetHint` caller).
  - This reuses the existing per-bucket `bucketsBootstrapMigrationComplete` flag — no new map, and `metadataCollections` is unchanged (it already skips the fallback when the bucket is complete).

Note: 
A migrated bucket whose `_default` is still present and which opted in per-DB (cluster flag off) now stays in dual-read at restart until the first `RefreshBucketBootstrapTarget` poll re-establishes complete — harmless (the fallback hits a present, drained `_default`; the primary holds the data). The dropped-`_default` cases that actually hang are all handled eagerly by the existence check.

Startup ordering (rest/server_context.go)
- `stampMetadataMigrationStatusDocs` runs after the legacy v3.0 but before config reads so a completed bucket disables its `_default` fallback before any config read.

I think a nice to have would be to not use `MetadataStore` at all as a wrapper unless migration is in progress/needed. But It felt a more risky change to make at this stage so this can be a future enhancement for maintainability maybe. 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

(both flake)
## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/809/
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/811/
