### PR TITLE
CBG-5481 Fix race in _index_init stop

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -438,10 +438,13 @@ func (h *handler) handlePostIndexInit() error {
 	action := cmp.Or(h.getQuery("action"), "start")
 
 	if action == "stop" {
-		h.server.DatabaseInitManager.Cancel(h.db.Name, fmt.Sprintf("Initialization stopped by %s", h.rq.URL))
+		// Stop (closing the terminator) must happen before Cancel (which sends context.Canceled to doneChan).
+		// AsyncIndexInitManager.Run suppresses errors when terminator.IsClosed(); if Cancel fires first,
+		// Run may receive the error before the terminator is closed and return it as a real failure.
 		if err := h.db.AsyncIndexInitManager.Stop(h.ctx()); err != nil {
 			return err
 		}
+		h.server.DatabaseInitManager.Cancel(h.db.Name, fmt.Sprintf("Initialization stopped by %s", h.rq.URL))
 		b, err := h.db.AsyncIndexInitManager.GetStatus(h.ctx())
 		if err != nil {
 			return err


### PR DESCRIPTION
CBG-5481 Fixes race in TestChangeIndexPartitionsStartStopAndRestart 

This is theoretically possible for non test usage but the only impact is that calling stop results in state error instead of stopped. It is still resumable.

AsyncIndexInitManager.Run receives from doneChan and suppresses the error only if terminator.IsClosed() is true.

1. Cancel sends context.Canceled to doneChan
2. Stop closes the terminator.

If 1 successfully returns before 2, then Database initialization cancelled: context canceled would occur.

A different fix and maybe one to do as well would be to change https://github.com/couchbase/sync_gateway/blob/e8f8ffa0fc66789ec72243fd6f9a6194afb17046/db/background_mgr_async_index_init.go#L41 to check `errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)`. I was somewhat reluctant to do this in case for some reason the error wasn't a user cancelation but on the other hand it is easy to reintroduce this problem. We had previously tried to fix this for some cases in https://github.com/couchbase/sync_gateway/commit/ef01c8c302c706b141c7eaefa32a7af6401be203 but there was still this underlying race.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/838/
