### PR TITLE
CBG-5463: complete migration when a pending db drops out of cluster

### DIFF
--- a/base/bootstrap.go
+++ b/base/bootstrap.go
@@ -52,6 +52,8 @@ type BootstrapConnection interface {
 	// for the given bucket; subsequent bootstrap reads for that bucket stop falling back to
 	// _default._default. Per-bucket so completing one bucket never disables another's fallback.
 	SetMigrationComplete(bucketName string)
+	// IsMigrationComplete returns true if bootstrap-metadata migration to _system._mobile has finished for the given bucket
+	IsMigrationComplete(bucketName string) bool
 	// GetMetadataMigrationStatus reads the bucket-level metadata-migration status doc directly from
 	// _system._mobile (never via the dual-collection wrapper). Returns ErrNotFound when the doc has
 	// not yet been stamped on this bucket.
@@ -509,6 +511,10 @@ func (cc *CouchbaseCluster) shouldFallback(err error, fallback *gocb.Collection)
 // operations.
 func (cc *CouchbaseCluster) SetMigrationComplete(bucketName string) {
 	cc.bucketsBootstrapMigrationComplete.Store(bucketName, true)
+}
+
+func (cc *CouchbaseCluster) IsMigrationComplete(bucketName string) bool {
+	return cc.bucketBootstrapMigrationComplete(bucketName)
 }
 
 // bucketBootstrapMigrationComplete reports whether bootstrap-metadata migration has been marked

--- a/base/bootstrap.go
+++ b/base/bootstrap.go
@@ -52,7 +52,7 @@ type BootstrapConnection interface {
 	// for the given bucket; subsequent bootstrap reads for that bucket stop falling back to
 	// _default._default. Per-bucket so completing one bucket never disables another's fallback.
 	SetMigrationComplete(bucketName string)
-	// IsMigrationComplete returns true if bootstrap-metadata migration to _system._mobile has finished for the given bucket
+	// IsMigrationComplete reports whether this process has marked bootstrap-metadata migration complete for the given bucket (local cache).
 	IsMigrationComplete(bucketName string) bool
 	// GetMetadataMigrationStatus reads the bucket-level metadata-migration status doc directly from
 	// _system._mobile (never via the dual-collection wrapper). Returns ErrNotFound when the doc has

--- a/base/metadata_migration_status.go
+++ b/base/metadata_migration_status.go
@@ -83,7 +83,7 @@ func NewMetadataMigrationStatus() *MetadataMigrationStatus {
 // Callers must pass the live registry-derived set so a DB added mid-migration isn't missed.
 func (s *MetadataMigrationStatus) AllDatabasesComplete(expected []string) bool {
 	if len(expected) == 0 {
-		return false
+		return true // no databases to wait for, complete migration
 	}
 	for _, id := range expected {
 		entry, ok := s.Databases[id]

--- a/base/rosmar_cluster.go
+++ b/base/rosmar_cluster.go
@@ -272,6 +272,10 @@ func (c *RosmarCluster) SetMigrationComplete(bucketName string) {
 	c.bucketsBootstrapMigrationComplete.Store(bucketName, true)
 }
 
+func (c *RosmarCluster) IsMigrationComplete(bucketName string) bool {
+	return c.bucketBootstrapMigrationComplete(bucketName)
+}
+
 // bucketBootstrapMigrationComplete reports whether bootstrap-metadata migration has been marked
 // complete for the given bucket. Absence of an entry means not-complete, so reads keep the
 // _default._default fallback.

--- a/rest/metadatamigrationtest/metadata_migration_test.go
+++ b/rest/metadatamigrationtest/metadata_migration_test.go
@@ -1607,10 +1607,6 @@ func TestDeleteNonMigratedDbUnblocksBootstrapMigration(t *testing.T) {
 // this node's status doc reads complete but its local "migration complete" cache (IsMigrationComplete) is updated too.
 // RecheckPendingBucketMetadataMigrations should converge that cache so the node stops falling back
 // to _default._default and stops re-doing the recheck work for that bucket every poll.
-//
-// bug: maybeCompleteBucketMetadataMigration returns early when it sees status.Bootstrap.State == complete,
-// *before* it reaches SetMigrationComplete. So the recheck sees the completed doc but never flips the local cache,
-// and IsMigrationComplete stays false indefinitely.
 func TestRecheckConvergesLocalCacheOnPeerCompletedMigration(t *testing.T) {
 	base.TestRequiresCollections(t)
 
@@ -1674,4 +1670,80 @@ func TestRecheckConvergesLocalCacheOnPeerCompletedMigration(t *testing.T) {
 	rt.ServerContext().RecheckPendingBucketMetadataMigrations(ctx)
 
 	require.True(t, conn.IsMigrationComplete(tb.GetName()), "finding 2: recheck observing a peer-completed status doc should converge the local migration-complete cache")
+}
+
+// TestDeleteAllDbsCompletesPendingBootstrapMigration is similar to TestDeleteNonMigratedDbUnblocksBootstrapMigration
+// except that it deletes *every* db (both the migrated db1 and the un-migrated db2) and asserts the same thing
+func TestDeleteAllDbsCompletesPendingBootstrapMigration(t *testing.T) {
+	base.TestRequiresCollections(t)
+
+	ctx := base.TestCtx(t)
+	tb := base.GetTestBucket(t)
+	defer tb.Close(ctx)
+
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		CustomTestBucket: tb.NoCloseClone(),
+		PersistentConfig: true,
+	})
+	defer rt.Close()
+
+	dataStore1, err := tb.GetNamedDataStore(0)
+	require.NoError(t, err)
+	db1Cfg := rt.NewDbConfig()
+	db1Cfg.UseSystemMobileMetadataCollection = base.Ptr(false)
+	db1Cfg.Scopes = rest.ScopesConfig{
+		dataStore1.ScopeName(): rest.ScopeConfig{
+			Collections: rest.CollectionsConfig{dataStore1.CollectionName(): {}},
+		},
+	}
+	rest.RequireStatus(t, rt.CreateDatabase("db1", db1Cfg), http.StatusCreated)
+
+	dataStore2, err := tb.GetNamedDataStore(1)
+	require.NoError(t, err)
+	db2Cfg := rt.NewDbConfig()
+	db2Cfg.UseSystemMobileMetadataCollection = base.Ptr(false)
+	db2Cfg.Scopes = rest.ScopesConfig{
+		dataStore2.ScopeName(): rest.ScopeConfig{
+			Collections: rest.CollectionsConfig{dataStore2.CollectionName(): {}},
+		},
+	}
+	rest.RequireStatus(t, rt.CreateDatabase("db2", db2Cfg), http.StatusCreated)
+
+	// Opt in for db1 and start its migration. This stamps the bucket-level status doc with
+	// Bootstrap.State == pending. The bucket cannot complete yet because db2 has not opted in.
+	db1Cfg.UseSystemMobileMetadataCollection = base.Ptr(true)
+	rest.RequireStatus(t, rt.UpsertDbConfig("db1", db1Cfg), http.StatusCreated)
+	rt.ServerContext().ForceClusterCompatRefresh(t, rt.Context())
+	resp := rt.SendAdminRequest(http.MethodPost, "/db1/_metadata_migration?action=start", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+
+	rt.WaitForMetadataMigrationStatusForDB(db.BackgroundProcessStateCompleted, "db1")
+
+	conn := rt.ServerContext().BootstrapContext.Connection
+
+	// Sanity check: with db2 still present and un-migrated, the bucket bootstrap migration is pending.
+	status, _, err := conn.GetMetadataMigrationStatus(ctx, tb.GetName())
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	require.Equal(t, base.MigrationStatePending, status.Bootstrap.State, "precondition: bucket migration should be pending while db2 is un-migrated")
+
+	// Delete every database in the bucket — both the migrated db1 and the un-migrated db2 — so the
+	// registry has no live entries left.
+	rest.RequireStatus(t, rt.SendAdminRequest(http.MethodDelete, "/db2/", ""), http.StatusOK)
+	rest.RequireStatus(t, rt.SendAdminRequest(http.MethodDelete, "/db1/", ""), http.StatusOK)
+
+	// Re-run the recheck on every tick (mirroring the config-polling cadence) and expect the bucket
+	// migration to converge to complete now that nothing blocks it. It never does — this assertion
+	// fails on the current code because maybeComplete bails at its len(expected) == 0 guard.
+	require.EventuallyWithT(rt.TB(), func(c *assert.CollectT) {
+		rt.ServerContext().RecheckPendingBucketMetadataMigrations(ctx)
+		status, _, err := conn.GetMetadataMigrationStatus(ctx, tb.GetName())
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, status) {
+			return
+		}
+		assert.Equal(c, base.MigrationStateComplete, status.Bootstrap.State, "deleting all dbs should let the pending bucket migration complete")
+	}, 5*time.Second, 100*time.Millisecond)
 }

--- a/rest/metadatamigrationtest/metadata_migration_test.go
+++ b/rest/metadatamigrationtest/metadata_migration_test.go
@@ -1602,3 +1602,76 @@ func TestDeleteNonMigratedDbUnblocksBootstrapMigration(t *testing.T) {
 		assert.Equal(c, base.MigrationStateComplete, status.Bootstrap.State, "bucket bootstrap migration should be complete")
 	}, 10*time.Second, 100*time.Millisecond)
 }
+
+// TestRecheckConvergesLocalCacheOnPeerCompletedMigration ensures when a node completes the bucket bootstrap migration,
+// this node's status doc reads complete but its local "migration complete" cache (IsMigrationComplete) is updated too.
+// RecheckPendingBucketMetadataMigrations should converge that cache so the node stops falling back
+// to _default._default and stops re-doing the recheck work for that bucket every poll.
+//
+// bug: maybeCompleteBucketMetadataMigration returns early when it sees status.Bootstrap.State == complete,
+// *before* it reaches SetMigrationComplete. So the recheck sees the completed doc but never flips the local cache,
+// and IsMigrationComplete stays false indefinitely.
+func TestRecheckConvergesLocalCacheOnPeerCompletedMigration(t *testing.T) {
+	base.TestRequiresCollections(t)
+
+	ctx := base.TestCtx(t)
+	tb := base.GetTestBucket(t)
+	defer tb.Close(ctx)
+
+	dataStore1, err := tb.GetNamedDataStore(0)
+	require.NoError(t, err)
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		CustomTestBucket: tb.NoCloseClone(),
+		PersistentConfig: true,
+	})
+	defer rt.Close()
+
+	db1Cfg := rt.NewDbConfig()
+	db1Cfg.UseSystemMobileMetadataCollection = base.Ptr(false)
+	db1Cfg.Scopes = rest.ScopesConfig{
+		dataStore1.ScopeName(): rest.ScopeConfig{
+			Collections: rest.CollectionsConfig{dataStore1.CollectionName(): {}},
+		},
+	}
+	rest.RequireStatus(t, rt.CreateDatabase("db1", db1Cfg), http.StatusCreated)
+
+	dataStore2, err := tb.GetNamedDataStore(1)
+	require.NoError(t, err)
+	db2Cfg := rt.NewDbConfig()
+	db2Cfg.UseSystemMobileMetadataCollection = base.Ptr(false)
+	db2Cfg.Scopes = rest.ScopesConfig{
+		dataStore2.ScopeName(): rest.ScopeConfig{
+			Collections: rest.CollectionsConfig{dataStore2.CollectionName(): {}},
+		},
+	}
+	rest.RequireStatus(t, rt.CreateDatabase("db2", db2Cfg), http.StatusCreated)
+
+	// Opt in for db1 and run its migration. db2 stays un-migrated, so this node never completes the
+	// bucket migration on its own — its local IsMigrationComplete cache stays false. (db2 also
+	// guarantees the recheck can't complete the bucket itself, isolating the test to the cache
+	// convergence path.)
+	db1Cfg.UseSystemMobileMetadataCollection = base.Ptr(true)
+	rest.RequireStatus(t, rt.UpsertDbConfig("db1", db1Cfg), http.StatusCreated)
+	rt.ServerContext().ForceClusterCompatRefresh(t, rt.Context())
+	resp := rt.SendAdminRequest(http.MethodPost, "/db1/_metadata_migration?action=start", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	rt.WaitForMetadataMigrationStatusForDB(db.BackgroundProcessStateCompleted, "db1")
+
+	conn := rt.ServerContext().BootstrapContext.Connection
+
+	// Simulate a peer node winning the completion: stamp the bucket status doc to complete directly.
+	// UpdateMetadataMigrationStatus only writes the doc — it does not touch this node's local cache,
+	// so IsMigrationComplete is still false afterwards, exactly as it would be on a peer that didn't
+	// run the completion itself.
+	_, err = conn.UpdateMetadataMigrationStatus(ctx, tb.GetName(), func(s *base.MetadataMigrationStatus) error {
+		s.Bootstrap.State = base.MigrationStateComplete
+		return nil
+	})
+	require.NoError(t, err)
+	require.False(t, conn.IsMigrationComplete(tb.GetName()), "precondition: local node should not have marked migration complete yet")
+
+	// The recheck observes the completed status doc; it should converge the local cache.
+	rt.ServerContext().RecheckPendingBucketMetadataMigrations(ctx)
+
+	require.True(t, conn.IsMigrationComplete(tb.GetName()), "finding 2: recheck observing a peer-completed status doc should converge the local migration-complete cache")
+}

--- a/rest/metadatamigrationtest/metadata_migration_test.go
+++ b/rest/metadatamigrationtest/metadata_migration_test.go
@@ -1537,3 +1537,68 @@ func TestMetadataMigrationNamedDBFirstThenDefaultSiblingExclusion(t *testing.T) 
 	rest.RequireStatus(t, resp, http.StatusOK)
 	assert.Contains(t, resp.Body.String(), `"name":"bob"`, "dbnamed must remain readable after dbdefault's later migration")
 }
+
+func TestDeleteNonMigratedDbUnblocksBootstrapMigration(t *testing.T) {
+	base.TestRequiresCollections(t)
+
+	ctx := base.TestCtx(t)
+	tb := base.GetTestBucket(t)
+	defer tb.Close(ctx)
+
+	dataStore1, err := tb.GetNamedDataStore(0)
+	require.NoError(t, err)
+	dataStore2, err := tb.GetNamedDataStore(1)
+	require.NoError(t, err)
+
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		CustomTestBucket: tb.NoCloseClone(),
+		PersistentConfig: true,
+	})
+	defer rt.Close()
+
+	db1Cfg := rt.NewDbConfig()
+	db1Cfg.UseSystemMobileMetadataCollection = base.Ptr(false)
+	db1Cfg.Scopes = rest.ScopesConfig{
+		dataStore1.ScopeName(): rest.ScopeConfig{
+			Collections: rest.CollectionsConfig{dataStore1.CollectionName(): {}},
+		},
+	}
+	rest.RequireStatus(t, rt.CreateDatabase("db1", db1Cfg), http.StatusCreated)
+
+	db2Cfg := rt.NewDbConfig()
+	db2Cfg.UseSystemMobileMetadataCollection = base.Ptr(false)
+	db2Cfg.Scopes = rest.ScopesConfig{
+		dataStore2.ScopeName(): rest.ScopeConfig{
+			Collections: rest.CollectionsConfig{dataStore2.CollectionName(): {}},
+		},
+	}
+	rest.RequireStatus(t, rt.CreateDatabase("db2", db2Cfg), http.StatusCreated)
+
+	// Opt in for db1 and start migration
+	db1Cfg.UseSystemMobileMetadataCollection = base.Ptr(true)
+	rest.RequireStatus(t, rt.UpsertDbConfig("db1", db1Cfg), http.StatusCreated)
+	rt.ServerContext().ForceClusterCompatRefresh(t, rt.Context())
+	resp := rt.SendAdminRequest(http.MethodPost, "/db1/_metadata_migration?action=start", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+
+	rt.WaitForMetadataMigrationStatusForDB(db.BackgroundProcessStateCompleted, "db1")
+
+	// Delete db2
+	resp = rt.SendAdminRequest(http.MethodDelete, "/db2/", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+
+	// force a recheck of pending bucket bootstrap migration, which takes place in config polling
+	rt.ServerContext().RecheckPendingBucketMetadataMigrations(ctx)
+
+	conn := rt.ServerContext().BootstrapContext.Connection
+	require.EventuallyWithT(rt.TB(), func(c *assert.CollectT) {
+		status, _, err := conn.GetMetadataMigrationStatus(ctx, tb.GetName())
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, status) {
+			return
+		}
+		assert.Equal(c, base.MigrationStateComplete, status.Bootstrap.State, "bucket bootstrap migration should be complete")
+	}, 10*time.Second, 100*time.Millisecond)
+}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -2530,7 +2530,6 @@ func (sc *ServerContext) maybeCompleteBucketMetadataMigration(ctx context.Contex
 		// No DBs in registry → nothing to migrate
 		return nil
 	}
-	fmt.Println("resistry ids", expected)
 
 	status, _, err := sc.BootstrapContext.Connection.GetMetadataMigrationStatus(ctx, bucketName)
 	if err != nil {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -2409,11 +2409,7 @@ func (sc *ServerContext) RecheckPendingBucketMetadataMigrations(ctx context.Cont
 	if sc.BootstrapContext == nil || sc.BootstrapContext.Connection == nil {
 		return
 	}
-	buckets, err := sc.BootstrapContext.Connection.GetConfigBuckets(ctx)
-	if err != nil {
-		base.WarnfCtx(ctx, "Couldn't list buckets to re-check bucket metadata migration: %v", err)
-		return
-	}
+	buckets := sc.ClusterCompat.trackedBucketList()
 	for _, bucket := range buckets {
 		if sc.BootstrapContext.Connection.IsMigrationComplete(bucket) {
 			// migration done for this bucket, fast path skip to next bucket
@@ -2529,10 +2525,6 @@ func (sc *ServerContext) maybeCompleteBucketMetadataMigration(ctx context.Contex
 		return fmt.Errorf("read registry for bucket %q: %w", bucketName, err)
 	}
 	expected := registryMetadataIDs(registry)
-	if len(expected) == 0 {
-		// No DBs in registry → nothing to migrate
-		return nil
-	}
 
 	status, _, err := sc.BootstrapContext.Connection.GetMetadataMigrationStatus(ctx, bucketName)
 	if err != nil {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -2403,9 +2403,12 @@ func (sc *ServerContext) initializeBootstrapConnection(ctx context.Context) erro
 	return nil
 }
 
-// RecheckPendingBucketMetadataMigrations will iterate through all buckets and check if any bucket metadata migrations
-// still in pending state can now be moved into in_progress state.
+// RecheckPendingBucketMetadataMigrations iterates through all config buckets and re-evaluates
+// whether bucket-level metadata migration can now be completed.
 func (sc *ServerContext) RecheckPendingBucketMetadataMigrations(ctx context.Context) {
+	if sc.BootstrapContext == nil || sc.BootstrapContext.Connection == nil {
+		return
+	}
 	buckets, err := sc.BootstrapContext.Connection.GetConfigBuckets(ctx)
 	if err != nil {
 		base.WarnfCtx(ctx, "Couldn't list buckets to re-check bucket metadata migration: %v", err)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -2415,7 +2415,7 @@ func (sc *ServerContext) RecheckPendingBucketMetadataMigrations(ctx context.Cont
 		return
 	}
 	for _, bucket := range buckets {
-		if done := sc.BootstrapContext.Connection.IsMigrationComplete(bucket); done {
+		if sc.BootstrapContext.Connection.IsMigrationComplete(bucket) {
 			// migration done for this bucket, fast path skip to next bucket
 			continue
 		}
@@ -2539,6 +2539,7 @@ func (sc *ServerContext) maybeCompleteBucketMetadataMigration(ctx context.Contex
 		return fmt.Errorf("read status doc for bucket %q: %w", bucketName, err)
 	}
 	if status.Bootstrap.State == base.MigrationStateComplete {
+		sc.BootstrapContext.Connection.SetMigrationComplete(bucketName)
 		return nil
 	}
 	if !status.AllDatabasesComplete(expected) {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -2391,6 +2391,7 @@ func (sc *ServerContext) initializeBootstrapConnection(ctx context.Context) erro
 					}
 					sc.ClusterCompat.Refresh(ctx)
 					sc.refreshBucketBootstrapTargets(ctx)
+					sc.RecheckPendingBucketMetadataMigrations(ctx)
 				}
 			}
 		}()
@@ -2400,6 +2401,25 @@ func (sc *ServerContext) initializeBootstrapConnection(ctx context.Context) erro
 	base.InfofCtx(ctx, base.KeyAll, "Finished initializing bootstrap connection")
 
 	return nil
+}
+
+// RecheckPendingBucketMetadataMigrations will iterate through all buckets and check if any bucket metadata migrations
+// still in pending state can now be moved into in_progress state.
+func (sc *ServerContext) RecheckPendingBucketMetadataMigrations(ctx context.Context) {
+	buckets, err := sc.BootstrapContext.Connection.GetConfigBuckets(ctx)
+	if err != nil {
+		base.WarnfCtx(ctx, "Couldn't list buckets to re-check bucket metadata migration: %v", err)
+		return
+	}
+	for _, bucket := range buckets {
+		if done := sc.BootstrapContext.Connection.IsMigrationComplete(bucket); done {
+			// migration done for this bucket, fast path skip to next bucket
+			continue
+		}
+		if err := sc.maybeCompleteBucketMetadataMigration(ctx, bucket); err != nil {
+			base.WarnfCtx(ctx, "Re-check of bucket %q metadata migration failed: %v", base.MD(bucket), err)
+		}
+	}
 }
 
 // resolveUseSystemMetadataCollection returns the effective use_system_metadata_collection
@@ -2510,6 +2530,7 @@ func (sc *ServerContext) maybeCompleteBucketMetadataMigration(ctx context.Contex
 		// No DBs in registry → nothing to migrate
 		return nil
 	}
+	fmt.Println("resistry ids", expected)
 
 	status, _, err := sc.BootstrapContext.Connection.GetMetadataMigrationStatus(ctx, bucketName)
 	if err != nil {


### PR DESCRIPTION
CBG-5463

When a bucket is in pending state due to a db being not migrated yet, we should poll to ensure that this is still the correct state to be in. Meaning if you delete a non migrated db from the bucket it should not hold up bootstrap level migration.

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/876/
