### PR TITLE
CBG-5514 support bucket specific credentials in db config

### DIFF
--- a/rest/main.go
+++ b/rest/main.go
@@ -428,7 +428,7 @@ func setBootstrapConnectionOptsFromStartupConfig(opts *bootstrapConnectionOpts, 
 
 // setBootstrapConnectionOptsFromDbConfig sets the bootstrapConnectionOpts struct with values from the db config.
 func setBootstrapConnectionOptsFromDbConfig(opts *bootstrapConnectionOpts, dbConfig DbConfig) {
-	if dbConfig.Server != nil {
+	if dbConfig.Server != nil && *dbConfig.Server != "" {
 		opts.server = *dbConfig.Server
 	}
 	opts.username = dbConfig.Username

--- a/rest/main_test.go
+++ b/rest/main_test.go
@@ -19,6 +19,173 @@ import (
 	"github.com/couchbase/sync_gateway/testing/require"
 )
 
+func TestBootstrapConnectionOptsConfigs(t *testing.T) {
+	bucketCreds := base.PerBucketCredentialsConfig{
+		"bucket1": {Username: "b1user", Password: "b1pass"},
+	}
+	tlsSkipVerify := base.Ptr(true)
+
+	testCases := []struct {
+		name          string
+		startupConfig StartupConfig
+		dbConfig      DbConfig
+		expected      bootstrapConnectionOpts
+	}{
+		{
+			name: "startup config only",
+			startupConfig: StartupConfig{
+				Bootstrap: BootstrapConfig{
+					Server:       "couchbase://startup-host",
+					Username:     "startupUser",
+					Password:     "startupPass",
+					X509CertPath: "startup-cert.pem",
+					X509KeyPath:  "startup-key.pem",
+					CACertPath:   "startup-ca.pem",
+				},
+				BucketCredentials: bucketCreds,
+			},
+			dbConfig: DbConfig{},
+			expected: bootstrapConnectionOpts{
+				server:                      "couchbase://startup-host",
+				username:                    "",
+				password:                    "",
+				x509CertPath:                "",
+				x509KeyPath:                 "",
+				caCertPath:                  "",
+				bucketCredentials:           bucketCreds,
+				useSystemMetadataCollection: DefaultUseSystemMetadataCollection,
+			},
+		},
+		{
+			name: "db config server overrides startup",
+			startupConfig: StartupConfig{
+				Bootstrap: BootstrapConfig{
+					Server:   "couchbase://startup-host",
+					Username: "startupUser",
+					Password: "startupPass",
+				},
+			},
+			dbConfig: DbConfig{
+				BucketConfig: BucketConfig{
+					Server:   base.Ptr("couchbase://db-host"),
+					Username: "dbUser",
+					Password: "dbPass",
+				},
+			},
+			expected: bootstrapConnectionOpts{
+				server:                      "couchbase://db-host",
+				username:                    "dbUser",
+				password:                    "dbPass",
+				useSystemMetadataCollection: DefaultUseSystemMetadataCollection,
+			},
+		},
+		{
+			name: "nil db config server preserves startup server",
+			startupConfig: StartupConfig{
+				Bootstrap: BootstrapConfig{Server: "couchbase://startup-host"},
+			},
+			dbConfig: DbConfig{},
+			expected: bootstrapConnectionOpts{
+				server:                      "couchbase://startup-host",
+				useSystemMetadataCollection: DefaultUseSystemMetadataCollection,
+			},
+		},
+		{
+			name: "empty db config server preserves startup server",
+			startupConfig: StartupConfig{
+				Bootstrap: BootstrapConfig{Server: "couchbase://startup-host"},
+			},
+			dbConfig: DbConfig{
+				BucketConfig: BucketConfig{Server: base.Ptr("")},
+			},
+			expected: bootstrapConnectionOpts{
+				server:                      "couchbase://startup-host",
+				useSystemMetadataCollection: DefaultUseSystemMetadataCollection,
+			},
+		},
+		{
+			name: "db config credentials override startup",
+			startupConfig: StartupConfig{
+				Bootstrap: BootstrapConfig{
+					Server:       "couchbase://host",
+					X509CertPath: "startup-cert.pem",
+					X509KeyPath:  "startup-key.pem",
+					CACertPath:   "startup-ca.pem",
+				},
+			},
+			dbConfig: DbConfig{
+				BucketConfig: BucketConfig{
+					Username:   "dbUser",
+					Password:   "dbPass",
+					CertPath:   "db-cert.pem",
+					KeyPath:    "db-key.pem",
+					CACertPath: "db-ca.pem",
+				},
+			},
+			expected: bootstrapConnectionOpts{
+				server:                      "couchbase://host",
+				username:                    "dbUser",
+				password:                    "dbPass",
+				x509CertPath:                "db-cert.pem",
+				x509KeyPath:                 "db-key.pem",
+				caCertPath:                  "db-ca.pem",
+				useSystemMetadataCollection: DefaultUseSystemMetadataCollection,
+			},
+		},
+		{
+			name: "tlsSkipVerify from startup config",
+			startupConfig: StartupConfig{
+				Bootstrap: BootstrapConfig{
+					Server:              "couchbase://host",
+					ServerTLSSkipVerify: tlsSkipVerify,
+				},
+			},
+			dbConfig: DbConfig{},
+			expected: bootstrapConnectionOpts{
+				server:                      "couchbase://host",
+				tlsSkipVerify:               tlsSkipVerify,
+				useSystemMetadataCollection: DefaultUseSystemMetadataCollection,
+			},
+		},
+		{
+			name: "useXattrConfig from startup unsupported config",
+			startupConfig: StartupConfig{
+				Bootstrap: BootstrapConfig{Server: "couchbase://host"},
+				Unsupported: UnsupportedConfig{
+					UseXattrConfig: base.Ptr(true),
+				},
+			},
+			dbConfig: DbConfig{},
+			expected: bootstrapConnectionOpts{
+				server:                      "couchbase://host",
+				useXattrConfig:              true,
+				useSystemMetadataCollection: DefaultUseSystemMetadataCollection,
+			},
+		},
+		{
+			name: "useSystemMetadataCollection set to true",
+			startupConfig: StartupConfig{
+				Bootstrap: BootstrapConfig{
+					Server:                      "couchbase://host",
+					UseSystemMetadataCollection: base.Ptr(true),
+				},
+			},
+			dbConfig: DbConfig{},
+			expected: bootstrapConnectionOpts{
+				server:                      "couchbase://host",
+				useSystemMetadataCollection: true,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := bootstrapConnectionOptsConfigs(&tc.startupConfig, tc.dbConfig)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
 func TestMain(m *testing.M) {
 	ctx := context.Background() // start of test process
 	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 8192, NumCollectionsPerBucket: 3}


### PR DESCRIPTION
CBG-5514 support bucket specific credentials in db config

This did not work for TestLegacyCredentialInheritance since server: "" would be used by DatabaseInitManager. This happened to work in our integration tests because passing "" to gocb.Connect will work if CBS is on localhost:8091

To test this out locally, use SG_TEST_COUCHBASE_SERVER_URL to something other than localhost and make sure there is no CBS on localhost.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/864/
