### PR TITLE
CBG-5518 remove pre-collections Couchbase Server support

### DIFF
--- a/base/collection.go
+++ b/base/collection.go
@@ -645,9 +645,6 @@ func (b *GocbV2Bucket) releaseQueryOp() {
 }
 
 func (b *GocbV2Bucket) ListDataStores(_ context.Context) ([]sgbucket.DataStoreName, error) {
-	if !b.IsSupported(sgbucket.BucketStoreFeatureCollections) {
-		return []sgbucket.DataStoreName{ScopeAndCollectionName{Scope: DefaultScope, Collection: DefaultCollection}}, nil
-	}
 	scopes, err := b.bucket.Collections().GetAllScopes(nil)
 	if err != nil {
 		return nil, err

--- a/base/collection_gocb.go
+++ b/base/collection_gocb.go
@@ -422,11 +422,9 @@ func (c *Collection) GetExpiry(ctx context.Context, k string) (expiry uint32, ge
 	}
 
 	getMetaOptions := gocbcore.GetMetaOptions{
-		Key:      []byte(k),
-		Deadline: c.Bucket.getBucketOpDeadline(),
-	}
-	if c.IsSupported(sgbucket.BucketStoreFeatureCollections) {
-		getMetaOptions.CollectionID = c.GetCollectionID()
+		Key:          []byte(k),
+		Deadline:     c.Bucket.getBucketOpDeadline(),
+		CollectionID: c.GetCollectionID(),
 	}
 
 	wg := sync.WaitGroup{}
@@ -564,10 +562,6 @@ func (c *Collection) GetCollectionID() uint32 {
 
 // setCollectionID sets private property of kv CollectionID.
 func (c *Collection) setCollectionID() error {
-	if !c.IsSupported(sgbucket.BucketStoreFeatureCollections) {
-		c.kvCollectionID = DefaultCollectionID
-		return nil
-	}
 	// default collection has a known ID
 	if c.IsDefaultScopeCollection() {
 		c.kvCollectionID = DefaultCollectionID

--- a/base/collection_n1ql.go
+++ b/base/collection_n1ql.go
@@ -43,9 +43,6 @@ func IsMobileSystemCollection(dsn sgbucket.DataStoreName) bool {
 
 // EscapedKeyspace returns the escaped fully-qualified identifier for the keyspace (e.g. `bucket`.`scope`.`collection`)
 func (c *Collection) EscapedKeyspace() string {
-	if !c.IsSupported(sgbucket.BucketStoreFeatureCollections) {
-		return fmt.Sprintf("`%s`", c.BucketName())
-	}
 	return fmt.Sprintf("`%s`.`%s`.`%s`", c.BucketName(), c.ScopeName(), c.CollectionName())
 }
 
@@ -70,17 +67,12 @@ func (c *Collection) BucketName() string {
 }
 
 func (c *Collection) indexManager() *indexManager {
-	m := &indexManager{
+	return &indexManager{
 		bucketName:     c.BucketName(),
 		collectionName: c.CollectionName(),
 		scopeName:      c.ScopeName(),
+		collection:     c.Collection.QueryIndexes(),
 	}
-	if !c.IsSupported(sgbucket.BucketStoreFeatureCollections) {
-		m.cluster = c.Bucket.cluster.QueryIndexes()
-	} else {
-		m.collection = c.Collection.QueryIndexes()
-	}
-	return m
 }
 
 // IndexMetaKeyspaceID returns the value of keyspace_id for the system:indexes table for the collection.
@@ -181,13 +173,7 @@ func (b *GocbV2Bucket) runQuery(scopeName string, statement string, n1qlOptions 
 		n1qlOptions = &gocb.QueryOptions{}
 	}
 
-	var queryResults *gocb.QueryResult
-	var err error
-	if b.IsSupported(sgbucket.BucketStoreFeatureCollections) {
-		queryResults, err = b.bucket.Scope(scopeName).Query(statement, n1qlOptions)
-	} else {
-		queryResults, err = b.cluster.Query(statement, n1qlOptions)
-	}
+	queryResults, err := b.bucket.Scope(scopeName).Query(statement, n1qlOptions)
 	// In the event that we get an error during query we should release a view op as Close() will not be called.
 	if err != nil {
 		b.releaseQueryOp()

--- a/base/dcp_client_test.go
+++ b/base/dcp_client_test.go
@@ -215,18 +215,12 @@ func TestDCPClientMultiFeedConsistency(t *testing.T) {
 				err := dataStore.Set(ctx, key, 0, nil, updatedBody)
 				require.NoError(t, err)
 			}
-			collection, ok := dataStore.(*Collection)
-			require.True(t, ok)
-			var collectionIDs []uint32
-			if collection.IsSupported(sgbucket.BucketStoreFeatureCollections) {
-				collectionIDs = append(collectionIDs, collection.GetCollectionID())
-			}
 
 			// Perform first one-shot DCP feed - normal one-shot
 			dcpClientOpts := GoCBDCPClientOptions{
 				OneShot:          true,
 				FailOnRollback:   true,
-				CollectionIDs:    collectionIDs,
+				CollectionIDs:    getCollectionIDs(t, bucket),
 				CheckpointPrefix: DefaultMetadataKeys.DCPCheckpointPrefix(t.Name()),
 				MetadataStore:    bucket.GetMetadataStore(),
 			}
@@ -264,7 +258,7 @@ func TestDCPClientMultiFeedConsistency(t *testing.T) {
 				InitialMetadata:  uuidMismatchMetadata,
 				FailOnRollback:   true,
 				OneShot:          true,
-				CollectionIDs:    collectionIDs,
+				CollectionIDs:    getCollectionIDs(t, bucket),
 				CheckpointPrefix: DefaultMetadataKeys.DCPCheckpointPrefix(t.Name()),
 				MetadataStore:    bucket.GetMetadataStore(),
 			}
@@ -283,7 +277,7 @@ func TestDCPClientMultiFeedConsistency(t *testing.T) {
 				InitialMetadata:  uuidMismatchMetadata,
 				FailOnRollback:   false,
 				OneShot:          true,
-				CollectionIDs:    collectionIDs,
+				CollectionIDs:    getCollectionIDs(t, bucket),
 				CheckpointPrefix: DefaultMetadataKeys.DCPCheckpointPrefix(t.Name()),
 				MetadataStore:    bucket.GetMetadataStore(),
 			}
@@ -340,18 +334,10 @@ func TestContinuousDCPRollback(t *testing.T) {
 	gocbv2Bucket, err := AsGocbV2Bucket(bucket.Bucket)
 	require.NoError(t, err)
 
-	collection, err := AsCollection(dataStore)
-	require.NoError(t, err)
-
-	var collectionIDs []uint32
-	if collection.IsSupported(sgbucket.BucketStoreFeatureCollections) {
-		collectionIDs = append(collectionIDs, collection.GetCollectionID())
-	}
-
 	dcpClientOpts := GoCBDCPClientOptions{
 		FailOnRollback:    false,
 		OneShot:           false,
-		CollectionIDs:     collectionIDs,
+		CollectionIDs:     getCollectionIDs(t, bucket),
 		CheckpointPrefix:  DefaultMetadataKeys.DCPCheckpointPrefix(t.Name()),
 		MetadataStoreType: DCPMetadataStoreInMemory,
 	}
@@ -388,7 +374,7 @@ func TestContinuousDCPRollback(t *testing.T) {
 		InitialMetadata:   dcpClient.GetMetadata(),
 		FailOnRollback:    false,
 		OneShot:           false,
-		CollectionIDs:     collectionIDs,
+		CollectionIDs:     getCollectionIDs(t, bucket),
 		CheckpointPrefix:  DefaultMetadataKeys.DCPCheckpointPrefix(t.Name()),
 		MetadataStoreType: DCPMetadataStoreInMemory,
 	}
@@ -621,12 +607,7 @@ func getCollectionIDs(t *testing.T, bucket *TestBucket) []uint32 {
 	collection, err := AsCollection(bucket.GetSingleDataStore())
 	require.NoError(t, err)
 
-	var collectionIDs []uint32
-	if collection.IsSupported(sgbucket.BucketStoreFeatureCollections) {
-		collectionIDs = append(collectionIDs, collection.GetCollectionID())
-	}
-	return collectionIDs
-
+	return []uint32{collection.GetCollectionID()}
 }
 
 func TestDCPFeedEventTypes(t *testing.T) {

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/couchbase/cbgt"
-	sgbucket "github.com/couchbase/sg-bucket"
 )
 
 const (
@@ -405,12 +404,6 @@ func initCBGTManager(ctx context.Context, bucket Bucket, spec BucketSpec, cfgSG 
 	if err == nil && connStrKvBufferSize != nil && *connStrKvBufferSize > idealKvConnectionBufferSize {
 		WarnfCtx(ctx, "DCP sharded import connection string includes %s=%d, which is more than the implicit %s=%d. This will result in increased memory usage.", kvBufferSizeKey, *connStrKvBufferSize, kvBufferSizeKey, idealKvConnectionBufferSize)
 	}
-	// Disable collections if unsupported
-	if !bucket.IsSupported(sgbucket.BucketStoreFeatureCollections) {
-		options["disableCollectionsSupport"] = "true"
-		options["disableStreamIDs"] = "true"
-	}
-
 	// Creates a new cbgt manager.
 	mgr := cbgt.NewManagerEx(
 		SGCbgtMetadataVersion, // cbgt metadata version, matching 3.0 clients

--- a/base/gocb_dcp_client.go
+++ b/base/gocb_dcp_client.go
@@ -137,20 +137,20 @@ func NewGocbDCPClient(ctx context.Context, callback sgbucket.FeedEventCallbackFu
 		return nil, fmt.Errorf("error generating DCP stream name: %w", err)
 	}
 	client := &GoCBDCPClient{
-		ctx:                 ctx,
-		dcpStreamName:       dcpStreamName,
-		workers:             make([]*DCPWorker, numWorkers),
-		numVbuckets:         numVbuckets,
-		callback:            callback,
-		spec:                bucket.GetSpec(),
-		terminator:          make(chan bool),
-		doneChannel:         make(chan error, 1),
-		failOnRollback:      options.FailOnRollback,
-		checkpointPrefix:    options.CheckpointPrefix,
-		dbStats:             options.DbStats,
-		agentPriority:       options.AgentPriority,
-		collectionIDs:       options.CollectionIDs,
-		feedContent:         options.FeedContent,
+		ctx:              ctx,
+		dcpStreamName:    dcpStreamName,
+		workers:          make([]*DCPWorker, numWorkers),
+		numVbuckets:      numVbuckets,
+		callback:         callback,
+		spec:             bucket.GetSpec(),
+		terminator:       make(chan bool),
+		doneChannel:      make(chan error, 1),
+		failOnRollback:   options.FailOnRollback,
+		checkpointPrefix: options.CheckpointPrefix,
+		dbStats:          options.DbStats,
+		agentPriority:    options.AgentPriority,
+		collectionIDs:    options.CollectionIDs,
+		feedContent:      options.FeedContent,
 	}
 
 	// Initialize active vbuckets

--- a/base/gocb_dcp_client.go
+++ b/base/gocb_dcp_client.go
@@ -48,7 +48,6 @@ type GoCBDCPClient struct {
 	workers                    []*DCPWorker                   // Workers for concurrent processing of incoming mutations and callback.  vbuckets are partitioned across workers
 	workersWg                  sync.WaitGroup                 // Active workers WG - used for signaling when the DCPClient workers have all stopped so the doneChannel can be closed
 	spec                       BucketSpec                     // Bucket spec for the target data store
-	supportsCollections        bool                           // Whether the target data store supports collections
 	numVbuckets                uint16                         // number of vbuckets on target data store
 	terminator                 chan bool                      // Used to close worker goroutines spawned by the DCPClient
 	doneChannel                chan error                     // Returns nil on successful completion of one-shot feed or external close of feed, error otherwise
@@ -144,7 +143,6 @@ func NewGocbDCPClient(ctx context.Context, callback sgbucket.FeedEventCallbackFu
 		numVbuckets:         numVbuckets,
 		callback:            callback,
 		spec:                bucket.GetSpec(),
-		supportsCollections: bucket.IsSupported(sgbucket.BucketStoreFeatureCollections),
 		terminator:          make(chan bool),
 		doneChannel:         make(chan error, 1),
 		failOnRollback:      options.FailOnRollback,
@@ -192,9 +190,8 @@ func NewGocbDCPClient(ctx context.Context, callback sgbucket.FeedEventCallbackFu
 
 // getCollectionHighSeqNo returns the highSeqNo for a given KV collection ID.
 func (dc *GoCBDCPClient) getCollectionHighSeqNos(collectionID uint32) ([]uint64, error) {
-	vbucketSeqnoOptions := gocbcore.GetVbucketSeqnoOptions{}
-	if dc.supportsCollections {
-		vbucketSeqnoOptions.FilterOptions = &gocbcore.GetVbucketSeqnoFilterOptions{CollectionID: collectionID}
+	vbucketSeqnoOptions := gocbcore.GetVbucketSeqnoOptions{
+		FilterOptions: &gocbcore.GetVbucketSeqnoFilterOptions{CollectionID: collectionID},
 	}
 	configSnapshot, err := dc.agent.ConfigSnapshot()
 	if err != nil {
@@ -389,9 +386,7 @@ func (dc *GoCBDCPClient) getAgentConfig(spec BucketSpec) (*gocbcore.DCPAgentConf
 	agentConfig.SecurityConfig.Auth = auth
 	agentConfig.SecurityConfig.TLSRootCAProvider = tlsRootCAProvider
 	agentConfig.UserAgent = "SyncGatewayDCP"
-	if dc.supportsCollections {
-		agentConfig.IoConfig.UseCollections = true
-	}
+	agentConfig.IoConfig.UseCollections = true
 	return &agentConfig, nil
 }
 
@@ -537,10 +532,8 @@ func (dc *GoCBDCPClient) openStreamRequest(vbID uint16) error {
 
 	vbMeta := dc.metadata.GetMeta(vbID)
 
-	options := gocbcore.OpenStreamOptions{}
-	// Always use a collection-aware feed if supported
-	if dc.supportsCollections {
-		options.FilterOptions = &gocbcore.OpenStreamFilterOptions{CollectionIDs: dc.collectionIDs}
+	options := gocbcore.OpenStreamOptions{
+		FilterOptions: &gocbcore.OpenStreamFilterOptions{CollectionIDs: dc.collectionIDs},
 	}
 
 	// This has to be buffered so that Cancel() below doesn't lead to blocking in the callback.

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -4555,9 +4555,6 @@ func TestBadDCPStart(t *testing.T) {
 	ctx := base.TestCtx(t)
 	bucket := base.GetTestBucket(t)
 	defer bucket.Close(ctx)
-	if !bucket.IsSupported(sgbucket.BucketStoreFeatureCollections) {
-		t.Skip("This test requires collections support on server (7.0 or greater)")
-	}
 	dbcOptions := DatabaseContextOptions{
 		Scopes: GetScopesOptions(t, bucket, 1),
 	}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -55,8 +55,6 @@ const (
 	CBXDCRCompatibleMinorVersion = 6
 )
 
-var errCollectionsUnsupported = base.HTTPErrorf(http.StatusBadRequest, "Named collections specified in database config, but not supported by connected Couchbase Server.")
-
 var ErrSuspendingDisallowed = errors.New("database does not allow suspending")
 
 var allServers = []serverType{publicServer, adminServer, metricsServer, diagnosticServer}
@@ -862,10 +860,6 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	collectionsRequiringResync := make([]base.ScopeAndCollectionName, 0)
 	collectionsRequiringAttachmentMigration := make([]base.ScopeAndCollectionName, 0)
 	if len(config.Scopes) > 0 {
-		if !bucket.IsSupported(sgbucket.BucketStoreFeatureCollections) {
-			return nil, errCollectionsUnsupported
-		}
-
 		for scopeName, scopeConfig := range config.Scopes {
 			for collectionName := range scopeConfig.Collections {
 				scName := base.ScopeAndCollectionName{Scope: scopeName, Collection: collectionName}

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/couchbase/gocbcore/v10/connstr"
-	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
@@ -674,57 +673,6 @@ func TestUseTLSServer(t *testing.T) {
 			}
 		})
 	}
-}
-
-// Test that we correctly error out when trying to use collections against a CBS that doesn't support them. NB: this
-// test only runs against Couchbase Server <7.0.
-func TestServerContextSetupCollectionsSupport(t *testing.T) {
-	ctx := base.TestCtx(t)
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("Requires Couchbase Server")
-	}
-
-	tb := base.GetTestBucket(t)
-	defer tb.Close(ctx)
-	if tb.IsSupported(sgbucket.BucketStoreFeatureCollections) {
-		t.Skip("Only runs on datastores without collections support")
-	}
-
-	serverConfig := &StartupConfig{
-		Bootstrap: BootstrapConfig{
-			UseTLSServer:        base.Ptr(base.ServerIsTLS(base.UnitTestUrl())),
-			ServerTLSSkipVerify: base.Ptr(base.TestTLSSkipVerify()),
-		},
-		API: APIConfig{CORS: &auth.CORSConfig{}, AdminInterface: DefaultAdminInterface},
-	}
-	serverContext := NewServerContext(ctx, serverConfig, false)
-	defer serverContext.Close(ctx)
-
-	dbConfig := DbConfig{
-		BucketConfig: BucketConfig{
-			Server:   base.Ptr(base.UnitTestUrl()),
-			Bucket:   base.Ptr(tb.GetName()),
-			Username: base.TestClusterUsername(),
-			Password: base.TestClusterPassword(),
-		},
-		Name:             tb.GetName(),
-		NumIndexReplicas: base.Ptr(uint(0)),
-		EnableXattrs:     base.Ptr(base.TestUseXattrs()),
-		Scopes: ScopesConfig{
-			"foo": ScopeConfig{
-				Collections: CollectionsConfig{
-					"bar": &CollectionConfig{},
-				},
-			},
-		},
-	}
-	_, err := serverContext._getOrAddDatabaseFromConfig(ctx, DatabaseConfig{DbConfig: dbConfig},
-		getOrAddDatabaseConfigOptions{
-			failFast:    false,
-			useExisting: false,
-		})
-
-	require.ErrorIs(t, err, errCollectionsUnsupported)
 }
 
 func TestLogFlush(t *testing.T) {


### PR DESCRIPTION
CBG-5518 remove pre-collections Couchbase Server support

Sync Gateway has a requirement of Couchbase Server 7.6 since Sync Gateway 4.0

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/872/
