### PR TITLE
CBG-5517 avoid data race/crash in RestTester.closed

### DIFF
--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -137,7 +137,7 @@ type RestTester struct {
 	metricsHandlerOnce      sync.Once
 	DiagnosticHandler       http.Handler
 	diagnosticHandlerOnce   sync.Once
-	closed                  bool
+	closed                  atomic.Bool
 }
 
 func (rt *RestTester) TB() testing.TB {
@@ -205,9 +205,8 @@ func NewRestTesterMultipleCollections(tb testing.TB, restConfig *RestTesterConfi
 func (rt *RestTester) Bucket() base.Bucket {
 	if rt.TB() == nil {
 		panic("RestTester not properly initialized please use NewRestTester function")
-	} else if rt.closed {
-		panic("RestTester was closed!")
 	}
+	require.False(rt.TB(), rt.closed.Load(), "RestTester was closed!")
 
 	if rt.TestBucket != nil {
 		return rt.TestBucket.Bucket
@@ -675,7 +674,7 @@ func (rt *RestTester) Close() {
 		panic("RestTester not properly initialized please use NewRestTester function")
 	}
 	ctx := rt.Context() // capture ctx before closing rt
-	rt.closed = true
+	require.True(rt.TB(), rt.closed.CompareAndSwap(false, true), "RestTester already closed")
 	if rt.RestTesterServerContext != nil {
 		rt.RestTesterServerContext.Close(ctx)
 	}


### PR DESCRIPTION
CBG-5517 avoid data race/crash in RestTester.closed

Avoid the following data race by making `RestTester.closed` an atomic and don't panic if it is already closed. testifies `EventuallyWithT` spawns a goroutine to run (and block) and this goroutine could be running while `RestTester` is closed. We want this to not cause the test harness to panic (in `Bucket()`'s closed check), nor to have a data race get flagged. https://github.com/stretchr/testify/blob/2a57335dc9cd6833daa820bc94d9b40c26a7917d/assert/assertions.go#L2107-L2128

I believe this fails because https://github.com/couchbase/sync_gateway/blob/f9e337ead6dab4f64b27f3f41c87cfac17b7f293/rest/attachmentmigrationtest/attachment_migration_api_test.go#L114 is waiting for Stopped but in fact this completes in the time for this case. However, I don't understand why the assertion is not logged, because it should be before the panic occurs. I will fix this error in a separate PR.

```
09:48:59 2026-06-30T06:44:54.239-07:00 [WRN] t:TestAttachmentMigrationAbort db:db Deprecation notice: setting database configuration option "disable_public_all_docs" to false is deprecated. In the future, public access to the all_docs API will be disabled by default. -- rest.dbcOptionsFromConfig() at server_context.go:1600
09:48:59 2026-06-30T06:44:54.240-07:00 [INF] t:TestAttachmentMigrationAbort db:db Opening db /db as bucket "rosmar1", pool "default", server <rosmar:/?mode=memory>
09:48:59 2026-06-30T06:44:54.240-07:00 [INF] t:TestAttachmentMigrationAbort db:db Opening rosmar database rosmar1 on <rosmar:/?mode=memory>
09:48:59 2026-06-30T06:44:54.241-07:00 [INF] t:TestAttachmentMigrationAbort db:db Design docs for current SG view version (2.1) found.
09:48:59 2026-06-30T06:44:54.241-07:00 [INF] t:TestAttachmentMigrationAbort db:db Verifying view availability for bucket
09:48:59 2026-06-30T06:44:54.242-07:00 [INF] t:TestAttachmentMigrationAbort db:db Views ready for bucket
09:48:59 2026-06-30T06:44:54.243-07:00 [INF] t:TestAttachmentMigrationAbort db:db Design docs for current SG view version (2.1) found.
09:48:59 2026-06-30T06:44:54.243-07:00 [INF] t:TestAttachmentMigrationAbort db:db Verifying view availability for bucket
09:48:59 2026-06-30T06:44:54.244-07:00 [INF] t:TestAttachmentMigrationAbort db:db Views ready for bucket
09:48:59 2026-06-30T06:44:54.247-07:00 [INF] t:TestAttachmentMigrationAbort c:CleanAgedItems db:db Created background task: "CleanAgedItems" with interval 1m0s
09:48:59 2026-06-30T06:44:54.247-07:00 [INF] t:TestAttachmentMigrationAbort db:db col:sg_test_0 Using default sync function "function(doc){channel(\"sg_test_0\");}" for database db.sg_test_0.sg_test_0
09:48:59 2026-06-30T06:44:54.247-07:00 [INF] t:TestAttachmentMigrationAbort db:db Waiting for database init to complete...
09:48:59 2026-06-30T06:44:54.247-07:00 [INF] t:TestAttachmentMigrationAbort db:db Database init completed, starting online processes
09:48:59 2026-06-30T06:44:54.247-07:00 [INF] t:TestAttachmentMigrationAbort c:InsertPendingEntries db:db Created background task: "InsertPendingEntries" with interval 2.5s
09:48:59 2026-06-30T06:44:54.247-07:00 [INF] t:TestAttachmentMigrationAbort c:CleanSkippedSequenceQueue db:db Created background task: "CleanSkippedSequenceQueue" with interval 30m0s
09:48:59 2026-06-30T06:44:54.249-07:00 [INF] t:TestAttachmentMigrationAbort db:db Using metadata purge interval of 30.00 days for tombstone compaction.
09:48:59 2026-06-30T06:44:54.249-07:00 [WRN] t:TestAttachmentMigrationAbort db:db Automatic compaction can only be enabled on nodes running an Import process -- db.(*DatabaseContext).StartOnlineProcesses() at database.go:2528
09:48:59 2026-06-30T06:44:54.249-07:00 [INF] t:TestAttachmentMigrationAbort c:TotalSyncTimeStat db:db Created background task: "TotalSyncTimeStat" with interval 1s
09:48:59 2026-06-30T06:44:54.249-07:00 [INF] t:TestAttachmentMigrationAbort db:db Attachment Migration: Starting new migration run with migration ID: a9dec874-d876-416f-a71d-8694e5f37543
09:48:59 2026-06-30T06:44:54.268-07:00 [INF] t:TestAttachmentMigrationAbort db:db [Migration: a9dec874-d876-416f-a71d-8694e5f37543] Finished migrating attachment metadata from sync data to global sync data. 0/0 docs changed
09:48:59 2026-06-30T06:44:54.384-07:00 [INF] HTTP: c:#008 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:44:54.755-07:00 [INF] HTTP: c:#009 db:db POST http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:44:54.756-07:00 [INF] c:#009 db:db Attachment Migration: Starting new migration run with migration ID: 8b6e03b4-1288-4afe-9859-3338365dcc20
09:48:59 2026-06-30T06:44:54.826-07:00 [INF] c:#009 db:db [Migration: 8b6e03b4-1288-4afe-9859-3338365dcc20] Finished migrating attachment metadata from sync data to global sync data. 0/200 docs changed
09:48:59 2026-06-30T06:44:54.836-07:00 [INF] HTTP: c:#010 db:db POST http://127.0.0.1/db/_attachment_migration?action=stop (as ADMIN)
09:48:59 2026-06-30T06:44:54.839-07:00 [INF] HTTP: c:#011 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:44:55.340-07:00 [INF] HTTP: c:#012 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:44:55.841-07:00 [INF] HTTP: c:#013 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:44:56.364-07:00 [INF] HTTP: c:#014 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:44:56.846-07:00 [INF] HTTP: c:#015 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:44:57.351-07:00 [INF] HTTP: c:#016 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:44:57.854-07:00 [INF] HTTP: c:#017 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026/06/30 06:44:57 TEST: Memory high water mark increased to 10.77 MB (heap: 8.77 MB stack: 2.00 MB)
09:48:59 2026-06-30T06:44:58.341-07:00 [INF] HTTP: c:#018 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:44:58.842-07:00 [INF] HTTP: c:#019 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:44:59.341-07:00 [INF] HTTP: c:#020 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:44:59.844-07:00 [INF] HTTP: c:#021 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:00.341-07:00 [INF] HTTP: c:#022 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:00.842-07:00 [INF] HTTP: c:#023 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:01.343-07:00 [INF] HTTP: c:#024 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:01.842-07:00 [INF] HTTP: c:#025 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:02.346-07:00 [INF] HTTP: c:#026 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:02.840-07:00 [INF] HTTP: c:#027 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026/06/30 06:45:02 TEST: Memory high water mark increased to 11.30 MB (heap: 9.30 MB stack: 2.00 MB)
09:48:59 2026-06-30T06:45:03.341-07:00 [INF] HTTP: c:#028 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:03.842-07:00 [INF] HTTP: c:#029 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:04.340-07:00 [INF] HTTP: c:#030 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:04.841-07:00 [INF] HTTP: c:#031 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:05.342-07:00 [INF] HTTP: c:#032 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:05.842-07:00 [INF] HTTP: c:#033 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:06.345-07:00 [INF] HTTP: c:#034 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:06.841-07:00 [INF] HTTP: c:#035 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:07.340-07:00 [INF] HTTP: c:#036 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:07.841-07:00 [INF] HTTP: c:#037 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026/06/30 06:45:07 TEST: Memory high water mark increased to 12.28 MB (heap: 10.31 MB stack: 1.97 MB)
09:48:59 2026-06-30T06:45:08.342-07:00 [INF] HTTP: c:#038 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:08.876-07:00 [INF] HTTP: c:#039 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:09.341-07:00 [INF] HTTP: c:#040 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:09.846-07:00 [INF] HTTP: c:#041 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:10.350-07:00 [INF] HTTP: c:#042 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:10.842-07:00 [INF] HTTP: c:#043 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:11.341-07:00 [INF] HTTP: c:#044 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:11.842-07:00 [INF] HTTP: c:#045 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:12.342-07:00 [INF] HTTP: c:#046 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:12.842-07:00 [INF] HTTP: c:#047 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:13.341-07:00 [INF] HTTP: c:#048 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:13.850-07:00 [INF] HTTP: c:#049 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:14.340-07:00 [INF] HTTP: c:#050 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:14.841-07:00 [INF] HTTP: c:#051 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:15.340-07:00 [INF] HTTP: c:#052 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:15.882-07:00 [INF] HTTP: c:#053 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:16.341-07:00 [INF] HTTP: c:#054 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:16.842-07:00 [INF] HTTP: c:#055 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:17.348-07:00 [INF] HTTP: c:#056 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026/06/30 06:45:17 TEST: Memory high water mark increased to 13.70 MB (heap: 11.70 MB stack: 2.00 MB)
09:48:59 2026-06-30T06:45:17.923-07:00 [INF] HTTP: c:#057 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:18.340-07:00 [INF] HTTP: c:#058 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:18.840-07:00 [INF] HTTP: c:#059 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:19.347-07:00 [INF] HTTP: c:#060 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:19.847-07:00 [INF] HTTP: c:#061 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:20.341-07:00 [INF] HTTP: c:#062 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:20.842-07:00 [INF] HTTP: c:#063 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:21.346-07:00 [INF] HTTP: c:#064 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:21.841-07:00 [INF] HTTP: c:#065 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:22.344-07:00 [INF] HTTP: c:#066 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:22.851-07:00 [INF] HTTP: c:#067 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:23.341-07:00 [INF] HTTP: c:#068 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:23.842-07:00 [INF] HTTP: c:#069 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:24.341-07:00 [INF] HTTP: c:#070 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:24.841-07:00 [INF] HTTP: c:#071 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:25.343-07:00 [INF] HTTP: c:#072 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:25.933-07:00 [INF] HTTP: c:#073 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:26.342-07:00 [INF] HTTP: c:#074 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:26.849-07:00 [INF] HTTP: c:#075 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:27.343-07:00 [INF] HTTP: c:#076 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:27.850-07:00 [INF] HTTP: c:#077 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:28.343-07:00 [INF] HTTP: c:#078 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:28.843-07:00 [INF] HTTP: c:#079 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:29.341-07:00 [INF] HTTP: c:#080 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:29.845-07:00 [INF] HTTP: c:#081 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:30.341-07:00 [INF] HTTP: c:#082 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:30.842-07:00 [INF] HTTP: c:#083 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:31.353-07:00 [INF] HTTP: c:#084 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:31.840-07:00 [INF] HTTP: c:#085 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:32.341-07:00 [INF] HTTP: c:#086 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:32.841-07:00 [INF] HTTP: c:#087 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:33.342-07:00 [INF] HTTP: c:#088 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:33.840-07:00 [INF] HTTP: c:#089 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:34.340-07:00 [INF] HTTP: c:#090 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:34.843-07:00 [INF] HTTP: c:#091 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:35.353-07:00 [INF] HTTP: c:#092 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:35.842-07:00 [INF] HTTP: c:#093 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:36.341-07:00 [INF] HTTP: c:#094 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:36.851-07:00 [INF] HTTP: c:#095 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:37.342-07:00 [INF] HTTP: c:#096 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:37.841-07:00 [INF] HTTP: c:#097 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:38.340-07:00 [INF] HTTP: c:#098 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:38.851-07:00 [INF] HTTP: c:#099 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:39.355-07:00 [INF] HTTP: c:#100 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:39.844-07:00 [INF] HTTP: c:#101 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:40.342-07:00 [INF] HTTP: c:#102 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:40.841-07:00 [INF] HTTP: c:#103 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:41.342-07:00 [INF] HTTP: c:#104 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:41.850-07:00 [INF] HTTP: c:#105 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:42.341-07:00 [INF] HTTP: c:#106 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:42.841-07:00 [INF] HTTP: c:#107 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:43.341-07:00 [INF] HTTP: c:#108 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:43.842-07:00 [INF] HTTP: c:#109 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:44.342-07:00 [INF] HTTP: c:#110 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:44.840-07:00 [INF] HTTP: c:#111 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:45.341-07:00 [INF] HTTP: c:#112 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:45.841-07:00 [INF] HTTP: c:#113 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:46.342-07:00 [INF] HTTP: c:#114 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:46.841-07:00 [INF] HTTP: c:#115 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:47.344-07:00 [INF] HTTP: c:#116 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:47.840-07:00 [INF] HTTP: c:#117 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:48.341-07:00 [INF] HTTP: c:#118 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:48.842-07:00 [INF] HTTP: c:#119 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:49.342-07:00 [INF] HTTP: c:#120 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:49.849-07:00 [INF] HTTP: c:#121 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:50.340-07:00 [INF] HTTP: c:#122 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:50.852-07:00 [INF] HTTP: c:#123 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:51.347-07:00 [INF] HTTP: c:#124 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:51.845-07:00 [INF] HTTP: c:#125 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:52.347-07:00 [INF] HTTP: c:#126 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:52.840-07:00 [INF] HTTP: c:#127 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:53.370-07:00 [INF] HTTP: c:#128 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:53.842-07:00 [INF] HTTP: c:#129 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 2026-06-30T06:45:54.341-07:00 [INF] HTTP: c:#130 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
09:48:59 ==================
09:48:59 
WARNING: DATA RACE
09:48:59 Read at 0x00c001117cbc by goroutine 2372:
09:48:59   github.com/couchbase/sync_gateway/rest.(*RestTester).Bucket()
09:48:59       C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/rest/utilities_testing.go:208 +0x89
09:48:59   github.com/couchbase/sync_gateway/rest.(*RestTester).ServerContext()
09:48:59       C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/rest/utilities_testing.go:529 +0x366
09:48:59   github.com/couchbase/sync_gateway/rest.(*RestTester).templateResource()
09:48:59       C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/rest/utilities_testing.go:719 +0x380
09:48:59   github.com/couchbase/sync_gateway/rest.(*RestTester).mustTemplateResource()
09:48:59       C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/rest/utilities_testing.go:773 +0x5b
09:48:59   github.com/couchbase/sync_gateway/rest.(*RestTester).SendAdminRequest()
09:48:59       C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/rest/utilities_testing.go:987 +0x6a
09:48:59   github.com/couchbase/sync_gateway/rest.waitForBackgroundManagerState[go.shape.struct { github.com/couchbase/sync_gateway/db.BackgroundManagerStatus; MigrationID string "json:\"migration_id\""; DocsChanged int64 "json:\"docs_changed\""; DocsProcessed int64 "json:\"docs_processed\""; DocsFailed int64 "json:\"docs_failed\"" }].func1()
09:48:59       C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/rest/utilities_testing_resttester.go:454 +0xb0
09:48:59   github.com/stretchr/testify/assert.EventuallyWithT.func1()
09:48:59       C:/Jenkins/workspace/sgw-windows-wix/godeps/pkg/mod/github.com/stretchr/testify@v1.11.1/assert/assertions.go:2096 +0xb3
09:48:59 
09:48:59 Previous write at 0x00c001117cbc by goroutine 1652:
09:48:59   github.com/couchbase/sync_gateway/rest.(*RestTester).Close()
09:48:59       C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/rest/utilities_testing.go:678 +0x99
09:48:59   github.com/couchbase/sync_gateway/rest/attachmentmigrationtest.TestAttachmentMigrationAbort.deferwrap1()
09:48:59       C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/rest/attachmentmigrationtest/attachment_migration_api_test.go:86 +0x2e
09:48:59   runtime.Goexit()
09:48:59       C:/Users/Administrator/cbdeps/go1.26.4/src/runtime/panic.go:694 +0x5d
09:48:59   github.com/stretchr/testify/require.EventuallyWithT()
09:48:59       C:/Jenkins/workspace/sgw-windows-wix/godeps/pkg/mod/github.com/stretchr/testify@v1.11.1/require/require.go:443 +0xf0
09:48:59   github.com/couchbase/sync_gateway/testing/require.EventuallyWithT()
09:48:59       C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/testing/require/require.go:947 +0xb0
09:48:59   github.com/couchbase/sync_gateway/rest.waitForBackgroundManagerState[go.shape.struct { github.com/couchbase/sync_gateway/db.BackgroundManagerStatus; MigrationID string "json:\"migration_id\""; DocsChanged int64 "json:\"docs_changed\""; DocsProcessed int64 "json:\"docs_processed\""; DocsFailed int64 "json:\"docs_failed\"" }]()
09:48:59       C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/rest/utilities_testing_resttester.go:453 +0x42c
09:48:59   github.com/couchbase/sync_gateway/rest.(*RestTester).WaitForAttachmentMigrationStatus()
09:48:59       C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/rest/utilities_testing_attachment.go:85 +0xe4
09:48:59   github.com/couchbase/sync_gateway/rest/attachmentmigrationtest.TestAttachmentMigrationAbort()
09:48:59       C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/rest/attachmentmigrationtest/attachment_migration_api_test.go:114 +0x613
09:48:59   github.com/couchbase/sync_gateway/rest.(*RestTester).SendAdminRequest()
09:48:59       C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/rest/utilities_testing.go:991 +0x2c8
09:48:59   github.com/couchbase/sync_gateway/rest/attachmentmigrationtest.TestAttachmentMigrationAbort()
09:48:59       C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/rest/attachmentmigrationtest/attachment_migration_api_test.go:111 +0x5de
09:48:59   github.com/couchbase/sync_gateway/rest.(*RestTester).SendAdminRequest()
09:48:59       C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/rest/utilities_testing.go:991 +0x2c8
09:48:59   github.com/couchbase/sync_gateway/rest/attachmentmigrationtest.TestAttachmentMigrationAbort()
09:48:59       C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/rest/attachmentmigrationtest/attachment_migration_api_test.go:107 +0x597
09:48:59   testing.tRunner()
09:48:59       C:/Users/Administrator/cbdeps/go1.26.4/src/testing/testing.go:2036 +0x1ca
09:48:59   testing.(*T).Run.gowrap1()
09:48:59       C:/Users/Administrator/cbdeps/go1.26.4/src/testing/testing.go:2101 +0x38
09:48:59 
09:48:59 Goroutine 2372 (running) created at:
09:48:59   github.com/stretchr/testify/assert.EventuallyWithT()
09:48:59       C:/Jenkins/workspace/sgw-windows-wix/godeps/pkg/mod/github.com/stretchr/testify@v1.11.1/assert/assertions.go:2119 +0x3a4
09:48:59   github.com/stretchr/testify/require.EventuallyWithT()
09:48:59       C:/Jenkins/workspace/sgw-windows-wix/godeps/pkg/mod/github.com/stretchr/testify@v1.11.1/require/require.go:440 +0xd1
09:48:59   github.com/couchbase/sync_gateway/testing/require.EventuallyWithT()
09:48:59       C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/testing/require/require.go:947 +0xb0
09:48:59   github.com/couchbase/sync_gateway/rest.waitForBackgroundManagerState[go.shape.struct { github.com/couchbase/sync_gateway/db.BackgroundManagerStatus; MigrationID string "json:\"migration_id\""; DocsChanged int64 "json:\"docs_changed\""; DocsProcessed int64 "json:\"docs_processed\""; DocsFailed int64 "json:\"docs_failed\"" }]()
09:48:59       C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/rest/utilities_testing_resttester.go:453 +0x42c
09:48:59   github.com/couchbase/sync_gateway/rest.(*RestTester).WaitForAttachmentMigrationStatus()
09:48:59       C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/rest/utilities_testing_attachment.go:85 +0xe4
09:48:59   github.com/couchbase/sync_gateway/rest/attachmentmigrationtest.TestAttachmentMigrationAbort()
09:48:59       C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/rest/attachmentmigrationtest/attachment_migration_api_test.go:114 +0x613
09:48:59   github.com/couchbase/sync_gateway/rest.(*RestTester).SendAdminRequest()
09:48:59       C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/rest/utilities_testing.go:991 +0x2c8
09:48:59   github.com/couchbase/sync_gateway/rest/attachmentmigrationtest.TestAttachmentMigrationAbort()
09:48:59       C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/rest/attachmentmigrationtest/attachment_migration_api_test.go:111 +0x5de
09:48:59   github.com/couchbase/sync_gateway/rest.(*RestTester).SendAdminRequest()
09:48:59       C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/rest/utilities_testing.go:991 +0x2c8
09:48:59   github.com/couchbase/sync_gateway/rest/attachmentmigrationtest.TestAttachmentMigrationAbort()
09:48:59       C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/rest/attachmentmigrationtest/attachment_migration_api_test.go:107 +0x597
09:48:59   testing.tRunner()
09:48:59       C:/Users/Administrator/cbdeps/go1.26.4/src/testing/testing.go:2036 +0x1ca
09:48:59   testing.(*T).Run.gowrap1()
09:48:59       C:/Users/Administrator/cbdeps/go1.26.4/src/testing/testing.go:2101 +0x38
09:48:59 
09:48:59 Goroutine 1652 (running) created at:
09:48:59   testing.(*T).Run()
09:48:59       C:/Users/Administrator/cbdeps/go1.26.4/src/testing/testing.go:2101 +0xb2a
09:48:59   testing.runTests.func1()
09:48:59       C:/Users/Administrator/cbdeps/go1.26.4/src/testing/testing.go:2585 +0x84
09:48:59   testing.tRunner()
09:48:59       C:/Users/Administrator/cbdeps/go1.26.4/src/testing/testing.go:2036 +0x1ca
09:48:59   testing.runTests()
09:48:59       C:/Users/Administrator/cbdeps/go1.26.4/src/testing/testing.go:2583 +0x9f7
09:48:59   testing.(*M).Run()
09:48:59       C:/Users/Administrator/cbdeps/go1.26.4/src/testing/testing.go:2443 +0xf4b
09:48:59   github.com/couchbase/sync_gateway/base.TestBucketPoolMain()
09:48:59       C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/base/main_test_bucket_pool.go:837 +0x6f8
09:48:59   github.com/couchbase/sync_gateway/db.TestBucketPoolWithIndexes()
09:48:59       C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/db/util_testing.go:507 +0xce
09:48:59   github.com/couchbase/sync_gateway/rest/attachmentmigrationtest.TestMain()
09:48:59       C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/rest/attachmentmigrationtest/main_test.go:24 +0x2f
09:48:59   main.main()
09:48:59       _testmain.go:64 +0x171
09:48:59 ==================
09:48:59 panic: RestTester was closed!
09:48:59 
09:48:59 goroutine 2369 [running]:
09:48:59 github.com/couchbase/sync_gateway/rest.(*RestTester).Bucket(0xc001117c20)
09:48:59 	C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/rest/utilities_testing.go:209 +0x4df8
09:48:59 github.com/couchbase/sync_gateway/rest.(*RestTester).ServerContext(...)
09:48:59 	C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/rest/utilities_testing.go:529
09:48:59 github.com/couchbase/sync_gateway/rest.(*RestTester).templateResource(0xc001117c20, {0x1421f28e3, 0x1e})
09:48:59 	C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/rest/utilities_testing.go:719 +0x367
09:48:59 github.com/couchbase/sync_gateway/rest.(*RestTester).mustTemplateResource(0xc001117c20, {0x1421f28e3, 0x1e})
09:48:59 	C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/rest/utilities_testing.go:773 +0x5c
09:48:59 github.com/couchbase/sync_gateway/rest.(*RestTester).SendAdminRequest(0xc001117c20, {0x1421c1234, 0x3}, {0x1421f28e3, 0x1e}, {0x0, 0x0})
09:48:59 	C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/rest/utilities_testing.go:987 +0x6b
09:48:59 github.com/couchbase/sync_gateway/rest.waitForBackgroundManagerState[...].func1()
09:48:59 	C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/rest/utilities_testing_resttester.go:454 +0xb1
09:48:59 github.com/stretchr/testify/assert.EventuallyWithT.func1()
09:48:59 	C:/Jenkins/workspace/sgw-windows-wix/godeps/pkg/mod/github.com/stretchr/testify@v1.11.1/assert/assertions.go:2096 +0xb4
09:48:59 created by github.com/stretchr/testify/assert.EventuallyWithT in goroutine 1692
09:48:59 	C:/Jenkins/workspace/sgw-windows-wix/godeps/pkg/mod/github.com/stretchr/testify@v1.11.1/assert/assertions.go:2119 +0x3a5
```
