### PR TITLE
CBG-5439 bootstrap run_e2e_tests.sh from main

### DIFF
--- a/integration-test/e2e/Jenkinsfile
+++ b/integration-test/e2e/Jenkinsfile
@@ -118,7 +118,12 @@ pipeline {
         stage('Run E2E Tests') {
             steps {
                 sshagent(credentials: ['CB_SG_Robot_Github_SSH_Key']) {
-                    sh '/bin/bash ./integration-test/e2e/run_e2e_tests.sh'
+                    sh '''
+                        set -eu
+                        mkdir -p integration-test/e2e
+                        curl -sSf https://raw.githubusercontent.com/couchbase/sync_gateway/main/integration-test/e2e/run_e2e_tests.sh -o integration-test/e2e/run_e2e_tests.sh
+                        /bin/bash integration-test/e2e/run_e2e_tests.sh
+                    '''
                 }
             }
         }


### PR DESCRIPTION
- setup jenkins to always pull jenkinsfile from main
- download the run_e2e_tests.sh companion script from main

Example:

SG_COMMIT = main https://jenkins.sgwdev.com/job/Couchbase%20Lite%20E2E/9/
SG_COMMIT = release/4.1.0 https://jenkins.sgwdev.com/job/Couchbase%20Lite%20E2E/11/

Note that older versions of Sync Gateway would need CBG-5213 which is only available on 4.1.0 and main. This isn't blocking this commit but it is something to think about for older maintenance releases.

When this gets merged, move the branch on the jenkins ui that it is pulling the jenkinsfile from