### PR TITLE
CBG-5519: remove non multi xattr subdoc support

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -2838,7 +2838,7 @@ func TestInvalidateRoles(t *testing.T) {
 	err = auth.InvalidateRoles("user", 10)
 	assert.NoError(t, err)
 
-	// Ensure the inval seq was set to 5 (raw get to avoid rebuild)
+	// Ensure the inval seq was set to 10 (raw get to avoid rebuild)
 	var userOut userImpl
 	_, err = leakyDataStore.Get(ctx, auth.DocIDForUser("user"), &userOut)
 	assert.NoError(t, err)

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -2843,12 +2843,7 @@ func TestInvalidateRoles(t *testing.T) {
 	_, err = leakyDataStore.Get(ctx, auth.DocIDForUser("user"), &userOut)
 	assert.NoError(t, err)
 
-	var expectedValue uint64
-	if leakyBucket.IsSupported(sgbucket.BucketStoreFeatureSubdocOperations) {
-		expectedValue = 10
-	} else {
-		expectedValue = 5
-	}
+	expectedValue := uint64(10)
 
 	assert.Equal(t, expectedValue, userOut.GetRoleInvalSeq())
 
@@ -2905,24 +2900,9 @@ func TestInvalidateChannels(t *testing.T) {
 			assert.NoError(t, err)
 
 			// Invalidate channels at invalSeq but cause cas retry by setting to 5
-			enableRetry := false
-			// If subdoc operations are supported, perform an initial invalidation at seq 5
-			if leakyBucket.IsSupported(sgbucket.BucketStoreFeatureSubdocOperations) {
-				err := auth.InvalidateDefaultChannels(testCase.name, testCase.isUser, 5)
-				assert.NoError(t, err)
+			err = auth.InvalidateDefaultChannels(testCase.name, testCase.isUser, 5)
+			assert.NoError(t, err)
 
-			} else {
-				// If subdoc ops aren't supported, use leakyBucket to invalidate
-				leakyDataStore.SetUpdateCallback(func(key string) {
-					if enableRetry {
-						enableRetry = false
-						err = auth.InvalidateDefaultChannels(testCase.name, testCase.isUser, 5)
-						assert.NoError(t, err)
-					}
-				})
-			}
-
-			enableRetry = true
 			err = auth.InvalidateDefaultChannels(testCase.name, testCase.isUser, 10)
 			assert.NoError(t, err)
 

--- a/base/bucket.go
+++ b/base/bucket.go
@@ -457,10 +457,10 @@ func AsViewStore(ds DataStore) (sgbucket.ViewStore, bool) {
 	return viewStore, ok
 }
 
-// AsSubdocStore returns a SubdocStore if the underlying dataStore implements and supports subdoc operations.
+// AsSubdocStore returns a SubdocStore if the underlying dataStore implements subdoc operations.
 func AsSubdocStore(ds DataStore) (sgbucket.SubdocStore, bool) {
 	subdocStore, ok := ds.(sgbucket.SubdocStore)
-	return subdocStore, ok && ds.IsSupported(sgbucket.BucketStoreFeatureSubdocOperations)
+	return subdocStore, ok
 }
 
 // AsRangeScanStore returns a RangeScanStore if the dataStore implements and supports range scan operations.

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -725,27 +725,13 @@ func TestMultiXattrRoundtrip(t *testing.T) {
 		xattrKeys[2]: []byte(`{"key3": "value3"}`),
 	}
 	_, err := dataStore.WriteWithXattrs(ctx, docID, 0, 0, []byte(`{"key": "value"}`), inputXattrs, nil, nil)
-	if dataStore.IsSupported(sgbucket.BucketStoreFeatureMultiXattrSubdocOperations) {
-		require.NoError(t, err)
-	} else {
-		require.ErrorContains(t, err, "invalid xattr key combination")
-		inputXattrs = map[string][]byte{
-			xattrKeys[0]: inputXattrs[xattrKeys[0]],
-		}
-		// write a document an xattrs, because subsequent GetXattrs needs a document to produce an error without multi-xattr support
-		_, err := dataStore.WriteWithXattrs(ctx, docID, 0, 0, []byte(`{"key": "value"}`), inputXattrs, nil, nil)
-		require.NoError(t, err)
-	}
+	require.NoError(t, err)
 
 	xattrs, _, err := dataStore.GetXattrs(ctx, docID, xattrKeys)
-	if dataStore.IsSupported(sgbucket.BucketStoreFeatureMultiXattrSubdocOperations) {
-		require.NoError(t, err)
-		for _, key := range xattrKeys {
-			require.Contains(t, maps.Keys(xattrs), key)
-			require.JSONEq(t, string(inputXattrs[key]), string(xattrs[key]))
-		}
-	} else {
-		require.ErrorContains(t, err, "not supported")
+	require.NoError(t, err)
+	for _, key := range xattrKeys {
+		require.Contains(t, maps.Keys(xattrs), key)
+		require.JSONEq(t, string(inputXattrs[key]), string(xattrs[key]))
 	}
 }
 
@@ -2325,15 +2311,8 @@ func TestUserXattrGetWithXattr(t *testing.T) {
 		"_sync": MustJSONMarshal(t, syncXattrVal),
 		"test":  MustJSONMarshal(t, userXattrVal),
 	}
-	if bucket.IsSupported(sgbucket.BucketStoreFeatureMultiXattrSubdocOperations) {
-		_, err = dataStore.UpdateXattrs(ctx, docKey, 0, cas, xattrs, nil)
-		require.NoError(t, err)
-	} else {
-		for k, v := range xattrs {
-			cas, err = dataStore.UpdateXattrs(ctx, docKey, 0, cas, map[string][]byte{k: v}, nil)
-			require.NoError(t, err)
-		}
-	}
+	_, err = dataStore.UpdateXattrs(ctx, docKey, 0, cas, xattrs, nil)
+	require.NoError(t, err)
 	var docValRet map[string]any
 	docRaw, xattrsResult, _, err := dataStore.GetWithXattrs(ctx, docKey, []string{SyncXattrName, "test"})
 	require.NoError(t, JSONUnmarshal(docRaw, &docValRet))
@@ -2676,11 +2655,6 @@ func TestWriteWithXattrsBodyUpdateXattrDelete(t *testing.T) {
 	xattrBody := []byte(`{"some": "val"}`)
 
 	cas, err := collection.WriteWithXattrs(ctx, docID, 0, 0, []byte(`{"foo": "bar"}`), map[string][]byte{xattr1Name: xattrBody, xattr2Name: xattrBody}, nil, nil)
-	// in Couchbase Server < 7.6, this will return an error because this is writing two xattrs
-	if !collection.IsSupported(sgbucket.BucketStoreFeatureMultiXattrSubdocOperations) {
-		require.ErrorContains(t, err, "SUBDOC_XATTR_INVALID_KEY_COMBO")
-		return
-	}
 	require.NoError(t, err)
 
 	_, err = collection.WriteWithXattrs(ctx, docID, 0, cas, []byte(`{"foo": "baz"}`), nil, []string{xattr1Name}, nil)
@@ -2706,10 +2680,6 @@ func TestWriteWithXattrsXattrWriteXattrDelete(t *testing.T) {
 	xattrBody := []byte(`{"some": "val"}`)
 
 	cas, err := collection.WriteWithXattrs(ctx, docID, 0, 0, []byte(`{"foo": "bar"}`), map[string][]byte{xattr1Name: xattrBody, xattr2Name: xattrBody}, nil, nil)
-	if !collection.IsSupported(sgbucket.BucketStoreFeatureMultiXattrSubdocOperations) {
-		require.ErrorContains(t, err, "SUBDOC_XATTR_INVALID_KEY_COMBO")
-		return
-	}
 	require.NoError(t, err)
 
 	newXattrBody := []byte(`{"another" : "val"}`)
@@ -2746,9 +2716,6 @@ func TestWriteUpdateWithXattrsDocumentTombstone(t *testing.T) {
 
 	bucket := GetTestBucket(t)
 	defer bucket.Close(ctx)
-	if !bucket.IsSupported(sgbucket.BucketStoreFeatureMultiXattrSubdocOperations) {
-		t.Skip("this test writes multiple xattrs")
-	}
 	dataStore := bucket.GetSingleDataStore()
 	key := t.Name()
 

--- a/base/collection_xattr.go
+++ b/base/collection_xattr.go
@@ -49,15 +49,6 @@ func (c *Collection) InsertTombstoneWithXattrs(ctx context.Context, k string, ex
 	c.Bucket.waitForAvailKvOp()
 	defer c.Bucket.releaseKvOp()
 
-	supportsTombstoneCreation := c.IsSupported(sgbucket.BucketStoreFeatureCreateDeletedWithXattr)
-
-	var docFlags gocb.SubdocDocFlag
-	if supportsTombstoneCreation {
-		docFlags = gocb.SubdocDocFlagCreateAsDeleted | gocb.SubdocDocFlagAccessDeleted | gocb.SubdocDocFlagAddDoc
-	} else {
-		docFlags = gocb.SubdocDocFlagMkDoc
-	}
-
 	mutateOps := make([]gocb.MutateInSpec, 0, len(xattrValue))
 	for xattrKey, value := range xattrValue {
 		mutateOps = append(mutateOps, gocb.UpsertSpec(xattrKey, bytesToRawMessage(value), UpsertSpecXattr))
@@ -65,11 +56,11 @@ func (c *Collection) InsertTombstoneWithXattrs(ctx context.Context, k string, ex
 
 	mutateOps = appendMacroExpansions(mutateOps, opts)
 	options := &gocb.MutateInOptions{
-		StoreSemantic: gocb.StoreSemanticsReplace, // set replace here, as we're explicitly setting SubdocDocFlagMkDoc above if tombstone creation is not supported
+		StoreSemantic: gocb.StoreSemanticsReplace,
 		Expiry:        CbsExpiryToDuration(exp),
 		Cas:           gocb.Cas(0),
 	}
-	options.Internal.DocFlags = docFlags
+	options.Internal.DocFlags = gocb.SubdocDocFlagCreateAsDeleted | gocb.SubdocDocFlagAccessDeleted | gocb.SubdocDocFlagAddDoc
 	result, mutateErr := c.Collection.MutateIn(k, mutateOps, options)
 	if mutateErr != nil {
 		return 0, mutateErr
@@ -191,17 +182,6 @@ func (c *Collection) SubdocWrite(ctx context.Context, k string, subdocKey string
 
 // subdocGetBodyAndXattrs retrieves the document body and xattrs in a single LookupIn subdoc operation.  Does not require both to exist.
 func (c *Collection) subdocGetBodyAndXattrs(ctx context.Context, k string, xattrKeys []string, fetchBody bool) (isTombstone bool, rawBody []byte, xattrs map[string][]byte, cas uint64, err error) {
-	xattrKey2 := ""
-	// Backward compatibility for one system xattr and one user xattr support.
-	if !c.IsSupported(sgbucket.BucketStoreFeatureMultiXattrSubdocOperations) {
-		if len(xattrKeys) > 2 {
-			return false, nil, nil, 0, fmt.Errorf("subdocGetBodyAndXattrs: more than 2 xattrKeys %+v not supported in this version of Couchbase Server", xattrKeys)
-		}
-		if len(xattrKeys) == 2 {
-			xattrKey2 = xattrKeys[1]
-			xattrKeys = []string{xattrKeys[0]}
-		}
-	}
 	xattrs = make(map[string][]byte, len(xattrKeys))
 	worker := func() (shouldRetry bool, err error, value uint64) {
 
@@ -283,29 +263,6 @@ func (c *Collection) subdocGetBodyAndXattrs(ctx context.Context, k string, xattr
 			shouldRetry = c.isRecoverableReadError(lookupErr)
 			return shouldRetry, lookupErr, uint64(0)
 		}
-		// If BucketStoreFeatureMultiXattrSubdocOperations is not supported, do a second get for the second xattr.
-		if xattrKey2 != "" {
-			xattrs2, xattr2Cas, xattr2Err := c.GetXattrs(ctx, k, []string{xattrKey2})
-			switch pkgerrors.Cause(xattr2Err) {
-			case gocb.ErrDocumentNotFound:
-				// If key not found it has been deleted in between the first op and this op.
-				return false, err, xattr2Cas
-			case ErrXattrNotFound:
-				// Xattr doesn't exist, can skip
-			case nil:
-				if cas != xattr2Cas {
-					return true, errors.New("cas mismatch between user xattr and document body"), uint64(0)
-				}
-			default:
-				// Unknown error occurred
-				// Shouldn't retry as any recoverable error will have been retried already in GetXattrs
-				return false, xattr2Err, uint64(0)
-			}
-			xattr2, ok := xattrs2[xattrKey2]
-			if ok {
-				xattrs[xattrKey2] = xattr2
-			}
-		}
 		return false, nil, cas
 	}
 
@@ -323,26 +280,17 @@ func (c *Collection) createTombstone(_ context.Context, k string, exp uint32, ca
 	c.Bucket.waitForAvailKvOp()
 	defer c.Bucket.releaseKvOp()
 
-	supportsTombstoneCreation := c.IsSupported(sgbucket.BucketStoreFeatureCreateDeletedWithXattr)
-
-	var docFlags gocb.SubdocDocFlag
-	if supportsTombstoneCreation {
-		docFlags = gocb.SubdocDocFlagCreateAsDeleted | gocb.SubdocDocFlagAccessDeleted | gocb.SubdocDocFlagAddDoc
-	} else {
-		docFlags = gocb.SubdocDocFlagMkDoc
-	}
-
 	mutateOps, err := getUpsertSpecsForXattrs(xattrs)
 	if err != nil {
 		return 0, err
 	}
 	mutateOps = appendMacroExpansions(mutateOps, opts)
 	options := &gocb.MutateInOptions{
-		StoreSemantic: gocb.StoreSemanticsReplace, // set replace here, as we're explicitly setting SubdocDocFlagMkDoc above if tombstone creation is not supported
+		StoreSemantic: gocb.StoreSemanticsReplace,
 		Expiry:        CbsExpiryToDuration(exp),
 		Cas:           gocb.Cas(cas),
 	}
-	options.Internal.DocFlags = docFlags
+	options.Internal.DocFlags = gocb.SubdocDocFlagCreateAsDeleted | gocb.SubdocDocFlagAccessDeleted | gocb.SubdocDocFlagAddDoc
 	result, mutateErr := c.Collection.MutateIn(k, mutateOps, options)
 	if mutateErr != nil {
 		return 0, mutateErr
@@ -427,9 +375,6 @@ func (c *Collection) UpdateXattrs(ctx context.Context, k string, exp uint32, cas
 }
 
 func (c *Collection) updateXattrs(ctx context.Context, k string, exp uint32, cas uint64, xattrs map[string][]byte, xattrsToDelete []string, opts *sgbucket.MutateInOptions) (casOut uint64, err error) {
-	if !c.IsSupported(sgbucket.BucketStoreFeatureMultiXattrSubdocOperations) && len(xattrs) >= 2 {
-		return 0, fmt.Errorf("UpdateXattrs: more than 1 xattr %v not supported in UpdateXattrs in this version of Couchbase Server", xattrs)
-	}
 	if cas == 0 && len(xattrsToDelete) > 0 {
 		return 0, sgbucket.ErrDeleteXattrOnDocumentInsert
 	}
@@ -617,27 +562,6 @@ func (c *Collection) deleteBodyAndXattrs(_ context.Context, k string, xattrKeys 
 		return ErrXattrNotFound
 	}
 	return mutateErr
-}
-
-// deleteBody deletes the document body of an existing document, and updates cas and crc32c in the associated xattr. Used in Couchbase Server < 6.6
-func (c *Collection) deleteBody(_ context.Context, k string, exp uint32, cas uint64, opts *sgbucket.MutateInOptions) (casOut uint64, err error) {
-	c.Bucket.waitForAvailKvOp()
-	defer c.Bucket.releaseKvOp()
-
-	mutateOps := []gocb.MutateInSpec{
-		gocb.RemoveSpec("", nil),
-	}
-	mutateOps = appendMacroExpansions(mutateOps, opts)
-	options := &gocb.MutateInOptions{
-		StoreSemantic: gocb.StoreSemanticsReplace,
-		Expiry:        CbsExpiryToDuration(exp),
-		Cas:           gocb.Cas(cas),
-	}
-	result, mutateErr := c.Collection.MutateIn(k, mutateOps, options)
-	if mutateErr != nil {
-		return 0, mutateErr
-	}
-	return uint64(result.Cas()), nil
 }
 
 // isKVError compares the status code of a gocb KeyValueError to the provided code.  Used for nested subdoc errors

--- a/base/collection_xattr_common.go
+++ b/base/collection_xattr_common.go
@@ -77,7 +77,6 @@ func (c *Collection) WriteTombstoneWithXattrs(ctx context.Context, k string, exp
 	if len(xattrs) == 0 {
 		return 0, sgbucket.ErrNeedXattrs
 	}
-	requiresBodyRemoval := false
 	if cas == 0 && len(xattrsToDelete) > 0 {
 		return 0, sgbucket.ErrDeleteXattrOnDocumentInsert
 	}
@@ -96,7 +95,6 @@ func (c *Collection) WriteTombstoneWithXattrs(ctx context.Context, k string, exp
 			if cas == 0 {
 				// if cas == 0, create a new server tombstone with xattr
 				casOut, tombstoneErr = c.createTombstone(ctx, k, exp, cas, xattrs, opts)
-				requiresBodyRemoval = !c.IsSupported(sgbucket.BucketStoreFeatureCreateDeletedWithXattr)
 			} else {
 				// If cas is non-zero, this is an already existing tombstone.  Update xattrs only
 				casOut, tombstoneErr = c.updateXattrs(ctx, k, exp, cas, xattrs, xattrsToDelete, opts)
@@ -114,36 +112,6 @@ func (c *Collection) WriteTombstoneWithXattrs(ctx context.Context, k string, exp
 	err, cas = RetryLoopCas(ctx, "WriteTombstoneWithXattrs", worker, DefaultRetrySleeper())
 	if err != nil {
 		err = pkgerrors.Wrapf(err, "Error during WriteTombstoneXattrs with key %v", UD(k).Redact())
-		return cas, err
-	}
-
-	// In the case where the SubdocDocFlagCreateAsDeleted is not available and we are performing the creation of a
-	// tombstoned document we need to perform this second operation. This is due to the fact that SubdocDocFlagMkDoc
-	// will have been used above instead which will create an empty body {} which we then need to delete here. If there
-	// is a CAS mismatch we exit the operation as this means there has been a subsequent update to the body.
-	if requiresBodyRemoval {
-		worker := func() (shouldRetry bool, err error, value uint64) {
-
-			casOut, removeErr := c.deleteBody(ctx, k, exp, cas, opts)
-			if removeErr != nil {
-				// If there is a cas mismatch the body has since been updated and so we don't need to bother removing
-				// body in this operation
-				if IsCasMismatch(removeErr) {
-					return false, nil, cas
-				}
-
-				shouldRetry = c.isRecoverableWriteError(removeErr)
-				return shouldRetry, removeErr, uint64(0)
-			}
-			return false, nil, casOut
-		}
-
-		err, cas = RetryLoopCas(ctx, "UpdateXattrDeleteBodySecondOp", worker, DefaultRetrySleeper())
-		if err != nil {
-			err = pkgerrors.Wrapf(err, "Error during UpdateTombstoneXattr delete op with key %v", UD(k).Redact())
-			return cas, err
-		}
-
 	}
 
 	return cas, err

--- a/base/collection_xattr_test.go
+++ b/base/collection_xattr_test.go
@@ -540,323 +540,321 @@ func TestWriteTombstoneWithXattrs(t *testing.T) {
 			writeErrorFunc: RequireDocNotFoundError,
 		},
 	}
-	if bucket.IsSupported(sgbucket.BucketStoreFeatureMultiXattrSubdocOperations) {
-		tests = append(tests, []testCase{
-			// alive document with multiple xattrs
-			/* CBG-3918, should be a cas mismatch error
-			{
-				name: "previousDoc=body+_xattr1,xattrsToUpdate=_xattr1+_xattr2,cas=0,deleteBody=true",
-				previousDoc: &sgbucket.BucketDocument{
-					Body: []byte(`{"foo": "bar"}`),
-					Xattrs: map[string][]byte{
-						"_xattr1": []byte(`{"a" : "b"}`),
-					},
-				},
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
-				},
-				cas:        zeroCas,
-				deleteBody: true,
-				writeErrorFunc: requireCasMismatchError,
-				finalXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
+	tests = append(tests, []testCase{
+		// alive document with multiple xattrs
+		/* CBG-3918, should be a cas mismatch error
+		{
+			name: "previousDoc=body+_xattr1,xattrsToUpdate=_xattr1+_xattr2,cas=0,deleteBody=true",
+			previousDoc: &sgbucket.BucketDocument{
+				Body: []byte(`{"foo": "bar"}`),
+				Xattrs: map[string][]byte{
+					"_xattr1": []byte(`{"a" : "b"}`),
 				},
 			},
-			*/
-			{
-				name: "previousDoc=body+_xattr1,xattrsToUpdate=_xattr1+_xattr2,cas=incorrect,deleteBody=true",
-				previousDoc: &sgbucket.BucketDocument{
-					Body: []byte(`{"foo": "bar"}`),
-					Xattrs: map[string][]byte{
-						"_xattr1": []byte(`{"a" : "b"}`),
-					},
-				},
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
-				},
-				cas:            incorrectCas,
-				deleteBody:     true,
-				writeErrorFunc: requireCasMismatchError,
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
 			},
-			{
-				name: "previousDoc=body+_xattr1,xattrsToUpdate=_xattr1+_xattr2,cas=correct,deleteBody=true",
-				previousDoc: &sgbucket.BucketDocument{
-					Body: []byte(`{"foo": "bar"}`),
-					Xattrs: map[string][]byte{
-						"_xattr1": []byte(`{"a" : "b"}`),
-					},
-				},
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
-				},
-				cas:        previousCas,
-				deleteBody: true,
-				finalXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
+			cas:        zeroCas,
+			deleteBody: true,
+			writeErrorFunc: requireCasMismatchError,
+			finalXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
+			},
+		},
+		*/
+		{
+			name: "previousDoc=body+_xattr1,xattrsToUpdate=_xattr1+_xattr2,cas=incorrect,deleteBody=true",
+			previousDoc: &sgbucket.BucketDocument{
+				Body: []byte(`{"foo": "bar"}`),
+				Xattrs: map[string][]byte{
+					"_xattr1": []byte(`{"a" : "b"}`),
 				},
 			},
-			{
-				name: "previousDoc=body+_xattr1+_xattr2,xattrsToUpdate=_xattr1+_xattr2,cas=0,deleteBody=false",
-				previousDoc: &sgbucket.BucketDocument{
-					Body: []byte(`{"foo": "bar"}`),
-					Xattrs: map[string][]byte{
-						"_xattr1": []byte(`{"a" : "b"}`),
-					},
-				},
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
-				},
-				cas:            zeroCas,
-				deleteBody:     false,
-				writeErrorFunc: requireCasMismatchError,
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
 			},
-			{
-				name: "previousDoc=body+_xattr1+_xattr2,xattrsToUpdate=_xattr1+_xattr2,cas=incorrect,deleteBody=false",
-				previousDoc: &sgbucket.BucketDocument{
-					Body: []byte(`{"foo": "bar"}`),
-					Xattrs: map[string][]byte{
-						"_xattr1": []byte(`{"a" : "b"}`),
-					},
-				},
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
-				},
-				cas:            incorrectCas,
-				deleteBody:     false,
-				writeErrorFunc: requireCasMismatchError,
-			},
-			{
-				name: "previousDoc=body+_xattr1+_xattr2,xattrsToUpdate=_xattr1+_xattr2,cas=correct,deleteBody=false",
-				previousDoc: &sgbucket.BucketDocument{
-					Body: []byte(`{"foo": "bar"}`),
-					Xattrs: map[string][]byte{
-						"_xattr1": []byte(`{"a" : "b"}`),
-					},
-				},
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
-				},
-				cas:        previousCas,
-				deleteBody: false,
-				finalBody:  []byte(`{"foo": "bar"}`),
-				finalXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
+			cas:            incorrectCas,
+			deleteBody:     true,
+			writeErrorFunc: requireCasMismatchError,
+		},
+		{
+			name: "previousDoc=body+_xattr1,xattrsToUpdate=_xattr1+_xattr2,cas=correct,deleteBody=true",
+			previousDoc: &sgbucket.BucketDocument{
+				Body: []byte(`{"foo": "bar"}`),
+				Xattrs: map[string][]byte{
+					"_xattr1": []byte(`{"a" : "b"}`),
 				},
 			},
-			// alive document with no xattrs
-			/* CBG-3918, should be a cas mismatch error
-			{
-				name: "previousDoc=body,xattrsToUpdate=_xattr1+_xattr2,cas=0,deleteBody=true",
-				previousDoc: &sgbucket.BucketDocument{
-					Body: []byte(`{"foo": "bar"}`),
-				},
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
-				},
-				cas:        zeroCas,
-				deleteBody: true,
-				writeErrorFunc: requireCasMismatchError,
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
+			},
+			cas:        previousCas,
+			deleteBody: true,
+			finalXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
+			},
+		},
+		{
+			name: "previousDoc=body+_xattr1+_xattr2,xattrsToUpdate=_xattr1+_xattr2,cas=0,deleteBody=false",
+			previousDoc: &sgbucket.BucketDocument{
+				Body: []byte(`{"foo": "bar"}`),
+				Xattrs: map[string][]byte{
+					"_xattr1": []byte(`{"a" : "b"}`),
 				},
 			},
-			*/
-			{
-				name: "previousDoc=body,xattrsToUpdate=_xattr1+_xattr2,cas=incorrect,deleteBody=true",
-				previousDoc: &sgbucket.BucketDocument{
-					Body: []byte(`{"foo": "bar"}`),
-				},
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
-				},
-				cas:            incorrectCas,
-				deleteBody:     true,
-				writeErrorFunc: requireCasMismatchError,
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
 			},
-			{
-				name: "previousDoc=body,xattrsToUpdate=_xattr1,cas=correct,deleteBody=true",
-				previousDoc: &sgbucket.BucketDocument{
-					Body: []byte(`{"foo": "bar"}`),
-				},
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
-				},
-				cas:        previousCas,
-				deleteBody: true,
-				finalXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
+			cas:            zeroCas,
+			deleteBody:     false,
+			writeErrorFunc: requireCasMismatchError,
+		},
+		{
+			name: "previousDoc=body+_xattr1+_xattr2,xattrsToUpdate=_xattr1+_xattr2,cas=incorrect,deleteBody=false",
+			previousDoc: &sgbucket.BucketDocument{
+				Body: []byte(`{"foo": "bar"}`),
+				Xattrs: map[string][]byte{
+					"_xattr1": []byte(`{"a" : "b"}`),
 				},
 			},
-			{
-				name: "previousDoc=body,xattrsToUpdate=_xattr1,cas=0,deleteBody=false",
-				previousDoc: &sgbucket.BucketDocument{
-					Body: []byte(`{"foo": "bar"}`),
-				},
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
-				},
-				cas:            zeroCas,
-				deleteBody:     false,
-				writeErrorFunc: requireCasMismatchError,
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
 			},
-			{
-				name: "previousDoc=body,xattrsToUpdate=_xattr1,cas=incorrect,deleteBody=false",
-				previousDoc: &sgbucket.BucketDocument{
-					Body: []byte(`{"foo": "bar"}`),
-				},
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
-				},
-				cas:            incorrectCas,
-				deleteBody:     false,
-				writeErrorFunc: requireCasMismatchError,
-			},
-			{
-				name: "previousDoc=body,xattrsToUpdate=_xattr1,cas=correct,deleteBody=false",
-				previousDoc: &sgbucket.BucketDocument{
-					Body: []byte(`{"foo": "bar"}`),
-				},
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
-				},
-				cas:        previousCas,
-				deleteBody: false,
-				finalBody:  []byte(`{"foo": "bar"}`),
-				finalXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
+			cas:            incorrectCas,
+			deleteBody:     false,
+			writeErrorFunc: requireCasMismatchError,
+		},
+		{
+			name: "previousDoc=body+_xattr1+_xattr2,xattrsToUpdate=_xattr1+_xattr2,cas=correct,deleteBody=false",
+			previousDoc: &sgbucket.BucketDocument{
+				Body: []byte(`{"foo": "bar"}`),
+				Xattrs: map[string][]byte{
+					"_xattr1": []byte(`{"a" : "b"}`),
 				},
 			},
-			// tombstone with multiple xattrs
-			{
-				name:        "previousDoc=nil,xattrsToUpdate=_xattr1+_xattr2,cas=0,deleteBody=true",
-				previousDoc: nil,
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
-				},
-				cas:            zeroCas,
-				deleteBody:     true,
-				writeErrorFunc: RequireDocNotFoundError,
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
 			},
-			{
-				name:        "previousDoc=nil,xattrsToUpdate=_xattr1+_xattr2,cas=incorrect,deleteBody=true",
-				previousDoc: nil,
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
-				},
-				cas:            incorrectCas,
-				deleteBody:     true,
-				writeErrorFunc: RequireDocNotFoundError,
+			cas:        previousCas,
+			deleteBody: false,
+			finalBody:  []byte(`{"foo": "bar"}`),
+			finalXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
 			},
-			{
-				name:        "previousDoc=nil,xattrsToUpdate=_xattr1,cas=0,deleteBody=false",
-				previousDoc: nil,
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
-				},
-				cas:        zeroCas,
-				deleteBody: false,
-				finalXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
+		},
+		// alive document with no xattrs
+		/* CBG-3918, should be a cas mismatch error
+		{
+			name: "previousDoc=body,xattrsToUpdate=_xattr1+_xattr2,cas=0,deleteBody=true",
+			previousDoc: &sgbucket.BucketDocument{
+				Body: []byte(`{"foo": "bar"}`),
+			},
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
+			},
+			cas:        zeroCas,
+			deleteBody: true,
+			writeErrorFunc: requireCasMismatchError,
+			},
+		},
+		*/
+		{
+			name: "previousDoc=body,xattrsToUpdate=_xattr1+_xattr2,cas=incorrect,deleteBody=true",
+			previousDoc: &sgbucket.BucketDocument{
+				Body: []byte(`{"foo": "bar"}`),
+			},
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
+			},
+			cas:            incorrectCas,
+			deleteBody:     true,
+			writeErrorFunc: requireCasMismatchError,
+		},
+		{
+			name: "previousDoc=body,xattrsToUpdate=_xattr1,cas=correct,deleteBody=true",
+			previousDoc: &sgbucket.BucketDocument{
+				Body: []byte(`{"foo": "bar"}`),
+			},
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
+			},
+			cas:        previousCas,
+			deleteBody: true,
+			finalXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
+			},
+		},
+		{
+			name: "previousDoc=body,xattrsToUpdate=_xattr1,cas=0,deleteBody=false",
+			previousDoc: &sgbucket.BucketDocument{
+				Body: []byte(`{"foo": "bar"}`),
+			},
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
+			},
+			cas:            zeroCas,
+			deleteBody:     false,
+			writeErrorFunc: requireCasMismatchError,
+		},
+		{
+			name: "previousDoc=body,xattrsToUpdate=_xattr1,cas=incorrect,deleteBody=false",
+			previousDoc: &sgbucket.BucketDocument{
+				Body: []byte(`{"foo": "bar"}`),
+			},
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
+			},
+			cas:            incorrectCas,
+			deleteBody:     false,
+			writeErrorFunc: requireCasMismatchError,
+		},
+		{
+			name: "previousDoc=body,xattrsToUpdate=_xattr1,cas=correct,deleteBody=false",
+			previousDoc: &sgbucket.BucketDocument{
+				Body: []byte(`{"foo": "bar"}`),
+			},
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
+			},
+			cas:        previousCas,
+			deleteBody: false,
+			finalBody:  []byte(`{"foo": "bar"}`),
+			finalXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
+			},
+		},
+		// tombstone with multiple xattrs
+		{
+			name:        "previousDoc=nil,xattrsToUpdate=_xattr1+_xattr2,cas=0,deleteBody=true",
+			previousDoc: nil,
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
+			},
+			cas:            zeroCas,
+			deleteBody:     true,
+			writeErrorFunc: RequireDocNotFoundError,
+		},
+		{
+			name:        "previousDoc=nil,xattrsToUpdate=_xattr1+_xattr2,cas=incorrect,deleteBody=true",
+			previousDoc: nil,
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
+			},
+			cas:            incorrectCas,
+			deleteBody:     true,
+			writeErrorFunc: RequireDocNotFoundError,
+		},
+		{
+			name:        "previousDoc=nil,xattrsToUpdate=_xattr1,cas=0,deleteBody=false",
+			previousDoc: nil,
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
+			},
+			cas:        zeroCas,
+			deleteBody: false,
+			finalXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
+			},
+		},
+		{
+			name:        "previousDoc=nil,xattrsToUpdate=_xattr1,cas=incorrect,deleteBody=false",
+			previousDoc: nil,
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
+			},
+			cas:            incorrectCas,
+			deleteBody:     false,
+			writeErrorFunc: RequireDocNotFoundError,
+		},
+		{
+			name:        "previousDoc=nil,xattrsToUpdate=_xattr1,xattrsToDelete=_xattr2,cas=0,deleteBody=false",
+			previousDoc: nil,
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+			},
+			xattrsToDelete: []string{"_xattr2"},
+			cas:            zeroCas,
+			finalXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+			},
+			writeErrorFunc: RequireXattrDeleteOnDocumentInsertError,
+		},
+		{
+			name:        "previousDoc=nil,xattrsToUpdate=_xattr1,xattrsToDelete=_xattr2,cas=0,deleteBody=true",
+			previousDoc: nil,
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+			},
+			xattrsToDelete: []string{"_xattr2"},
+			cas:            zeroCas,
+			finalXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+			},
+			deleteBody:     true,
+			writeErrorFunc: RequireXattrDeleteOnDocumentInsertError,
+		},
+		{
+			name: "previousDoc=body+_xattr1,_xattr2,xattrsToUpdate=_xattr1,xattrsToDelete=_xattr2,cas=correct,deleteBody=false",
+			previousDoc: &sgbucket.BucketDocument{
+				Body: []byte(`{"foo": "bar"}`),
+				Xattrs: map[string][]byte{
+					"_xattr1": []byte(`{"a" : "b"}`),
+					"_xattr2": []byte(`{"c": "d"}`),
 				},
 			},
-			{
-				name:        "previousDoc=nil,xattrsToUpdate=_xattr1,cas=incorrect,deleteBody=false",
-				previousDoc: nil,
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
-				},
-				cas:            incorrectCas,
-				deleteBody:     false,
-				writeErrorFunc: RequireDocNotFoundError,
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
 			},
-			{
-				name:        "previousDoc=nil,xattrsToUpdate=_xattr1,xattrsToDelete=_xattr2,cas=0,deleteBody=false",
-				previousDoc: nil,
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-				},
-				xattrsToDelete: []string{"_xattr2"},
-				cas:            zeroCas,
-				finalXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-				},
-				writeErrorFunc: RequireXattrDeleteOnDocumentInsertError,
+			xattrsToDelete: []string{"_xattr2"},
+			cas:            previousCas,
+			deleteBody:     false,
+			finalXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
 			},
-			{
-				name:        "previousDoc=nil,xattrsToUpdate=_xattr1,xattrsToDelete=_xattr2,cas=0,deleteBody=true",
-				previousDoc: nil,
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-				},
-				xattrsToDelete: []string{"_xattr2"},
-				cas:            zeroCas,
-				finalXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-				},
-				deleteBody:     true,
-				writeErrorFunc: RequireXattrDeleteOnDocumentInsertError,
-			},
-			{
-				name: "previousDoc=body+_xattr1,_xattr2,xattrsToUpdate=_xattr1,xattrsToDelete=_xattr2,cas=correct,deleteBody=false",
-				previousDoc: &sgbucket.BucketDocument{
-					Body: []byte(`{"foo": "bar"}`),
-					Xattrs: map[string][]byte{
-						"_xattr1": []byte(`{"a" : "b"}`),
-						"_xattr2": []byte(`{"c": "d"}`),
-					},
-				},
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-				},
-				xattrsToDelete: []string{"_xattr2"},
-				cas:            previousCas,
-				deleteBody:     false,
-				finalXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-				},
-				finalBody: []byte(`{"foo": "bar"}`),
-			},
-			{
-				name: "previousDoc=body+_xattr1,_xattr2,xattrsToUpdate=_xattr1,xattrsToDelete=_xattr2,cas=correct,deleteBody=true",
-				previousDoc: &sgbucket.BucketDocument{
-					Body: []byte(`{"foo": "bar"}`),
-					Xattrs: map[string][]byte{
-						"_xattr1": []byte(`{"a" : "b"}`),
-						"_xattr2": []byte(`{"c": "d"}`),
-					},
-				},
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-				},
-				xattrsToDelete: []string{"_xattr2"},
-				cas:            previousCas,
-				deleteBody:     true,
-				finalXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
+			finalBody: []byte(`{"foo": "bar"}`),
+		},
+		{
+			name: "previousDoc=body+_xattr1,_xattr2,xattrsToUpdate=_xattr1,xattrsToDelete=_xattr2,cas=correct,deleteBody=true",
+			previousDoc: &sgbucket.BucketDocument{
+				Body: []byte(`{"foo": "bar"}`),
+				Xattrs: map[string][]byte{
+					"_xattr1": []byte(`{"a" : "b"}`),
+					"_xattr2": []byte(`{"c": "d"}`),
 				},
 			},
-		}...)
-	}
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+			},
+			xattrsToDelete: []string{"_xattr2"},
+			cas:            previousCas,
+			deleteBody:     true,
+			finalXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+			},
+		},
+	}...)
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -1007,74 +1005,72 @@ func TestWriteUpdateWithXattrs(t *testing.T) {
 		},
 	}
 
-	if bucket.IsSupported(sgbucket.BucketStoreFeatureMultiXattrSubdocOperations) {
-		tests = append(tests, []testCase{
-			{
-				name: "previousDoc=body+_xattr1,_xattr2,updatedDoc=_xattr1",
-				previousDoc: &sgbucket.BucketDocument{
-					Body: []byte(`{"foo": "bar"}`),
-					Xattrs: map[string][]byte{
-						"_xattr1": []byte(`{"a" : "b"}`),
-						"_xattr2": []byte(`{"e" : "f"}`),
-					},
-				},
-				updatedDoc: sgbucket.UpdatedDoc{
-					Xattrs:      map[string][]byte{"_xattr1": []byte(`{"c" : "d"}`)},
-					IsTombstone: true,
-				},
-				finalXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c" : "d"}`),
+	tests = append(tests, []testCase{
+		{
+			name: "previousDoc=body+_xattr1,_xattr2,updatedDoc=_xattr1",
+			previousDoc: &sgbucket.BucketDocument{
+				Body: []byte(`{"foo": "bar"}`),
+				Xattrs: map[string][]byte{
+					"_xattr1": []byte(`{"a" : "b"}`),
 					"_xattr2": []byte(`{"e" : "f"}`),
 				},
 			},
-			{
-				name: "previousDoc=_xattr1,xattr2,updatedDoc=_xattr1",
-				previousDoc: &sgbucket.BucketDocument{
-					Xattrs: map[string][]byte{
-						"_xattr1": []byte(`{"a" : "b"}`),
-						"_xattr2": []byte(`{"e" : "f"}`),
-					},
-				},
-				updatedDoc: sgbucket.UpdatedDoc{
-					Xattrs:      map[string][]byte{"_xattr1": []byte(`{"c" : "d"}`)},
-					IsTombstone: true,
-				},
-				finalXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c" : "d"}`),
+			updatedDoc: sgbucket.UpdatedDoc{
+				Xattrs:      map[string][]byte{"_xattr1": []byte(`{"c" : "d"}`)},
+				IsTombstone: true,
+			},
+			finalXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c" : "d"}`),
+				"_xattr2": []byte(`{"e" : "f"}`),
+			},
+		},
+		{
+			name: "previousDoc=_xattr1,xattr2,updatedDoc=_xattr1",
+			previousDoc: &sgbucket.BucketDocument{
+				Xattrs: map[string][]byte{
+					"_xattr1": []byte(`{"a" : "b"}`),
 					"_xattr2": []byte(`{"e" : "f"}`),
 				},
 			},
-			{
-				name: "previousDoc=_xattr1,xattr2,updatedDoc=tombstone+_xattr1",
-				previousDoc: &sgbucket.BucketDocument{
-					Xattrs: map[string][]byte{
-						"_xattr1": []byte(`{"a" : "b"}`),
-						"_xattr2": []byte(`{"e" : "f"}`),
-					},
-				},
-				updatedDoc: sgbucket.UpdatedDoc{
-					IsTombstone: true,
-					Xattrs:      map[string][]byte{"_xattr1": []byte(`{"c" : "d"}`)}},
-				finalXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c" : "d"}`),
+			updatedDoc: sgbucket.UpdatedDoc{
+				Xattrs:      map[string][]byte{"_xattr1": []byte(`{"c" : "d"}`)},
+				IsTombstone: true,
+			},
+			finalXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c" : "d"}`),
+				"_xattr2": []byte(`{"e" : "f"}`),
+			},
+		},
+		{
+			name: "previousDoc=_xattr1,xattr2,updatedDoc=tombstone+_xattr1",
+			previousDoc: &sgbucket.BucketDocument{
+				Xattrs: map[string][]byte{
+					"_xattr1": []byte(`{"a" : "b"}`),
 					"_xattr2": []byte(`{"e" : "f"}`),
 				},
 			},
-			{
-				name: "delete xattr on tombstone resurection",
-				previousDoc: &sgbucket.BucketDocument{
-					Xattrs: map[string][]byte{
-						"_xattr1": []byte(`{"foo": "bar"}`),
-					},
-				},
-				updatedDoc: sgbucket.UpdatedDoc{
-					Doc:            []byte(`{"foo": "bar"}`),
-					XattrsToDelete: []string{"xattr1"},
-				},
-				errorsIs: sgbucket.ErrDeleteXattrOnTombstone,
+			updatedDoc: sgbucket.UpdatedDoc{
+				IsTombstone: true,
+				Xattrs:      map[string][]byte{"_xattr1": []byte(`{"c" : "d"}`)}},
+			finalXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c" : "d"}`),
+				"_xattr2": []byte(`{"e" : "f"}`),
 			},
-		}...)
-	}
+		},
+		{
+			name: "delete xattr on tombstone resurection",
+			previousDoc: &sgbucket.BucketDocument{
+				Xattrs: map[string][]byte{
+					"_xattr1": []byte(`{"foo": "bar"}`),
+				},
+			},
+			updatedDoc: sgbucket.UpdatedDoc{
+				Doc:            []byte(`{"foo": "bar"}`),
+				XattrsToDelete: []string{"xattr1"},
+			},
+			errorsIs: sgbucket.ErrDeleteXattrOnTombstone,
+		},
+	}...)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := TestCtx(t)
@@ -1215,39 +1211,37 @@ func TestWriteWithXattrs(t *testing.T) {
 			errorIs: sgbucket.ErrNilXattrValue,
 		},
 	}
-	if bucket.IsSupported(sgbucket.BucketStoreFeatureMultiXattrSubdocOperations) {
-		tests = append(tests, []testCase{
-			{
-				name:           "body=true,xattrs=nil,xattrsToDelete=xattr1,xattr2,cas=0",
-				body:           []byte(`{"foo": "bar"}`),
-				xattrsToDelete: []string{"xattr1", "xattr2"},
-				errorIs:        sgbucket.ErrDeleteXattrOnDocumentInsert,
-			},
-			{
-				name:           "body=true,xattrs=nil,xattrsToDelete=xattr1,xattr2,cas=incorrect",
-				body:           []byte(`{"foo": "bar"}`),
-				xattrsToDelete: []string{"xattr1", "xattr2"},
-				cas:            uint64(1),
-				errorFunc:      requireDocNotFoundOrCasMismatchError,
-			},
-			{
-				name:           "body=true,xattrs=xattr1,xattrsToDelete=xattr1,xattr2,cas=0",
-				body:           []byte(`{"foo": "bar"}`),
-				xattrs:         map[string][]byte{"xattr1": []byte(`{"a" : "b"}`)},
-				xattrsToDelete: []string{"xattr1", "xattr2"},
-				errorIs:        sgbucket.ErrDeleteXattrOnDocumentInsert,
-			},
+	tests = append(tests, []testCase{
+		{
+			name:           "body=true,xattrs=nil,xattrsToDelete=xattr1,xattr2,cas=0",
+			body:           []byte(`{"foo": "bar"}`),
+			xattrsToDelete: []string{"xattr1", "xattr2"},
+			errorIs:        sgbucket.ErrDeleteXattrOnDocumentInsert,
+		},
+		{
+			name:           "body=true,xattrs=nil,xattrsToDelete=xattr1,xattr2,cas=incorrect",
+			body:           []byte(`{"foo": "bar"}`),
+			xattrsToDelete: []string{"xattr1", "xattr2"},
+			cas:            uint64(1),
+			errorFunc:      requireDocNotFoundOrCasMismatchError,
+		},
+		{
+			name:           "body=true,xattrs=xattr1,xattrsToDelete=xattr1,xattr2,cas=0",
+			body:           []byte(`{"foo": "bar"}`),
+			xattrs:         map[string][]byte{"xattr1": []byte(`{"a" : "b"}`)},
+			xattrsToDelete: []string{"xattr1", "xattr2"},
+			errorIs:        sgbucket.ErrDeleteXattrOnDocumentInsert,
+		},
 
-			{
-				name:           "body=true,xattrs=xattr1,xattrsToDelete=xattr1,xattr2,cas=incorrect",
-				body:           []byte(`{"foo": "bar"}`),
-				xattrs:         map[string][]byte{"xattr1": []byte(`{"a" : "b"}`)},
-				xattrsToDelete: []string{"xattr1", "xattr2"},
-				cas:            uint64(1),
-				errorIs:        sgbucket.ErrUpsertAndDeleteSameXattr,
-			},
-		}...)
-	}
+		{
+			name:           "body=true,xattrs=xattr1,xattrsToDelete=xattr1,xattr2,cas=incorrect",
+			body:           []byte(`{"foo": "bar"}`),
+			xattrs:         map[string][]byte{"xattr1": []byte(`{"a" : "b"}`)},
+			xattrsToDelete: []string{"xattr1", "xattr2"},
+			cas:            uint64(1),
+			errorIs:        sgbucket.ErrUpsertAndDeleteSameXattr,
+		},
+	}...)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := TestCtx(t)
@@ -1422,23 +1416,21 @@ func TestWriteResurrectionWithXattrs(t *testing.T) {
 			errorFunc:   requireDocFoundOrCasMismatchError,
 		},
 	}
-	if bucket.IsSupported(sgbucket.BucketStoreFeatureMultiXattrSubdocOperations) {
-		tests = append(tests, []testCase{
-			{
-				name: "previousDoc=_xattr1,xattrsToUpdate=_xattr1+_xattr2,updatedBody=body",
-				previousDoc: &sgbucket.BucketDocument{
-					Xattrs: map[string][]byte{
-						"_xattr1": []byte(`{"a" : "b"}`),
-					},
+	tests = append(tests, []testCase{
+		{
+			name: "previousDoc=_xattr1,xattrsToUpdate=_xattr1+_xattr2,updatedBody=body",
+			previousDoc: &sgbucket.BucketDocument{
+				Xattrs: map[string][]byte{
+					"_xattr1": []byte(`{"a" : "b"}`),
 				},
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
-				},
-				updatedBody: []byte(`{"foo": "bar"}`),
 			},
-		}...)
-	}
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
+			},
+			updatedBody: []byte(`{"foo": "bar"}`),
+		},
+	}...)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := TestCtx(t)

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -566,10 +566,6 @@ func TestResyncMou(t *testing.T) {
 	db, ctx := setupTestDBWithOptionsAndImport(t, nil, DatabaseContextOptions{})
 	defer db.Close(ctx)
 
-	if !db.Bucket.IsSupported(sgbucket.BucketStoreFeatureMultiXattrSubdocOperations) {
-		t.Skip("Test requires multi-xattr subdoc operations, CBS 7.6 or higher")
-	}
-
 	initialImportCount := db.DbStats.SharedBucketImport().ImportCount.Value()
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 	docBody := Body{"foo": "bar"}

--- a/db/crud.go
+++ b/db/crud.go
@@ -73,63 +73,37 @@ func (c *DatabaseCollection) GetDocumentWithRaw(ctx context.Context, docid strin
 	if key == "" {
 		return nil, nil, base.HTTPErrorf(400, "Invalid doc ID")
 	}
-	if c.UseXattrs() {
-		doc, rawBucketDoc, err = c.GetDocWithXattrs(ctx, key, unmarshalLevel)
+	doc, rawBucketDoc, err = c.GetDocWithXattrs(ctx, key, unmarshalLevel)
+	if err != nil {
+		return nil, nil, err
+	}
+	isSgWrite, crc32Match, _ := doc.IsSGWrite(ctx, rawBucketDoc.Body)
+	if crc32Match {
+		c.dbStats().Database().Crc32MatchCount.Add(1)
+	}
+
+	// If existing doc wasn't an SG Write, import the doc.
+	if !isSgWrite {
+		// reload to get revseqno for on-demand import
+		doc, rawBucketDoc, err = c.getDocWithXattrs(ctx, key, c.syncGlobalSyncMouRevSeqNoAndUserXattrKeys(), unmarshalLevel)
 		if err != nil {
 			return nil, nil, err
 		}
-		isSgWrite, crc32Match, _ := doc.IsSGWrite(ctx, rawBucketDoc.Body)
-		if crc32Match {
-			c.dbStats().Database().Crc32MatchCount.Add(1)
-		}
-
-		// If existing doc wasn't an SG Write, import the doc.
+		isSgWrite, _, _ := doc.IsSGWrite(ctx, rawBucketDoc.Body)
 		if !isSgWrite {
-			// reload to get revseqno for on-demand import
-			doc, rawBucketDoc, err = c.getDocWithXattrs(ctx, key, c.syncGlobalSyncMouRevSeqNoAndUserXattrKeys(), unmarshalLevel)
-			if err != nil {
-				return nil, nil, err
+			var importErr error
+			doc, importErr = c.OnDemandImportForGet(ctx, docid, doc, rawBucketDoc.Body, rawBucketDoc.Xattrs, rawBucketDoc.Cas)
+			if importErr != nil {
+				return nil, nil, importErr
 			}
-			isSgWrite, _, _ := doc.IsSGWrite(ctx, rawBucketDoc.Body)
-			if !isSgWrite {
-				var importErr error
-				doc, importErr = c.OnDemandImportForGet(ctx, docid, doc, rawBucketDoc.Body, rawBucketDoc.Xattrs, rawBucketDoc.Cas)
-				if importErr != nil {
-					return nil, nil, importErr
-				}
-				// nil, nil returned when ErrImportCancelled is swallowed by importDoc switch
-				if doc == nil {
-					return nil, nil, base.ErrNotFound
-				}
+			// nil, nil returned when ErrImportCancelled is swallowed by importDoc switch
+			if doc == nil {
+				return nil, nil, base.ErrNotFound
 			}
 		}
-		if !doc.HasValidSyncData() {
-			return nil, nil, base.HTTPErrorf(404, "Not imported")
-		}
-	} else {
-		rawDoc, cas, getErr := c.dataStore.GetRaw(ctx, key)
-		if getErr != nil {
-			return nil, nil, getErr
-		}
-
-		doc, err = unmarshalDocument(key, rawDoc)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		if !doc.HasValidSyncData() {
-			// Check whether doc has been upgraded to use xattrs
-			upgradeDoc, _ := c.checkForUpgrade(ctx, docid, unmarshalLevel)
-			if upgradeDoc == nil {
-				return nil, nil, base.HTTPErrorf(404, "Not imported")
-			}
-			doc = upgradeDoc
-		}
-
-		rawBucketDoc = &sgbucket.BucketDocument{
-			Body: rawDoc,
-			Cas:  cas,
-		}
+	}
+	if !doc.HasValidSyncData() {
+		return nil, nil, base.HTTPErrorf(404, "Not imported")
 	}
 
 	return doc, rawBucketDoc, nil
@@ -2987,7 +2961,7 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 			}
 
 			updatedDoc.Xattrs = map[string][]byte{base.SyncXattrName: rawSyncXattr, base.VvXattrName: rawVvXattr}
-			if rawMouXattr != nil && db.useMou() {
+			if rawMouXattr != nil {
 				updatedDoc.Xattrs[base.MouXattrName] = rawMouXattr
 			}
 			if rawGlobalSync != nil {
@@ -3764,20 +3738,6 @@ func (c *DatabaseCollection) ComputeRolesForUser(ctx context.Context, user auth.
 	}
 
 	return roleChannelSet, nil
-}
-
-// Checks whether a document has a mobile xattr.  Used when running in non-xattr mode to support no downtime upgrade.
-func (c *DatabaseCollection) checkForUpgrade(ctx context.Context, key string, unmarshalLevel DocumentUnmarshalLevel) (*Document, *sgbucket.BucketDocument) {
-	// If we are using xattrs or Couchbase Server doesn't support them, an upgrade isn't going to be in progress
-	if c.UseXattrs() || !c.dataStore.IsSupported(sgbucket.BucketStoreFeatureXattrs) {
-		return nil, nil
-	}
-
-	doc, rawDocument, err := c.GetDocWithXattrs(ctx, key, unmarshalLevel)
-	if err != nil || doc == nil || !doc.HasValidSyncData() {
-		return nil, nil
-	}
-	return doc, rawDocument
 }
 
 // legacyRevToHybridLogicalVector will take a legacy revID and convert it to a HybridLogicalVector, used for when a

--- a/db/database.go
+++ b/db/database.go
@@ -174,7 +174,6 @@ type DatabaseContext struct {
 	RequireResync               base.ScopeAndCollectionNames      // Collections requiring resync before database can go online
 	RequireAttachmentMigration  base.ScopeAndCollectionNames      // Collections that require the attachment migration background task to run against
 	CORS                        *auth.CORSConfig                  // CORS configuration
-	EnableMou                   bool                              // Write _mou xattr when performing metadata-only update.  Set based on bucket capability on connect
 	WasInitializedSynchronously bool                              // true if the database was initialized synchronously
 	BroadcastSlowMode           atomic.Bool                       // bool to indicate if a slower ticker value should be used to notify changes feeds of changes
 	DatabaseStartupError        *DatabaseError                    // Error that occurred during database online processes startup
@@ -490,9 +489,6 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 	cleanupFunctions = append(cleanupFunctions, func() {
 		dbContext.cancelContextFunc(errors.New("DatabaseContext failed to initialize"))
 	})
-
-	// Check if server version supports multi-xattr operations, required for mou handling
-	dbContext.EnableMou = bucket.IsSupported(sgbucket.BucketStoreFeatureMultiXattrSubdocOperations)
 
 	// Initialize metadata ID and keys
 	metaKeys := base.NewMetadataKeys(options.MetadataID)
@@ -2084,10 +2080,6 @@ func (context *DatabaseContext) numIndexPartitions() uint32 {
 
 func (context *DatabaseContext) UseViews() bool {
 	return context.Options.UseViews
-}
-
-func (context *DatabaseContext) UseMou() bool {
-	return context.EnableMou
 }
 
 func (context *DatabaseContext) DeltaSyncEnabled() bool {

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -420,10 +420,6 @@ func (c *DatabaseCollection) invalRoleChannels(ctx context.Context, rolename str
 	c.dbCtx.invalRoleChannels(ctx, rolename, base.ScopeAndCollectionNames{c.ScopeAndCollectionName()}, invalSeq)
 }
 
-func (c *DatabaseCollection) useMou() bool {
-	return c.dbCtx.UseMou()
-}
-
 func (c *DatabaseCollection) ScopeAndCollectionName() base.ScopeAndCollectionName {
 	return base.NewScopeAndCollectionName(c.ScopeName, c.Name)
 }

--- a/db/import.go
+++ b/db/import.go
@@ -93,7 +93,7 @@ func (db *DatabaseCollectionWithUser) ImportDoc(ctx context.Context, docid strin
 	} else {
 		if existingDoc.Deleted {
 			existingBucketDoc.Xattrs[base.SyncXattrName], err = base.JSONMarshal(existingDoc.SyncData)
-			if err == nil && existingDoc.MetadataOnlyUpdate != nil && db.useMou() {
+			if err == nil && existingDoc.MetadataOnlyUpdate != nil {
 				existingBucketDoc.Xattrs[base.MouXattrName], err = base.JSONMarshal(existingDoc.MetadataOnlyUpdate)
 			}
 			if existingDoc.HLV != nil {
@@ -337,7 +337,7 @@ func (db *DatabaseCollectionWithUser) importDoc(ctx context.Context, docid strin
 		}
 
 		// If this is a metadata-only update, set metadataOnlyUpdate based on old doc's cas and mou
-		if metadataOnlyUpdate && db.useMou() {
+		if metadataOnlyUpdate {
 			newDoc.MetadataOnlyUpdate = computeMetadataOnlyUpdate(doc.Cas, revNo, doc.MetadataOnlyUpdate)
 		}
 

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -75,20 +75,15 @@ func TestFeedImport(t *testing.T) {
 
 	// verify mou and rev seqno
 	xattrs, _, err = collection.dataStore.GetXattrs(ctx, key, []string{base.MouXattrName, base.VirtualXattrRevSeqNo, base.VvXattrName})
-	if db.UseMou() {
-		var mou *MetadataOnlyUpdate
-		require.NoError(t, err)
-		mouXattr, mouOk := xattrs[base.MouXattrName]
-		require.True(t, mouOk)
-		require.NoError(t, base.JSONUnmarshal(mouXattr, &mou))
-		require.Equal(t, base.CasToString(writeCas), mou.PreviousHexCAS)
-		require.Equal(t, base.CasToString(importCas), mou.HexCAS)
-		// curr revSeqNo should be 2, so prev revSeqNo is 1
-		require.Equal(t, revSeqNo-1, mou.PreviousRevSeqNo)
-	} else {
-		// Expect not found fetching mou xattr
-		require.Error(t, err)
-	}
+	var mou *MetadataOnlyUpdate
+	require.NoError(t, err)
+	mouXattr, mouOk := xattrs[base.MouXattrName]
+	require.True(t, mouOk)
+	require.NoError(t, base.JSONUnmarshal(mouXattr, &mou))
+	require.Equal(t, base.CasToString(writeCas), mou.PreviousHexCAS)
+	require.Equal(t, base.CasToString(importCas), mou.HexCAS)
+	// curr revSeqNo should be 2, so prev revSeqNo is 1
+	require.Equal(t, revSeqNo-1, mou.PreviousRevSeqNo)
 	require.Contains(t, maps.Keys(xattrs), base.VvXattrName)
 	var hlv HybridLogicalVector
 	require.NoError(t, base.JSONUnmarshal(xattrs[base.VvXattrName], &hlv))
@@ -168,14 +163,10 @@ func TestOnDemandImport(t *testing.T) {
 		doc, err := collection.GetDocument(ctx, getKey, DocUnmarshalAll)
 		require.NoError(t, err)
 
-		if db.UseMou() {
-			require.NotNil(t, doc.MetadataOnlyUpdate)
-			require.Equal(t, base.CasToString(writeCas), doc.MetadataOnlyUpdate.PreviousHexCAS)
-			require.Equal(t, base.CasToString(doc.Cas), doc.MetadataOnlyUpdate.HexCAS)
-			require.Equal(t, startingRevSeqNo, doc.MetadataOnlyUpdate.PreviousRevSeqNo)
-		} else {
-			require.Nil(t, doc.MetadataOnlyUpdate)
-		}
+		require.NotNil(t, doc.MetadataOnlyUpdate)
+		require.Equal(t, base.CasToString(writeCas), doc.MetadataOnlyUpdate.PreviousHexCAS)
+		require.Equal(t, base.CasToString(doc.Cas), doc.MetadataOnlyUpdate.HexCAS)
+		require.Equal(t, startingRevSeqNo, doc.MetadataOnlyUpdate.PreviousRevSeqNo)
 		require.Equal(t, db.EncodedSourceID, doc.HLV.SourceID)
 	})
 
@@ -234,19 +225,14 @@ func TestOnDemandImport(t *testing.T) {
 				// fetch the mou xattr directly doc to confirm import (to avoid triggering on-demand get import)
 				// verify mou
 				xattrs, importCas, err := collection.dataStore.GetXattrs(ctx, writeKey, []string{base.MouXattrName, base.VvXattrName})
-				if db.UseMou() {
-					require.NoError(t, err)
-					mouXattr, mouOk := xattrs[base.MouXattrName]
-					var mou *MetadataOnlyUpdate
-					require.True(t, mouOk)
-					require.NoError(t, base.JSONUnmarshal(mouXattr, &mou))
-					require.Equal(t, base.CasToString(writeCas), mou.PreviousHexCAS)
-					require.Equal(t, base.CasToString(importCas), mou.HexCAS)
-					require.Equal(t, startingRevSeqNo, mou.PreviousRevSeqNo)
-				} else {
-					// expect not found fetching mou xattr
-					require.Error(t, err)
-				}
+				require.NoError(t, err)
+				mouXattr, mouOk := xattrs[base.MouXattrName]
+				var mou *MetadataOnlyUpdate
+				require.True(t, mouOk)
+				require.NoError(t, base.JSONUnmarshal(mouXattr, &mou))
+				require.Equal(t, base.CasToString(writeCas), mou.PreviousHexCAS)
+				require.Equal(t, base.CasToString(importCas), mou.HexCAS)
+				require.Equal(t, startingRevSeqNo, mou.PreviousRevSeqNo)
 				var hlv HybridLogicalVector
 				require.Contains(t, maps.Keys(xattrs), base.VvXattrName)
 				require.NoError(t, base.JSONUnmarshal(xattrs[base.VvXattrName], &hlv))
@@ -258,9 +244,6 @@ func TestOnDemandImport(t *testing.T) {
 	// Verify that the reload performed before an on-demand import (crud.go GetDocumentWithRaw)
 	// fetches the _mou xattr, so rawBucketDoc returned to the caller contains it.
 	t.Run("on-demand get includes mou xattr in reload", func(t *testing.T) {
-		if !db.UseMou() {
-			t.Skip("Test requires MOU support")
-		}
 		docKey := baseKey + "_mouReload"
 		collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 
@@ -297,9 +280,6 @@ func TestOnDemandImport(t *testing.T) {
 	// Verify that GetDocSyncData fetches _revseqno so the on-demand import it triggers
 	// records the correct PreviousRevSeqNo in _mou (not 0).
 	t.Run("on-demand GetDocSyncData sets correct mou pRev", func(t *testing.T) {
-		if !db.UseMou() {
-			t.Skip("Test requires MOU support")
-		}
 		docKey := baseKey + "_syncDataMou"
 		collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 
@@ -1255,10 +1235,6 @@ func TestMetadataOnlyUpdate(t *testing.T) {
 	db, ctx := setupTestDBWithOptionsAndImport(t, nil, DatabaseContextOptions{})
 	defer db.Close(ctx)
 
-	if !db.Bucket.IsSupported(sgbucket.BucketStoreFeatureMultiXattrSubdocOperations) {
-		t.Skip("Test requires multi-xattr subdoc operations, CBS 7.6 or higher")
-	}
-
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 
 	bodyBytes := []byte(`{"foo":"bar"}`)
@@ -1337,11 +1313,7 @@ func TestImportResurrectionMou(t *testing.T) {
 		return db.DbStats.SharedBucketImport().ImportCount.Value()
 	}, 1)
 	syncData, mou, _ = getSyncAndMou(t, collection, docID)
-	if db.Bucket.IsSupported(sgbucket.BucketStoreFeatureMultiXattrSubdocOperations) {
-		require.NotNil(t, mou)
-	} else {
-		require.Nil(t, mou)
-	}
+	require.NotNil(t, mou)
 	require.NotNil(t, syncData)
 
 	// Delete via SDK, the mou will be updated by the import process
@@ -1350,11 +1322,7 @@ func TestImportResurrectionMou(t *testing.T) {
 		return db.DbStats.SharedBucketImport().ImportCount.Value()
 	}, 2)
 	syncData, mou, _ = getSyncAndMou(t, collection, docID)
-	if db.Bucket.IsSupported(sgbucket.BucketStoreFeatureMultiXattrSubdocOperations) {
-		require.NotNil(t, mou)
-	} else {
-		require.Nil(t, mou)
-	}
+	require.NotNil(t, mou)
 	require.NotNil(t, syncData)
 
 	// replace initial doc, expect mou to be removed

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -225,20 +225,6 @@ func purgeWithDCPFeed(ctx context.Context, bucket base.Bucket, tbp *base.TestBuc
 		if !ok {
 			purgeErrors = purgeErrors.Append(fmt.Errorf("Could not find collection ID %d for %#+v doc over DCP", event.CollectionID, event))
 		}
-		// If Couchbase Server < 7.6, we need to delete xattrs one at a time, since it doesn't support subdoc multi-xattr operations.
-		if len(xattrs) >= 1 && !bucket.IsSupported(sgbucket.BucketStoreFeatureMultiXattrSubdocOperations) {
-			for _, xattr := range xattrs {
-				err := dataStore.DeleteSubDocPaths(ctx, docID, xattr)
-				if err != nil {
-					purgeErrors = purgeErrors.Append(fmt.Errorf("error purging xattr %s from docID %s: %w", xattr, docID, err))
-					tbp.Logf(ctx, "%s", err)
-					return false
-				}
-			}
-			xattrs = nil // reset xattrs to nil so we don't try to delete the doc with xattrs
-
-		}
-
 		purgeErr := dataStore.DeleteWithXattrs(ctx, docID, xattrs)
 		if base.IsDocNotFoundError(purgeErr) { // doc is a tombstone
 			// If key no longer exists, need to add and and remove to remove a Sync Gateway tombstone.

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/couchbase/clog"
-	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
@@ -2634,10 +2633,6 @@ func TestPrevRevNoPopulationImportFeed(t *testing.T) {
 	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
 	dataStore := rt.GetSingleDataStore()
-
-	if !rt.Bucket().IsSupported(sgbucket.BucketStoreFeatureMultiXattrSubdocOperations) {
-		t.Skip("Test requires multi-xattr subdoc operations, CBS 7.6 or higher")
-	}
 
 	// Create doc via the SDK
 	mobileKey := t.Name()


### PR DESCRIPTION
CBG-5519: remove non multi xattr subdoc support

Since Sync Gateway 4.0 requires Couchbase Server 7.6, this code is no longer relevant.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/873/
