### PR TITLE
CBG-5506 Fix flaky TestActiveReplicatorConflictPreUpgradedVersionEachSide

### DIFF
--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -786,6 +786,7 @@ func AssertWaitForStat(t testing.TB, getStatFunc func() int64, expected int64) (
 
 // RequireWaitForStat will retry for up to 20 seconds until the result of getStatFunc is equal to the expected value.
 func RequireWaitForStat(t testing.TB, getStatFunc func() int64, expected int64) (val int64) {
+	t.Helper()
 	require.NotNil(t, getStatFunc, "Function for RequireWaitForStat cannot be nil")
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		val = getStatFunc()

--- a/rest/replicatortest/replicator_test_legacy_rev_test.go
+++ b/rest/replicatortest/replicator_test_legacy_rev_test.go
@@ -767,10 +767,16 @@ func TestActiveReplicatorConflictPreUpgradedVersionEachSide(t *testing.T) {
 				require.NoError(t, ar.Start(ctx1))
 
 				if tc.activeWins {
-					base.RequireWaitForStat(t, func() int64 {
-						return replicationStats.ConflictResolvedLocalCount.Value()
-					}, 1)
-					verPostConflictRes, _ := rt1.GetDoc(docID)
+					// ConflictResolvedLocalCount is incremented inside the updateAndReturnDoc callback,
+					// before the CAS write commits. A plain GetDoc after RequireWaitForStat can still
+					// see the pre-resolution rev. Poll both the stat and the version change together so
+					// verPostConflictRes is always the committed post-resolution rev when we use it below.
+					var verPostConflictRes rest.DocVersion
+					require.EventuallyWithT(t, func(c *assert.CollectT) {
+						assert.Equal(c, int64(1), replicationStats.ConflictResolvedLocalCount.Value())
+						verPostConflictRes, _ = rt1.GetDoc(docID)
+						assert.NotEqual(c, legacyRevRT1, verPostConflictRes.RevTreeID)
+					}, 10*time.Second, 50*time.Millisecond)
 					rt2.WaitForLegacyRev(docID, verPostConflictRes.RevTreeID, []byte(`{"channels":["alice"],"source":"rt1"}`))
 					rt2Doc := rt2.GetDocument(docID)
 					rest.RequireHistoryContains(t, rt2Doc.History, []string{initLegacyRevRT2, legacyRevRT2, verPostConflictRes.RevTreeID})

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2346,12 +2346,14 @@ func RequireDocVersionNotNil(t *testing.T, version DocVersion) {
 
 // RequireDocVersionEqual calls t.Fail if two document versions are not equal.
 func RequireDocVersionEqual(t testing.TB, expected, actual DocVersion) {
+	t.Helper()
 	require.Equal(t, expected.CV, actual.CV, "Versions mismatch.  Expected: %v, Actual: %v", expected, actual)
 	require.Equal(t, expected.RevTreeID, actual.RevTreeID, "Versions mismatch.  Expected: %v, Actual: %v", expected, actual)
 }
 
 // RequireHistoryContains fails test if rev tree does not contain all expected revIDs
 func RequireHistoryContains(t *testing.T, docHistory db.RevTree, expHistoryIDs []string) {
+	t.Helper()
 	require.Lenf(t, docHistory, len(expHistoryIDs), "Expected history to contain %d revIDs, but it had %d.  History: %v", len(expHistoryIDs), len(docHistory), docHistory)
 	for _, revID := range expHistoryIDs {
 		_, ok := docHistory[revID]
@@ -2361,6 +2363,7 @@ func RequireHistoryContains(t *testing.T, docHistory db.RevTree, expHistoryIDs [
 
 // RequireDocRevTreeEqual fails test if rev tree id's are not equal
 func RequireDocRevTreeEqual(t *testing.T, expected, actual DocVersion) {
+	t.Helper()
 	require.Equal(t, expected.RevTreeID, actual.RevTreeID)
 }
 

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -135,6 +135,7 @@ func (rt *RestTester) GetDocument(docID string) *db.Document {
 
 // WaitForLegacyRev waits for a legacy revision ID (1-abc) to exist. If the document is not found, the test will fail.
 func (rt *RestTester) WaitForLegacyRev(docID, legacyRevID string, expectedBody []byte) *db.Document {
+	rt.TB().Helper()
 	rt.WaitForVersionRevIDOnly(docID, db.DocVersion{RevTreeID: legacyRevID})
 	doc := rt.GetDocument(docID)
 	encodedCV, err := db.LegacyRevToRevTreeEncodedVersion(legacyRevID)
@@ -220,6 +221,7 @@ func (rt *RestTester) GetAllDBsVerbose() []DbSummary {
 
 // WaitForVersion retries a GET for a given document version until it returns 200 or 201 for a given document and revision. If version is not found, the test will fail.
 func (rt *RestTester) WaitForVersion(docID string, version DocVersion) {
+	rt.TB().Helper()
 	if version.RevTreeID == "" {
 		require.NotEqual(rt.TB(), "", version.CV.String(), "Expected CV if RevTreeID is empty for version %#v in WaitForVersion", version)
 	}
@@ -231,7 +233,7 @@ func (rt *RestTester) WaitForVersion(docID string, version DocVersion) {
 		var body db.Body
 		require.NoError(rt.TB(), base.JSONUnmarshal(rawResponse.Body.Bytes(), &body))
 		if version.RevTreeID != "" {
-			assert.Equal(c, version.RevTreeID, body.ExtractRev())
+			assert.Equal(c, version.RevTreeID, body.ExtractRev(), "docID: %s", docID)
 		}
 		if version.CV.IsEmpty() {
 			return
@@ -239,17 +241,19 @@ func (rt *RestTester) WaitForVersion(docID string, version DocVersion) {
 		if !assert.Contains(c, maps.Keys(body), db.BodyCV) {
 			return
 		}
-		assert.Equal(c, version.CV.String(), body[db.BodyCV].(string))
+		assert.Equal(c, version.CV.String(), body[db.BodyCV].(string), "docID: %s", docID)
 	}, 10*time.Second, 50*time.Millisecond)
 }
 
 func (rt *RestTester) WaitForVersionRevIDOnly(docID string, version DocVersion) {
+	rt.TB().Helper()
 	version.CV = db.Version{} // empty cv so WaitForVersion only asserts on revID
 	rt.WaitForVersion(docID, version)
 }
 
 // WaitForCV waits for the document's current version to match the expectedVersion. Fails the test harness. WaitForVersion should be used in the general case to test revtree and and cv behavior.
 func (rt *RestTester) WaitForVersionHLVOnly(docID string, version DocVersion) {
+	rt.TB().Helper()
 	version.RevTreeID = ""
 	rt.WaitForVersion(docID, version)
 }


### PR DESCRIPTION
[CBG-5506](https://jira.issues.couchbase.com/browse/CBG-5506) Fix flaky TestActiveReplicatorConflictPreUpgradedVersionEachSide

ConflictResolvedLocalCount is incremented inside the updateAndReturnDoc callback, before the CAS write commits to the bucket. The test was calling RequireWaitForStat then GetDoc immediately after, which could return the pre-resolution rev if the write hadn't yet been acknowledged. That stale revID was then passed to WaitForLegacyRev on rt2, which
had already moved past it, causing the wait to time out.

Fix by polling the stat and the version change in a single EventuallyWithT loop, ensuring verPostConflictRes always reflects the committed post-resolution write before it is used.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>CBG-0000


[CBG-5506]: https://couchbasecloud.atlassian.net/browse/CBG-5506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ