### PR TITLE
CBG-4713 fix TestMultiCollectionImportRemoveCollection flake

### DIFF
--- a/rest/importtest/collections_import_test.go
+++ b/rest/importtest/collections_import_test.go
@@ -426,7 +426,7 @@ func TestMultiCollectionImportRemoveCollection(t *testing.T) {
 
 	rt.WaitForChanges(docCount*2, "/{{.keyspace}}/_changes", "", true)
 	// there should be 10 documents datastore1_{10..19}
-	require.Equal(t, int64(docCount), rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value())
+	base.RequireWaitForStat(t, rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value, int64(docCount))
 
 	// Get the import version from the persisted config to ensure it didn't change
 	updatedImportVersion := GetImportVersion(t, rt, dbName)


### PR DESCRIPTION
Use RequireWaitForStat:

The ImportCount doesn't get incremented until the new doc with metadata has been written. It is possible that the caching feed and changes feed see this value before this stat is incremented.

See https://github.com/couchbase/sync_gateway/pull/7607 for prior art.