### PR TITLE
CBG-5466: handling for when _default doesn't exist and you attempt to create db without use_system_metadata_collection true

### DIFF
--- a/db/database_error.go
+++ b/db/database_error.go
@@ -27,6 +27,7 @@ var DatabaseErrorMap = map[databaseErrorCode]string{
 	DatabaseEnableStarChannelFalseError: "Enable star channel is set to false",
 	DatabaseClusterCompatVersionError:   "Bucket has metadata from a newer Sync Gateway cluster compat version",
 	DatabaseInvalidResyncPartitions:     "resync_partitions exceeds number of vBuckets",
+	DatabaseNoMetadataStore:             "No metadata store for db metadata to be stored in",
 }
 
 type databaseErrorCode uint8
@@ -45,6 +46,7 @@ const (
 	DatabaseEnableStarChannelFalseError databaseErrorCode = 10
 	DatabaseClusterCompatVersionError   databaseErrorCode = 11
 	DatabaseInvalidResyncPartitions     databaseErrorCode = 12
+	DatabaseNoMetadataStore             databaseErrorCode = 13
 )
 
 func NewDatabaseError(code databaseErrorCode) *DatabaseError {

--- a/rest/defaultcollectiondroptest/default_collection_drop_test.go
+++ b/rest/defaultcollectiondroptest/default_collection_drop_test.go
@@ -58,6 +58,9 @@ func TestDatabaseSurvivesDefaultCollectionDropAfterMetadataMigration(t *testing.
 	namedDataStore, err := tb.GetNamedDataStore(0)
 	require.NoError(t, err)
 	namedCollection := base.ScopeAndCollectionName{Scope: namedDataStore.ScopeName(), Collection: namedDataStore.CollectionName()}
+	namedDatastore2, err := tb.GetNamedDataStore(1)
+	require.NoError(t, err)
+	namedCollection2 := base.ScopeAndCollectionName{Scope: namedDatastore2.ScopeName(), Collection: namedDatastore2.CollectionName()}
 
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
 		CustomTestBucket: tb.NoCloseClone(),
@@ -158,4 +161,19 @@ func TestDatabaseSurvivesDefaultCollectionDropAfterMetadataMigration(t *testing.
 	resp = rt.SendAdminRequest(http.MethodGet, "/"+keyspace+"/doc1", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
 	assert.Contains(t, resp.Body.String(), `"value":"hello"`)
+
+	// Try create a new db against the bucket with no _default without opting into the system metadata collection.
+	// This should fail because the legacy metadata store is gone.
+	newDbConfig := rt.NewDbConfig()
+	newDbConfig.Scopes = rest.ScopesConfig{
+		namedCollection2.ScopeName(): rest.ScopeConfig{
+			Collections: rest.CollectionsConfig{
+				namedCollection2.CollectionName(): {},
+			},
+		},
+	}
+	newDbConfig.UseSystemMobileMetadataCollection = base.Ptr(false)
+	resp = rt.CreateDatabase("newdb", newDbConfig)
+	rest.RequireStatus(t, resp, http.StatusInternalServerError)
+	assert.Contains(t, resp.Body.String(), "_default._default does not exist on bucket")
 }

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -812,7 +812,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	// and whether index initialization should build metadata indexes on _default. Defaults to true so
 	// legacy (non-opted-in) DBs — where _default is the metadata store and always exists — and the
 	// "couldn't determine existence" case both preserve existing behavior.
-	defaultCollectionPresent := true
+	defaultCollectionPresent, defaultErr := defaultCollectionExists(ctx, bucket)
 	if resolveUseSystemMetadataCollection(sc.Config, &config.DbConfig) {
 		primaryMetadataStore, err := bucket.NamedDataStore(ctx, base.MobileSystemScopeAndCollectionName())
 		if err != nil {
@@ -827,12 +827,10 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		// in which case we can mark the per-DB MetadataStore wrapper as MigrationComplete and skip
 		// dual-read mode. If it exists, probe for legacy _sync:seq to determine whether we need to keep
 		// dual-read mode active.
-		defaultExists, defaultErr := defaultCollectionExists(ctx, bucket)
 		switch {
 		case defaultErr != nil:
 			base.WarnfCtx(ctx, "db:%s unable to determine whether _default._default exists while resolving metadata fallback: %v — keeping dual-read mode", base.MD(dbName), defaultErr)
-		case !defaultExists:
-			defaultCollectionPresent = false
+		case !defaultCollectionPresent:
 			metaStore.SetMigrationComplete()
 			base.InfofCtx(ctx, base.KeyConfig, "db:%s _default._default does not exist — marking per-DB MetadataStore wrapper migration-complete (no legacy fallback collection to read from)", base.MD(dbName))
 		case !probeLegacyPerDBMetadata(ctx, fallbackStore, config.MetadataID):
@@ -853,6 +851,11 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		}
 		contextOptions.MetadataStore = metaStore
 	} else {
+		if !defaultCollectionPresent {
+			// If the _default._default collection has been dropped by a customer, we can't use it for metadata.
+			// This is a misconfiguration, so log an error and fail the database load.
+			return nil, fmt.Errorf("use_system_metadata_collection disabled but _default._default does not exist on bucket %s — cannot use legacy collection for metadata for db %s", base.MD(spec.BucketName), base.UD(dbName))
+		}
 		contextOptions.MetadataStore = bucket.DefaultDataStore(ctx)
 	}
 	err = validateMetadataStore(ctx, contextOptions.MetadataStore)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -802,7 +802,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	// Database-level metadata (sequence allocator, syncInfo, _sync:user:*, _sync:role:*, etc.)
 	// is targeted at:
 	//   - _default._default when use_system_metadata_collection is disabled at both the cluster
-	//     and per-DB level (legacy behaviour; simplest RBAC, _default cannot be dropped by customers)
+	//     and per-DB level (legacy behaviour; simplest RBAC, _default cannot be dropped by customers for this case)
 	//   - _system._mobile (with read-fallback to _default._default) when enabled at either level,
 	//     via base.MetadataStore. For a brand-new database with no legacy metadata in
 	//     _default._default the wrapper is immediately marked MigrationComplete so reads go
@@ -812,7 +812,13 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	// and whether index initialization should build metadata indexes on _default. Defaults to true so
 	// legacy (non-opted-in) DBs — where _default is the metadata store and always exists — and the
 	// "couldn't determine existence" case both preserve existing behavior.
-	defaultCollectionPresent, defaultErr := defaultCollectionExists(ctx, bucket)
+	defaultCollectionPresent := true
+	var defaultErr error
+	if present, err := defaultCollectionExists(ctx, bucket); err != nil {
+		defaultErr = err
+	} else {
+		defaultCollectionPresent = present
+	}
 	if resolveUseSystemMetadataCollection(sc.Config, &config.DbConfig) {
 		primaryMetadataStore, err := bucket.NamedDataStore(ctx, base.MobileSystemScopeAndCollectionName())
 		if err != nil {
@@ -854,7 +860,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		if !defaultCollectionPresent {
 			// If the _default._default collection has been dropped by a customer, we can't use it for metadata.
 			// This is a misconfiguration, fail the database load.
-			return nil, fmt.Errorf("use_system_metadata_collection disabled but _default._default does not exist on bucket %s — cannot use legacy collection for metadata for db %s", base.MD(spec.BucketName), base.UD(dbName))
+			return nil, fmt.Errorf("use_system_metadata_collection disabled but _default._default does not exist on bucket %s — cannot use legacy collection for metadata for db %s", base.MD(spec.BucketName), base.MD(dbName))
 		}
 		contextOptions.MetadataStore = bucket.DefaultDataStore(ctx)
 	}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -853,7 +853,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	} else {
 		if !defaultCollectionPresent {
 			// If the _default._default collection has been dropped by a customer, we can't use it for metadata.
-			// This is a misconfiguration, so log an error and fail the database load.
+			// This is a misconfiguration, fail the database load.
 			return nil, fmt.Errorf("use_system_metadata_collection disabled but _default._default does not exist on bucket %s — cannot use legacy collection for metadata for db %s", base.MD(spec.BucketName), base.UD(dbName))
 		}
 		contextOptions.MetadataStore = bucket.DefaultDataStore(ctx)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -860,6 +860,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		if !defaultCollectionPresent {
 			// If the _default._default collection has been dropped by a customer, we can't use it for metadata.
 			// This is a misconfiguration, fail the database load.
+			sc._handleInvalidDatabaseConfig(ctx, spec.BucketName, config, db.NewDatabaseError(db.DatabaseNoMetadataStore))
 			return nil, fmt.Errorf("use_system_metadata_collection disabled but _default._default does not exist on bucket %s — cannot use legacy collection for metadata for db %s", base.MD(spec.BucketName), base.MD(dbName))
 		}
 		contextOptions.MetadataStore = bucket.DefaultDataStore(ctx)


### PR DESCRIPTION

CBG-5466

Error during db load process when default collection doesn't exist and you have not opted into `use_system_metadata_collection` 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/860/
