### PR TITLE
[4.1.0 Backport] CBG-5339: do not send starting sequence greater than end sequence

### DIFF
--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -188,7 +188,10 @@ func (c *DCPCommon) loadCheckpoint(vbNo uint16) (vbMetadata []byte, snapshotStar
 	var snapshotMetadata ShardedImportDCPMetadata
 	unmarshalErr := JSONUnmarshal(rawValue, &snapshotMetadata)
 	if unmarshalErr != nil {
-		return []byte{}, 0, 0, err
+		return []byte{}, 0, 0, unmarshalErr
+	}
+	if c.endSeqNos != nil && snapshotMetadata.SnapStart > c.endSeqNos[vbNo] {
+		return rawValue, c.endSeqNos[vbNo], c.endSeqNos[vbNo], nil
 	}
 	return rawValue, snapshotMetadata.SnapStart, snapshotMetadata.SnapEnd, nil
 

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -359,9 +359,6 @@ func TestResyncManagerDCPRunTwice(t *testing.T) {
 }
 
 func TestResyncManagerDCPResumeStoppedProcess(t *testing.T) {
-	if usingShardedResync(t) {
-		t.Skip("CBG-5468 test flakes via not running to completition after resume")
-	}
 	docsToCreate := 5000
 	// rosmar runs too quickly, increase doc count
 	if base.UnitTestUrlIsWalrus() {


### PR DESCRIPTION
CBG-5339

Backports #8376 to 4.1.0 release branch

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/824/