### PR TITLE
CBG-5520 always use CBS preserve expiry feature

### DIFF
--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -2549,9 +2549,6 @@ func TestUpsertOptionPreserveExpiry(t *testing.T) {
 	bucket := GetTestBucket(t)
 	defer bucket.Close(ctx)
 	dataStore := bucket.GetSingleDataStore()
-	if !bucket.IsSupported(sgbucket.BucketStoreFeaturePreserveExpiry) {
-		t.Skip("Preserve expiry is not supported with this CBS version. Skipping test...")
-	}
 
 	testCases := []struct {
 		name          string

--- a/db/crud.go
+++ b/db/crud.go
@@ -2945,7 +2945,7 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 				return
 			}
 			// If importing and the sync function has modified the expiry, allow sgbucket.MutateInOptions to modify the expiry
-			if db.dataStore.IsSupported(sgbucket.BucketStoreFeaturePreserveExpiry) && updatedDoc.Expiry != nil {
+			if updatedDoc.Expiry != nil {
 				opts.PreserveExpiry = false
 			}
 			docSequence = doc.Sequence

--- a/db/import.go
+++ b/db/import.go
@@ -144,20 +144,7 @@ func (db *DatabaseCollectionWithUser) importDoc(ctx context.Context, docid strin
 	var newRev string
 	var alreadyImportedDoc *Document
 
-	mutationOptions := &sgbucket.MutateInOptions{}
-	if db.dataStore.IsSupported(sgbucket.BucketStoreFeaturePreserveExpiry) {
-		mutationOptions.PreserveExpiry = true
-	} else {
-		// Get the doc expiry if it wasn't passed in and preserve expiry is not supported
-		if expiry == nil {
-			getExpiry, getExpiryErr := db.dataStore.GetExpiry(ctx, docid)
-			if getExpiryErr != nil {
-				return nil, getExpiryErr
-			}
-			expiry = &getExpiry
-		}
-		existingDoc.Expiry = *expiry
-	}
+	mutationOptions := &sgbucket.MutateInOptions{PreserveExpiry: true}
 
 	docUpdateEvent := Import
 	// do not update rev cache for any imports (CBG-4494 and CBG-4550)


### PR DESCRIPTION
CBG-5520 always use CBS preserve expiry feature

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/880/
