### PR TITLE
CBG-5529 correct misleading log message

### DIFF
--- a/db/indexes.go
+++ b/db/indexes.go
@@ -524,9 +524,9 @@ func GetIndexNames(options InitializeIndexOptions, indexDefs map[SGIndexType]SGI
 
 // ShouldUseLegacySyncDocsIndex returns true if the syncDocs index should be used for queries of principal docs. Returns false if targeted users and roles indexes should be used.
 func ShouldUseLegacySyncDocsIndex(ctx context.Context, collection base.N1QLStore, useXattrs bool) bool {
-	onlinePrincipalIndexes, err := GetOnlinePrincipalIndexes(context.Background(), collection, useXattrs)
+	onlinePrincipalIndexes, err := GetOnlinePrincipalIndexes(ctx, collection, useXattrs)
 	if err != nil {
-		base.WarnfCtx(ctx, "Error getting online status of principal indexes: %v, falling back to using syncDocs index", err)
+		base.WarnfCtx(ctx, "Error getting online status of principal indexes: %v, will use separate users and roles indexes", err)
 		return false
 	}
 	return shouldUseLegacySyncDocsIndex(onlinePrincipalIndexes)


### PR DESCRIPTION
CBG-5529 correct misleading log message

This would only occur if there was an error in the N1QL service, and has no functional impact.
