### PR TITLE
CBG-5339 do not send starting sequence greater than end sequence

### DIFF
--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -190,6 +190,9 @@ func (c *DCPCommon) loadCheckpoint(vbNo uint16) (vbMetadata []byte, snapshotStar
 	if unmarshalErr != nil {
 		return []byte{}, 0, 0, err
 	}
+	if c.endSeqNos != nil && snapshotMetadata.SnapStart > c.endSeqNos[vbNo] {
+		return rawValue, c.endSeqNos[vbNo], c.endSeqNos[vbNo], nil
+	}
 	return rawValue, snapshotMetadata.SnapStart, snapshotMetadata.SnapEnd, nil
 
 }

--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -188,7 +188,7 @@ func (c *DCPCommon) loadCheckpoint(vbNo uint16) (vbMetadata []byte, snapshotStar
 	var snapshotMetadata ShardedImportDCPMetadata
 	unmarshalErr := JSONUnmarshal(rawValue, &snapshotMetadata)
 	if unmarshalErr != nil {
-		return []byte{}, 0, 0, err
+		return []byte{}, 0, 0, unmarshalErr
 	}
 	if c.endSeqNos != nil && snapshotMetadata.SnapStart > c.endSeqNos[vbNo] {
 		return rawValue, c.endSeqNos[vbNo], c.endSeqNos[vbNo], nil

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -359,9 +359,6 @@ func TestResyncManagerDCPRunTwice(t *testing.T) {
 }
 
 func TestResyncManagerDCPResumeStoppedProcess(t *testing.T) {
-	if usingShardedResync(t) {
-		t.Skip("CBG-5468 test flakes via not running to completition after resume")
-	}
 	docsToCreate := 5000
 	// rosmar runs too quickly, increase doc count
 	if base.UnitTestUrlIsWalrus() {


### PR DESCRIPTION
CBG-5339 do not send starting sequence greater than end sequence

Sometimes we see the following:

1. EndSeq: 1924
2. snapshotMarker snapStart: 0, snapEnd: 1933
3. Mutation on seq 11
4. snapshotMarker snapStart: 1934, snapEnd: 1934
5. Mutation _sync:dcp_ck::sg:resync-distributed:3ddd294b-169b-44f8-922c-4e14ca2ba7bc79 for vb: 11, SnapStart: 1934

I do not know why we see the mutation past the sequence end, but because there is a snapshot marker, then `checkAndUpdateVbucketState` will call `OpaqueSet` https://github.com/couchbase/cbgt/blob/9f50201be383250600c51a1d0a4b77bfa500bc0a/feed_dcp_gocbcore_observer.go#L83 even if `DCPDest` decides not to process this.

This checkpoint is written in the test because of `ForceCheckpointWrite`, but I'm not sure if `DCPDest.persistCheckpoint` could be called in any different circumstances. Keeping `ForceCheckpointWrite` allows us to avoid double processing documents when a DCP feed stops and restarts or gets rebalanced across nodes.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/823/ (failed due to timeout and high -count ,not failure)
