### PR TITLE
CBG-5500 remove unused UseXattrs/KvTLSPort from BucketSpec

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -116,8 +116,6 @@ type BucketSpec struct {
 	Auth                          AuthHandler
 	Certpath, Keypath, CACertPath string         // X.509 auth parameters
 	TLSSkipVerify                 bool           // Use insecureSkipVerify when secure scheme (couchbases) is used and cacertpath is undefined
-	KvTLSPort                     int            // Port to use for memcached over TLS.  Required for cbdatasource auth when using TLS
-	UseXattrs                     bool           // Whether to use xattrs to store _sync metadata.  Used during view initialization
 	ViewQueryTimeoutSecs          *uint32        // the view query timeout in seconds (default: 75 seconds)
 	MaxConcurrentQueryOps         *int           // maximum number of concurrent query operations (default: DefaultMaxConcurrentQueryOps)
 	BucketOpTimeout               *time.Duration // How long bucket ops should block returning "operation timed out". If nil, uses GoCB default.  GoCB buckets only.
@@ -302,16 +300,6 @@ func GetBucket(ctx context.Context, spec BucketSpec) (bucket Bucket, err error) 
 		if err != nil {
 			return nil, err
 		}
-
-		// If XATTRS are enabled via enable_shared_bucket_access config flag, assert that Couchbase Server is 5.0
-		// or later, otherwise refuse to connect to the bucket since pre 5.0 versions don't support XATTRs
-		if spec.UseXattrs {
-			if !bucket.IsSupported(sgbucket.BucketStoreFeatureXattrs) {
-				WarnfCtx(ctx, "If using XATTRS, Couchbase Server version must be >= 5.0.")
-				return nil, ErrFatalBucketConnection
-			}
-		}
-
 	}
 
 	// TODO: CBG-2529 - LoggingBucket has been removed - pending a new approach to logging all bucket operations

--- a/base/leaky_datastore.go
+++ b/base/leaky_datastore.go
@@ -393,7 +393,6 @@ func (lds *LeakyDataStore) GetSpec() BucketSpec {
 		// Return a minimal struct:
 		return BucketSpec{
 			BucketName: lds.bucket.GetName(),
-			UseXattrs:  true,
 		}
 	}
 }

--- a/base/main_test_bucket_pool_util.go
+++ b/base/main_test_bucket_pool_util.go
@@ -53,7 +53,6 @@ func getTestBucketSpec(clusterSpec CouchbaseClusterSpec, testBucketName tbpBucke
 			Username: clusterSpec.Username,
 			Password: TestClusterPassword(),
 		},
-		UseXattrs:     TestUseXattrs(),
 		BucketName:    string(testBucketName),
 		TLSSkipVerify: clusterSpec.TLSSkipVerify,
 		// use longer timeout than DefaultBucketOpTimeout to avoid timeouts in test harness from using buckets after flush, which takes some time to reinitialize

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1318,7 +1318,8 @@ Database:
       description: The key path (private key) for X.509 bucket auth
       type: string
     kv_tls_port:
-      description: The Memcached TLS port.
+      description: The Memcached TLS port. This value is ignored, a port has to be specified in the connection string.
+      deprecated: true
       type: integer
       default: 11207
     local_doc_expiry_secs:

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1317,11 +1317,6 @@ Database:
     keypath:
       description: The key path (private key) for X.509 bucket auth
       type: string
-    kv_tls_port:
-      description: The Memcached TLS port. This value is ignored, a port has to be specified in the connection string.
-      deprecated: true
-      type: integer
-      default: 11207
     local_doc_expiry_secs:
       description: The number of seconds before a `_local` document should expire.
       type: integer
@@ -1809,6 +1804,11 @@ Database:
       enum:
         - DCP
       deprecated: true
+    kv_tls_port:
+      description: The Memcached TLS port. This value is ignored, a port has to be specified in the connection string.
+      deprecated: true
+      type: integer
+      default: 11207
     num_index_replicas:
       description: |-
         **Deprecated, please use the database setting `index.num_replicas` instead**

--- a/rest/config.go
+++ b/rest/config.go
@@ -112,7 +112,6 @@ func (dc *DbConfig) MakeBucketSpec(server string) base.BucketSpec {
 	bc := &dc.BucketConfig
 
 	bucketName := ""
-	tlsPort := 11207
 
 	// treat all walrus: as in memory storage, any persistent storage would have to be converted to rosmar
 	if strings.HasPrefix(server, "walrus:") {
@@ -123,17 +122,12 @@ func (dc *DbConfig) MakeBucketSpec(server string) base.BucketSpec {
 		bucketName = *bc.Bucket
 	}
 
-	if bc.KvTLSPort != 0 {
-		tlsPort = bc.KvTLSPort
-	}
-
 	return base.BucketSpec{
 		Server:                server,
 		BucketName:            bucketName,
 		Keypath:               bc.KeyPath,
 		Certpath:              bc.CertPath,
 		CACertPath:            bc.CACertPath,
-		KvTLSPort:             tlsPort,
 		Auth:                  bc,
 		MaxConcurrentQueryOps: bc.MaxConcurrentQueryOps,
 	}

--- a/rest/config.go
+++ b/rest/config.go
@@ -103,7 +103,7 @@ type BucketConfig struct {
 	CertPath              string  `json:"certpath,omitempty"`                 // Cert path (public key) for X.509 bucket auth
 	KeyPath               string  `json:"keypath,omitempty"`                  // Key path (private key) for X.509 bucket auth
 	CACertPath            string  `json:"cacertpath,omitempty"`               // Root CA cert path for X.509 bucket auth
-	KvTLSPort             int     `json:"kv_tls_port,omitempty"`              // Memcached TLS port, if not default (11207)
+	KvTLSPort             int     `json:"kv_tls_port,omitempty"`              // Deprecated: this has no effect and is present for compatibility with older database configs.
 	MaxConcurrentQueryOps *int    `json:"max_concurrent_query_ops,omitempty"` // Max concurrent  query ops
 }
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -686,11 +686,6 @@ func GetBucketSpec(ctx context.Context, config *DatabaseConfig, serverConfig *St
 		spec.ViewQueryTimeoutSecs = config.ViewQueryTimeoutSecs
 	}
 
-	spec.UseXattrs = config.UseXattrs()
-	if !spec.UseXattrs {
-		base.WarnfCtx(ctx, "Running Sync Gateway without shared bucket access is deprecated. Recommendation: set enable_shared_bucket_access=true")
-	}
-
 	if config.BucketOpTimeoutMs != nil {
 		operationTimeout := time.Millisecond * time.Duration(*config.BucketOpTimeoutMs)
 		spec.BucketOpTimeout = &operationTimeout

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -221,7 +221,6 @@ func bucketConfigFromTestBucket(tb *base.TestBucket) BucketConfig {
 		CertPath:   tb.BucketSpec.Certpath,
 		KeyPath:    tb.BucketSpec.Keypath,
 		CACertPath: tb.BucketSpec.CACertPath,
-		KvTLSPort:  tb.BucketSpec.KvTLSPort,
 	}
 }
 


### PR DESCRIPTION
CBG-5500 remove unused UseXattrs/KvTLSPort from BucketSpec

- Update docs to indicate that KvTLSPort is unused, though it has been at least since gocb was used.
- Remove unused option for `UseXattrs`, it was set by the REST package but unused.

This is part of a bigger removal process of the xattr code, but it is easier to do in easy to digest stages. I want to isolate test and non test PRs.

- [x] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/858/ 