### PR TITLE
CBG-3534 Fix flaky TestActiveReplicatorEdgeCheckpointNameCollisions

### DIFF
--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -3589,6 +3589,8 @@ func TestActiveReplicatorEdgeCheckpointNameCollisions(t *testing.T) {
 		changesResults = edge2.WaitForChanges(numRT1DocsInitial, "/{{.keyspace}}/_changes?since=0", "", true)
 
 		edge2PullCheckpointer := edge2Replicator.Pull.GetSingleCollection(t).Checkpointer
+		base.RequireWaitForStat(t, func() int64 { return edge2PullCheckpointer.Stats().ProcessedSequenceCount }, numRT1DocsInitial)
+		base.RequireWaitForStat(t, func() int64 { return edge2PullCheckpointer.Stats().ExpectedSequenceCount }, numRT1DocsInitial)
 		edge2PullCheckpointer.CheckpointNow()
 
 		// make sure that edge 2 didn't use a checkpoint


### PR DESCRIPTION
CBG-3534 Fix flaky TestActiveReplicatorEdgeCheckpointNameCollisions

WaitForChanges returns as soon as docs are visible in the _changes feed (after the DB write), but sgr2PullProcessedSeqCallback — which marks a sequence as processed in the checkpointer — is called immediately after the write. In versionVector mode, writing a doc with HLV computation can take ~30ms vs ~2ms in revTree mode, creating a window where WaitForChanges returns while the lowest expected sequence (seq 2) is still being processed.

When CheckpointNow() runs at that point, _calculateSafeExpectedSeqsIdx() finds seq 2 not yet in processedSeqs and returns -1, so no checkpoint is saved and SetCheckpointCount stays at 0.

The fix mirrors the RequireWaitForStat guards already present for edge1: wait for both ProcessedSequenceCount and ExpectedSequenceCount to reach numRT1DocsInitial before calling CheckpointNow() on edge2.

Adding a sleep here https://github.com/couchbase/sync_gateway/blob/e8f8ffa0fc66789ec72243fd6f9a6194afb17046/db/blip_handler.go#L1396 can reproduce this error.