### PR TITLE
CBG-5457 fix test text assertion

### DIFF
--- a/rest/adminapitest/resync_test.go
+++ b/rest/adminapitest/resync_test.go
@@ -488,7 +488,7 @@ func TestResyncPartitionsValidation(t *testing.T) {
 		}
 		resp := rt.CreateDatabase("db1", dbConfig)
 		rest.RequireStatus(t, resp, http.StatusInternalServerError)
-		assert.Contains(t, resp.Body.String(), "resync_partitions must be between 1 and")
+		assert.Contains(t, resp.BodyString(), db.DatabaseErrorMap[db.DatabaseInvalidResyncPartitions])
 	})
 
 	t.Run("valid custom partitions are used by ResyncManagerDCP", func(t *testing.T) {


### PR DESCRIPTION
CBG-5457 fix test text assertion

Fix up of 8da07c63730fcd38e608e549895a1f5dac409b73, the text changed very slightly.

Test only runs with cb_sg_enterprise and Couchbase Server and was subtly missed.