### PR TITLE
CBG-5536 fix attachment revpos corruption on CAS retry

### DIFF
--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -1659,11 +1659,10 @@ func TestAttachmentMigrationCASRetryOnUpdate(t *testing.T) {
 
 			if tc.casFailure {
 				leakyDS.SetUpdateCallback(attachmentMigrationCASRetryCallback(t, ctx, collection, docID))
+				defer leakyDS.SetUpdateCallback(nil)
 			}
 
 			tc.update(t, docID)
-
-			leakyDS.SetUpdateCallback(nil)
 
 			require.Empty(t, GetRawSyncXattr(t, ds, docID).AttachmentsPre4dot0)
 			require.Equal(t, attachmentMigrationCASRetryExpected, GetRawGlobalSyncAttachments(t, ds, docID))

--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -1525,7 +1525,7 @@ func TestLargeAttachments(t *testing.T) {
 
 // attachmentMigrationCASRetrySetup creates a doc with an attachment, then moves the attachment
 // back to AttachmentsPre4dot0 to simulate a document that has not yet been through the background
-// migration. Returns the doc and the initial Put rev so callers can use both.
+// migration.
 func attachmentMigrationCASRetrySetup(t *testing.T, ctx context.Context, collection *DatabaseCollectionWithUser, docID string) {
 	t.Helper()
 	_, _, err := collection.Put(ctx, docID, Body{

--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -1520,4 +1521,152 @@ func TestLargeAttachments(t *testing.T) {
 	})
 	require.ErrorAs(t, err, &httpErr, "Created doc with huge attachment")
 	require.Equal(t, http.StatusRequestEntityTooLarge, httpErr.Status)
+}
+
+// attachmentMigrationCASRetrySetup creates a doc with an attachment, then moves the attachment
+// back to AttachmentsPre4dot0 to simulate a document that has not yet been through the background
+// migration. Returns the doc and the initial Put rev so callers can use both.
+func attachmentMigrationCASRetrySetup(t *testing.T, ctx context.Context, collection *DatabaseCollectionWithUser, docID string) {
+	t.Helper()
+	_, _, err := collection.Put(ctx, docID, Body{
+		"test": "doc",
+		BodyAttachments: AttachmentsMeta{
+			"camera.txt": map[string]any{"data": "Q2Fub24gRU9TIDVEIE1hcmsgSVY="},
+		},
+	})
+	require.NoError(t, err)
+
+	ds := collection.GetCollectionDatastore()
+	xattrs, cas, err := ds.GetXattrs(ctx, docID, []string{base.SyncXattrName, base.GlobalXattrName})
+	require.NoError(t, err)
+	var bucketSyncData SyncData
+	require.NoError(t, base.JSONUnmarshal(xattrs[base.SyncXattrName], &bucketSyncData))
+	var globalXattr GlobalSyncData
+	require.NoError(t, base.JSONUnmarshal(xattrs[base.GlobalXattrName], &globalXattr))
+
+	bucketSyncData.AttachmentsPre4dot0 = globalXattr.Attachments
+	syncBytes := base.MustJSONMarshal(t, bucketSyncData)
+	_, err = ds.WriteWithXattrs(ctx, docID, 0, cas, []byte(`{"test":"doc"}`),
+		map[string][]byte{base.SyncXattrName: syncBytes}, []string{base.GlobalXattrName}, nil)
+	require.NoError(t, err)
+}
+
+// attachmentMigrationCASRetryCallback returns an UpdateCallback that calls MigrateAttachmentMetadata
+// exactly once for the given docID, changing the document CAS and forcing WriteUpdateWithXattrs to retry.
+func attachmentMigrationCASRetryCallback(t *testing.T, ctx context.Context, collection *DatabaseCollectionWithUser, docID string) func(string) {
+	t.Helper()
+	var once sync.Once
+	return func(key string) {
+		if key != docID {
+			return
+		}
+		once.Do(func() {
+			ds := collection.GetCollectionDatastore()
+			xattrs, cas, err := ds.GetXattrs(ctx, docID, []string{base.SyncXattrName})
+			require.NoError(t, err)
+			var syncData SyncData
+			require.NoError(t, base.JSONUnmarshal(xattrs[base.SyncXattrName], &syncData))
+			require.NoError(t, collection.MigrateAttachmentMetadata(ctx, docID, cas, &syncData))
+		})
+	}
+}
+
+const attachmentMigrationCASRetryDigest = "sha1-VoSNiNQGHE1HirIS5HMxj6CrlHI="
+const attachmentMigrationCASRetryData = "Q2Fub24gRU9TIDVEIE1hcmsgSVY="
+
+var attachmentMigrationCASRetryExpected = AttachmentMap{
+	"camera.txt": {
+		Digest:  attachmentMigrationCASRetryDigest,
+		Length:  20,
+		Revpos:  2,
+		Version: 2,
+		Stub:    true,
+	},
+}
+
+// TestAttachmentMigrationCASRetryOnUpdate verifies that PutExistingCurrentVersion and
+// PutExistingRevWithConflictResolution both preserve revpos=2 when a CAS retry is forced
+// by concurrent attachment migration. The maps.Clone reset in each function is the guard:
+// without it, the retry sees a stub mutated by the first invocation and applies a parent
+// lookup that returns the migrated revpos=1.
+func TestAttachmentMigrationCASRetryOnUpdate(t *testing.T) {
+	db, ctx := setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), base.LeakyBucketConfig{})
+	defer db.Close(ctx)
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+	ds := collection.GetCollectionDatastore()
+
+	leakyDS, ok := base.AsLeakyDataStore(ds)
+	require.True(t, ok)
+
+	// putCurrentVersion calls PutExistingCurrentVersion (HLV/versionVector BLIP path).
+	putCurrentVersion := func(t *testing.T, docID string) {
+		existingDoc, err := collection.GetDocument(ctx, docID, DocUnmarshalSync)
+		require.NoError(t, err)
+		incomingHLV := &HybridLogicalVector{
+			SourceID:         "cbl1",
+			Version:          existingDoc.HLV.Version + 1,
+			PreviousVersions: HLVVersions{existingDoc.HLV.SourceID: existingDoc.HLV.Version},
+		}
+		// newDoc carries the attachment as inline data, simulating what ForEachStubAttachment
+		// places in newDoc.Attachments() after downloading the data from the CBL client.
+		newDoc := &Document{ID: docID}
+		newDoc.SetAttachments(AttachmentsMeta{
+			"camera.txt": map[string]any{"data": attachmentMigrationCASRetryData},
+		})
+		newDoc.UpdateBody(Body{"some": "update"})
+		_, _, _, err = collection.PutExistingCurrentVersion(ctx, PutDocOptions{
+			NewDoc:    newDoc,
+			NewDocHLV: incomingHLV,
+		})
+		require.NoError(t, err)
+	}
+
+	// putExistingRev calls PutExistingRevWithConflictResolution (rev-tree BLIP path).
+	putExistingRev := func(t *testing.T, docID string) {
+		existingDoc, err := collection.GetDocument(ctx, docID, DocUnmarshalSync)
+		require.NoError(t, err)
+		existingRevID := existingDoc.GetRevTreeID()
+		incomingRevID := "2-attachmentmigrationcasretrytest"
+		newDoc := &Document{ID: docID, RevID: incomingRevID}
+		newDoc.SetAttachments(AttachmentsMeta{
+			"camera.txt": map[string]any{"data": attachmentMigrationCASRetryData},
+		})
+		newDoc.UpdateBody(Body{"some": "update"})
+		_, _, err = collection.PutExistingRevWithConflictResolution(ctx, PutDocOptions{
+			NewDoc:         newDoc,
+			RevTreeHistory: []string{incomingRevID, existingRevID},
+			DocUpdateEvent: ExistingVersionWithUpdateToHLV,
+		})
+		require.NoError(t, err)
+	}
+
+	testCases := []struct {
+		name       string
+		casFailure bool
+		update     func(t *testing.T, docID string)
+	}{
+		{name: "PutExistingCurrentVersion no CAS failure", casFailure: false, update: putCurrentVersion},
+		{name: "PutExistingCurrentVersion CAS failure", casFailure: true, update: putCurrentVersion},
+		{name: "PutExistingRevWithConflictResolution no CAS failure", casFailure: false, update: putExistingRev},
+		{name: "PutExistingRevWithConflictResolution CAS failure", casFailure: true, update: putExistingRev},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			docID := "doc_" + strings.ReplaceAll(tc.name, " ", "_")
+
+			attachmentMigrationCASRetrySetup(t, ctx, collection, docID)
+
+			if tc.casFailure {
+				leakyDS.SetUpdateCallback(attachmentMigrationCASRetryCallback(t, ctx, collection, docID))
+			}
+
+			tc.update(t, docID)
+
+			leakyDS.SetUpdateCallback(nil)
+
+			require.Empty(t, GetRawSyncXattr(t, ds, docID).AttachmentsPre4dot0)
+			require.Equal(t, attachmentMigrationCASRetryExpected, GetRawGlobalSyncAttachments(t, ds, docID))
+		})
+	}
 }

--- a/db/crud.go
+++ b/db/crud.go
@@ -1356,7 +1356,12 @@ func (db *DatabaseCollectionWithUser) Put(ctx context.Context, docid string, bod
 	}
 
 	// Pull out attachments
-	newDoc.SetAttachments(GetBodyAttachments(body))
+	// originalBodyAtts is captured here so that each invocation of the WriteUpdateWithXattrs callback
+	// starts with the unmodified client-provided attachment map. storeAttachments mutates
+	// newDoc.Attachments() in place (replacing data with stubs); without reset, a CAS retry would
+	// see the stub from the prior invocation and apply an incorrect parent-revpos lookup.
+	originalBodyAtts := GetBodyAttachments(body)
+	newDoc.SetAttachments(originalBodyAtts)
 	delete(body, BodyAttachments)
 
 	delete(body, BodyRevisions)
@@ -1373,6 +1378,11 @@ func (db *DatabaseCollectionWithUser) Put(ctx context.Context, docid string, bod
 		var isSgWrite bool
 		var crc32Match bool
 
+		// (Be careful: this block can be invoked multiple times if there are races!)
+		// Reset to the original client-provided attachment map so that storeAttachments always
+		// processes the original data rather than stubs left from a prior invocation.
+		newDoc.SetAttachments(maps.Clone(originalBodyAtts))
+
 		// Is this doc an sgWrite?
 		if doc != nil {
 			isSgWrite, crc32Match, _ = doc.IsSGWrite(ctx, nil)
@@ -1381,7 +1391,6 @@ func (db *DatabaseCollectionWithUser) Put(ctx context.Context, docid string, bod
 			}
 		}
 
-		// (Be careful: this block can be invoked multiple times if there are races!)
 		// If the existing doc isn't an SG write, import prior to updating
 		if doc != nil && !isSgWrite && db.UseXattrs() {
 			err := db.OnDemandImportForWrite(ctx, newDoc.ID, doc, deleted)
@@ -1509,8 +1518,10 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 
 	docUpdateEvent := ExistingVersion
 	updateRevCache := true
+	originalNewDocAtts := maps.Clone(opts.NewDoc.Attachments())
 	doc, newRevID, err = db.updateAndReturnDoc(ctx, opts.NewDoc.ID, true, &opts.NewDoc.DocExpiry, nil, docUpdateEvent, opts.ExistingDoc, false, updateRevCache, func(doc *Document) (resultDoc *Document, resultAttachmentData updatedAttachments, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
 		// (Be careful: this block can be invoked multiple times if there are races!)
+		opts.NewDoc.SetAttachments(maps.Clone(originalNewDocAtts))
 
 		var isSgWrite bool
 		var crc32Match bool
@@ -1770,8 +1781,10 @@ func (db *DatabaseCollectionWithUser) PutExistingRevWithConflictResolution(ctx c
 	docHistory := opts.RevTreeHistory
 	allowImport := db.UseXattrs()
 	updateRevCache := true
+	originalNewDocAtts := maps.Clone(newDoc.Attachments())
 	doc, _, err = db.updateAndReturnDoc(ctx, newDoc.ID, allowImport, &newDoc.DocExpiry, nil, opts.DocUpdateEvent, opts.ExistingDoc, false, updateRevCache, func(doc *Document) (resultDoc *Document, resultAttachmentData updatedAttachments, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
 		// (Be careful: this block can be invoked multiple times if there are races!)
+		newDoc.SetAttachments(maps.Clone(originalNewDocAtts))
 
 		var isSgWrite bool
 		var crc32Match bool

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2904,6 +2904,7 @@ func TestAttachmentMigrationToGlobalXattrOnUpdate(t *testing.T) {
 						require.NoError(t, collection.MigrateAttachmentMetadata(ctx, docID, cas, &syncData))
 					})
 				})
+				defer rt.LeakyBucket().SetUpdateCallback(nil)
 			}
 
 			body = `{"some":"update","_attachments":{"camera.txt":{"data":"Q2Fub24gRU9TIDVEIE1hcmsgSVY="}}}`

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2835,57 +2835,94 @@ func TestLegacyAttachmentMigrationToGlobalXattrOnImport(t *testing.T) {
 	}, db.GetRawGlobalSyncAttachments(t, ds, docID))
 }
 
-// TestAttachmentMigrationToGlobalXattrOnUpdate:
-//   - Create doc with attachment defined
-//   - Set doc in bucket to move attachment from global xattr to old location in sync data
-//   - Update this doc through sync gateway
-//   - Assert that the attachment metadata in moved from sync data to global xattr on update
+// TestAttachmentMigrationToGlobalXattrOnUpdate verifies that attachment metadata ends up in the
+// global xattr with revpos=2 after a doc update, both with and without a concurrent CAS failure.
+//
+// The "CAS failure" subtest deterministically injects a CAS mismatch by running MigrateAttachmentMetadata
+// inside the LeakyBucket UpdateCallback — which fires after the SG write callback builds its stubs but
+// before the actual write to the datastore. This changes the document CAS, causing WriteUpdateWithXattrs
+// to retry. The fix in storeAttachments (ver-field guard) must preserve revpos=2 on that retry.
 func TestAttachmentMigrationToGlobalXattrOnUpdate(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{AutoImport: base.Ptr(false)})
+	rt := NewRestTester(t, &RestTesterConfig{
+		AutoImport:        base.Ptr(false),
+		LeakyBucketConfig: &base.LeakyBucketConfig{},
+	})
 	defer rt.Close()
 	ds := rt.GetSingleDataStore()
 	collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
 
-	docID := "baa"
-
-	body := `{"test":"doc","_attachments":{"camera.txt":{"data":"Q2Fub24gRU9TIDVEIE1hcmsgSVY="}}}`
-	vrs := rt.PutDoc(docID, body)
-
-	// get xattrs, remove the global xattr and move attachments back to sync data in the bucket
-	xattrs, cas, err := collection.GetCollectionDatastore().GetXattrs(ctx, docID, []string{base.SyncXattrName, base.GlobalXattrName})
-	require.NoError(t, err)
-	require.Contains(t, maps.Keys(xattrs), base.GlobalXattrName)
-	require.Contains(t, maps.Keys(xattrs), base.SyncXattrName)
-
-	var bucketSyncData db.SyncData
-	require.NoError(t, base.JSONUnmarshal(xattrs[base.SyncXattrName], &bucketSyncData))
-	var globalXattr db.GlobalSyncData
-	require.NoError(t, base.JSONUnmarshal(xattrs[base.GlobalXattrName], &globalXattr))
-
-	bucketSyncData.AttachmentsPre4dot0 = globalXattr.Attachments
-	syncBytes := base.MustJSONMarshal(t, bucketSyncData)
-	xattrBytes := map[string][]byte{
-		base.SyncXattrName: syncBytes,
+	testCases := []struct {
+		name       string
+		casFailure bool
+	}{
+		{name: "no CAS failure on update", casFailure: false},
+		{name: "CAS failure on update", casFailure: true},
 	}
-	// add new update sync data but also remove global xattr from doc
-	_, err = collection.GetCollectionDatastore().WriteWithXattrs(ctx, docID, 0, cas, []byte(`{"test":"doc"}`), xattrBytes, []string{base.GlobalXattrName}, nil)
-	require.NoError(t, err)
 
-	// update doc
-	body = `{"some":"update","_attachments":{"camera.txt":{"data":"Q2Fub24gRU9TIDVEIE1hcmsgSVY="}}}`
-	_ = rt.UpdateDoc(docID, vrs, body)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			docID := "doc_" + strings.ReplaceAll(tc.name, " ", "_")
 
-	// assert that the attachments moved to global xattr after doc update
-	require.Empty(t, db.GetRawSyncXattr(t, ds, docID).AttachmentsPre4dot0)
-	require.Equal(t, db.AttachmentMap{
-		"camera.txt": {
-			Digest:  "sha1-VoSNiNQGHE1HirIS5HMxj6CrlHI=",
-			Length:  20,
-			Revpos:  2,
-			Version: 2,
-			Stub:    true,
-		},
-	}, db.GetRawGlobalSyncAttachments(t, ds, docID))
+			// Create doc with attachment.
+			body := `{"test":"doc","_attachments":{"camera.txt":{"data":"Q2Fub24gRU9TIDVEIE1hcmsgSVY="}}}`
+			vrs := rt.PutDoc(docID, body)
+
+			// Read xattrs, remove global xattr, move attachments back to AttachmentsPre4dot0 in sync data.
+			// This simulates a document that has not yet been through the background attachment migration.
+			xattrs, cas, err := collection.GetCollectionDatastore().GetXattrs(ctx, docID, []string{base.SyncXattrName, base.GlobalXattrName})
+			require.NoError(t, err)
+			require.Contains(t, maps.Keys(xattrs), base.GlobalXattrName)
+			require.Contains(t, maps.Keys(xattrs), base.SyncXattrName)
+
+			var bucketSyncData db.SyncData
+			require.NoError(t, base.JSONUnmarshal(xattrs[base.SyncXattrName], &bucketSyncData))
+			var globalXattr db.GlobalSyncData
+			require.NoError(t, base.JSONUnmarshal(xattrs[base.GlobalXattrName], &globalXattr))
+
+			bucketSyncData.AttachmentsPre4dot0 = globalXattr.Attachments
+			syncBytes := base.MustJSONMarshal(t, bucketSyncData)
+			_, err = collection.GetCollectionDatastore().WriteWithXattrs(ctx, docID, 0, cas, []byte(`{"test":"doc"}`),
+				map[string][]byte{base.SyncXattrName: syncBytes}, []string{base.GlobalXattrName}, nil)
+			require.NoError(t, err)
+
+			rt.WaitForPendingChanges()
+			if tc.casFailure {
+				// UpdateCallback fires after the SG write callback completes (stubs created) but before
+				// the datastore write. Calling MigrateAttachmentMetadata here changes the doc CAS,
+				// which forces WriteUpdateWithXattrs to retry. sync.Once ensures we only inject the
+				// failure on the first attempt so the retry can succeed.
+				var once sync.Once
+				rt.LeakyBucket().SetUpdateCallback(func(key string) {
+					if key != docID {
+						return
+					}
+					once.Do(func() {
+						xattrs, cas, err := collection.GetCollectionDatastore().GetXattrs(ctx, docID, []string{base.SyncXattrName})
+						require.NoError(t, err)
+						var syncData db.SyncData
+						require.NoError(t, base.JSONUnmarshal(xattrs[base.SyncXattrName], &syncData))
+						require.NoError(t, collection.MigrateAttachmentMetadata(ctx, docID, cas, &syncData))
+					})
+				})
+			}
+
+			body = `{"some":"update","_attachments":{"camera.txt":{"data":"Q2Fub24gRU9TIDVEIE1hcmsgSVY="}}}`
+			_ = rt.UpdateDoc(docID, vrs, body)
+
+			rt.LeakyBucket().SetUpdateCallback(nil)
+
+			require.Empty(t, db.GetRawSyncXattr(t, ds, docID).AttachmentsPre4dot0)
+			require.Equal(t, db.AttachmentMap{
+				"camera.txt": {
+					Digest:  "sha1-VoSNiNQGHE1HirIS5HMxj6CrlHI=",
+					Length:  20,
+					Revpos:  2,
+					Version: 2,
+					Stub:    true,
+				},
+			}, db.GetRawGlobalSyncAttachments(t, ds, docID))
+		})
+	}
 }
 
 func TestBlipPushRevWithAttachment(t *testing.T) {

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2841,7 +2841,7 @@ func TestLegacyAttachmentMigrationToGlobalXattrOnImport(t *testing.T) {
 // The "CAS failure" subtest deterministically injects a CAS mismatch by running MigrateAttachmentMetadata
 // inside the LeakyBucket UpdateCallback — which fires after the SG write callback builds its stubs but
 // before the actual write to the datastore. This changes the document CAS, causing WriteUpdateWithXattrs
-// to retry. The fix in storeAttachments (ver-field guard) must preserve revpos=2 on that retry.
+// to retry. The maps.Clone reset in the relevant Put/PutExisting* codepaths must preserve revpos=2 on that retry.
 func TestAttachmentMigrationToGlobalXattrOnUpdate(t *testing.T) {
 	rt := NewRestTester(t, &RestTesterConfig{
 		AutoImport:        base.Ptr(false),


### PR DESCRIPTION
CBG-5536 fix attachment revpos corruption on CAS retry

Note: revpos isn't actually _used_ by any code but I think this exposes an underlying bug.

I tried to find all functions which might be affected and write tests for them, but I would appreciate the reviewer looking as well.

Claude did notice that there other shadowed variables in this loop and I don't know how they should get handled or fixed:

- When resolveHLVConflict fires and sets opts.RevTreeHistory = updatedHistory (line ~1673), a subsequent CAS retry re-enters the closure with the already-merged history. The resolveHLVConflict path may fire again on the changed doc state, merging the already-merged history and producing a doubly-mangled previousRevTreeID or an incorrect new rev tree entry." https://github.com/couchbase/sync_gateway/blob/0a5a88d5b1d6b2dd6ee62ed5d2aec269b9f5fb20/db/crud.go#L1636
- "After conflict resolution, newRev = docHistory[0] (the resolved rev). On CAS retry, newRev is the resolved ID rather than the original opts.RevTreeHistory[0], so IsIllegalConflict is called with the wrong parent ID, and addRevision may insert a duplicate or mislabelled node in the rev tree." https://github.com/couchbase/sync_gateway/blob/0a5a88d5b1d6b2dd6ee62ed5d2aec269b9f5fb20/db/crud.go#L1804
- "Conflict resolution fires on the first invocation and sets docHistory = updatedHistory (line 1839) and newRev = docHistory[0] (line 1843). CAS write fails. On retry, the closure re-enters with the already-resolved docHistory — the conflict check and history-building loop execute against post-resolution state, potentially resolving again against the wrong base, producing a malformed rev tree or incorrect parent." https://github.com/couchbase/sync_gateway/blob/0a5a88d5b1d6b2dd6ee62ed5d2aec269b9f5fb20/db/crud.go#L1800

This is the test flake:

```
09:37:38 2026-07-02T13:35:39.184Z [INF] t:TestAttachmentMigrationToGlobalXattrOnUpdate db:db Attachment Migration: Starting new migration run with migration ID: 668dc60f-ec87-4788-b99c-080a040dd942
09:37:38 2026-07-02T13:35:39.187Z [INF] HTTP: c:#3686 db:db col:sg_test_0 PUT http://127.0.0.1/db.sg_test_0.sg_test_0/<ud>baa</ud> (as ADMIN)
09:37:38 2026-07-02T13:35:39.188Z [INF] HTTP: c:#3687 db:db col:sg_test_0 PUT http://127.0.0.1/db.sg_test_0.sg_test_0/<ud>baa</ud>?rev=18be7c73c7080000@rosmar1 (as ADMIN)
09:37:38 2026-07-02T13:35:39.191Z [INF] t:TestAttachmentMigrationToGlobalXattrOnUpdate db:db [Migration: 668dc60f-ec87-4788-b99c-080a040dd942] Finished migrating attachment metadata from sync data to global sync data. 1/1 docs changed
09:37:38 
--- FAIL: TestAttachmentMigrationToGlobalXattrOnUpdate (0.02s)
09:37:38     attachment_test.go:2880: 
09:37:38         	Error Trace:	/home/ubuntu/workspace/sgw-unix-build/4.2.0/enterprise/sync_gateway/rest/attachment_test.go:2880
09:37:38         	Error:      	Not equal: 
09:37:38         	            	expected: db.AttachmentMap{"camera.txt":db.DocAttachment{ContentType:"", Digest:"sha1-VoSNiNQGHE1HirIS5HMxj6CrlHI=", Length:20, Revpos:2, Stub:true, Version:2, Data:[]uint8(nil)}}
09:37:38         	            	actual  : db.AttachmentMap{"camera.txt":db.DocAttachment{ContentType:"", Digest:"sha1-VoSNiNQGHE1HirIS5HMxj6CrlHI=", Length:20, Revpos:1, Stub:true, Version:2, Data:[]uint8(nil)}}
09:37:38         	            	
09:37:38         	            	Diff:
09:37:38         	            	--- Expected
09:37:38         	            	+++ Actual
09:37:38         	            	@@ -5,3 +5,3 @@
09:37:38         	            	   Length: (int) 20,
09:37:38         	            	-  Revpos: (int) 2,
09:37:38         	            	+  Revpos: (int) 1,
09:37:38         	            	   Stub: (bool) true,
09:37:38         	Test:       	TestAttachmentMigrationToGlobalXattrOnUpdate
```

When `storeAttachments` is called inside the `WriteUpdateWithXattrs` callback, it mutates `newDoc.Attachments()` in place — replacing `{data:...}` entries with stubs. On a CAS retry (e.g. because a concurrent background migration changed the doc's CAS) the callback runs again, but now sees stubs instead of the original data. `retrieveAncestorAttachments` then returns the pre-migration revpos=1 from the parent, overwriting the correct revpos=2.

Fix: capture the original attachment map before the callback and reset via `maps.Clone` at the top of each invocation in `Put`, `PutExistingCurrentVersion`, and `PutExistingRevWithConflictResolution`, making `storeAttachments` idempotent across retries.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/886/
