### PR TITLE
CBG-5484: Support resync invalidate principals on both primary and fallback metadata collections

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -36,6 +36,10 @@ const (
 	TestEnvTLSSkipVerify     = "SG_TEST_TLS_SKIP_VERIFY"
 	DefaultTestTLSSkipVerify = true
 
+	// Env variable to enable _system._mobile collection for SG metadata
+	TestEnvUseSystemMetadataCollection     = "SG_TEST_USE_SYSTEM_METADATA_COLLECTION"
+	DefaultTestUseSystemMetadataCollection = false
+
 	// Walrus by default, but can set to "Couchbase" to have it use http://127.0.0.1:8091
 	TestEnvSyncGatewayBackingStore = "SG_TEST_BACKING_STORE"
 	TestEnvBackingStoreCouchbase   = "Couchbase"

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -227,7 +227,7 @@ func TestTLSSkipVerify() bool {
 	return val
 }
 
-// TestUseSystemMetadataCollection returns true if Sync Gateway should use the system metadata collection in tests. Default: DefaultTestTLSSkipVerify
+// TestUseSystemMetadataCollection returns true if Sync Gateway should use the system metadata collection in tests. Default: DefaultTestUseSystemMetadataCollection
 func TestUseSystemMetadataCollection() bool {
 	useSystemMetadataCollection, isSet := os.LookupEnv(TestEnvUseSystemMetadataCollection)
 	if !isSet {

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -227,6 +227,21 @@ func TestTLSSkipVerify() bool {
 	return val
 }
 
+// TestUseSystemMetadataCollection returns true if Sync Gateway should use the system metadata collection in tests. Default: DefaultTestTLSSkipVerify
+func TestUseSystemMetadataCollection() bool {
+	useSystemMetadataCollection, isSet := os.LookupEnv(TestEnvUseSystemMetadataCollection)
+	if !isSet {
+		return DefaultTestUseSystemMetadataCollection
+	}
+
+	val, err := strconv.ParseBool(useSystemMetadataCollection)
+	if err != nil {
+		panic(fmt.Sprintf("unable to parse %q value %q: %v", TestEnvUseSystemMetadataCollection, useSystemMetadataCollection, err))
+	}
+
+	return val
+}
+
 func TestUseCouchbaseServerDockerName() (bool, string) {
 	testX509CouchbaseServerDockerName, isSet := os.LookupEnv(TestEnvCouchbaseServerDockerName)
 	if !isSet {

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -839,7 +839,9 @@ func initializePrincipalDocsIndex(ctx context.Context, db *DatabaseContext) erro
 	if metadataStore, ok := db.MetadataStore.(*base.MetadataStore); ok {
 		// need to ensure both primary and fallback have index
 		dataStores = append(dataStores, metadataStore.Primary())
-		dataStores = append(dataStores, metadataStore.Fallback())
+		if !metadataStore.MigrationComplete() {
+			dataStores = append(dataStores, metadataStore.Fallback())
+		}
 	} else {
 		dataStores = append(dataStores, db.MetadataStore)
 	}

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -834,10 +834,16 @@ type ResyncManagerStatusDocDCP struct {
 
 // initializePrincipalDocsIndex creates the metadata indexes required for resync
 func initializePrincipalDocsIndex(ctx context.Context, db *DatabaseContext) error {
-	n1qlStore, ok := base.AsN1QLStore(db.MetadataStore)
-	if !ok {
-		return errors.New("Cannot create indexes on non-Couchbase data store.")
+	var dataStores []base.DataStore
+
+	if metadataStore, ok := db.MetadataStore.(*base.MetadataStore); ok {
+		// need to ensure both primary and fallback have index
+		dataStores = append(dataStores, metadataStore.Primary())
+		dataStores = append(dataStores, metadataStore.Fallback())
+	} else {
+		dataStores = append(dataStores, db.MetadataStore)
 	}
+
 	options := InitializeIndexOptions{
 		WaitForIndexesOnlineOption: base.WaitForIndexesDefault,
 		NumReplicas:                db.Options.NumIndexReplicas,
@@ -846,7 +852,17 @@ func initializePrincipalDocsIndex(ctx context.Context, db *DatabaseContext) erro
 		NumPartitions:              db.numIndexPartitions(),
 	}
 
-	return InitializeIndexes(ctx, n1qlStore, options)
+	var me *base.MultiError
+	for _, ds := range dataStores {
+		n1qlStore, ok := base.AsN1QLStore(ds)
+		if !ok {
+			return fmt.Errorf("Cannot create indexes on non-Couchbase data store.")
+		}
+		if err := InitializeIndexes(ctx, n1qlStore, options); err != nil {
+			me = me.Append(err)
+		}
+	}
+	return me.ErrorOrNil()
 }
 
 // getResyncDCPClientOptions returns the default set of DCPClientOptions suitable for resync. collectionIDs

--- a/db/indexes.go
+++ b/db/indexes.go
@@ -413,7 +413,15 @@ func InitializeIndexes(ctx context.Context, n1QLStore base.N1QLStore, options In
 		return nil
 	}
 
-	indexesMeta, err := base.GetIndexesMeta(ctx, n1QLStore, requiredIndexes.FullIndexNames())
+	var (
+		indexesMeta map[string]base.IndexMeta
+		err         error
+	)
+	if base.IsMobileSystemCollection(n1QLStore) {
+		indexesMeta, err = base.GetSystemCollectionIndexesMeta(ctx, n1QLStore, n1QLStore.ScopeName(), n1QLStore.CollectionName(), requiredIndexes.FullIndexNames())
+	} else {
+		indexesMeta, err = base.GetIndexesMeta(ctx, n1QLStore, requiredIndexes.FullIndexNames())
+	}
 	if err != nil {
 		base.WarnfCtx(ctx, "Error getting indexes meta: %v - continuing to create", err)
 	}
@@ -432,7 +440,7 @@ func InitializeIndexes(ctx context.Context, n1QLStore base.N1QLStore, options In
 
 	if len(requiredIndexes) == 0 {
 		// all indexes are already online so we can return early without any per-index queries
-		base.InfofCtx(ctx, base.KeyAll, "Indexes ready - already online when checked")
+		base.InfofCtx(ctx, base.KeyAll, "Indexes ready for %q - already online when checked", n1QLStore.GetName())
 		return nil
 	}
 

--- a/db/indexes.go
+++ b/db/indexes.go
@@ -417,6 +417,7 @@ func InitializeIndexes(ctx context.Context, n1QLStore base.N1QLStore, options In
 		indexesMeta map[string]base.IndexMeta
 		err         error
 	)
+	// TODO: Could probably always route through `GetSystemCollectionIndexesMeta` but will defer for post-4.1 cleanup?
 	if base.IsMobileSystemCollection(n1QLStore) {
 		indexesMeta, err = base.GetSystemCollectionIndexesMeta(ctx, n1QLStore, n1QLStore.ScopeName(), n1QLStore.CollectionName(), requiredIndexes.FullIndexNames())
 	} else {

--- a/db/indexes.go
+++ b/db/indexes.go
@@ -441,7 +441,7 @@ func InitializeIndexes(ctx context.Context, n1QLStore base.N1QLStore, options In
 
 	if len(requiredIndexes) == 0 {
 		// all indexes are already online so we can return early without any per-index queries
-		base.InfofCtx(ctx, base.KeyAll, "Indexes ready for %q - already online when checked", n1QLStore.GetName())
+		base.InfofCtx(ctx, base.KeyAll, "Indexes ready for %q - already online when checked", base.MD(n1QLStore.GetName()))
 		return nil
 	}
 

--- a/rest/adminapitest/resync_test.go
+++ b/rest/adminapitest/resync_test.go
@@ -252,6 +252,12 @@ func TestResyncInvalidatePrincipals(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			// this condition is not allowed via regular db config-level validation
+			// but RestTester code doesn't perform full dbconfig validation to block this
+			if test.useSystemScopeMetadataCollection && base.TestsDisableGSI() {
+				t.Skip("use_views not supported with system scoped metadata collection")
+			}
+
 			rt := rest.NewRestTester(t, &rest.RestTesterConfig{
 				PersistentConfig:                 true,
 				SyncFn:                           initialSyncFn,

--- a/rest/adminapitest/resync_test.go
+++ b/rest/adminapitest/resync_test.go
@@ -222,6 +222,20 @@ func TestResyncRegenerateSequencesPrincipals(t *testing.T) {
 }
 
 func TestResyncInvalidatePrincipals(t *testing.T) {
+	var tests = []struct {
+		name                             string
+		useSystemScopeMetadataCollection bool
+	}{
+		{
+			name:                             "useSystemScopeMetadataCollection=false",
+			useSystemScopeMetadataCollection: false,
+		},
+		{
+			name:                             "useSystemScopeMetadataCollection=true",
+			useSystemScopeMetadataCollection: true,
+		},
+	}
+
 	initialSyncFn := `
 	function(doc) {
 		access(doc.userName, "channelABC");
@@ -236,71 +250,76 @@ func TestResyncInvalidatePrincipals(t *testing.T) {
 		role(doc.userName, "role:roleDEF");
 	}`
 
-	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
-		PersistentConfig: true,
-		SyncFn:           initialSyncFn,
-	})
-	defer rt.Close()
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+				PersistentConfig:                 true,
+				SyncFn:                           initialSyncFn,
+				UseSystemScopeMetadataCollection: base.Ptr(test.useSystemScopeMetadataCollection),
+			})
+			defer rt.Close()
 
-	dbConfig := rt.NewDbConfig()
-	ds := rt.TestBucket.GetSingleDataStore()
-	scopeName := ds.ScopeName()
-	collectionName := ds.CollectionName()
+			dbConfig := rt.NewDbConfig()
+			ds := rt.TestBucket.GetSingleDataStore()
+			scopeName := ds.ScopeName()
+			collectionName := ds.CollectionName()
 
-	rest.RequireStatus(t, rt.CreateDatabase("db1", dbConfig), http.StatusCreated)
+			rest.RequireStatus(t, rt.CreateDatabase("db1", dbConfig), http.StatusCreated)
 
-	// Set up user and role
-	username := "alice"
-	rolename := "foo"
-	grantingDocID := "grantDoc"
-	grantingDocBody := `{
+			// Set up user and role
+			username := "alice"
+			rolename := "foo"
+			grantingDocID := "grantDoc"
+			grantingDocBody := `{
 		"userName":"alice",
 		"roleName":"foo"
 	}`
-	rt.CreateUser(username, nil)
+			rt.CreateUser(username, nil)
 
-	response := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_role/"+rolename, rest.GetRolePayload(t, rolename, rt.GetSingleDataStore(), nil))
-	rest.RequireStatus(t, response, http.StatusCreated)
+			response := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_role/"+rolename, rest.GetRolePayload(t, rolename, rt.GetSingleDataStore(), nil))
+			rest.RequireStatus(t, response, http.StatusCreated)
 
-	// Write doc to perform dynamic grants
-	response = rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+grantingDocID, grantingDocBody)
-	rest.RequireStatus(t, response, http.StatusCreated)
+			// Write doc to perform dynamic grants
+			response = rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+grantingDocID, grantingDocBody)
+			rest.RequireStatus(t, response, http.StatusCreated)
 
-	ctx := rt.Context()
-	user, err := rt.GetDatabase().Authenticator(ctx).GetUser(username)
-	require.NoError(t, err)
-	channels := user.CollectionChannels(scopeName, collectionName)
-	_, ok := channels["channelABC"]
-	require.True(t, ok, "user should have channel channelABC")
-	roles := user.RoleNames()
-	_, ok = roles["roleABC"]
-	require.True(t, ok, "user should have role roleABC")
+			ctx := rt.Context()
+			user, err := rt.GetDatabase().Authenticator(ctx).GetUser(username)
+			require.NoError(t, err)
+			channels := user.CollectionChannels(scopeName, collectionName)
+			_, ok := channels["channelABC"]
+			require.True(t, ok, "user should have channel channelABC")
+			roles := user.RoleNames()
+			_, ok = roles["roleABC"]
+			require.True(t, ok, "user should have role roleABC")
 
-	rt.TakeDbOffline()
+			rt.TakeDbOffline()
 
-	// Update the sync function
-	rt.SyncFn = updatedSyncFn
-	updatedDbConfig := rt.NewDbConfig()
-	rt.UpsertDbConfig("db1", updatedDbConfig)
-	rt.TakeDbOffline()
+			// Update the sync function
+			rt.SyncFn = updatedSyncFn
+			updatedDbConfig := rt.NewDbConfig()
+			rt.UpsertDbConfig("db1", updatedDbConfig)
+			rt.TakeDbOffline()
 
-	// Run resync
-	rest.RequireStatus(t, rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_resync?action=start", ""), http.StatusOK)
-	_ = rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
+			// Run resync
+			rest.RequireStatus(t, rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_resync?action=start", ""), http.StatusOK)
+			_ = rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
 
-	// validate user channels and roles have been updated
-	user, err = rt.GetDatabase().Authenticator(ctx).GetUser(username)
-	require.NoError(t, err)
-	channels = user.CollectionChannels(scopeName, collectionName)
-	_, ok = channels["channelABC"]
-	require.False(t, ok, "user should not have channel channelABC")
-	_, ok = channels["channelDEF"]
-	require.True(t, ok, "user should have channel channelDEF")
-	roles = user.RoleNames()
-	_, ok = roles["roleABC"]
-	require.False(t, ok, "user should not have role roleABC")
-	_, ok = roles["roleDEF"]
-	require.True(t, ok, "user should have role roleDEF")
+			// validate user channels and roles have been updated
+			user, err = rt.GetDatabase().Authenticator(ctx).GetUser(username)
+			require.NoError(t, err)
+			channels = user.CollectionChannels(scopeName, collectionName)
+			_, ok = channels["channelABC"]
+			require.False(t, ok, "user should not have channel channelABC")
+			_, ok = channels["channelDEF"]
+			require.True(t, ok, "user should have channel channelDEF")
+			roles = user.RoleNames()
+			_, ok = roles["roleABC"]
+			require.False(t, ok, "user should not have role roleABC")
+			_, ok = roles["roleDEF"]
+			require.True(t, ok, "user should have role roleDEF")
+		})
+	}
 }
 
 func TestResyncDoesNotWriteDocBody(t *testing.T) {

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -51,33 +51,34 @@ import (
 
 // RestTesterConfig represents configuration for sync gateway
 type RestTesterConfig struct {
-	GuestEnabled                    bool                        // If this is true, Admin Party is in full effect
-	SyncFn                          string                      // put the sync() function source in here (optional)
-	ImportFilter                    string                      // put the import filter function source in here (optional)
-	DatabaseConfig                  *DatabaseConfig             // Supports additional config options.  BucketConfig, Name, Sync, Unsupported will be ignored (overridden)
-	MutateStartupConfig             func(config *StartupConfig) // Function to mutate the startup configuration before the server context gets created. This overrides options the RT sets.
-	InitSyncSeq                     uint64                      // If specified, initializes _sync:seq on bucket creation.  Not supported when running against walrus
-	AllowConflicts                  bool                        // Enable conflicts mode.  By default, conflicts will not allowed
-	EnableUserQueries               bool                        // Enable the feature-flag for user N1QL/etc queries
-	CustomTestBucket                *base.TestBucket            // If set, use this bucket instead of requesting a new one.
-	LeakyBucketConfig               *base.LeakyBucketConfig     // Set to create and use a leaky bucket on the RT and DB. A test bucket cannot be passed in if using this option.
-	adminInterface                  string                      // adminInterface overrides the default admin interface.
-	SgReplicateEnabled              bool                        // SgReplicateManager disabled by default for RestTester
-	AutoImport                      *bool
-	HideProductInfo                 bool
-	AdminInterfaceAuthentication    bool
-	metricsInterfaceAuthentication  bool
-	enableAdminAuthPermissionsCheck bool
-	useTLSServer                    bool // If true, TLS will be required for communications with CBS. Default: false
-	PersistentConfig                bool
-	GroupID                         *string
-	serverless                      bool // Runs SG in serverless mode. Must be used in conjunction with persistent config
-	collectionConfig                collectionConfiguration
-	numCollections                  int
-	nodeClusterCompatVersion        *base.ClusterCompatVersion // alternate cluster compat version this node identifies as. Defaults to base.NodeClusterCompatVersion.
-	allowDbConfigEnvVars            *bool
-	maxConcurrentRevs               *int
-	UseXattrConfig                  bool
+	GuestEnabled                     bool                        // If this is true, Admin Party is in full effect
+	SyncFn                           string                      // put the sync() function source in here (optional)
+	ImportFilter                     string                      // put the import filter function source in here (optional)
+	DatabaseConfig                   *DatabaseConfig             // Supports additional config options.  BucketConfig, Name, Sync, Unsupported will be ignored (overridden)
+	MutateStartupConfig              func(config *StartupConfig) // Function to mutate the startup configuration before the server context gets created. This overrides options the RT sets.
+	InitSyncSeq                      uint64                      // If specified, initializes _sync:seq on bucket creation.  Not supported when running against walrus
+	AllowConflicts                   bool                        // Enable conflicts mode.  By default, conflicts will not allowed
+	EnableUserQueries                bool                        // Enable the feature-flag for user N1QL/etc queries
+	CustomTestBucket                 *base.TestBucket            // If set, use this bucket instead of requesting a new one.
+	LeakyBucketConfig                *base.LeakyBucketConfig     // Set to create and use a leaky bucket on the RT and DB. A test bucket cannot be passed in if using this option.
+	adminInterface                   string                      // adminInterface overrides the default admin interface.
+	SgReplicateEnabled               bool                        // SgReplicateManager disabled by default for RestTester
+	AutoImport                       *bool
+	HideProductInfo                  bool
+	AdminInterfaceAuthentication     bool
+	metricsInterfaceAuthentication   bool
+	enableAdminAuthPermissionsCheck  bool
+	useTLSServer                     bool // If true, TLS will be required for communications with CBS. Default: false
+	PersistentConfig                 bool
+	GroupID                          *string
+	serverless                       bool // Runs SG in serverless mode. Must be used in conjunction with persistent config
+	collectionConfig                 collectionConfiguration
+	numCollections                   int
+	nodeClusterCompatVersion         *base.ClusterCompatVersion // alternate cluster compat version this node identifies as. Defaults to base.NodeClusterCompatVersion.
+	allowDbConfigEnvVars             *bool
+	maxConcurrentRevs                *int
+	UseXattrConfig                   bool
+	UseSystemScopeMetadataCollection *bool
 }
 
 type collectionConfiguration uint8
@@ -272,6 +273,12 @@ func (rt *RestTester) Bucket() base.Bucket {
 				Password: base.TestClusterPassword(),
 			},
 		}
+	}
+
+	if rt.RestTesterConfig.UseSystemScopeMetadataCollection != nil {
+		sc.Bootstrap.UseSystemMetadataCollection = rt.RestTesterConfig.UseSystemScopeMetadataCollection
+	} else {
+		sc.Bootstrap.UseSystemMetadataCollection = base.Ptr(base.TestUseSystemMetadataCollection())
 	}
 
 	if rt.RestTesterConfig.GroupID != nil {


### PR DESCRIPTION
CBG-5484

Unblocks resync working for a system-scope enabled database

Fixes:
- Allows support for invalidating principals on a database mid-migration (supporting principal invalidation in both locations)
- Fixes error when running resync on a database using the system scope for metadata storage
```
2026-06-19T12:11:11.232+01:00 [INF] c:ae193ecd-c986-4c7e-854f-829b85fae203 db:db1 Finished running resync. 1/1 docs changed
2026-06-19T12:11:12.149+01:00 [INF] DCP: feed_dcp_gocbcore: onError, name: db0xbdcaa3f7_resync_index_ebdcf3da0a0d06ba_fd7746b4, bucketName: b1, bucketUUID: b4fdd2eb0b656b09891844e0feb55a12, err: OpenStream, error waiting for vb: 21, err: disconnected
2026-06-19T12:11:12.164+01:00 [ERR] c:#006 db:db1 Error: Cannot create indexes on non-Couchbase data store. -- db.(*BackgroundManager[...]).start.func3() at background_mgr.go:300
```

## testing

```
2026-06-19T13:58:29.438+01:00 [INF] c:5bb03340-7b83-403d-bd79-06fb72282610 db:db1 Finished running resync. 1/1 docs changed
2026-06-19T13:58:29.473+01:00 [INF] c:5bb03340-7b83-403d-bd79-06fb72282610 db:db1 Indexes ready for "b1._system._mobile" - already online when checked
2026-06-19T13:58:29.483+01:00 [INF] c:5bb03340-7b83-403d-bd79-06fb72282610 db:db1 Indexes ready for "b1" - already online when checked
2026-06-19T13:58:29.483+01:00 [INF] c:5bb03340-7b83-403d-bd79-06fb72282610 db:db1 Invalidating channel caches of users/roles...
```
- [x] integration test for coverage
- [x] global test env var for system collection opt-in (not completely passing but test-only issues present)

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/826/
  - `TestDatabaseInitConcurrentDatabasesSameBucket` flake
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/828/
