### PR TITLE
CBG-5502: Skip log redaction on `sg_stack_trace.log`

### DIFF
--- a/tools-tests/tasks_test.py
+++ b/tools-tests/tasks_test.py
@@ -271,6 +271,14 @@ def test_task_logging(verbosity, task_platform, tmp_path):
             "/abs/path/expvars.json",
             False,
         ),
+        (
+            "sg_stack_trace.log",
+            False,
+        ),
+        (
+            "/abs/path/sg_stack_trace-2024-01-01.log.gz",
+            False,
+        ),
     ],
 )
 @pytest.mark.parametrize("use_pathlib", [True, False])

--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -819,7 +819,7 @@ def redactable_file(filename: Union[pathlib.Path, str]) -> bool:
     Return True if the file should be redacted, otherwise False.
     """
     filename = pathlib.Path(filename)
-    if filename.name.startswith(("pprof", "expvars.json")):
+    if filename.name.startswith(("pprof", "expvars.json", "sg_stack_trace")):
         return False
     return filename.stem != "sync_gateway"
 


### PR DESCRIPTION
CBG-5502

Stack traces (goroutine dumps from `/_debug/pprof/goroutine`) never contain redactable info, so exclude `sg_stack_trace.log` from sgcollect redaction.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- n/a