### PR TITLE
CBG-5498 use common functions for waiting for background mgr  

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -12,11 +12,11 @@ package base
 
 import (
 	"errors"
-	"os"
 	"strings"
 	"time"
 
 	"github.com/couchbaselabs/rosmar"
+	"github.com/couchbase/sync_gateway/testing/sgtest"
 )
 
 const (
@@ -25,8 +25,7 @@ const (
 	GuestUsername = "GUEST"
 	ISO8601Format = "2006-01-02T15:04:05.000Z07:00"
 
-	kTestCouchbaseServerURL = "couchbase://127.0.0.1"
-	kTestWalrusURL          = rosmar.InMemoryURL
+	kTestWalrusURL = rosmar.InMemoryURL
 
 	// Env variable to enable user to override the Couchbase Server URL used in tests
 	TestEnvCouchbaseServerUrl = "SG_TEST_COUCHBASE_SERVER_URL"
@@ -230,29 +229,9 @@ const (
 )
 
 // UnitTestUrl returns the configured test URL.
+// Deprecated: use sgtest.UnitTestUrl() in new code.
 func UnitTestUrl() string {
-	if TestUseCouchbaseServer() {
-		testCouchbaseServerUrl := os.Getenv(TestEnvCouchbaseServerUrl)
-		if testCouchbaseServerUrl != "" {
-			// If user explicitly set a Test Couchbase Server URL, use that
-			return testCouchbaseServerUrl
-		}
-		// Otherwise fallback to hardcoded default
-		return kTestCouchbaseServerURL
-	} else {
-		testWalrusUrl := os.Getenv(TestEnvWalrusUrl)
-		if testWalrusUrl != "" {
-			// If user explicitly set a Test Walrus URL, use that
-			return testWalrusUrl
-		}
-		// Otherwise fallback to hardcoded default
-		return kTestWalrusURL
-	}
-}
-
-// UnitTestUrlIsWalrus returns true if we're running with a Walrus test URL.
-func UnitTestUrlIsWalrus() bool {
-	return ServerIsWalrus(UnitTestUrl())
+	return sgtest.UnitTestUrl()
 }
 
 // ServerIsTLS returns true if the server URL is using an accepted secure protocol as it's prefix

--- a/base/constants.go
+++ b/base/constants.go
@@ -15,8 +15,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/couchbaselabs/rosmar"
 	"github.com/couchbase/sync_gateway/testing/sgtest"
+	"github.com/couchbaselabs/rosmar"
 )
 
 const (

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -36,6 +36,7 @@ import (
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/testing/assert"
 	"github.com/couchbase/sync_gateway/testing/require"
+	"github.com/couchbase/sync_gateway/testing/sgtest"
 	"github.com/couchbaselabs/rosmar"
 )
 
@@ -319,10 +320,16 @@ func TestDisableRevCache() bool {
 	return false
 }
 
-// Check the whether tests are being run with SG_TEST_BACKING_STORE=Couchbase
+// TestUseCouchbaseServer reports whether tests are configured to run against a real Couchbase Server cluster.
+// Deprecated: use sgtest.TestUseCouchbaseServer() in new code.
 func TestUseCouchbaseServer() bool {
-	backingStore := os.Getenv(TestEnvSyncGatewayBackingStore)
-	return strings.EqualFold(backingStore, TestEnvBackingStoreCouchbase)
+	return sgtest.TestUseCouchbaseServer()
+}
+
+// UnitTestUrlIsWalrus reports whether tests are running against an in-memory Walrus/Rosmar store.
+// Deprecated: use sgtest.UnitTestUrlIsWalrus() in new code.
+func UnitTestUrlIsWalrus() bool {
+	return sgtest.UnitTestUrlIsWalrus()
 }
 
 func TestUseWalrus() bool {

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -16,7 +16,6 @@ import (
 	"fmt"
 	"maps"
 	"net/http"
-	"os"
 	"slices"
 	"strconv"
 	"strings"
@@ -31,6 +30,7 @@ import (
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/testing/assert"
 	"github.com/couchbase/sync_gateway/testing/require"
+	"github.com/couchbase/sync_gateway/testing/sgtest"
 )
 
 func (db *DatabaseContext) CacheCompactActive() bool {
@@ -352,7 +352,7 @@ var viewsAndGSIBucketInit base.TBPBucketInitFunc = func(ctx context.Context, b b
 		if base.TestsDisableGSI() {
 			// create views if walrus (GSI=true), all collections
 			// Couchbase Server doesn't support views on a non-default collection and neither does Sync Gateway for CBS
-			if !base.UnitTestUrlIsWalrus() && !base.IsDefaultCollection(dataStore.ScopeName(), dataStore.CollectionName()) {
+			if !sgtest.UnitTestUrlIsWalrus() && !base.IsDefaultCollection(dataStore.ScopeName(), dataStore.CollectionName()) {
 				continue
 			}
 			if err := viewBucketReadier(ctx, dataStore, tbp); err != nil {
@@ -928,14 +928,16 @@ func WaitForBackgroundManagerHeartbeatDocRemoval[O any](t testing.TB, mgr *Backg
 	}, 10*time.Second, 10*time.Millisecond)
 }
 
+// GetState returns the current process state. Defined in test-utility code so it is available for
+// the backgroundManagerResponse interface constraint in rest/utilities_testing_resttester.go without
+// adding the method to the production BackgroundManagerStatus type.
+func (s BackgroundManagerStatus) GetState() BackgroundProcessState {
+	return s.State
+}
+
 // RequireBackgroundManagerState waits for a BackgroundManager to reach a given state or fails test harness.
 func RequireBackgroundManagerState[O any](t testing.TB, mgr *BackgroundManager[O], expState BackgroundProcessState) BackgroundManagerStatus {
-	waitTime := 10 * time.Second
-	if !base.UnitTestUrlIsWalrus() || base.IsRaceDetectorEnabled(t) || os.Getenv("CI") != "" {
-		// Increase wait time for CI tests against Couchbase Server, they can take longer to run.
-		// Generally everything runs in 10 seconds, but when it does not, it is not worth flagging the failures.
-		waitTime = 30 * time.Second
-	}
+	waitTime := sgtest.GetBackgroundManagerStatusTransitionTimeout(t)
 	ctx := base.TestCtx(t)
 	var status *BackgroundManagerStatus
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -1169,5 +1171,5 @@ func MigrateSeqCounterForTest(t testing.TB, ctx context.Context, ms *base.Metada
 
 // usingShardedResync returns true if cbgt based resync will be used for test
 func usingShardedResync(testing.TB) bool {
-	return base.IsEnterpriseEdition() && !base.UnitTestUrlIsWalrus()
+	return base.IsEnterpriseEdition() && !sgtest.UnitTestUrlIsWalrus()
 }

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -928,9 +928,8 @@ func WaitForBackgroundManagerHeartbeatDocRemoval[O any](t testing.TB, mgr *Backg
 	}, 10*time.Second, 10*time.Millisecond)
 }
 
-// GetState returns the current process state. Defined in test-utility code so it is available for
-// the backgroundManagerResponse interface constraint in rest/utilities_testing_resttester.go without
-// adding the method to the production BackgroundManagerStatus type.
+// GetState returns the current process state. This method lets response types embedding
+// BackgroundManagerStatus satisfy the backgroundManagerResponse constraint used by REST test helpers.
 func (s BackgroundManagerStatus) GetState() BackgroundProcessState {
 	return s.State
 }

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3184,22 +3184,8 @@ func TestTombstoneCompactionAPI(t *testing.T) {
 	resp = rt.SendAdminRequest("POST", "/{{.db}}/_compact", "")
 	RequireStatus(t, resp, http.StatusOK)
 
-	err = rt.WaitForCondition(func() bool {
-		resp = rt.SendAdminRequest("GET", "/{{.db}}/_compact", "")
-		RequireStatus(t, resp, http.StatusOK)
-
-		err = base.JSONUnmarshal(resp.BodyBytes(), &tombstoneCompactionStatus)
-		assert.NoError(t, err)
-
-		return tombstoneCompactionStatus.State == db.BackgroundProcessStateCompleted
-	})
-	assert.NoError(t, err)
+	tombstoneCompactionStatus = rt.WaitForTombstoneCompactionStatus(db.BackgroundProcessStateCompleted)
 	assert.True(t, rt.GetDatabase().DbStats.Database().CompactionTombstoneStartTime.Value() > firstStartTimeStat)
-
-	resp = rt.SendAdminRequest("GET", "/{{.db}}/_compact", "")
-	RequireStatus(t, resp, http.StatusOK)
-	err = base.JSONUnmarshal(resp.BodyBytes(), &tombstoneCompactionStatus)
-	assert.NoError(t, err)
 
 	assert.Equal(t, db.BackgroundProcessStateCompleted, tombstoneCompactionStatus.State)
 	assert.Empty(t, tombstoneCompactionStatus.LastErrorMessage)

--- a/rest/attachmentcompactiontest/attachment_compaction_api_test.go
+++ b/rest/attachmentcompactiontest/attachment_compaction_api_test.go
@@ -165,7 +165,7 @@ func TestAttachmentCompactionPersistence(t *testing.T) {
 	// Attempt to start again from rt2 --> Should resume based on aborted state (same compactionID)
 	resp = rt2.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
-	status = rt2.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateCompleted)
+	status = rt2.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateRunning)
 	assert.Equal(t, compactID, status.CompactID)
 
 	// Wait for compaction to complete

--- a/rest/attachmentcompactiontest/attachment_compaction_api_test.go
+++ b/rest/attachmentcompactiontest/attachment_compaction_api_test.go
@@ -36,7 +36,7 @@ func TestAttachmentCompactionAPI(t *testing.T) {
 	defer func() {
 		resp := rt.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment&reset=true", "")
 		rest.RequireStatus(t, resp, http.StatusOK)
-		_ = rt.WaitForAttachmentCompactionStatus(t, db.BackgroundProcessStateCompleted)
+		_ = rt.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateCompleted)
 	}()
 	// Perform GET before compact has been ran, ensure it starts in valid 'stopped' state
 	resp := rt.SendAdminRequest("GET", "/{{.db}}/_compact?type=attachment", "")
@@ -58,7 +58,7 @@ func TestAttachmentCompactionAPI(t *testing.T) {
 	resp = rt.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment", "")
 	rest.RequireStatus(t, resp, http.StatusServiceUnavailable)
 
-	rt.WaitForAttachmentCompactionStatus(t, db.BackgroundProcessStateCompleted)
+	rt.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateCompleted)
 
 	dataStore := rt.GetSingleDataStore()
 	collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
@@ -88,7 +88,7 @@ func TestAttachmentCompactionAPI(t *testing.T) {
 	resp = rt.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
 
-	rt.WaitForAttachmentCompactionStatus(t, db.BackgroundProcessStateCompleted)
+	rt.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateCompleted)
 
 	// Validate results of GET
 	resp = rt.SendAdminRequest("GET", "/{{.db}}/_compact?type=attachment", "")
@@ -110,7 +110,7 @@ func TestAttachmentCompactionAPI(t *testing.T) {
 	rest.RequireStatus(t, resp, http.StatusOK)
 
 	// Wait for run to complete
-	_ = rt.WaitForAttachmentCompactionStatus(t, db.BackgroundProcessStateStopped)
+	_ = rt.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateStopped)
 }
 
 func TestAttachmentCompactionPersistence(t *testing.T) {
@@ -134,7 +134,7 @@ func TestAttachmentCompactionPersistence(t *testing.T) {
 	resp := rt1.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
 
-	_ = rt1.WaitForAttachmentCompactionStatus(t, db.BackgroundProcessStateCompleted)
+	_ = rt1.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateCompleted)
 
 	// Ensure compaction is marked complete on the other node too
 	var rt2AttachmentStatus db.AttachmentManagerResponse
@@ -147,13 +147,13 @@ func TestAttachmentCompactionPersistence(t *testing.T) {
 	// Start compaction again
 	resp = rt1.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
-	status := rt1.WaitForAttachmentCompactionStatus(t, db.BackgroundProcessStateRunning)
+	status := rt1.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateRunning)
 	compactID := status.CompactID
 
 	// Abort process early from rt1
 	resp = rt1.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment&action=stop", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
-	status = rt2.WaitForAttachmentCompactionStatus(t, db.BackgroundProcessStateStopped)
+	status = rt2.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateStopped)
 
 	// Ensure aborted status is present on rt2
 	resp = rt2.SendAdminRequest("GET", "/{{.db}}/_compact?type=attachment", "")
@@ -165,11 +165,11 @@ func TestAttachmentCompactionPersistence(t *testing.T) {
 	// Attempt to start again from rt2 --> Should resume based on aborted state (same compactionID)
 	resp = rt2.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
-	status = rt2.WaitForAttachmentCompactionStatus(t, db.BackgroundProcessStateRunning)
+	status = rt2.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateCompleted)
 	assert.Equal(t, compactID, status.CompactID)
 
 	// Wait for compaction to complete
-	_ = rt1.WaitForAttachmentCompactionStatus(t, db.BackgroundProcessStateCompleted)
+	_ = rt1.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateCompleted)
 }
 
 func TestAttachmentCompactionDryRun(t *testing.T) {
@@ -198,7 +198,7 @@ func TestAttachmentCompactionDryRun(t *testing.T) {
 
 	resp := rt.SendAdminRequest("POST", "/db/_compact?type=attachment&dry_run=true", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
-	status := rt.WaitForAttachmentCompactionStatus(t, db.BackgroundProcessStateCompleted)
+	status := rt.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateCompleted)
 	assert.True(t, status.DryRun)
 	if !base.UnitTestUrlIsWalrus() && !base.TestsDisableGSI() {
 		// It is possible for Couchbase Server GSI runs which use DCP purge to two DCP events from a previous
@@ -221,7 +221,7 @@ func TestAttachmentCompactionDryRun(t *testing.T) {
 
 	resp = rt.SendAdminRequest("POST", "/db/_compact?type=attachment", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
-	status = rt.WaitForAttachmentCompactionStatus(t, db.BackgroundProcessStateCompleted)
+	status = rt.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateCompleted)
 	assert.False(t, status.DryRun)
 	assert.Equal(t, int64(5), status.PurgedAttachments)
 
@@ -243,13 +243,13 @@ func TestAttachmentCompactionReset(t *testing.T) {
 	// Start compaction
 	resp := rt.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
-	status := rt.WaitForAttachmentCompactionStatus(t, db.BackgroundProcessStateRunning)
+	status := rt.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateRunning)
 	compactID := status.CompactID
 
 	// Stop compaction before complete -- enters aborted state
 	resp = rt.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment&action=stop", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
-	status = rt.WaitForAttachmentCompactionStatus(t, db.BackgroundProcessStateStopped)
+	status = rt.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateStopped)
 
 	// Ensure status is aborted
 	resp = rt.SendAdminRequest("GET", "/{{.db}}/_compact?type=attachment", "")
@@ -262,11 +262,12 @@ func TestAttachmentCompactionReset(t *testing.T) {
 	// Start compaction again but with reset=true --> meaning it shouldn't try to resume
 	resp = rt.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment&reset=true", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
-	status = rt.WaitForAttachmentCompactionStatus(t, db.BackgroundProcessStateRunning)
+	status = rt.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateRunning)
 	assert.NotEqual(t, compactID, status.CompactID)
 
-	// Wait for completion before closing test
-	_ = rt.WaitForAttachmentCompactionStatus(t, db.BackgroundProcessStateCompleted)
+	// Wait for completion and verify the completed run also carries a different compactID
+	status = rt.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateCompleted)
+	assert.NotEqual(t, compactID, status.CompactID)
 }
 
 func TestAttachmentCompactionInvalidDocs(t *testing.T) {
@@ -308,7 +309,7 @@ func TestAttachmentCompactionInvalidDocs(t *testing.T) {
 	// Start compaction
 	resp = rt.SendAdminRequest("POST", "/db/_compact?type=attachment", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
-	status := rt.WaitForAttachmentCompactionStatus(t, db.BackgroundProcessStateCompleted)
+	status := rt.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateCompleted)
 
 	assert.Equal(t, int64(2), status.PurgedAttachments)
 	assert.Equal(t, int64(1), status.MarkedAttachments)
@@ -333,7 +334,7 @@ func TestAttachmentCompactionStartTimeAndStats(t *testing.T) {
 	// Start compaction
 	resp := rt.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
-	status := rt.WaitForAttachmentCompactionStatus(t, db.BackgroundProcessStateCompleted)
+	status := rt.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateCompleted)
 
 	// Check stats and start time response is correct
 	firstStartTime := status.StartTime
@@ -345,7 +346,7 @@ func TestAttachmentCompactionStartTimeAndStats(t *testing.T) {
 	// Start compaction again
 	resp = rt.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
-	status = rt.WaitForAttachmentCompactionStatus(t, db.BackgroundProcessStateCompleted)
+	status = rt.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateCompleted)
 
 	// Check that stats have been updated to new run and previous attachment count stat remains
 	assert.True(t, status.StartTime.After(firstStartTime))
@@ -377,7 +378,7 @@ func TestAttachmentCompactionAbort(t *testing.T) {
 	resp = rt.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment&action=stop", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
 
-	status := rt.WaitForAttachmentCompactionStatus(t, db.BackgroundProcessStateStopped)
+	status := rt.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateStopped)
 	assert.Equal(t, int64(0), status.PurgedAttachments)
 }
 
@@ -406,12 +407,12 @@ func TestAttachmentCompactionMarkPhaseRollback(t *testing.T) {
 	// kick off compaction and wait for "mark" phase to begin
 	resp := rt.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
-	_ = rt.WaitForAttachmentCompactionStatus(t, db.BackgroundProcessStateRunning)
+	_ = rt.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateRunning)
 
 	// immediately stop the compaction process (we just need the status data to be persisted to the bucket)
 	resp = rt.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment&action=stop", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
-	stat := rt.WaitForAttachmentCompactionStatus(t, db.BackgroundProcessStateStopped)
+	stat := rt.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateStopped)
 	require.Equal(t, string(db.MarkPhase), stat.Phase)
 
 	// alter persisted dcp metadata from the first run to force a rollback
@@ -426,7 +427,7 @@ func TestAttachmentCompactionMarkPhaseRollback(t *testing.T) {
 	// kick off a new run attempting to start it again (should force into rollback handling)
 	resp = rt.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment&action=start", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
-	_ = rt.WaitForAttachmentCompactionStatus(t, db.BackgroundProcessStateCompleted)
+	_ = rt.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateCompleted)
 
 	// Validate results of recovered attachment compaction process
 	resp = rt.SendAdminRequest("GET", "/{{.db}}/_compact?type=attachment", "")

--- a/rest/attachmentmigrationtest/attachment_migration_api_test.go
+++ b/rest/attachmentmigrationtest/attachment_migration_api_test.go
@@ -46,7 +46,7 @@ func TestAttachmentMigrationAPI(t *testing.T) {
 	assert.Empty(t, migrationStatus.LastErrorMessage)
 
 	// Wait for run on startup to complete
-	_ = rt.WaitForAttachmentMigrationStatus( db.BackgroundProcessStateCompleted)
+	_ = rt.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateCompleted)
 
 	// add some docs for migration
 	numDocs := addDocsForMigrationProcess(t, ctx, collection)
@@ -60,7 +60,7 @@ func TestAttachmentMigrationAPI(t *testing.T) {
 	rest.RequireStatus(t, resp, http.StatusServiceUnavailable)
 
 	// Wait for run to complete
-	_ = rt.WaitForAttachmentMigrationStatus( db.BackgroundProcessStateCompleted)
+	_ = rt.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateCompleted)
 
 	// Perform GET after migration has been ran, ensure it starts in valid 'stopped' state
 	resp = rt.SendAdminRequest("GET", "/{{.db}}/_attachment_migration", "")
@@ -87,7 +87,7 @@ func TestAttachmentMigrationAbort(t *testing.T) {
 	collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
 
 	// Wait for run on startup to complete
-	_ = rt.WaitForAttachmentMigrationStatus( db.BackgroundProcessStateCompleted)
+	_ = rt.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateCompleted)
 
 	numDocs := 20
 	if base.UnitTestUrlIsWalrus() {
@@ -111,7 +111,7 @@ func TestAttachmentMigrationAbort(t *testing.T) {
 	resp = rt.SendAdminRequest("POST", "/{{.db}}/_attachment_migration?action=stop", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
 
-	status := rt.WaitForAttachmentMigrationStatus( db.BackgroundProcessStateStopped)
+	status := rt.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateStopped)
 	assert.Equal(t, int64(0), status.DocsChanged)
 }
 
@@ -125,7 +125,7 @@ func TestAttachmentMigrationReset(t *testing.T) {
 	collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
 
 	// Wait for run on startup to complete
-	_ = rt.WaitForAttachmentMigrationStatus( db.BackgroundProcessStateCompleted)
+	_ = rt.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateCompleted)
 
 	// add some docs for migration
 	numDocs := addDocsForMigrationProcess(t, ctx, collection)
@@ -133,13 +133,13 @@ func TestAttachmentMigrationReset(t *testing.T) {
 	// start migration
 	resp := rt.SendAdminRequest("POST", "/{{.db}}/_attachment_migration", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
-	status := rt.WaitForAttachmentMigrationStatus( db.BackgroundProcessStateRunning)
+	status := rt.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateRunning)
 	migrationID := status.MigrationID
 
 	// Stop migration
 	resp = rt.SendAdminRequest("POST", "/{{.db}}/_attachment_migration?action=stop", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
-	status = rt.WaitForAttachmentMigrationStatus( db.BackgroundProcessStateStopped)
+	status = rt.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateStopped)
 
 	// make sure status is stopped
 	resp = rt.SendAdminRequest("GET", "/{{.db}}/_attachment_migration", "")
@@ -152,11 +152,11 @@ func TestAttachmentMigrationReset(t *testing.T) {
 	// reset migration run
 	resp = rt.SendAdminRequest("POST", "/{{.db}}/_attachment_migration?reset=true", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
-	status = rt.WaitForAttachmentMigrationStatus( db.BackgroundProcessStateRunning)
+	status = rt.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateRunning)
 	assert.NotEqual(t, migrationID, status.MigrationID)
 
 	// wait to complete
-	status = rt.WaitForAttachmentMigrationStatus( db.BackgroundProcessStateCompleted)
+	status = rt.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateCompleted)
 	// assert all docs are processed again
 	assert.Equal(t, numDocs, status.DocsProcessed)
 }
@@ -176,8 +176,8 @@ func TestAttachmentMigrationMultiNode(t *testing.T) {
 	collection, ctx := rt1.GetSingleTestDatabaseCollectionWithUser()
 
 	// Wait for startup run to complete, assert completed status is on both nodes
-	_ = rt1.WaitForAttachmentMigrationStatus( db.BackgroundProcessStateCompleted)
-	_ = rt2.WaitForAttachmentMigrationStatus( db.BackgroundProcessStateCompleted)
+	_ = rt1.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateCompleted)
+	_ = rt2.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateCompleted)
 
 	// add some docs for migration
 	addDocsForMigrationProcess(t, ctx, collection)
@@ -185,7 +185,7 @@ func TestAttachmentMigrationMultiNode(t *testing.T) {
 	// kick off migration on node 1
 	resp := rt1.SendAdminRequest("POST", "/{{.db}}/_attachment_migration", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
-	status := rt1.WaitForAttachmentMigrationStatus( db.BackgroundProcessStateRunning)
+	status := rt1.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateRunning)
 	migrationID := status.MigrationID
 
 	// While node 1's migration is running, attempting to start on node 2 must return 503.
@@ -196,7 +196,7 @@ func TestAttachmentMigrationMultiNode(t *testing.T) {
 	// stop migration
 	resp = rt1.SendAdminRequest("POST", "/{{.db}}/_attachment_migration?action=stop", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
-	_ = rt1.WaitForAttachmentMigrationStatus( db.BackgroundProcessStateStopped)
+	_ = rt1.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateStopped)
 
 	// assert that node 2 also has stopped status
 	var rt2MigrationStatus db.AttachmentMigrationManagerResponse
@@ -214,9 +214,9 @@ func TestAttachmentMigrationMultiNode(t *testing.T) {
 	rest.RequireStatus(t, resp, http.StatusOK)
 
 	// Wait for run to be marked as complete on both nodes
-	status = rt1.WaitForAttachmentMigrationStatus( db.BackgroundProcessStateCompleted)
+	status = rt1.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateCompleted)
 	assert.Equal(t, migrationID, status.MigrationID)
-	_ = rt2.WaitForAttachmentMigrationStatus( db.BackgroundProcessStateCompleted)
+	_ = rt2.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateCompleted)
 }
 
 func addDocsForMigrationProcess(t *testing.T, ctx context.Context, collection *db.DatabaseCollectionWithUser) int64 {

--- a/rest/attachmentmigrationtest/attachment_migration_api_test.go
+++ b/rest/attachmentmigrationtest/attachment_migration_api_test.go
@@ -46,7 +46,7 @@ func TestAttachmentMigrationAPI(t *testing.T) {
 	assert.Empty(t, migrationStatus.LastErrorMessage)
 
 	// Wait for run on startup to complete
-	_ = rt.WaitForAttachmentMigrationStatus(t, db.BackgroundProcessStateCompleted)
+	_ = rt.WaitForAttachmentMigrationStatus( db.BackgroundProcessStateCompleted)
 
 	// add some docs for migration
 	numDocs := addDocsForMigrationProcess(t, ctx, collection)
@@ -60,7 +60,7 @@ func TestAttachmentMigrationAPI(t *testing.T) {
 	rest.RequireStatus(t, resp, http.StatusServiceUnavailable)
 
 	// Wait for run to complete
-	_ = rt.WaitForAttachmentMigrationStatus(t, db.BackgroundProcessStateCompleted)
+	_ = rt.WaitForAttachmentMigrationStatus( db.BackgroundProcessStateCompleted)
 
 	// Perform GET after migration has been ran, ensure it starts in valid 'stopped' state
 	resp = rt.SendAdminRequest("GET", "/{{.db}}/_attachment_migration", "")
@@ -87,7 +87,7 @@ func TestAttachmentMigrationAbort(t *testing.T) {
 	collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
 
 	// Wait for run on startup to complete
-	_ = rt.WaitForAttachmentMigrationStatus(t, db.BackgroundProcessStateCompleted)
+	_ = rt.WaitForAttachmentMigrationStatus( db.BackgroundProcessStateCompleted)
 
 	numDocs := 20
 	if base.UnitTestUrlIsWalrus() {
@@ -111,7 +111,7 @@ func TestAttachmentMigrationAbort(t *testing.T) {
 	resp = rt.SendAdminRequest("POST", "/{{.db}}/_attachment_migration?action=stop", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
 
-	status := rt.WaitForAttachmentMigrationStatus(t, db.BackgroundProcessStateStopped)
+	status := rt.WaitForAttachmentMigrationStatus( db.BackgroundProcessStateStopped)
 	assert.Equal(t, int64(0), status.DocsChanged)
 }
 
@@ -125,7 +125,7 @@ func TestAttachmentMigrationReset(t *testing.T) {
 	collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
 
 	// Wait for run on startup to complete
-	_ = rt.WaitForAttachmentMigrationStatus(t, db.BackgroundProcessStateCompleted)
+	_ = rt.WaitForAttachmentMigrationStatus( db.BackgroundProcessStateCompleted)
 
 	// add some docs for migration
 	numDocs := addDocsForMigrationProcess(t, ctx, collection)
@@ -133,13 +133,13 @@ func TestAttachmentMigrationReset(t *testing.T) {
 	// start migration
 	resp := rt.SendAdminRequest("POST", "/{{.db}}/_attachment_migration", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
-	status := rt.WaitForAttachmentMigrationStatus(t, db.BackgroundProcessStateRunning)
+	status := rt.WaitForAttachmentMigrationStatus( db.BackgroundProcessStateRunning)
 	migrationID := status.MigrationID
 
 	// Stop migration
 	resp = rt.SendAdminRequest("POST", "/{{.db}}/_attachment_migration?action=stop", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
-	status = rt.WaitForAttachmentMigrationStatus(t, db.BackgroundProcessStateStopped)
+	status = rt.WaitForAttachmentMigrationStatus( db.BackgroundProcessStateStopped)
 
 	// make sure status is stopped
 	resp = rt.SendAdminRequest("GET", "/{{.db}}/_attachment_migration", "")
@@ -152,11 +152,11 @@ func TestAttachmentMigrationReset(t *testing.T) {
 	// reset migration run
 	resp = rt.SendAdminRequest("POST", "/{{.db}}/_attachment_migration?reset=true", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
-	status = rt.WaitForAttachmentMigrationStatus(t, db.BackgroundProcessStateRunning)
+	status = rt.WaitForAttachmentMigrationStatus( db.BackgroundProcessStateRunning)
 	assert.NotEqual(t, migrationID, status.MigrationID)
 
 	// wait to complete
-	status = rt.WaitForAttachmentMigrationStatus(t, db.BackgroundProcessStateCompleted)
+	status = rt.WaitForAttachmentMigrationStatus( db.BackgroundProcessStateCompleted)
 	// assert all docs are processed again
 	assert.Equal(t, numDocs, status.DocsProcessed)
 }
@@ -176,8 +176,8 @@ func TestAttachmentMigrationMultiNode(t *testing.T) {
 	collection, ctx := rt1.GetSingleTestDatabaseCollectionWithUser()
 
 	// Wait for startup run to complete, assert completed status is on both nodes
-	_ = rt1.WaitForAttachmentMigrationStatus(t, db.BackgroundProcessStateCompleted)
-	_ = rt2.WaitForAttachmentMigrationStatus(t, db.BackgroundProcessStateCompleted)
+	_ = rt1.WaitForAttachmentMigrationStatus( db.BackgroundProcessStateCompleted)
+	_ = rt2.WaitForAttachmentMigrationStatus( db.BackgroundProcessStateCompleted)
 
 	// add some docs for migration
 	addDocsForMigrationProcess(t, ctx, collection)
@@ -185,7 +185,7 @@ func TestAttachmentMigrationMultiNode(t *testing.T) {
 	// kick off migration on node 1
 	resp := rt1.SendAdminRequest("POST", "/{{.db}}/_attachment_migration", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
-	status := rt1.WaitForAttachmentMigrationStatus(t, db.BackgroundProcessStateRunning)
+	status := rt1.WaitForAttachmentMigrationStatus( db.BackgroundProcessStateRunning)
 	migrationID := status.MigrationID
 
 	// While node 1's migration is running, attempting to start on node 2 must return 503.
@@ -196,7 +196,7 @@ func TestAttachmentMigrationMultiNode(t *testing.T) {
 	// stop migration
 	resp = rt1.SendAdminRequest("POST", "/{{.db}}/_attachment_migration?action=stop", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
-	_ = rt1.WaitForAttachmentMigrationStatus(t, db.BackgroundProcessStateStopped)
+	_ = rt1.WaitForAttachmentMigrationStatus( db.BackgroundProcessStateStopped)
 
 	// assert that node 2 also has stopped status
 	var rt2MigrationStatus db.AttachmentMigrationManagerResponse
@@ -214,9 +214,9 @@ func TestAttachmentMigrationMultiNode(t *testing.T) {
 	rest.RequireStatus(t, resp, http.StatusOK)
 
 	// Wait for run to be marked as complete on both nodes
-	status = rt1.WaitForAttachmentMigrationStatus(t, db.BackgroundProcessStateCompleted)
+	status = rt1.WaitForAttachmentMigrationStatus( db.BackgroundProcessStateCompleted)
 	assert.Equal(t, migrationID, status.MigrationID)
-	_ = rt2.WaitForAttachmentMigrationStatus(t, db.BackgroundProcessStateCompleted)
+	_ = rt2.WaitForAttachmentMigrationStatus( db.BackgroundProcessStateCompleted)
 }
 
 func addDocsForMigrationProcess(t *testing.T, ctx context.Context, collection *db.DatabaseCollectionWithUser) int64 {

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -3507,10 +3507,7 @@ func TestTombstoneCompaction(t *testing.T) {
 				} else {
 					resp := rt.SendAdminRequest("POST", "/{{.db}}/_compact", "")
 					rest.RequireStatus(t, resp, http.StatusOK)
-					err := rt.WaitForCondition(func() bool {
-						return rt.GetDatabase().TombstoneCompactionManager.GetRunState() == db.BackgroundProcessStateCompleted
-					})
-					assert.NoError(t, err)
+					_ = rt.WaitForTombstoneCompactionStatus(db.BackgroundProcessStateCompleted)
 
 					numIdleKvOpsAfter := int(base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().NumIdleKvOps.Value())
 					numIdleQueryOpsAfter := int(base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().NumIdleQueryOps.Value())

--- a/rest/upgradetest/upgrade_registry_test.go
+++ b/rest/upgradetest/upgrade_registry_test.go
@@ -198,7 +198,7 @@ func TestLegacyMetadataID(t *testing.T) {
 	resp := legacyRT.SendAdminRequest("PUT", "/db/testLegacyMetadataID", `{"test":"test"}`)
 	rest.RequireStatus(t, resp, http.StatusCreated)
 
-	legacyRT.WaitForAttachmentMigrationStatus(t, db.BackgroundProcessStateCompleted)
+	legacyRT.WaitForAttachmentMigrationStatus( db.BackgroundProcessStateCompleted)
 
 	dbConfigString := getDbConfigFromLegacyConfig(legacyRT)
 	legacyRT.Close()
@@ -265,7 +265,7 @@ func TestMetadataIDWithConfigGroups(t *testing.T) {
 	resp := legacyRT.SendAdminRequest("PUT", "/db/testLegacyMetadataID", `{"test":"test"}`)
 	assert.Equal(t, http.StatusCreated, resp.Code)
 
-	legacyRT.WaitForAttachmentMigrationStatus(t, db.BackgroundProcessStateCompleted)
+	legacyRT.WaitForAttachmentMigrationStatus( db.BackgroundProcessStateCompleted)
 	dbConfigString := getDbConfigFromLegacyConfig(legacyRT)
 	legacyRT.Close()
 

--- a/rest/upgradetest/upgrade_registry_test.go
+++ b/rest/upgradetest/upgrade_registry_test.go
@@ -198,7 +198,7 @@ func TestLegacyMetadataID(t *testing.T) {
 	resp := legacyRT.SendAdminRequest("PUT", "/db/testLegacyMetadataID", `{"test":"test"}`)
 	rest.RequireStatus(t, resp, http.StatusCreated)
 
-	legacyRT.WaitForAttachmentMigrationStatus( db.BackgroundProcessStateCompleted)
+	legacyRT.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateCompleted)
 
 	dbConfigString := getDbConfigFromLegacyConfig(legacyRT)
 	legacyRT.Close()
@@ -265,7 +265,7 @@ func TestMetadataIDWithConfigGroups(t *testing.T) {
 	resp := legacyRT.SendAdminRequest("PUT", "/db/testLegacyMetadataID", `{"test":"test"}`)
 	assert.Equal(t, http.StatusCreated, resp.Code)
 
-	legacyRT.WaitForAttachmentMigrationStatus( db.BackgroundProcessStateCompleted)
+	legacyRT.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateCompleted)
 	dbConfigString := getDbConfigFromLegacyConfig(legacyRT)
 	legacyRT.Close()
 

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -41,6 +41,7 @@ import (
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbase/sync_gateway/testing/assert"
 	"github.com/couchbase/sync_gateway/testing/require"
+	"github.com/couchbase/sync_gateway/testing/sgtest"
 	"github.com/google/uuid"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -181,7 +182,7 @@ func newRestTester(tb testing.TB, restConfig *RestTesterConfig, collectionConfig
 	}
 	rt.RestTesterConfig.collectionConfig = collectionConfig
 	rt.RestTesterConfig.numCollections = numCollections
-	rt.RestTesterConfig.useTLSServer = base.ServerIsTLS(base.UnitTestUrl())
+	rt.RestTesterConfig.useTLSServer = base.ServerIsTLS(sgtest.UnitTestUrl())
 	return &rt
 }
 
@@ -362,7 +363,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 		if rt.DatabaseConfig.UseViews == nil {
 			rt.DatabaseConfig.UseViews = base.Ptr(base.TestsDisableGSI())
 		}
-		if base.TestsUseNamedCollections() && rt.collectionConfig != useSingleCollectionDefaultOnly && (rt.DatabaseConfig.useGSI() || base.UnitTestUrlIsWalrus()) {
+		if base.TestsUseNamedCollections() && rt.collectionConfig != useSingleCollectionDefaultOnly && (rt.DatabaseConfig.useGSI() || sgtest.UnitTestUrlIsWalrus()) {
 			// If scopes is already set, assume the caller has a plan
 			if rt.DatabaseConfig.Scopes == nil {
 				// Configure non default collections by default
@@ -925,7 +926,7 @@ func (rt *RestTester) WaitForChanges(numChangesExpected int, changesURL, usernam
 	waitTime := 20 * time.Second // some tests rely on cbgt import which can be quite slow if it needs to rollback
 	if db.HasCachingFeedDelay(rt.TB()) {
 		waitTime *= db.GetCachingFeedDelayFactor(rt.TB())
-	} else if base.UnitTestUrlIsWalrus() && !base.IsRaceDetectorEnabled(rt.TB()) && os.Getenv("CI") == "" {
+	} else if sgtest.UnitTestUrlIsWalrus() && !sgtest.IsRaceDetectorEnabled(rt.TB()) && os.Getenv("CI") == "" {
 		// local rosmar will never take a long time, but it is sometimes slower in jenkins/github actions
 		waitTime = 1 * time.Second
 	}
@@ -1109,7 +1110,7 @@ func (rt *RestTester) WaitForDatabaseState(dbName string, targetState string) {
 func (rt *RestTester) WaitForBucketMetadataMigrationComplete(bucketName string) {
 	timeout := 10 * time.Second
 	pollInterval := 100 * time.Millisecond
-	if !base.UnitTestUrlIsWalrus() || base.IsRaceDetectorEnabled(rt.TB()) || os.Getenv("CI") != "" {
+	if !sgtest.UnitTestUrlIsWalrus() || sgtest.IsRaceDetectorEnabled(rt.TB()) || os.Getenv("CI") != "" {
 		timeout = 60 * time.Second
 		pollInterval = 500 * time.Millisecond
 	}
@@ -2579,7 +2580,7 @@ func (rt *RestTester) NewDbConfig() DbConfig {
 	}
 	if base.TestsDisableGSI() {
 		// Walrus is peculiar in that it needs to run with views, but can run most GSI tests, including collections
-		if !base.UnitTestUrlIsWalrus() {
+		if !sgtest.UnitTestUrlIsWalrus() {
 			config.UseViews = base.Ptr(true)
 		}
 	} else {
@@ -2597,7 +2598,7 @@ func (rt *RestTester) NewDbConfig() DbConfig {
 	}
 
 	// Setup scopes.
-	if base.TestsUseNamedCollections() && rt.collectionConfig != useSingleCollectionDefaultOnly && (base.UnitTestUrlIsWalrus() || config.useGSI()) {
+	if base.TestsUseNamedCollections() && rt.collectionConfig != useSingleCollectionDefaultOnly && (sgtest.UnitTestUrlIsWalrus() || config.useGSI()) {
 		config.Scopes = GetCollectionsConfigWithFiltering(rt.TB(), rt.TestBucket, rt.numCollections, stringPtrOrNil(rt.SyncFn), stringPtrOrNil(rt.ImportFilter))
 	} else {
 		config.Sync = stringPtrOrNil(rt.SyncFn)
@@ -2695,21 +2696,21 @@ func (sc *ServerContext) AllInvalidDatabaseNames(_ *testing.T) []string {
 
 // RequireBucketSpecificCredentials skips tests if bucket specific credentials are required
 func RequireBucketSpecificCredentials(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
+	if sgtest.UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server since rosmar has no bucket specific credentials")
 	}
 }
 
 // RequireN1QLIndexes skips tests if N1QL indexes are required
 func RequireN1QLIndexes(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
+	if sgtest.UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server since rosmar has no support for N1QL indexes")
 	}
 }
 
 // RequireGocbDCPResync skips tests if not gocb backed buckets.
 func RequireGocbDCPResync(t *testing.T) {
-	if !base.UnitTestUrlIsWalrus() {
+	if !sgtest.UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server since rosmar has no support for DCP resync")
 	}
 }

--- a/rest/utilities_testing_attachment.go
+++ b/rest/utilities_testing_attachment.go
@@ -11,32 +11,20 @@ package rest
 import (
 	"context"
 	"maps"
-	"net/http"
 	"slices"
 	"testing"
-	"time"
 
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
-	"github.com/couchbase/sync_gateway/testing/assert"
 	"github.com/couchbase/sync_gateway/testing/require"
 )
 
-func (rt *RestTester) WaitForAttachmentCompactionStatus(t *testing.T, state db.BackgroundProcessState) db.AttachmentManagerResponse {
-	var response db.AttachmentManagerResponse
-	err := rt.WaitForConditionWithOptions(func() bool {
-		resp := rt.SendAdminRequest("GET", "/{{.db}}/_compact?type=attachment", "")
-		RequireStatus(t, resp, http.StatusOK)
-
-		err := base.JSONUnmarshal(resp.BodyBytes(), &response)
-		assert.NoError(t, err)
-
-		return response.State == state
-	}, 90, 1000)
-	assert.NoError(t, err)
-
-	return response
+// WaitForAttachmentCompactionStatus waits for the expectedState of the attachment compaction background job to be
+// reached by polling the REST API until that state
+// is reached. Fails test harness if it is not reached within timeout.
+func (rt *RestTester) WaitForAttachmentCompactionStatus(expectedState db.BackgroundProcessState) db.AttachmentManagerResponse {
+	return waitForBackgroundManagerState[db.AttachmentManagerResponse](rt, "/{{.db}}/_compact?type=attachment", expectedState)
 }
 
 func CreateLegacyAttachmentDoc(t *testing.T, ctx context.Context, collection *db.DatabaseCollectionWithUser, docID string, body []byte, attID string, attBody []byte) string {
@@ -89,20 +77,14 @@ func CreateLegacyAttachmentDoc(t *testing.T, ctx context.Context, collection *db
 	return attDocID
 }
 
-func (rt *RestTester) WaitForAttachmentMigrationStatus(t *testing.T, state db.BackgroundProcessState) db.AttachmentMigrationManagerResponse {
-	var response db.AttachmentMigrationManagerResponse
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		resp := rt.SendAdminRequest("GET", "/{{.db}}/_attachment_migration", "")
-		require.Equal(c, http.StatusOK, resp.Code)
-
-		err := base.JSONUnmarshal(resp.BodyBytes(), &response)
-		require.NoError(c, err)
-		assert.Equal(c, state, response.State)
-	}, time.Second*20, time.Millisecond*100)
+// WaitForAttachmentMigrationStatus waits for the expectedState to be reached for the attachment migration background
+// job by polling the REST API until that state is reached. Fails test harness if it is not reached within timeout.
+func (rt *RestTester) WaitForAttachmentMigrationStatus(state db.BackgroundProcessState) db.AttachmentMigrationManagerResponse {
+	response := waitForBackgroundManagerState[db.AttachmentMigrationManagerResponse](rt, "/{{.db}}/_attachment_migration", state)
 	// Wait for heartbeat doc removal if the state change will result in its removal. Allows calling start
 	// immediately after db.BackgroundProcessStateStopped without error.
 	if !slices.Contains([]db.BackgroundProcessState{db.BackgroundProcessStateRunning, db.BackgroundProcessStateStopping}, state) {
-		db.WaitForBackgroundManagerHeartbeatDocRemoval(t, rt.GetDatabase().AttachmentMigrationManager)
+		db.WaitForBackgroundManagerHeartbeatDocRemoval(rt.TB(), rt.GetDatabase().AttachmentMigrationManager)
 	}
 	return response
 }

--- a/rest/utilities_testing_attachment.go
+++ b/rest/utilities_testing_attachment.go
@@ -24,6 +24,7 @@ import (
 // reached by polling the REST API until that state
 // is reached. Fails test harness if it is not reached within timeout.
 func (rt *RestTester) WaitForAttachmentCompactionStatus(expectedState db.BackgroundProcessState) db.AttachmentManagerResponse {
+	rt.TB().Helper()
 	return waitForBackgroundManagerState[db.AttachmentManagerResponse](rt, "/{{.db}}/_compact?type=attachment", expectedState)
 }
 
@@ -80,6 +81,7 @@ func CreateLegacyAttachmentDoc(t *testing.T, ctx context.Context, collection *db
 // WaitForAttachmentMigrationStatus waits for the expectedState to be reached for the attachment migration background
 // job by polling the REST API until that state is reached. Fails test harness if it is not reached within timeout.
 func (rt *RestTester) WaitForAttachmentMigrationStatus(state db.BackgroundProcessState) db.AttachmentMigrationManagerResponse {
+	rt.TB().Helper()
 	response := waitForBackgroundManagerState[db.AttachmentMigrationManagerResponse](rt, "/{{.db}}/_attachment_migration", state)
 	// Wait for heartbeat doc removal if the state change will result in its removal. Allows calling start
 	// immediately after db.BackgroundProcessStateStopped without error.

--- a/rest/utilities_testing_bootstrap.go
+++ b/rest/utilities_testing_bootstrap.go
@@ -17,6 +17,7 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/testing/assert"
 	"github.com/couchbase/sync_gateway/testing/require"
+	"github.com/couchbase/sync_gateway/testing/sgtest"
 	"github.com/google/uuid"
 )
 
@@ -38,18 +39,18 @@ func BootstrapStartupConfigForTest(t *testing.T) StartupConfig {
 	config.API.MetricsInterface = randomPort
 	config.Unsupported.DiagnosticInterface = randomPort
 
-	config.Bootstrap.Server = base.UnitTestUrl()
+	config.Bootstrap.Server = sgtest.UnitTestUrl()
 	config.Bootstrap.Username = base.TestClusterUsername()
 	config.Bootstrap.Password = base.TestClusterPassword()
 	config.Bootstrap.ServerTLSSkipVerify = base.Ptr(base.TestTLSSkipVerify())
-	config.Bootstrap.UseTLSServer = base.Ptr(base.ServerIsTLS(base.UnitTestUrl()))
+	config.Bootstrap.UseTLSServer = base.Ptr(base.ServerIsTLS(sgtest.UnitTestUrl()))
 
 	uniqueUUID, err := uuid.NewRandom()
 	require.NoError(t, err)
 
 	if base.IsEnterpriseEdition() {
 		config.Bootstrap.ConfigGroupID = uniqueUUID.String()
-	} else if !base.UnitTestUrlIsWalrus() {
+	} else if !sgtest.UnitTestUrlIsWalrus() {
 		t.Skip("BootstrapStartupConfigForTest requires EE support, since the config files can be read by future tests in the bucket pool")
 	}
 

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -440,6 +440,7 @@ type backgroundManagerResponse interface {
 // longer for CBS or CI environments. The CBS/CI timeout is larger than db.RequireBackgroundManagerState
 // (which uses direct in-process access) to cover HTTP round-trip overhead.
 func waitForBackgroundManagerState[T backgroundManagerResponse](rt *RestTester, url string, state db.BackgroundProcessState) T {
+	rt.TB().Helper()
 	timeout := sgtest.GetBackgroundManagerStatusTransitionTimeout(rt.TB())
 	pollInterval := 10 * time.Millisecond
 	if !sgtest.UnitTestUrlIsWalrus() || sgtest.IsRaceDetectorEnabled(rt.TB()) || os.Getenv("CI") != "" {
@@ -455,11 +456,12 @@ func waitForBackgroundManagerState[T backgroundManagerResponse](rt *RestTester, 
 		require.Equal(c, http.StatusOK, resp.Code)
 		require.NoError(c, base.JSONUnmarshal(resp.BodyBytes(), &response))
 		assert.Equal(c, state, response.GetState())
-	}, timeout, pollInterval)
+	}, timeout, pollInterval, "waiting for %s to reach state %q", url, state)
 	return response
 }
 
 func (rt *RestTester) waitForResyncDCPStatus(status db.BackgroundProcessState, dbName string) db.ResyncManagerResponseDCP {
+	rt.TB().Helper()
 	resyncStatus := waitForBackgroundManagerState[db.ResyncManagerResponseDCP](rt, "/"+dbName+"/_resync", status)
 	if !slices.Contains([]db.BackgroundProcessState{db.BackgroundProcessStateRunning, db.BackgroundProcessStateStopping}, status) {
 		db.WaitForBackgroundManagerHeartbeatDocRemoval(rt.TB(), rt.GetDatabase().ResyncManager)
@@ -470,18 +472,21 @@ func (rt *RestTester) waitForResyncDCPStatus(status db.BackgroundProcessState, d
 // WaitForTombstoneCompactionStatus waits for the expectedState of the tombstone compaction background job to be reached by polling
 // the REST API until that state is reached. Fails test harness if it is not reached within timeout.
 func (rt *RestTester) WaitForTombstoneCompactionStatus(state db.BackgroundProcessState) db.TombstoneManagerResponse {
+	rt.TB().Helper()
 	return waitForBackgroundManagerState[db.TombstoneManagerResponse](rt, "/{{.db}}/_compact", state)
 }
 
 // WaitForMetadataMigrationStatus waits for the expectedState of the metadata migration background job to be reached by polling
 // the REST API until that state is reached. Fails test harness if it is not reached within timeout.
 func (rt *RestTester) WaitForMetadataMigrationStatus(status db.BackgroundProcessState) db.MigrationManagerResponse {
+	rt.TB().Helper()
 	return rt.WaitForMetadataMigrationStatusForDB(status, "{{.db}}")
 }
 
 // WaitForMetadataMigrationStatusForDB waits for the expectedState of the metadata migration background job to be reached by polling
 // the REST API until that state is reached on the named db. Fails test harness if it is not reached within timeout.
 func (rt *RestTester) WaitForMetadataMigrationStatusForDB(status db.BackgroundProcessState, dbName string) db.MigrationManagerResponse {
+	rt.TB().Helper()
 	return waitForBackgroundManagerState[db.MigrationManagerResponse](rt, "/"+dbName+"/_metadata_migration", status)
 }
 

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -25,6 +25,7 @@ import (
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbase/sync_gateway/testing/assert"
 	"github.com/couchbase/sync_gateway/testing/require"
+	"github.com/couchbase/sync_gateway/testing/sgtest"
 )
 
 // Run is equivalent to testing.T.Run() but updates the RestTester's TB to the new testing.T
@@ -428,52 +429,60 @@ func (rt *RestTester) WaitForResyncDCPStatusForDB(status db.BackgroundProcessSta
 	return rt.waitForResyncDCPStatus(status, dbName)
 }
 
-func (rt *RestTester) waitForResyncDCPStatus(status db.BackgroundProcessState, dbName string) db.ResyncManagerResponseDCP {
-	timeout := 10 * time.Second
+// backgroundManagerResponse is satisfied by any REST response type that embeds db.BackgroundManagerStatus.
+type backgroundManagerResponse interface {
+	GetState() db.BackgroundProcessState
+}
+
+// waitForBackgroundManagerState polls url via GET until the background manager response reaches the expected state.
+// T must be a struct that embeds db.BackgroundManagerStatus, which carries the JSON "status" field.
+// Timeouts are adaptive via sgtest.GetBackgroundManagerStatusTransitionTimeout: shorter for Walrus/unit tests,
+// longer for CBS or CI environments. The CBS/CI timeout is larger than db.RequireBackgroundManagerState
+// (which uses direct in-process access) to cover HTTP round-trip overhead.
+func waitForBackgroundManagerState[T backgroundManagerResponse](rt *RestTester, url string, state db.BackgroundProcessState) T {
+	timeout := sgtest.GetBackgroundManagerStatusTransitionTimeout(rt.TB())
 	pollInterval := 10 * time.Millisecond
-	if !base.UnitTestUrlIsWalrus() || base.IsRaceDetectorEnabled(rt.TB()) || os.Getenv("CI") != "" {
-		timeout = 60 * time.Second
+	if !sgtest.UnitTestUrlIsWalrus() || sgtest.IsRaceDetectorEnabled(rt.TB()) || os.Getenv("CI") != "" {
 		pollInterval = 500 * time.Millisecond
 	}
-	var resyncStatus db.ResyncManagerResponseDCP
+	var response T
 	require.EventuallyWithT(rt.TB(), func(c *assert.CollectT) {
-		response := rt.SendAdminRequest("GET", "/"+dbName+"/_resync", "")
-		RequireStatus(rt.TB(), response, http.StatusOK)
-		require.NoError(rt.TB(), json.Unmarshal(response.BodyBytes(), &resyncStatus))
-
-		assert.Equal(c, status, resyncStatus.State)
+		resp := rt.SendAdminRequest("GET", url, "")
+		// Use c (not rt.TB()) for all assertions so that failures are recorded on the
+		// CollectT and not on the real testing.T. EventuallyWithT runs the condition in a
+		// goroutine; calling rt.TB().Errorf/FailNow from that goroutine after the test
+		// has completed causes a "Fail in goroutine after TestXxx has completed" panic.
+		require.Equal(c, http.StatusOK, resp.Code)
+		require.NoError(c, base.JSONUnmarshal(resp.BodyBytes(), &response))
+		assert.Equal(c, state, response.GetState())
 	}, timeout, pollInterval)
+	return response
+}
+
+func (rt *RestTester) waitForResyncDCPStatus(status db.BackgroundProcessState, dbName string) db.ResyncManagerResponseDCP {
+	resyncStatus := waitForBackgroundManagerState[db.ResyncManagerResponseDCP](rt, "/"+dbName+"/_resync", status)
 	if !slices.Contains([]db.BackgroundProcessState{db.BackgroundProcessStateRunning, db.BackgroundProcessStateStopping}, status) {
 		db.WaitForBackgroundManagerHeartbeatDocRemoval(rt.TB(), rt.GetDatabase().ResyncManager)
 	}
 	return resyncStatus
 }
 
+// WaitForTombstoneCompactionStatus waits for the expectedState of the tombstone compaction background job to be reached by polling
+// the REST API until that state is reached. Fails test harness if it is not reached within timeout.
+func (rt *RestTester) WaitForTombstoneCompactionStatus(state db.BackgroundProcessState) db.TombstoneManagerResponse {
+	return waitForBackgroundManagerState[db.TombstoneManagerResponse](rt, "/{{.db}}/_compact", state)
+}
+
+// WaitForMetadataMigrationStatus waits for the expectedState of the metadata migration background job to be reached by polling
+// the REST API until that state is reached. Fails test harness if it is not reached within timeout.
 func (rt *RestTester) WaitForMetadataMigrationStatus(status db.BackgroundProcessState) db.MigrationManagerResponse {
-	return rt.waitForMetadataMigrationStatus(status, "{{.db}}")
+	return rt.WaitForMetadataMigrationStatusForDB(status, "{{.db}}")
 }
 
+// WaitForMetadataMigrationStatusForDB waits for the expectedState of the metadata migration background job to be reached by polling
+// the REST API until that state is reached on the named db. Fails test harness if it is not reached within timeout.
 func (rt *RestTester) WaitForMetadataMigrationStatusForDB(status db.BackgroundProcessState, dbName string) db.MigrationManagerResponse {
-	return rt.waitForMetadataMigrationStatus(status, dbName)
-}
-
-func (rt *RestTester) waitForMetadataMigrationStatus(status db.BackgroundProcessState, dbName string) db.MigrationManagerResponse {
-	timeout := 10 * time.Second
-	pollInterval := 10 * time.Millisecond
-	if !base.UnitTestUrlIsWalrus() || base.IsRaceDetectorEnabled(rt.TB()) || os.Getenv("CI") != "" {
-		timeout = 60 * time.Second
-		pollInterval = 500 * time.Millisecond
-	}
-
-	var migrationStatus db.MigrationManagerResponse
-	require.EventuallyWithT(rt.TB(), func(c *assert.CollectT) {
-		response := rt.SendAdminRequest("GET", "/"+dbName+"/_metadata_migration", "")
-		RequireStatus(rt.TB(), response, http.StatusOK)
-		require.NoError(rt.TB(), json.Unmarshal(response.BodyBytes(), &migrationStatus))
-
-		assert.Equal(c, status, migrationStatus.State)
-	}, timeout, pollInterval)
-	return migrationStatus
+	return waitForBackgroundManagerState[db.MigrationManagerResponse](rt, "/"+dbName+"/_metadata_migration", status)
 }
 
 // UpdatePersistedBucketName will update the persisted config bucket name to name specified in parameters

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -437,8 +437,7 @@ type backgroundManagerResponse interface {
 // waitForBackgroundManagerState polls url via GET until the background manager response reaches the expected state.
 // T must be a struct that embeds db.BackgroundManagerStatus, which carries the JSON "status" field.
 // Timeouts are adaptive via sgtest.GetBackgroundManagerStatusTransitionTimeout: shorter for Walrus/unit tests,
-// longer for CBS or CI environments. The CBS/CI timeout is larger than db.RequireBackgroundManagerState
-// (which uses direct in-process access) to cover HTTP round-trip overhead.
+// longer for CBS, CI, or race-detector builds.
 func waitForBackgroundManagerState[T backgroundManagerResponse](rt *RestTester, url string, state db.BackgroundProcessState) T {
 	rt.TB().Helper()
 	timeout := sgtest.GetBackgroundManagerStatusTransitionTimeout(rt.TB())

--- a/rest/x509_test.go
+++ b/rest/x509_test.go
@@ -118,7 +118,7 @@ func TestAttachmentCompactionRun(t *testing.T) {
 	resp := rt.SendAdminRequest("POST", "/db/_compact?type=attachment", "")
 	RequireStatus(t, resp, http.StatusOK)
 
-	status := rt.WaitForAttachmentCompactionStatus(t, db.BackgroundProcessStateCompleted)
+	status := rt.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateCompleted)
 	assert.Equal(t, int64(20), status.MarkedAttachments)
 }
 

--- a/testing/sgtest/norace.go
+++ b/testing/sgtest/norace.go
@@ -1,0 +1,19 @@
+// Copyright 2026-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+//go:build !race
+// +build !race
+
+package sgtest
+
+import "testing"
+
+// IsRaceDetectorEnabled returns false when compiled without -race.
+func IsRaceDetectorEnabled(_ testing.TB) bool {
+	return false
+}

--- a/testing/sgtest/race.go
+++ b/testing/sgtest/race.go
@@ -1,0 +1,19 @@
+// Copyright 2026-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+//go:build race
+// +build race
+
+package sgtest
+
+import "testing"
+
+// IsRaceDetectorEnabled returns true when compiled with -race.
+func IsRaceDetectorEnabled(_ testing.TB) bool {
+	return true
+}

--- a/testing/sgtest/sgtest.go
+++ b/testing/sgtest/sgtest.go
@@ -52,9 +52,7 @@ func UnitTestUrlIsWalrus() bool {
 }
 
 // GetBackgroundManagerStatusTransitionTimeout returns the appropriate wait timeout for background
-// manager state transitions. CBS and CI environments get a longer budget to account for slower
-// execution; the REST-layer timeout is intentionally larger than the direct-access variant
-// (db.RequireBackgroundManagerState uses 30 s for CBS) to cover HTTP round-trip overhead.
+// manager state transitions. CBS, CI, and race-detector builds get a longer budget to account for slower execution.
 func GetBackgroundManagerStatusTransitionTimeout(t testing.TB) time.Duration {
 	if !UnitTestUrlIsWalrus() || IsRaceDetectorEnabled(t) || os.Getenv("CI") != "" {
 		return 60 * time.Second

--- a/testing/sgtest/sgtest.go
+++ b/testing/sgtest/sgtest.go
@@ -1,0 +1,63 @@
+// Copyright 2026-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+// Package sgtest contains test environment utilities shared across all SG packages.
+// It intentionally has no dependency on any SG package to avoid import cycles.
+package sgtest
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	rosmar "github.com/couchbaselabs/rosmar"
+)
+
+const (
+	testEnvBackingStore          = "SG_TEST_BACKING_STORE"
+	testEnvBackingStoreCouchbase = "Couchbase"
+	testEnvCouchbaseServerURL    = "SG_TEST_COUCHBASE_SERVER_URL"
+	testEnvRosmarURL             = "SG_TEST_ROSMAR_URL"
+	defaultCouchbaseServerURL    = "couchbase://127.0.0.1"
+)
+
+// TestUseCouchbaseServer reports whether tests are configured to run against a real Couchbase Server cluster.
+func TestUseCouchbaseServer() bool {
+	return strings.EqualFold(os.Getenv(testEnvBackingStore), testEnvBackingStoreCouchbase)
+}
+
+// UnitTestUrl returns the configured test server URL.
+func UnitTestUrl() string {
+	if TestUseCouchbaseServer() {
+		if u := os.Getenv(testEnvCouchbaseServerURL); u != "" {
+			return u
+		}
+		return defaultCouchbaseServerURL
+	}
+	if u := os.Getenv(testEnvRosmarURL); u != "" {
+		return u
+	}
+	return rosmar.InMemoryURL
+}
+
+// UnitTestUrlIsWalrus reports whether tests are running against an in-memory Walrus/Rosmar store.
+func UnitTestUrlIsWalrus() bool {
+	return !TestUseCouchbaseServer()
+}
+
+// GetBackgroundManagerStatusTransitionTimeout returns the appropriate wait timeout for background
+// manager state transitions. CBS and CI environments get a longer budget to account for slower
+// execution; the REST-layer timeout is intentionally larger than the direct-access variant
+// (db.RequireBackgroundManagerState uses 30 s for CBS) to cover HTTP round-trip overhead.
+func GetBackgroundManagerStatusTransitionTimeout(t testing.TB) time.Duration {
+	if !UnitTestUrlIsWalrus() || IsRaceDetectorEnabled(t) || os.Getenv("CI") != "" {
+		return 60 * time.Second
+	}
+	return 10 * time.Second
+}

--- a/xdcr/cbs_xdcr.go
+++ b/xdcr/cbs_xdcr.go
@@ -74,7 +74,7 @@ func isClusterPresent(ctx context.Context, bucket *base.GocbV2Bucket) (bool, err
 
 // createCluster creates an XDCR cluster.
 func createCluster(ctx context.Context, bucket *base.GocbV2Bucket) error {
-	serverURL, err := url.Parse(base.UnitTestUrl())
+	serverURL, err := url.Parse(bucket.Spec.Server)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
CBG-5498 use common functions for waiting for background mgr  

There are several tests which are failing intermittently (AttachmentMigration, AttachmentCompaction) that I am trying to debug better. Improve helper code.

- Create common functions for all background manager code that have better error reporting
- Move test code into an sgtest package so it is clearer when something is a test only import and shouldn't be used by
  non test code. I'm neutral on this but it might eventually allow us to drop base/util_testing.go that gets compiled into (and then out of - main.go)
- The time for some of the rosmar waits reduces from 20s to 10s where WaitForCondition was called.
- WaitForAttachmentCompactionStatus reduces from 90s to 60s for CBS, which I think was unintentional
- fix a bug in the rosmar package which forces use of UnitTestUrlIsWalrsu


## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/847/
