### PR TITLE
CBG-5509: use leakybucket to for background manager tests that require stopping

### DIFF
--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -149,6 +149,12 @@ type LeakyBucketConfig struct {
 	// WriteWithXattrCallback is ran before WriteWithXattr is called. This can be used to trigger a CAS retry
 	WriteWithXattrCallback func(key string)
 
+	// UpdateXattrsCallback is called before UpdateXattrs. Useful for injecting delays or errors per-key.
+	UpdateXattrsCallback func(key string)
+
+	// WriteUpdateWithXattrsCallback is called before WriteUpdateWithXattrs. Useful for injecting delays per-key.
+	WriteUpdateWithXattrsCallback func(key string)
+
 	// IncrCallback issues a callback during incr.  Used for sequence allocation race tests
 	IncrCallback func()
 
@@ -372,6 +378,30 @@ func (b *LeakyBucket) getWriteWithXattrCallback() func(string) {
 	b.configLock.RLock()
 	defer b.configLock.RUnlock()
 	return b._config.WriteWithXattrCallback
+}
+
+func (b *LeakyBucket) getUpdateXattrsCallback() func(string) {
+	b.configLock.RLock()
+	defer b.configLock.RUnlock()
+	return b._config.UpdateXattrsCallback
+}
+
+func (b *LeakyBucket) setUpdateXattrsCallback(fn func(string)) {
+	b.configLock.Lock()
+	defer b.configLock.Unlock()
+	b._config.UpdateXattrsCallback = fn
+}
+
+func (b *LeakyBucket) getWriteUpdateWithXattrsCallback() func(string) {
+	b.configLock.RLock()
+	defer b.configLock.RUnlock()
+	return b._config.WriteUpdateWithXattrsCallback
+}
+
+func (b *LeakyBucket) setWriteUpdateWithXattrsCallback(fn func(string)) {
+	b.configLock.Lock()
+	defer b.configLock.Unlock()
+	b._config.WriteUpdateWithXattrsCallback = fn
 }
 
 func (b *LeakyBucket) getSetXattrCallback() func(string) error {

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -410,6 +410,12 @@ func (b *LeakyBucket) getSetXattrCallback() func(string) error {
 	return b._config.SetXattrCallback
 }
 
+func (b *LeakyBucket) setSetXattrCallback(fn func(string) error) {
+	b.configLock.Lock()
+	defer b.configLock.Unlock()
+	b._config.SetXattrCallback = fn
+}
+
 func (b *LeakyBucket) getN1QLQueryCallback() func(context.Context, string, map[string]any, ConsistencyMode, bool) error {
 	b.configLock.RLock()
 	defer b.configLock.RUnlock()

--- a/base/leaky_datastore.go
+++ b/base/leaky_datastore.go
@@ -286,6 +286,9 @@ func (lds *LeakyDataStore) WriteWithXattrs(ctx context.Context, k string, exp ui
 }
 
 func (lds *LeakyDataStore) WriteUpdateWithXattrs(ctx context.Context, k string, xattrKeys []string, exp uint32, previous *sgbucket.BucketDocument, opts *sgbucket.MutateInOptions, callback sgbucket.WriteUpdateWithXattrsFunc) (casOut uint64, err error) {
+	if cb := lds.bucket.getWriteUpdateWithXattrsCallback(); cb != nil {
+		cb(k)
+	}
 	updateCb := lds.bucket.getUpdateCallback()
 	forceTimeoutKeys := lds.bucket.getForceTimeoutErrorOnUpdateKeys()
 
@@ -376,7 +379,24 @@ func (lds *LeakyDataStore) IsSupported(feature sgbucket.BucketStoreFeature) bool
 }
 
 func (lds *LeakyDataStore) UpdateXattrs(ctx context.Context, k string, exp uint32, cas uint64, xv map[string][]byte, opts *sgbucket.MutateInOptions) (casOut uint64, err error) {
+	if cb := lds.bucket.getUpdateXattrsCallback(); cb != nil {
+		cb(k)
+	}
 	return lds.dataStore.UpdateXattrs(ctx, k, exp, cas, xv, opts)
+}
+
+func (lds *LeakyDataStore) SetUpdateXattrsCallback(callback func(key string)) {
+	lds.bucket.setUpdateXattrsCallback(callback)
+}
+
+func (lds *LeakyDataStore) SetXattrCallback(callback func(key string) error) {
+	lds.bucket.configLock.Lock()
+	defer lds.bucket.configLock.Unlock()
+	lds.bucket._config.SetXattrCallback = callback
+}
+
+func (lds *LeakyDataStore) SetWriteUpdateWithXattrsCallback(callback func(key string)) {
+	lds.bucket.setWriteUpdateWithXattrsCallback(callback)
 }
 
 func (lds *LeakyDataStore) WriteTombstoneWithXattrs(ctx context.Context, k string, exp uint32, cas uint64, xv map[string][]byte, xattrsToDelete []string, deleteBody bool, opts *sgbucket.MutateInOptions) (casOut uint64, err error) {

--- a/base/leaky_datastore.go
+++ b/base/leaky_datastore.go
@@ -390,9 +390,7 @@ func (lds *LeakyDataStore) SetUpdateXattrsCallback(callback func(key string)) {
 }
 
 func (lds *LeakyDataStore) SetXattrCallback(callback func(key string) error) {
-	lds.bucket.configLock.Lock()
-	defer lds.bucket.configLock.Unlock()
-	lds.bucket._config.SetXattrCallback = callback
+	lds.bucket.setSetXattrCallback(callback)
 }
 
 func (lds *LeakyDataStore) SetWriteUpdateWithXattrsCallback(callback func(key string)) {

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -913,6 +913,26 @@ func GetVbucketForKey(ctx context.Context, bucket Bucket, key string) (vbNo uint
 	return sgbucket.VBHash(key, maxVbNo), nil
 }
 
+// VBucket0DocIDs returns 5 doc IDs that all hash to vBucket 0 for every supported vBucket count
+// (64, 100, 128, 1024). Placing multiple test docs on the same vBucket ensures they are processed
+// sequentially by a single DCP worker on CBS, which is required when a test pauses one doc and
+// needs the remaining docs to stay unprocessed until the pause is released.
+//
+// Keys were pre-computed using sgbucket.VBHash. On CBS, each key is verified at runtime.
+func VBucket0DocIDs(t testing.TB, bucket Bucket) []string {
+	keys := []string{"abbacomes", "baba", "ob", "rz", "aex"}
+	ctx := TestCtx(t)
+	for _, key := range keys {
+		vbNo, err := GetVbucketForKey(ctx, bucket, key)
+		if err != nil {
+			// Not a CBS bucket (e.g. Rosmar); static list was verified at generation time.
+			break
+		}
+		require.Equal(t, uint32(0), vbNo, "key %q should map to vBucket 0 (got %d)", key, vbNo)
+	}
+	return keys
+}
+
 // MoveDocument moves the document from src to dst
 // Note: does not handle xattr contents
 func MoveDocument(t testing.TB, docID string, dst, src DataStore) {

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -13,6 +13,8 @@ package base
 import (
 	"bytes"
 	"context"
+	"crypto/sha1"
+	"encoding/base64"
 	"errors"
 	"flag"
 	"fmt"
@@ -913,14 +915,18 @@ func GetVbucketForKey(ctx context.Context, bucket Bucket, key string) (vbNo uint
 	return sgbucket.VBHash(key, maxVbNo), nil
 }
 
-// VBucket0DocIDs returns 5 doc IDs that all hash to vBucket 0 for every supported vBucket count
+// VBucket0DocIDs returns count doc IDs that all hash to vBucket 0 for every supported vBucket count
 // (64, 100, 128, 1024). Placing multiple test docs on the same vBucket ensures they are processed
 // sequentially by a single DCP worker on CBS, which is required when a test pauses one doc and
 // needs the remaining docs to stay unprocessed until the pause is released.
 //
 // Keys were pre-computed using sgbucket.VBHash. On CBS, each key is verified at runtime.
-func VBucket0DocIDs(t testing.TB, bucket Bucket) []string {
-	keys := []string{"abbacomes", "baba", "ob", "rz", "aex"}
+// count must be between 1 and 5 inclusive.
+func VBucket0DocIDs(t testing.TB, bucket Bucket, count int) []string {
+	all := []string{"abbacomes", "baba", "ob", "rz", "aex"}
+	require.GreaterOrEqual(t, count, 1, "VBucket0DocIDs: count must be at least 1")
+	require.LessOrEqual(t, count, len(all), "VBucket0DocIDs: count %d exceeds the %d pre-computed keys", count, len(all))
+	keys := all[:count]
 	ctx := TestCtx(t)
 	for _, key := range keys {
 		vbNo, err := GetVbucketForKey(ctx, bucket, key)
@@ -931,6 +937,39 @@ func VBucket0DocIDs(t testing.TB, bucket Bucket) []string {
 		require.Equal(t, uint32(0), vbNo, "key %q should map to vBucket 0 (got %d)", key, vbNo)
 	}
 	return keys
+}
+
+// VBucket0AttachmentBodies returns count attachment body byte slices whose v1 attachment data
+// keys (_sync:att:sha1-<digest>) all hash to vBucket 0 for every supported vBucket count
+// (64, 100, 128, 1024). Using these bodies with CreateLegacyAttachmentDoc ensures the
+// SetXattrs calls made by the compaction mark phase are processed by a single DCP worker
+// on CBS, preventing concurrent double-close of test synchronisation channels.
+//
+// Bodies were pre-computed by brute-force search. On CBS, each derived key is verified at runtime.
+// count must be between 1 and 5 inclusive.
+func VBucket0AttachmentBodies(t testing.TB, bucket Bucket, count int) [][]byte {
+	all := [][]byte{
+		[]byte("att1224"),
+		[]byte("att1231"),
+		[]byte("att1763"),
+		[]byte("att1906"),
+		[]byte("att2328"),
+	}
+	require.GreaterOrEqual(t, count, 1, "VBucket0AttachmentBodies: count must be at least 1")
+	require.LessOrEqual(t, count, len(all), "VBucket0AttachmentBodies: count %d exceeds the %d pre-computed bodies", count, len(all))
+	bodies := all[:count]
+	ctx := TestCtx(t)
+	for _, body := range bodies {
+		h := sha1.Sum(body)
+		attKey := AttPrefix + "sha1-" + base64.StdEncoding.EncodeToString(h[:])
+		vbNo, err := GetVbucketForKey(ctx, bucket, attKey)
+		if err != nil {
+			// Not a CBS bucket (e.g. Rosmar); static list was verified at generation time.
+			break
+		}
+		require.Equal(t, uint32(0), vbNo, "attachment key %q should map to vBucket 0 (got %d)", attKey, vbNo)
+	}
+	return bodies
 }
 
 // MoveDocument moves the document from src to dst

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -928,13 +928,12 @@ func VBucket0DocIDs(t testing.TB, bucket Bucket, count int) []string {
 	require.LessOrEqual(t, count, len(all), "VBucket0DocIDs: count %d exceeds the %d pre-computed keys", count, len(all))
 	keys := all[:count]
 	ctx := TestCtx(t)
-	for _, key := range keys {
-		vbNo, err := GetVbucketForKey(ctx, bucket, key)
-		if err != nil {
-			// Not a CBS bucket (e.g. Rosmar); static list was verified at generation time.
-			break
+	if _, ok := AsCouchbaseBucketStore(bucket); ok {
+		for _, key := range keys {
+			vbNo, err := GetVbucketForKey(ctx, bucket, key)
+			require.NoError(t, err)
+			require.Equal(t, uint32(0), vbNo, "key %q should map to vBucket 0 (got %d)", key, vbNo)
 		}
-		require.Equal(t, uint32(0), vbNo, "key %q should map to vBucket 0 (got %d)", key, vbNo)
 	}
 	return keys
 }
@@ -959,15 +958,14 @@ func VBucket0AttachmentBodies(t testing.TB, bucket Bucket, count int) [][]byte {
 	require.LessOrEqual(t, count, len(all), "VBucket0AttachmentBodies: count %d exceeds the %d pre-computed bodies", count, len(all))
 	bodies := all[:count]
 	ctx := TestCtx(t)
-	for _, body := range bodies {
-		h := sha1.Sum(body)
-		attKey := AttPrefix + "sha1-" + base64.StdEncoding.EncodeToString(h[:])
-		vbNo, err := GetVbucketForKey(ctx, bucket, attKey)
-		if err != nil {
-			// Not a CBS bucket (e.g. Rosmar); static list was verified at generation time.
-			break
+	if _, ok := AsCouchbaseBucketStore(bucket); ok {
+		for _, body := range bodies {
+			h := sha1.Sum(body)
+			attKey := AttPrefix + "sha1-" + base64.StdEncoding.EncodeToString(h[:])
+			vbNo, err := GetVbucketForKey(ctx, bucket, attKey)
+			require.NoError(t, err)
+			require.Equal(t, uint32(0), vbNo, "attachment key %q should map to vBucket 0 (got %d)", attKey, vbNo)
 		}
-		require.Equal(t, uint32(0), vbNo, "attachment key %q should map to vBucket 0 (got %d)", attKey, vbNo)
 	}
 	return bodies
 }

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -914,9 +914,9 @@ func GetVbucketForKey(ctx context.Context, bucket Bucket, key string) (uint32, e
 // remaining docs to stay unprocessed until the pause is released.
 //
 // Keys were pre-computed using sgbucket.VBHash and are verified at runtime.
-// count must be between 1 and 5 inclusive.
+// count must be between 1 and 6 inclusive.
 func VBucket0DocIDs(t testing.TB, bucket Bucket, count int) []string {
-	all := []string{"abbacomes", "baba", "ob", "rz", "aex"}
+	all := []string{"abbacomes", "baba", "ob", "rz", "aex", "fbz"}
 	require.GreaterOrEqual(t, count, 1, "VBucket0DocIDs: count must be at least 1")
 	require.LessOrEqual(t, count, len(all), "VBucket0DocIDs: count %d exceeds the %d pre-computed keys", count, len(all))
 	keys := all[:count]

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -900,27 +900,20 @@ func AssertTimestampGreaterThan(t *testing.T, e1, e2 int64, msgAndArgs ...any) b
 	return assert.Greater(t, e1, e2, msgAndArgs...)
 }
 
-func GetVbucketForKey(ctx context.Context, bucket Bucket, key string) (vbNo uint32, err error) {
-
-	cbBucket, ok := AsCouchbaseBucketStore(bucket)
-	if !ok {
-		return 0, fmt.Errorf("GetVbucketForKey not supported for non-Couchbase bucket")
-	}
-
-	maxVbNo, err := cbBucket.GetMaxVbno(ctx)
+func GetVbucketForKey(ctx context.Context, bucket Bucket, key string) (uint32, error) {
+	maxVbNo, err := bucket.GetMaxVbno(ctx)
 	if err != nil {
 		return 0, err
 	}
-
 	return sgbucket.VBHash(key, maxVbNo), nil
 }
 
 // VBucket0DocIDs returns count doc IDs that all hash to vBucket 0 for every supported vBucket count
-// (64, 100, 128, 1024). Placing multiple test docs on the same vBucket ensures they are processed
-// sequentially by a single DCP worker on CBS, which is required when a test pauses one doc and
-// needs the remaining docs to stay unprocessed until the pause is released.
+// (32, 64, 100, 128, 1024). Placing multiple test docs on the same vBucket ensures they are processed
+// sequentially by a single DCP worker, which is required when a test pauses one doc and needs the
+// remaining docs to stay unprocessed until the pause is released.
 //
-// Keys were pre-computed using sgbucket.VBHash. On CBS, each key is verified at runtime.
+// Keys were pre-computed using sgbucket.VBHash and are verified at runtime.
 // count must be between 1 and 5 inclusive.
 func VBucket0DocIDs(t testing.TB, bucket Bucket, count int) []string {
 	all := []string{"abbacomes", "baba", "ob", "rz", "aex"}
@@ -928,21 +921,19 @@ func VBucket0DocIDs(t testing.TB, bucket Bucket, count int) []string {
 	require.LessOrEqual(t, count, len(all), "VBucket0DocIDs: count %d exceeds the %d pre-computed keys", count, len(all))
 	keys := all[:count]
 	ctx := TestCtx(t)
-	if _, ok := AsCouchbaseBucketStore(bucket); ok {
-		for _, key := range keys {
-			vbNo, err := GetVbucketForKey(ctx, bucket, key)
-			require.NoError(t, err)
-			require.Equal(t, uint32(0), vbNo, "key %q should map to vBucket 0 (got %d)", key, vbNo)
-		}
+	for _, key := range keys {
+		vbNo, err := GetVbucketForKey(ctx, bucket, key)
+		require.NoError(t, err)
+		require.Equal(t, uint32(0), vbNo, "key %q should map to vBucket 0 (got %d)", key, vbNo)
 	}
 	return keys
 }
 
 // VBucket0AttachmentBodies returns count attachment body byte slices whose v1 attachment data
 // keys (_sync:att:sha1-<digest>) all hash to vBucket 0 for every supported vBucket count
-// (64, 100, 128, 1024). Using these bodies with CreateLegacyAttachmentDoc ensures the
-// SetXattrs calls made by the compaction mark phase are processed by a single DCP worker
-// on CBS, preventing concurrent double-close of test synchronisation channels.
+// (32, 64, 100, 128, 1024). Using these bodies with CreateLegacyAttachmentDoc ensures the
+// SetXattrs calls made by the compaction mark phase are processed by a single DCP worker,
+// preventing concurrent double-close of test synchronisation channels.
 //
 // Bodies were pre-computed by brute-force search. On CBS, each derived key is verified at runtime.
 // count must be between 1 and 5 inclusive.
@@ -958,14 +949,12 @@ func VBucket0AttachmentBodies(t testing.TB, bucket Bucket, count int) [][]byte {
 	require.LessOrEqual(t, count, len(all), "VBucket0AttachmentBodies: count %d exceeds the %d pre-computed bodies", count, len(all))
 	bodies := all[:count]
 	ctx := TestCtx(t)
-	if _, ok := AsCouchbaseBucketStore(bucket); ok {
-		for _, body := range bodies {
-			h := sha1.Sum(body)
-			attKey := AttPrefix + "sha1-" + base64.StdEncoding.EncodeToString(h[:])
-			vbNo, err := GetVbucketForKey(ctx, bucket, attKey)
-			require.NoError(t, err)
-			require.Equal(t, uint32(0), vbNo, "attachment key %q should map to vBucket 0 (got %d)", attKey, vbNo)
-		}
+	for _, body := range bodies {
+		h := sha1.Sum(body)
+		attKey := AttPrefix + "sha1-" + base64.StdEncoding.EncodeToString(h[:])
+		vbNo, err := GetVbucketForKey(ctx, bucket, attKey)
+		require.NoError(t, err)
+		require.Equal(t, uint32(0), vbNo, "attachment key %q should map to vBucket 0 (got %d)", attKey, vbNo)
 	}
 	return bodies
 }

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -781,12 +781,13 @@ func TestResyncUsingDCPStreamReset(t *testing.T) {
 
 	rt := rest.NewRestTester(t,
 		&rest.RestTesterConfig{
-			SyncFn: syncFn,
+			SyncFn:            syncFn,
+			LeakyBucketConfig: &base.LeakyBucketConfig{},
 		},
 	)
 	defer rt.Close()
 
-	const numDocs = 1000
+	const numDocs = 10
 
 	// create some docs
 	for i := range numDocs {
@@ -795,16 +796,19 @@ func TestResyncUsingDCPStreamReset(t *testing.T) {
 
 	rt.TakeDbOffline()
 
+	// Pause resync at the first user document so stop arrives while genuinely in-flight.
+	pauser := newResyncPauser(rt)
+
 	// start a resync run
 	response := rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
 	rest.RequireStatus(t, response, http.StatusOK)
-
-	resyncManagerStatus := rt.WaitForResyncDCPStatus(db.BackgroundProcessStateRunning)
-	resyncID := resyncManagerStatus.ResyncID
+	pauser.WaitUntilBlocked()
+	resyncID := rt.WaitForResyncDCPStatus(db.BackgroundProcessStateRunning).ResyncID
 
 	// stop resync before it completes, assert it has been aborted
 	response = rt.SendAdminRequest("POST", "/db/_resync?action=stop", "")
 	rest.RequireStatus(t, response, http.StatusOK)
+	pauser.Release()
 
 	_ = rt.WaitForResyncDCPStatus(db.BackgroundProcessStateStopped)
 
@@ -812,23 +816,22 @@ func TestResyncUsingDCPStreamReset(t *testing.T) {
 	response = rt.SendAdminRequest("POST", "/db/_resync?reset=true", "")
 	rest.RequireStatus(t, response, http.StatusOK)
 
-	// grab new resync status from rest run, assert the resync id is not the same as the first
+	// grab new resync status from reset run, assert the resync id is not the same as the first
 	// run and that the docs processed is equal to number of docs we have created
-	resyncManagerStatus = rt.WaitForResyncDCPStatus(db.BackgroundProcessStateRunning)
+	resyncManagerStatus := rt.WaitForResyncDCPStatus(db.BackgroundProcessStateRunning)
 	assert.NotEqual(t, resyncID, resyncManagerStatus.ResyncID)
 
 	resyncManagerStatus = rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
 	if !base.UnitTestUrlIsWalrus() && !base.TestsDisableGSI() {
 		// It is possible for Couchbase Server GSI runs which use DCP purge to two DCP events from a previous
 		// test.
-		// 1. doc1 mutation
-		// 2. doc1 deletion
+		// 1. doc mutation
+		// 2. doc deletion
 		//
 		// In a test, these will not be resynced but docsProcessed is incremented. Relax
 		// the assertion to greater than the number of documents.
 		assert.GreaterOrEqual(t, int(resyncManagerStatus.DocsProcessed), numDocs)
 	} else {
-
 		assert.Equal(t, int64(numDocs), resyncManagerStatus.DocsProcessed)
 	}
 }
@@ -1424,23 +1427,26 @@ func TestResyncStopUsingDCPStream(t *testing.T) {
 		channel("x")
 	}`
 
-	testBucket := base.GetTestBucket(t)
-
 	rt := rest.NewRestTester(t,
 		&rest.RestTesterConfig{
-			SyncFn:           syncFn,
-			CustomTestBucket: testBucket,
+			SyncFn:            syncFn,
+			LeakyBucketConfig: &base.LeakyBucketConfig{},
 		},
 	)
 	defer rt.Close()
 
-	numOfDocs := 1000
-	// gsi is slower than views, so update the number of documents for views so stopping the resync will not complete
-	if base.TestsDisableGSI() {
-		numOfDocs = 5000
-	}
-	for i := range numOfDocs {
-		rt.CreateTestDoc(fmt.Sprintf("doc%d", i))
+	// All docs on vBucket 0 so a single DCP worker processes them serially. Without this,
+	// workers on other vBuckets could run unblocked while the pauser holds the vBucket 0 worker,
+	// letting SyncFunctionCount reach numOfDocs*2 before stop arrives and causing the assertion
+	// at the end to fail.
+	//
+	// The pauser eliminates the race between "DCP finishes all docs → completed" and "stop
+	// command arrives → stopped", so numOfDocs can be kept small for test speed without
+	// risking the process completing before stop is issued.
+	docKeys := base.VBucket0DocIDs(t, rt.Bucket())
+	const numOfDocs = 5
+	for _, key := range docKeys {
+		rt.CreateTestDoc(key)
 	}
 
 	rt.WaitForPendingChanges()
@@ -1449,12 +1455,16 @@ func TestResyncStopUsingDCPStream(t *testing.T) {
 
 	rt.TakeDbOffline()
 
+	// Pause resync at the first user document so the stop arrives while genuinely in-flight.
+	pauser := newResyncPauser(rt)
+
 	response := rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
 	rest.RequireStatus(t, response, http.StatusOK)
-	rt.WaitForResyncDCPStatus(db.BackgroundProcessStateRunning)
+	pauser.WaitUntilBlocked()
 
 	response = rt.SendAdminRequest("POST", "/db/_resync?action=stop", "")
 	rest.RequireStatus(t, response, http.StatusOK)
+	pauser.Release()
 
 	rt.WaitForResyncDCPStatus(db.BackgroundProcessStateStopped)
 
@@ -4259,4 +4269,43 @@ func TestRetrieveMetadataStoreModeInStatus(t *testing.T) {
 	rest.RequireStatus(t, resp, http.StatusOK)
 	require.NoError(t, json.Unmarshal(resp.BodyBytes(), &statusResponse))
 	assert.Equal(t, base.MetadataStoreModeFallbackInactive, statusResponse.Databases["db"].MetadataStoreMode)
+}
+
+// resyncPauser blocks the resync DCP stream at the first user document it encounters,
+// letting tests assert resync is genuinely in-flight before issuing stop commands.
+type resyncPauser struct {
+	t       testing.TB
+	blocked chan struct{}
+	blockCh chan struct{}
+	ds      *base.LeakyDataStore
+}
+
+func newResyncPauser(rt *rest.RestTester) *resyncPauser {
+	leakyDS, ok := base.AsLeakyDataStore(rt.Bucket().DefaultDataStore(rt.Context()))
+	require.True(rt.TB(), ok, "datastore must be a LeakyDataStore")
+	p := &resyncPauser{
+		t:       rt.TB(),
+		blocked: make(chan struct{}),
+		blockCh: make(chan struct{}),
+		ds:      leakyDS,
+	}
+	leakyDS.SetWriteUpdateWithXattrsCallback(func(key string) {
+		if strings.HasPrefix(key, "_sync:") {
+			return
+		}
+		close(p.blocked)
+		<-p.blockCh
+	})
+	return p
+}
+
+// WaitUntilBlocked blocks until resync is paused at a user document, proving it is in-flight.
+func (p *resyncPauser) WaitUntilBlocked() {
+	base.RequireChanClosed(p.t, p.blocked)
+}
+
+// Release clears the callback so subsequent documents pass through, then unblocks the paused doc.
+func (p *resyncPauser) Release() {
+	p.ds.SetWriteUpdateWithXattrsCallback(nil)
+	close(p.blockCh)
 }

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -814,14 +814,24 @@ func TestResyncUsingDCPStreamReset(t *testing.T) {
 
 	_ = rt.WaitForResyncDCPStatus(db.BackgroundProcessStateStopped)
 
+	// Set up a pauser for the reset run so we can observe "running" before it completes.
+	// The reset resync calls WriteUpdateWithXattrs for every user doc (even when unchanged),
+	// so the pauser fires. All docs are on vBucket 0, ensuring only one DCP worker fires the callback.
+	pauser2 := newResyncPauser(rt)
+
 	// reset the resync process through the endpoint
 	response = rt.SendAdminRequest("POST", "/db/_resync?reset=true", "")
 	rest.RequireStatus(t, response, http.StatusOK)
+
+	// Block until the reset resync is genuinely in-flight, then verify running state.
+	pauser2.WaitUntilBlocked()
 
 	// grab new resync status from reset run, assert the resync id is not the same as the first
 	// run and that the docs processed is equal to number of docs we have created
 	resyncManagerStatus := rt.WaitForResyncDCPStatus(db.BackgroundProcessStateRunning)
 	assert.NotEqual(t, resyncID, resyncManagerStatus.ResyncID)
+
+	pauser2.Release()
 
 	resyncManagerStatus = rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
 	if !base.UnitTestUrlIsWalrus() && !base.TestsDisableGSI() {

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -4298,7 +4298,7 @@ func newResyncPauser(rt *rest.RestTester) *resyncPauser {
 			return
 		}
 		close(p.blocked)
-		<-p.blockCh
+		base.RequireChanClosed(p.t, p.blockCh)
 	})
 	return p
 }

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -787,11 +787,13 @@ func TestResyncUsingDCPStreamReset(t *testing.T) {
 	)
 	defer rt.Close()
 
-	const numDocs = 10
-
-	// create some docs
-	for i := range numDocs {
-		rt.CreateTestDoc(fmt.Sprintf("doc%d", i))
+	// All docs on vBucket 0 so a single DCP worker processes them serially. This ensures the
+	// callback in newResyncPauser (which fires for any user doc) cannot be triggered by two
+	// goroutines simultaneously, preventing a double-close panic on p.blocked.
+	docKeys := base.VBucket0DocIDs(t, rt.Bucket(), 5)
+	numDocs := len(docKeys)
+	for _, key := range docKeys {
+		rt.CreateTestDoc(key)
 	}
 
 	rt.TakeDbOffline()
@@ -1443,8 +1445,8 @@ func TestResyncStopUsingDCPStream(t *testing.T) {
 	// The pauser eliminates the race between "DCP finishes all docs → completed" and "stop
 	// command arrives → stopped", so numOfDocs can be kept small for test speed without
 	// risking the process completing before stop is issued.
-	docKeys := base.VBucket0DocIDs(t, rt.Bucket())
-	const numOfDocs = 5
+	docKeys := base.VBucket0DocIDs(t, rt.Bucket(), 5)
+	numOfDocs := len(docKeys)
 	for _, key := range docKeys {
 		rt.CreateTestDoc(key)
 	}
@@ -4273,6 +4275,8 @@ func TestRetrieveMetadataStoreModeInStatus(t *testing.T) {
 
 // resyncPauser blocks the resync DCP stream at the first user document it encounters,
 // letting tests assert resync is genuinely in-flight before issuing stop commands.
+// Tests using this pauser must ensure all docs are on vBucket 0 (via base.VBucket0DocIDs)
+// so only a single DCP worker fires the callback.
 type resyncPauser struct {
 	t       testing.TB
 	blocked chan struct{}

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -4319,7 +4319,13 @@ func (p *resyncPauser) WaitUntilBlocked() {
 }
 
 // Release clears the callback so subsequent documents pass through, then unblocks the paused doc.
+// It asserts that the callback was actually triggered before releasing.
 func (p *resyncPauser) Release() {
+	select {
+	case <-p.blocked:
+	default:
+		require.FailNow(p.t, "resyncPauser.Release called before callback was triggered; call WaitUntilBlocked first")
+	}
 	p.ds.SetWriteUpdateWithXattrsCallback(nil)
 	close(p.blockCh)
 }

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -4295,7 +4295,7 @@ type resyncPauser struct {
 }
 
 func newResyncPauser(rt *rest.RestTester) *resyncPauser {
-	leakyDS, ok := base.AsLeakyDataStore(rt.Bucket().DefaultDataStore(rt.Context()))
+	leakyDS, ok := base.AsLeakyDataStore(rt.GetSingleDataStore())
 	require.True(rt.TB(), ok, "datastore must be a LeakyDataStore")
 	p := &resyncPauser{
 		t:       rt.TB(),

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbase/sync_gateway/rest"
 	"github.com/couchbase/sync_gateway/testing/assert"
+	"github.com/couchbase/sync_gateway/testing/sgtest"
 )
 
 // Reproduces CBG-1412 - JSON strings in some responses not being correctly escaped
@@ -787,9 +788,8 @@ func TestResyncUsingDCPStreamReset(t *testing.T) {
 	)
 	defer rt.Close()
 
-	// All docs on vBucket 0 so a single DCP worker processes them serially. This ensures the
-	// callback in newResyncPauser (which fires for any user doc) cannot be triggered by two
-	// goroutines simultaneously, preventing a double-close panic on p.blocked.
+	// All docs on vBucket 0 so a single DCP worker processes them serially, avoiding a
+	// double-close panic from concurrent callback invocations.
 	docKeys := base.VBucket0DocIDs(t, rt.Bucket(), 5)
 	numDocs := len(docKeys)
 	for _, key := range docKeys {
@@ -800,6 +800,8 @@ func TestResyncUsingDCPStreamReset(t *testing.T) {
 
 	// Pause resync at the first user document so stop arrives while genuinely in-flight.
 	pauser := newResyncPauser(rt)
+	defer pauser.Close()
+	pauser.Pause()
 
 	// start a resync run
 	response := rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
@@ -814,24 +816,22 @@ func TestResyncUsingDCPStreamReset(t *testing.T) {
 
 	_ = rt.WaitForResyncDCPStatus(db.BackgroundProcessStateStopped)
 
-	// Set up a pauser for the reset run so we can observe "running" before it completes.
-	// The reset resync calls WriteUpdateWithXattrs for every user doc (even when unchanged),
-	// so the pauser fires. All docs are on vBucket 0, ensuring only one DCP worker fires the callback.
-	pauser2 := newResyncPauser(rt)
+	// Pause again for the reset run so we can observe "running" before it completes.
+	pauser.Pause()
 
 	// reset the resync process through the endpoint
 	response = rt.SendAdminRequest("POST", "/db/_resync?reset=true", "")
 	rest.RequireStatus(t, response, http.StatusOK)
 
 	// Block until the reset resync is genuinely in-flight, then verify running state.
-	pauser2.WaitUntilBlocked()
+	pauser.WaitUntilBlocked()
 
 	// grab new resync status from reset run, assert the resync id is not the same as the first
 	// run and that the docs processed is equal to number of docs we have created
 	resyncManagerStatus := rt.WaitForResyncDCPStatus(db.BackgroundProcessStateRunning)
 	assert.NotEqual(t, resyncID, resyncManagerStatus.ResyncID)
 
-	pauser2.Release()
+	pauser.Release()
 
 	resyncManagerStatus = rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
 	if !base.UnitTestUrlIsWalrus() && !base.TestsDisableGSI() {
@@ -1469,6 +1469,8 @@ func TestResyncStopUsingDCPStream(t *testing.T) {
 
 	// Pause resync at the first user document so the stop arrives while genuinely in-flight.
 	pauser := newResyncPauser(rt)
+	defer pauser.Close()
+	pauser.Pause()
 
 	response := rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
 	rest.RequireStatus(t, response, http.StatusOK)
@@ -4283,49 +4285,70 @@ func TestRetrieveMetadataStoreModeInStatus(t *testing.T) {
 	assert.Equal(t, base.MetadataStoreModeFallbackInactive, statusResponse.Databases["db"].MetadataStoreMode)
 }
 
-// resyncPauser blocks the resync DCP stream at the first user document it encounters,
-// letting tests assert resync is genuinely in-flight before issuing stop commands.
-// Tests using this pauser must ensure all docs are on vBucket 0 (via base.VBucket0DocIDs)
-// so only a single DCP worker fires the callback.
+// resyncPauser blocks the resync DCP stream at the first user document it encounters. Can be
+// Paused and Released multiple times across a test.
+// Tests using this pauser must ensure all docs are on vBucket 0 (via base.VBucket0DocIDs) so only
+// a single DCP worker fires the callback.
 type resyncPauser struct {
-	t       testing.TB
-	blocked chan struct{}
-	blockCh chan struct{}
-	ds      *base.LeakyDataStore
+	t           testing.TB
+	blocked     chan struct{}
+	blockCh     chan struct{}
+	ds          *base.LeakyDataStore
+	callbackSet atomic.Bool
 }
 
 func newResyncPauser(rt *rest.RestTester) *resyncPauser {
 	leakyDS, ok := base.AsLeakyDataStore(rt.GetSingleDataStore())
 	require.True(rt.TB(), ok, "datastore must be a LeakyDataStore")
-	p := &resyncPauser{
-		t:       rt.TB(),
-		blocked: make(chan struct{}),
-		blockCh: make(chan struct{}),
-		ds:      leakyDS,
+	return &resyncPauser{
+		t:  rt.TB(),
+		ds: leakyDS,
 	}
-	leakyDS.SetWriteUpdateWithXattrsCallback(func(key string) {
+}
+
+// Pause arms the pauser to block resync at the first user document it encounters. Call Release
+// before pausing again.
+func (p *resyncPauser) Pause() {
+	if !p.callbackSet.CompareAndSwap(false, true) {
+		require.FailNow(p.t, "resyncPauser.Pause called while already paused; call Release first")
+	}
+	p.blocked = make(chan struct{})
+	p.blockCh = make(chan struct{})
+	p.ds.SetWriteUpdateWithXattrsCallback(func(key string) {
 		if strings.HasPrefix(key, "_sync:") {
 			return
 		}
 		close(p.blocked)
-		base.RequireChanClosed(p.t, p.blockCh)
+		// Runs on the resync DCP goroutine, so use the goroutine-safe wait.
+		sgtest.RequireChanClosedFromCallback(p.t, p.blockCh)
 	})
-	return p
 }
 
-// WaitUntilBlocked blocks until resync is paused at a user document, proving it is in-flight.
+// WaitUntilBlocked blocks until resync is paused at a user document.
 func (p *resyncPauser) WaitUntilBlocked() {
+	p.t.Helper()
 	base.RequireChanClosed(p.t, p.blocked)
 }
 
-// Release clears the callback so subsequent documents pass through, then unblocks the paused doc.
-// It asserts that the callback was actually triggered before releasing.
+// Release clears the callback and unblocks the paused doc. Fails the test if not currently paused.
 func (p *resyncPauser) Release() {
-	select {
-	case <-p.blocked:
-	default:
-		require.FailNow(p.t, "resyncPauser.Release called before callback was triggered; call WaitUntilBlocked first")
+	if !p.release() {
+		require.FailNow(p.t, "resyncPauser.Release called while not paused")
+	}
+}
+
+// Close releases the pauser and resets the LeakyBucket callback.
+func (p *resyncPauser) Close() {
+	p.release()
+}
+
+// release clears the callback and unblocks the paused doc if currently paused, reporting whether
+// it was paused.
+func (p *resyncPauser) release() bool {
+	if !p.callbackSet.CompareAndSwap(true, false) {
+		return false
 	}
 	p.ds.SetWriteUpdateWithXattrsCallback(nil)
 	close(p.blockCh)
+	return true
 }

--- a/rest/attachmentcompactiontest/attachment_compaction_api_test.go
+++ b/rest/attachmentcompactiontest/attachment_compaction_api_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/couchbase/gocbcore/v10"
@@ -29,7 +30,9 @@ func TestAttachmentCompactionAPI(t *testing.T) {
 	}
 
 	// attachment compaction has to run on default collection, we can't run on multiple scopes right now for SG_TEST_USE_DEFAULT_COLLECTION = false
-	rt := rest.NewRestTesterDefaultCollection(t, nil)
+	rt := rest.NewRestTesterDefaultCollection(t, &rest.RestTesterConfig{
+		LeakyBucketConfig: &base.LeakyBucketConfig{},
+	})
 	defer rt.Close()
 
 	// cleanup attachments left behind
@@ -38,7 +41,8 @@ func TestAttachmentCompactionAPI(t *testing.T) {
 		rest.RequireStatus(t, resp, http.StatusOK)
 		_ = rt.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateCompleted)
 	}()
-	// Perform GET before compact has been ran, ensure it starts in valid 'stopped' state
+
+	// Perform GET before compact has been run — verify initial state.
 	resp := rt.SendAdminRequest("GET", "/{{.db}}/_compact?type=attachment", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
 
@@ -50,21 +54,11 @@ func TestAttachmentCompactionAPI(t *testing.T) {
 	require.Equal(t, int64(0), response.PurgedAttachments)
 	require.Empty(t, response.LastErrorMessage)
 
-	// Kick off compact
-	resp = rt.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment", "")
-	rest.RequireStatus(t, resp, http.StatusOK)
-
-	// Attempt to kick off again and validate it correctly errors
-	resp = rt.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment", "")
-	rest.RequireStatus(t, resp, http.StatusServiceUnavailable)
-
-	rt.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateCompleted)
-
 	dataStore := rt.GetSingleDataStore()
 	collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
 
 	// Create some legacy attachments to be marked but not compacted
-	for i := range 20 {
+	for i := range 3 {
 		docID := fmt.Sprintf("testDoc-%d", i)
 		attID := fmt.Sprintf("testAtt-%d", i)
 		attBody := map[string]any{"value": strconv.Itoa(i)}
@@ -79,15 +73,24 @@ func TestAttachmentCompactionAPI(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	for i := range 5 {
+	for i := range 2 {
 		docID := fmt.Sprintf("%s%s%d", base.AttPrefix, "unmarked", i)
 		makeUnmarkedDoc(docID)
 	}
 
+	// Pause at the first attachment mark so the concurrent-start 503 check arrives while running.
+	pauser := newCompactionPauser(rt)
+
 	// Start attachment compaction run
 	resp = rt.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
+	pauser.WaitUntilBlocked()
 
+	// Attempt to kick off again and validate it correctly errors
+	resp = rt.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment", "")
+	rest.RequireStatus(t, resp, http.StatusServiceUnavailable)
+
+	pauser.Release()
 	rt.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateCompleted)
 
 	// Validate results of GET
@@ -97,19 +100,20 @@ func TestAttachmentCompactionAPI(t *testing.T) {
 	err = base.JSONUnmarshal(resp.BodyBytes(), &response)
 	require.NoError(t, err)
 	require.Equal(t, db.BackgroundProcessStateCompleted, response.State)
-	require.Equal(t, int64(20), response.MarkedAttachments)
-	require.Equal(t, int64(5), response.PurgedAttachments)
+	require.Equal(t, int64(3), response.MarkedAttachments)
+	require.Equal(t, int64(2), response.PurgedAttachments)
 	require.Empty(t, response.LastErrorMessage)
 
-	// Start another run
+	// Start another run and stop it mid-flight.
+	pauser = newCompactionPauser(rt)
 	resp = rt.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
+	pauser.WaitUntilBlocked()
 
-	// Attempt to terminate that run
 	resp = rt.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment&action=stop", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
+	pauser.Release()
 
-	// Wait for run to complete
 	_ = rt.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateStopped)
 }
 
@@ -144,16 +148,24 @@ func TestAttachmentCompactionPersistence(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, rt2AttachmentStatus.State, db.BackgroundProcessStateCompleted)
 
+	// Add a legacy attachment so the mark phase has something to block on.
+	collection, ctx := rt1.GetSingleTestDatabaseCollectionWithUser()
+	rest.CreateLegacyAttachmentDoc(t, ctx, collection, t.Name(), []byte("{}"), "att", []byte("att body"))
+
+	// Pause at the mark phase so stop arrives while genuinely in-flight.
+	pauser := newCompactionPauser(rt1)
+
 	// Start compaction again
 	resp = rt1.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
-	status := rt1.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateRunning)
-	compactID := status.CompactID
+	pauser.WaitUntilBlocked()
+	compactID := rt1.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateRunning).CompactID
 
 	// Abort process early from rt1
 	resp = rt1.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment&action=stop", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
-	status = rt2.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateStopped)
+	pauser.Release()
+	rt2.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateStopped)
 
 	// Ensure aborted status is present on rt2
 	resp = rt2.SendAdminRequest("GET", "/{{.db}}/_compact?type=attachment", "")
@@ -165,7 +177,7 @@ func TestAttachmentCompactionPersistence(t *testing.T) {
 	// Attempt to start again from rt2 --> Should resume based on aborted state (same compactionID)
 	resp = rt2.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
-	status = rt2.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateRunning)
+	status := rt2.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateRunning)
 	assert.Equal(t, compactID, status.CompactID)
 
 	// Wait for compaction to complete
@@ -237,19 +249,28 @@ func TestAttachmentCompactionReset(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
-	rt := rest.NewRestTester(t, nil)
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		LeakyBucketConfig: &base.LeakyBucketConfig{},
+	})
 	defer rt.Close()
+
+	collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
+	rest.CreateLegacyAttachmentDoc(t, ctx, collection, t.Name(), []byte("{}"), "att", []byte("att body"))
+
+	// Pause compaction at the mark of the first attachment so stop arrives while genuinely in-flight.
+	pauser := newCompactionPauser(rt)
 
 	// Start compaction
 	resp := rt.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
-	status := rt.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateRunning)
-	compactID := status.CompactID
+	pauser.WaitUntilBlocked()
+	compactID := rt.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateRunning).CompactID
 
 	// Stop compaction before complete -- enters aborted state
 	resp = rt.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment&action=stop", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
-	status = rt.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateStopped)
+	pauser.Release()
+	rt.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateStopped)
 
 	// Ensure status is aborted
 	resp = rt.SendAdminRequest("GET", "/{{.db}}/_compact?type=attachment", "")
@@ -262,7 +283,7 @@ func TestAttachmentCompactionReset(t *testing.T) {
 	// Start compaction again but with reset=true --> meaning it shouldn't try to resume
 	resp = rt.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment&reset=true", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
-	status = rt.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateRunning)
+	status := rt.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateRunning)
 	assert.NotEqual(t, compactID, status.CompactID)
 
 	// Wait for completion and verify the completed run also carries a different compactID
@@ -359,24 +380,23 @@ func TestAttachmentCompactionAbort(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
-	rt := rest.NewRestTester(t, nil)
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		LeakyBucketConfig: &base.LeakyBucketConfig{},
+	})
 	defer rt.Close()
 
 	collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
-	for i := range 1000 {
-		docID := fmt.Sprintf("testDoc-%d", i)
-		attID := fmt.Sprintf("testAtt-%d", i)
-		attBody := map[string]any{"value": strconv.Itoa(i)}
-		attJSONBody, err := base.JSONMarshal(attBody)
-		require.NoError(t, err)
-		rest.CreateLegacyAttachmentDoc(t, ctx, collection, docID, []byte("{}"), attID, attJSONBody)
-	}
+	rest.CreateLegacyAttachmentDoc(t, ctx, collection, t.Name(), []byte("{}"), "att", []byte("att body"))
+
+	pauser := newCompactionPauser(rt)
 
 	resp := rt.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
+	pauser.WaitUntilBlocked()
 
 	resp = rt.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment&action=stop", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
+	pauser.Release()
 
 	status := rt.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateStopped)
 	assert.Equal(t, int64(0), status.PurgedAttachments)
@@ -441,4 +461,44 @@ func TestAttachmentCompactionMarkPhaseRollback(t *testing.T) {
 	require.Equal(t, int64(0), response.MarkedAttachments)
 	require.Equal(t, int64(1000), response.PurgedAttachments)
 
+}
+
+// compactionPauser blocks the attachment compaction mark phase at the first attachment it encounters,
+// letting tests assert compaction is genuinely in-flight before issuing stop or reset commands.
+type compactionPauser struct {
+	t       testing.TB
+	blocked chan struct{}
+	blockCh chan struct{}
+	ds      *base.LeakyDataStore
+}
+
+func newCompactionPauser(rt *rest.RestTester) *compactionPauser {
+	leakyDS, ok := base.AsLeakyDataStore(rt.Bucket().DefaultDataStore(rt.Context()))
+	require.True(rt.TB(), ok, "datastore must be a LeakyDataStore")
+	p := &compactionPauser{
+		t:       rt.TB(),
+		blocked: make(chan struct{}),
+		blockCh: make(chan struct{}),
+		ds:      leakyDS,
+	}
+	leakyDS.SetXattrCallback(func(key string) error {
+		if !strings.HasPrefix(key, base.AttPrefix) {
+			return nil
+		}
+		close(p.blocked)
+		<-p.blockCh
+		return nil
+	})
+	return p
+}
+
+// WaitUntilBlocked blocks until compaction is paused at an attachment doc, proving it is in-flight.
+func (p *compactionPauser) WaitUntilBlocked() {
+	base.RequireChanClosed(p.t, p.blocked)
+}
+
+// Release clears the callback so subsequent docs pass through, then unblocks the paused doc.
+func (p *compactionPauser) Release() {
+	p.ds.SetXattrCallback(nil)
+	close(p.blockCh)
 }

--- a/rest/attachmentcompactiontest/attachment_compaction_api_test.go
+++ b/rest/attachmentcompactiontest/attachment_compaction_api_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -21,6 +22,7 @@ import (
 	"github.com/couchbase/sync_gateway/rest"
 	"github.com/couchbase/sync_gateway/testing/assert"
 	"github.com/couchbase/sync_gateway/testing/require"
+	"github.com/couchbase/sync_gateway/testing/sgtest"
 )
 
 func TestAttachmentCompactionAPI(t *testing.T) {
@@ -57,15 +59,14 @@ func TestAttachmentCompactionAPI(t *testing.T) {
 	dataStore := rt.GetSingleDataStore()
 	collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
 
-	// Create some legacy attachments to be marked but not compacted.
-	// Bodies are chosen so their _sync:att:sha1-<digest> keys all land on vBucket 0, ensuring
-	// the mark phase processes them serially on a single DCP worker (CBS). This prevents
-	// concurrent SetXattr calls from different workers from racing to close the pauser channel.
+	// Create some legacy attachments to be marked but not compacted. Both doc keys and attachment
+	// bodies land on vBucket 0 so the mark phase stays serial on a single DCP worker — otherwise
+	// concurrent SetXattrs calls race to close the pauser channel.
+	docIDs := base.VBucket0DocIDs(t, rt.Bucket(), 3)
 	attBodies := base.VBucket0AttachmentBodies(t, rt.Bucket(), 3)
 	for i, attBody := range attBodies {
-		docID := fmt.Sprintf("testDoc-%d", i)
 		attID := fmt.Sprintf("testAtt-%d", i)
-		rest.CreateLegacyAttachmentDoc(t, ctx, collection, docID, []byte("{}"), attID, attBody)
+		rest.CreateLegacyAttachmentDoc(t, ctx, collection, docIDs[i], []byte("{}"), attID, attBody)
 	}
 
 	// Create some 'unmarked' attachments
@@ -81,6 +82,8 @@ func TestAttachmentCompactionAPI(t *testing.T) {
 
 	// Pause at the first attachment mark so the concurrent-start 503 check arrives while running.
 	pauser := newCompactionPauser(rt)
+	defer pauser.Close()
+	pauser.Pause()
 
 	// Start attachment compaction run
 	resp = rt.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment", "")
@@ -106,7 +109,7 @@ func TestAttachmentCompactionAPI(t *testing.T) {
 	require.Empty(t, response.LastErrorMessage)
 
 	// Start another run and stop it mid-flight.
-	pauser = newCompactionPauser(rt)
+	pauser.Pause()
 	resp = rt.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
 	pauser.WaitUntilBlocked()
@@ -156,6 +159,8 @@ func TestAttachmentCompactionPersistence(t *testing.T) {
 
 	// Pause at the mark phase so stop arrives while genuinely in-flight.
 	pauser := newCompactionPauser(rt1)
+	defer pauser.Close()
+	pauser.Pause()
 
 	// Start compaction again
 	resp = rt1.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment", "")
@@ -262,6 +267,8 @@ func TestAttachmentCompactionReset(t *testing.T) {
 
 	// Pause compaction at the mark of the first attachment so stop arrives while genuinely in-flight.
 	pauser := newCompactionPauser(rt)
+	defer pauser.Close()
+	pauser.Pause()
 
 	// Start compaction
 	resp := rt.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment", "")
@@ -397,6 +404,8 @@ func TestAttachmentCompactionAbort(t *testing.T) {
 	rest.CreateLegacyAttachmentDoc(t, ctx, collection, t.Name(), []byte("{}"), "att", []byte("att body"))
 
 	pauser := newCompactionPauser(rt)
+	defer pauser.Close()
+	pauser.Pause()
 
 	resp := rt.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
@@ -471,45 +480,73 @@ func TestAttachmentCompactionMarkPhaseRollback(t *testing.T) {
 
 }
 
-// compactionPauser blocks the attachment compaction mark phase at the first attachment it encounters,
-// letting tests assert compaction is genuinely in-flight before issuing stop or reset commands.
-// Tests using this pauser must ensure all legacy attachment bodies are chosen via
-// base.VBucket0AttachmentBodies so their _sync:att: keys land on vBucket 0, keeping the mark
-// phase serial on a single DCP worker.
+// compactionPauser blocks the compaction mark phase at the first attachment it encounters. Can be
+// Paused and Released multiple times across a test.
+// With more than one legacy attachment doc, both the parent doc keys (base.VBucket0DocIDs) and the
+// attachment bodies (base.VBucket0AttachmentBodies) must land on vBucket 0: the mark phase's
+// SetXattrs calls run on whichever goroutine processes the parent doc's mutation, not one keyed
+// off the attachment's own vBucket, so constraining only the bodies still allows concurrent calls.
 type compactionPauser struct {
-	t       testing.TB
-	blocked chan struct{}
-	blockCh chan struct{}
-	ds      *base.LeakyDataStore
+	t           testing.TB
+	blocked     chan struct{}
+	blockCh     chan struct{}
+	ds          *base.LeakyDataStore
+	callbackSet atomic.Bool
 }
 
 func newCompactionPauser(rt *rest.RestTester) *compactionPauser {
 	leakyDS, ok := base.AsLeakyDataStore(rt.Bucket().DefaultDataStore(rt.Context()))
 	require.True(rt.TB(), ok, "datastore must be a LeakyDataStore")
-	p := &compactionPauser{
-		t:       rt.TB(),
-		blocked: make(chan struct{}),
-		blockCh: make(chan struct{}),
-		ds:      leakyDS,
+	return &compactionPauser{
+		t:  rt.TB(),
+		ds: leakyDS,
 	}
-	leakyDS.SetXattrCallback(func(key string) error {
+}
+
+// Pause arms the pauser to block the mark phase at the first attachment it encounters. Call
+// Release before pausing again.
+func (p *compactionPauser) Pause() {
+	if !p.callbackSet.CompareAndSwap(false, true) {
+		require.FailNow(p.t, "compactionPauser.Pause called while already paused; call Release first")
+	}
+	p.blocked = make(chan struct{})
+	p.blockCh = make(chan struct{})
+	p.ds.SetXattrCallback(func(key string) error {
 		if !strings.HasPrefix(key, base.AttPrefix) {
 			return nil
 		}
 		close(p.blocked)
-		base.RequireChanClosed(p.t, p.blockCh)
+		// Runs on the mark phase's goroutine, so use the goroutine-safe wait.
+		sgtest.RequireChanClosedFromCallback(p.t, p.blockCh)
 		return nil
 	})
-	return p
 }
 
-// WaitUntilBlocked blocks until compaction is paused at an attachment doc, proving it is in-flight.
+// WaitUntilBlocked blocks until compaction is paused at an attachment doc.
 func (p *compactionPauser) WaitUntilBlocked() {
+	p.t.Helper()
 	base.RequireChanClosed(p.t, p.blocked)
 }
 
-// Release clears the callback so subsequent docs pass through, then unblocks the paused doc.
+// Release clears the callback and unblocks the paused doc. Fails the test if not currently paused.
 func (p *compactionPauser) Release() {
+	if !p.release() {
+		require.FailNow(p.t, "compactionPauser.Release called while not paused")
+	}
+}
+
+// Close releases the pauser and resets the LeakyBucket callback.
+func (p *compactionPauser) Close() {
+	p.release()
+}
+
+// release clears the callback and unblocks the paused doc if currently paused, reporting whether
+// it was paused.
+func (p *compactionPauser) release() bool {
+	if !p.callbackSet.CompareAndSwap(true, false) {
+		return false
+	}
 	p.ds.SetXattrCallback(nil)
 	close(p.blockCh)
+	return true
 }

--- a/rest/attachmentcompactiontest/attachment_compaction_api_test.go
+++ b/rest/attachmentcompactiontest/attachment_compaction_api_test.go
@@ -497,7 +497,7 @@ func newCompactionPauser(rt *rest.RestTester) *compactionPauser {
 			return nil
 		}
 		close(p.blocked)
-		<-p.blockCh
+		base.RequireChanClosed(p.t, p.blockCh)
 		return nil
 	})
 	return p

--- a/rest/attachmentcompactiontest/attachment_compaction_api_test.go
+++ b/rest/attachmentcompactiontest/attachment_compaction_api_test.go
@@ -11,9 +11,9 @@ package attachmentcompactiontest
 import (
 	"fmt"
 	"net/http"
-	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/couchbase/gocbcore/v10"
 	"github.com/couchbase/sync_gateway/base"
@@ -57,14 +57,15 @@ func TestAttachmentCompactionAPI(t *testing.T) {
 	dataStore := rt.GetSingleDataStore()
 	collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
 
-	// Create some legacy attachments to be marked but not compacted
-	for i := range 3 {
+	// Create some legacy attachments to be marked but not compacted.
+	// Bodies are chosen so their _sync:att:sha1-<digest> keys all land on vBucket 0, ensuring
+	// the mark phase processes them serially on a single DCP worker (CBS). This prevents
+	// concurrent SetXattr calls from different workers from racing to close the pauser channel.
+	attBodies := base.VBucket0AttachmentBodies(t, rt.Bucket(), 3)
+	for i, attBody := range attBodies {
 		docID := fmt.Sprintf("testDoc-%d", i)
 		attID := fmt.Sprintf("testAtt-%d", i)
-		attBody := map[string]any{"value": strconv.Itoa(i)}
-		attJSONBody, err := base.JSONMarshal(attBody)
-		require.NoError(t, err)
-		rest.CreateLegacyAttachmentDoc(t, ctx, collection, docID, []byte("{}"), attID, attJSONBody)
+		rest.CreateLegacyAttachmentDoc(t, ctx, collection, docID, []byte("{}"), attID, attBody)
 	}
 
 	// Create some 'unmarked' attachments
@@ -125,10 +126,11 @@ func TestAttachmentCompactionPersistence(t *testing.T) {
 	tb := base.GetTestBucket(t)
 	noCloseTB := tb.NoCloseClone()
 
-	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
+	// Attachment Compaction only runs on _default._default
+	rt1 := rest.NewRestTesterDefaultCollection(t, &rest.RestTesterConfig{
 		CustomTestBucket: noCloseTB,
 	})
-	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
+	rt2 := rest.NewRestTesterDefaultCollection(t, &rest.RestTesterConfig{
 		CustomTestBucket: tb,
 	})
 	defer rt2.Close()
@@ -249,7 +251,8 @@ func TestAttachmentCompactionReset(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
-	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+	// Attachment Compaction only runs on _default._default
+	rt := rest.NewRestTesterDefaultCollection(t, &rest.RestTesterConfig{
 		LeakyBucketConfig: &base.LeakyBucketConfig{},
 	})
 	defer rt.Close()
@@ -343,7 +346,7 @@ func TestAttachmentCompactionStartTimeAndStats(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
-	rt := rest.NewRestTester(t, nil)
+	rt := rest.NewRestTesterDefaultCollection(t, nil)
 	defer rt.Close()
 
 	// Create attachment with no doc reference
@@ -364,6 +367,10 @@ func TestAttachmentCompactionStartTimeAndStats(t *testing.T) {
 	assert.NotEqual(t, 0, firstStartTimeStat)
 	assert.Equal(t, int64(1), databaseStats.NumAttachmentsCompacted.Value())
 
+	// CompactionAttachmentStartTime has second granularity; sleep to ensure the second run starts
+	// in a different second so the stat value strictly increases.
+	time.Sleep(time.Second)
+
 	// Start compaction again
 	resp = rt.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
@@ -380,7 +387,8 @@ func TestAttachmentCompactionAbort(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
-	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+	// Attachment Compaction only runs on _default._default
+	rt := rest.NewRestTesterDefaultCollection(t, &rest.RestTesterConfig{
 		LeakyBucketConfig: &base.LeakyBucketConfig{},
 	})
 	defer rt.Close()
@@ -465,6 +473,9 @@ func TestAttachmentCompactionMarkPhaseRollback(t *testing.T) {
 
 // compactionPauser blocks the attachment compaction mark phase at the first attachment it encounters,
 // letting tests assert compaction is genuinely in-flight before issuing stop or reset commands.
+// Tests using this pauser must ensure all legacy attachment bodies are chosen via
+// base.VBucket0AttachmentBodies so their _sync:att: keys land on vBucket 0, keeping the mark
+// phase serial on a single DCP worker.
 type compactionPauser struct {
 	t       testing.TB
 	blocked chan struct{}

--- a/rest/attachmentcompactiontest/attachment_compaction_api_test.go
+++ b/rest/attachmentcompactiontest/attachment_compaction_api_test.go
@@ -37,6 +37,9 @@ func TestAttachmentCompactionAPI(t *testing.T) {
 	})
 	defer rt.Close()
 
+	// Avoid racing the automatic startup migration against the mark phase below.
+	_ = rt.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateCompleted)
+
 	// cleanup attachments left behind
 	defer func() {
 		resp := rt.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment&reset=true", "")
@@ -310,6 +313,9 @@ func TestAttachmentCompactionInvalidDocs(t *testing.T) {
 	// attachment compaction has to run on default collection, we can't run on multiple scopes right now for SG_TEST_USE_DEFAULT_COLLECTION = false
 	rt := rest.NewRestTesterDefaultCollection(t, nil)
 	defer rt.Close()
+
+	// Avoid racing the automatic startup migration against the mark phase below.
+	_ = rt.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateCompleted)
 
 	dataStore := rt.GetSingleDataStore()
 	// Create a raw binary doc

--- a/rest/attachmentmigrationtest/attachment_migration_api_test.go
+++ b/rest/attachmentmigrationtest/attachment_migration_api_test.go
@@ -82,6 +82,7 @@ func TestAttachmentMigrationAbort(t *testing.T) {
 		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
 			AutoImport: false, // turn off import feed to stop the feed migrating attachments
 		}},
+		LeakyBucketConfig: &base.LeakyBucketConfig{},
 	})
 	defer rt.Close()
 	collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
@@ -89,30 +90,25 @@ func TestAttachmentMigrationAbort(t *testing.T) {
 	// Wait for run on startup to complete
 	_ = rt.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateCompleted)
 
-	numDocs := 20
-	if base.UnitTestUrlIsWalrus() {
-		numDocs *= 10
-	}
-	// add some docs to arrive over dcp
-	for i := range numDocs {
-		key := fmt.Sprintf("%s_%d", t.Name(), i)
-		docBody := db.Body{
-			"value": 1234,
-		}
-		_, _, err := collection.Put(ctx, key, docBody)
-		require.NoError(t, err)
-	}
+	// Create one doc with legacy attachment metadata — enough for migration to block on.
+	docID := t.Name()
+	rest.CreateLegacyAttachmentDoc(t, ctx, collection, docID, []byte(`{"value":1234}`), "att", []byte("att body"))
+
+	// Pause migration mid-document so stop arrives while it is genuinely in-flight.
+	pauser := newMigrationPauser(rt, docID)
 
 	// start migration
 	resp := rt.SendAdminRequest("POST", "/{{.db}}/_attachment_migration", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
+	pauser.WaitUntilBlocked()
 
 	// stop the migration job
 	resp = rt.SendAdminRequest("POST", "/{{.db}}/_attachment_migration?action=stop", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
+	pauser.Release()
 
 	status := rt.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateStopped)
-	assert.Equal(t, int64(0), status.DocsChanged)
+	assert.Equal(t, int64(1), status.DocsChanged)
 }
 
 func TestAttachmentMigrationReset(t *testing.T) {
@@ -120,6 +116,7 @@ func TestAttachmentMigrationReset(t *testing.T) {
 		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
 			AutoImport: false, // turn off import feed to stop the feed migrating attachments
 		}},
+		LeakyBucketConfig: &base.LeakyBucketConfig{},
 	})
 	defer rt.Close()
 	collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
@@ -130,16 +127,21 @@ func TestAttachmentMigrationReset(t *testing.T) {
 	// add some docs for migration
 	numDocs := addDocsForMigrationProcess(t, ctx, collection)
 
+	// Pause migration at the first legacy doc so stop arrives while it is genuinely in-flight.
+	docID := fmt.Sprintf("%s_0", t.Name())
+	pauser := newMigrationPauser(rt, docID)
+
 	// start migration
 	resp := rt.SendAdminRequest("POST", "/{{.db}}/_attachment_migration", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
-	status := rt.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateRunning)
-	migrationID := status.MigrationID
+	pauser.WaitUntilBlocked()
+	migrationID := rt.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateRunning).MigrationID
 
 	// Stop migration
 	resp = rt.SendAdminRequest("POST", "/{{.db}}/_attachment_migration?action=stop", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
-	status = rt.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateStopped)
+	pauser.Release()
+	rt.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateStopped)
 
 	// make sure status is stopped
 	resp = rt.SendAdminRequest("GET", "/{{.db}}/_attachment_migration", "")
@@ -152,7 +154,7 @@ func TestAttachmentMigrationReset(t *testing.T) {
 	// reset migration run
 	resp = rt.SendAdminRequest("POST", "/{{.db}}/_attachment_migration?reset=true", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
-	status = rt.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateRunning)
+	status := rt.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateRunning)
 	assert.NotEqual(t, migrationID, status.MigrationID)
 
 	// wait to complete
@@ -165,11 +167,16 @@ func TestAttachmentMigrationMultiNode(t *testing.T) {
 	tb := base.GetTestBucket(t)
 	noCloseTB := tb.NoCloseClone()
 
+	dbCfg := &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+		AutoImport: false, // turn off import feed to stop the feed migrating attachments
+	}}
 	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
 		CustomTestBucket: noCloseTB,
+		DatabaseConfig:   dbCfg,
 	})
 	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
 		CustomTestBucket: tb,
+		DatabaseConfig:   dbCfg,
 	})
 	defer rt2.Close()
 	defer rt1.Close()
@@ -182,9 +189,15 @@ func TestAttachmentMigrationMultiNode(t *testing.T) {
 	// add some docs for migration
 	addDocsForMigrationProcess(t, ctx, collection)
 
+	// Pause migration at the first legacy doc so stop arrives while it is genuinely in-flight.
+	// noCloseTB is already a LeakyBucket so its datastore satisfies the LeakyDataStore check.
+	docID := fmt.Sprintf("%s_0", t.Name())
+	pauser := newMigrationPauser(rt1, docID)
+
 	// kick off migration on node 1
 	resp := rt1.SendAdminRequest("POST", "/{{.db}}/_attachment_migration", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
+	pauser.WaitUntilBlocked()
 	status := rt1.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateRunning)
 	migrationID := status.MigrationID
 
@@ -196,6 +209,7 @@ func TestAttachmentMigrationMultiNode(t *testing.T) {
 	// stop migration
 	resp = rt1.SendAdminRequest("POST", "/{{.db}}/_attachment_migration?action=stop", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
+	pauser.Release()
 	_ = rt1.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateStopped)
 
 	// assert that node 2 also has stopped status
@@ -264,4 +278,43 @@ func addDocsForMigrationProcess(t *testing.T, ctx context.Context, collection *d
 		db.MoveAttachmentXattrFromGlobalToSync(t, collection.GetCollectionDatastore(), key, value, true)
 	}
 	return numDocs
+}
+
+// migrationPauser blocks the attachment migration at a specific document, letting tests
+// assert migration is genuinely in-flight before issuing stop or reset commands.
+type migrationPauser struct {
+	t       testing.TB
+	blocked chan struct{}
+	blockCh chan struct{}
+	ds      *base.LeakyDataStore
+}
+
+func newMigrationPauser(rt *rest.RestTester, docID string) *migrationPauser {
+	leakyDS, ok := base.AsLeakyDataStore(rt.Bucket().DefaultDataStore(rt.Context()))
+	require.True(rt.TB(), ok, "datastore must be a LeakyDataStore")
+	p := &migrationPauser{
+		t:       rt.TB(),
+		blocked: make(chan struct{}),
+		blockCh: make(chan struct{}),
+		ds:      leakyDS,
+	}
+	leakyDS.SetUpdateXattrsCallback(func(key string) {
+		if key != docID {
+			return
+		}
+		close(p.blocked)
+		<-p.blockCh
+	})
+	return p
+}
+
+// WaitUntilBlocked blocks until migration is paused at docID, proving it is in-flight.
+func (p *migrationPauser) WaitUntilBlocked() {
+	base.RequireChanClosed(p.t, p.blocked)
+}
+
+// Release clears the callback so subsequent docs pass through, then unblocks the paused doc.
+func (p *migrationPauser) Release() {
+	p.ds.SetUpdateXattrsCallback(nil)
+	close(p.blockCh)
 }

--- a/rest/attachmentmigrationtest/attachment_migration_api_test.go
+++ b/rest/attachmentmigrationtest/attachment_migration_api_test.go
@@ -51,7 +51,7 @@ func TestAttachmentMigrationAPI(t *testing.T) {
 	_ = rt.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateCompleted)
 
 	// add some docs for migration
-	numDocs := addDocsForMigrationProcess(t, ctx, collection)
+	numDocs, _ := addDocsForMigrationProcess(t, ctx, collection, rt.Bucket())
 
 	// kick off migration
 	resp = rt.SendAdminRequest("POST", "/{{.db}}/_attachment_migration", "")
@@ -129,10 +129,10 @@ func TestAttachmentMigrationReset(t *testing.T) {
 	_ = rt.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateCompleted)
 
 	// add some docs for migration
-	numDocs := addDocsForMigrationProcess(t, ctx, collection)
+	numDocs, legacyKeys := addDocsForMigrationProcess(t, ctx, collection, rt.Bucket())
 
 	// Pause migration at the first legacy doc so stop arrives while it is genuinely in-flight.
-	docID := fmt.Sprintf("%s_0", t.Name())
+	docID := legacyKeys[0]
 	pauser := newMigrationPauser(rt)
 	defer pauser.Close()
 	pauser.Pause(docID)
@@ -157,10 +157,13 @@ func TestAttachmentMigrationReset(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, db.BackgroundProcessStateStopped, migrationStatus.State)
 
-	// Pause the reset run at the next legacy doc — docID above was already migrated, so it
-	// won't trigger the callback again.
-	docID2 := fmt.Sprintf("%s_1", t.Name())
-	pauser.Pause(docID2)
+	// On a real cluster, stopping isn't instant, so any number of legacyKeys may already be
+	// migrated by now. Use a fresh doc instead of guessing which legacyKey is still unmigrated.
+	resetDocID := base.VBucket0DocIDs(t, rt.Bucket(), 6)[5]
+	rest.CreateLegacyAttachmentDoc(t, ctx, collection, resetDocID, []byte(`{"value":1234}`), "att", []byte("att body"))
+	numDocs++
+
+	pauser.Pause(resetDocID)
 
 	// reset migration run
 	resp = rt.SendAdminRequest("POST", "/{{.db}}/_attachment_migration?reset=true", "")
@@ -173,7 +176,7 @@ func TestAttachmentMigrationReset(t *testing.T) {
 	// wait to complete
 	status = rt.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateCompleted)
 	// assert all docs are processed again
-	assert.Equal(t, numDocs, status.DocsProcessed)
+	assert.GreaterOrEqual(t, status.DocsProcessed, numDocs)
 }
 
 func TestAttachmentMigrationMultiNode(t *testing.T) {
@@ -252,17 +255,27 @@ func TestAttachmentMigrationMultiNode(t *testing.T) {
 	_ = rt2.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateCompleted)
 }
 
-func addDocsForMigrationProcess(t *testing.T, ctx context.Context, collection *db.DatabaseCollectionWithUser) int64 {
+// addDocsForMigrationProcess creates numDocs docs and converts the first half to the legacy
+// attachment format needing migration. Returns the doc count and the legacy docs' keys.
+func addDocsForMigrationProcess(t *testing.T, ctx context.Context, collection *db.DatabaseCollectionWithUser, bucket base.Bucket) (int64, []string) {
 	numDocs := int64(10)
-	if base.UnitTestUrlIsWalrus() {
-		numDocs *= 20
+	legacyCount := numDocs / 2
+
+	keys := make([]string, numDocs)
+	for i := range keys {
+		keys[i] = fmt.Sprintf("%s_%d", t.Name(), i)
 	}
-	for i := range numDocs {
+	// Put the legacy docs on vBucket 0 so a single DCP worker processes them serially — required
+	// by tests that pause migration on one legacy doc and expect the rest to stay unmigrated
+	// until released; otherwise other DCP workers could migrate them concurrently.
+	copy(keys, base.VBucket0DocIDs(t, bucket, int(legacyCount)))
+	legacyKeys := keys[:legacyCount]
+
+	for _, key := range keys {
 		docBody := db.Body{
 			"value":            1234,
 			db.BodyAttachments: map[string]any{"myatt": map[string]any{"content_type": "text/plain", "data": "SGVsbG8gV29ybGQh"}},
 		}
-		key := fmt.Sprintf("%s_%d", t.Name(), i)
 		_, doc, err := collection.Put(ctx, key, docBody)
 		require.NoError(t, err)
 		require.Equal(t, db.AttachmentsMeta{
@@ -288,15 +301,14 @@ func addDocsForMigrationProcess(t *testing.T, ctx context.Context, collection *d
 		require.Empty(t, db.GetRawSyncXattr(t, collection.GetCollectionDatastore(), key).AttachmentsPre4dot0)
 	}
 
-	// Move some subset of the documents attachment metadata from global sync to sync data
-	for j := range numDocs / 2 {
-		key := fmt.Sprintf("%s_%d", t.Name(), j)
+	// Move the legacy subset's attachment metadata from global sync to sync data
+	for _, key := range legacyKeys {
 		value, _, err := collection.GetCollectionDatastore().GetRaw(ctx, key)
 		require.NoError(t, err)
 
 		db.MoveAttachmentXattrFromGlobalToSync(t, collection.GetCollectionDatastore(), key, value, true)
 	}
-	return numDocs
+	return numDocs, legacyKeys
 }
 
 // migrationPauser blocks attachment migration at a specific document. Can be Paused and

--- a/rest/attachmentmigrationtest/attachment_migration_api_test.go
+++ b/rest/attachmentmigrationtest/attachment_migration_api_test.go
@@ -294,7 +294,7 @@ type migrationPauser struct {
 }
 
 func newMigrationPauser(rt *rest.RestTester, docID string) *migrationPauser {
-	leakyDS, ok := base.AsLeakyDataStore(rt.Bucket().DefaultDataStore(rt.Context()))
+	leakyDS, ok := base.AsLeakyDataStore(rt.GetSingleDataStore())
 	require.True(rt.TB(), ok, "datastore must be a LeakyDataStore")
 	p := &migrationPauser{
 		t:       rt.TB(),

--- a/rest/attachmentmigrationtest/attachment_migration_api_test.go
+++ b/rest/attachmentmigrationtest/attachment_migration_api_test.go
@@ -307,7 +307,7 @@ func newMigrationPauser(rt *rest.RestTester, docID string) *migrationPauser {
 			return
 		}
 		close(p.blocked)
-		<-p.blockCh
+		base.RequireChanClosed(p.t, p.blockCh)
 	})
 	return p
 }

--- a/rest/attachmentmigrationtest/attachment_migration_api_test.go
+++ b/rest/attachmentmigrationtest/attachment_migration_api_test.go
@@ -186,13 +186,17 @@ func TestAttachmentMigrationMultiNode(t *testing.T) {
 	_ = rt1.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateCompleted)
 	_ = rt2.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateCompleted)
 
-	// add some docs for migration
-	addDocsForMigrationProcess(t, ctx, collection)
+	// Create legacy attachment docs all on vBucket 0. This ensures the DCP worker for vBucket 0
+	// processes them sequentially: blocking the first doc keeps the rest queued, so doneChan
+	// cannot close before the terminator fires and the select can reliably pick "stopped".
+	vb0IDs := base.VBucket0DocIDs(t, rt1.Bucket(), 5)
+	for _, id := range vb0IDs {
+		rest.CreateLegacyAttachmentDoc(t, ctx, collection, id, []byte(`{}`), "att", []byte("att body"))
+	}
 
-	// Pause migration at the first legacy doc so stop arrives while it is genuinely in-flight.
+	// Pause migration at the first vBucket 0 doc so stop arrives while it is genuinely in-flight.
 	// noCloseTB is already a LeakyBucket so its datastore satisfies the LeakyDataStore check.
-	docID := fmt.Sprintf("%s_0", t.Name())
-	pauser := newMigrationPauser(rt1, docID)
+	pauser := newMigrationPauser(rt1, vb0IDs[0])
 
 	// kick off migration on node 1
 	resp := rt1.SendAdminRequest("POST", "/{{.db}}/_attachment_migration", "")

--- a/rest/attachmentmigrationtest/attachment_migration_api_test.go
+++ b/rest/attachmentmigrationtest/attachment_migration_api_test.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sync/atomic"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -21,6 +22,7 @@ import (
 	"github.com/couchbase/sync_gateway/rest"
 	"github.com/couchbase/sync_gateway/testing/assert"
 	"github.com/couchbase/sync_gateway/testing/require"
+	"github.com/couchbase/sync_gateway/testing/sgtest"
 )
 
 func TestAttachmentMigrationAPI(t *testing.T) {
@@ -95,7 +97,9 @@ func TestAttachmentMigrationAbort(t *testing.T) {
 	rest.CreateLegacyAttachmentDoc(t, ctx, collection, docID, []byte(`{"value":1234}`), "att", []byte("att body"))
 
 	// Pause migration mid-document so stop arrives while it is genuinely in-flight.
-	pauser := newMigrationPauser(rt, docID)
+	pauser := newMigrationPauser(rt)
+	defer pauser.Close()
+	pauser.Pause(docID)
 
 	// start migration
 	resp := rt.SendAdminRequest("POST", "/{{.db}}/_attachment_migration", "")
@@ -129,7 +133,9 @@ func TestAttachmentMigrationReset(t *testing.T) {
 
 	// Pause migration at the first legacy doc so stop arrives while it is genuinely in-flight.
 	docID := fmt.Sprintf("%s_0", t.Name())
-	pauser := newMigrationPauser(rt, docID)
+	pauser := newMigrationPauser(rt)
+	defer pauser.Close()
+	pauser.Pause(docID)
 
 	// start migration
 	resp := rt.SendAdminRequest("POST", "/{{.db}}/_attachment_migration", "")
@@ -151,11 +157,18 @@ func TestAttachmentMigrationReset(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, db.BackgroundProcessStateStopped, migrationStatus.State)
 
+	// Pause the reset run at the next legacy doc — docID above was already migrated, so it
+	// won't trigger the callback again.
+	docID2 := fmt.Sprintf("%s_1", t.Name())
+	pauser.Pause(docID2)
+
 	// reset migration run
 	resp = rt.SendAdminRequest("POST", "/{{.db}}/_attachment_migration?reset=true", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
+	pauser.WaitUntilBlocked()
 	status := rt.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateRunning)
 	assert.NotEqual(t, migrationID, status.MigrationID)
+	pauser.Release()
 
 	// wait to complete
 	status = rt.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateCompleted)
@@ -196,7 +209,9 @@ func TestAttachmentMigrationMultiNode(t *testing.T) {
 
 	// Pause migration at the first vBucket 0 doc so stop arrives while it is genuinely in-flight.
 	// noCloseTB is already a LeakyBucket so its datastore satisfies the LeakyDataStore check.
-	pauser := newMigrationPauser(rt1, vb0IDs[0])
+	pauser := newMigrationPauser(rt1)
+	defer pauser.Close()
+	pauser.Pause(vb0IDs[0])
 
 	// kick off migration on node 1
 	resp := rt1.SendAdminRequest("POST", "/{{.db}}/_attachment_migration", "")
@@ -284,41 +299,67 @@ func addDocsForMigrationProcess(t *testing.T, ctx context.Context, collection *d
 	return numDocs
 }
 
-// migrationPauser blocks the attachment migration at a specific document, letting tests
-// assert migration is genuinely in-flight before issuing stop or reset commands.
+// migrationPauser blocks attachment migration at a specific document. Can be Paused and
+// Released multiple times across a test.
 type migrationPauser struct {
-	t       testing.TB
-	blocked chan struct{}
-	blockCh chan struct{}
-	ds      *base.LeakyDataStore
+	t           testing.TB
+	blocked     chan struct{}
+	blockCh     chan struct{}
+	ds          *base.LeakyDataStore
+	callbackSet atomic.Bool
 }
 
-func newMigrationPauser(rt *rest.RestTester, docID string) *migrationPauser {
+func newMigrationPauser(rt *rest.RestTester) *migrationPauser {
 	leakyDS, ok := base.AsLeakyDataStore(rt.GetSingleDataStore())
 	require.True(rt.TB(), ok, "datastore must be a LeakyDataStore")
-	p := &migrationPauser{
-		t:       rt.TB(),
-		blocked: make(chan struct{}),
-		blockCh: make(chan struct{}),
-		ds:      leakyDS,
+	return &migrationPauser{
+		t:  rt.TB(),
+		ds: leakyDS,
 	}
-	leakyDS.SetUpdateXattrsCallback(func(key string) {
+}
+
+// Pause arms the pauser to block migration at docID. Call Release before pausing again.
+func (p *migrationPauser) Pause(docID string) {
+	if !p.callbackSet.CompareAndSwap(false, true) {
+		require.FailNow(p.t, "migrationPauser.Pause called while already paused; call Release first")
+	}
+	p.blocked = make(chan struct{})
+	p.blockCh = make(chan struct{})
+	p.ds.SetUpdateXattrsCallback(func(key string) {
 		if key != docID {
 			return
 		}
 		close(p.blocked)
-		base.RequireChanClosed(p.t, p.blockCh)
+		// Runs on the migration job's goroutine, so use the goroutine-safe wait.
+		sgtest.RequireChanClosedFromCallback(p.t, p.blockCh)
 	})
-	return p
 }
 
-// WaitUntilBlocked blocks until migration is paused at docID, proving it is in-flight.
+// WaitUntilBlocked blocks until migration is paused at docID.
 func (p *migrationPauser) WaitUntilBlocked() {
+	p.t.Helper()
 	base.RequireChanClosed(p.t, p.blocked)
 }
 
-// Release clears the callback so subsequent docs pass through, then unblocks the paused doc.
+// Release clears the callback and unblocks the paused doc. Fails the test if not currently paused.
 func (p *migrationPauser) Release() {
+	if !p.release() {
+		require.FailNow(p.t, "migrationPauser.Release called while not paused")
+	}
+}
+
+// Close releases the pauser and resets the LeakyBucket callback.
+func (p *migrationPauser) Close() {
+	p.release()
+}
+
+// release clears the callback and unblocks the paused doc if currently paused, reporting whether
+// it was paused.
+func (p *migrationPauser) release() bool {
+	if !p.callbackSet.CompareAndSwap(true, false) {
+		return false
+	}
 	p.ds.SetUpdateXattrsCallback(nil)
 	close(p.blockCh)
+	return true
 }

--- a/rest/attachmentmigrationtest/attachment_migration_test.go
+++ b/rest/attachmentmigrationtest/attachment_migration_test.go
@@ -314,10 +314,9 @@ func TestMigrationNoReRunStartStopDb(t *testing.T) {
 func TestStartMigrationAlreadyRunningProcess(t *testing.T) {
 	base.TestRequiresCollections(t)
 	base.RequireNumTestDataStores(t, 1)
-	tb := base.GetTestBucket(t)
 	rtConfig := &rest.RestTesterConfig{
-		CustomTestBucket: tb,
-		PersistentConfig: true,
+		LeakyBucketConfig: &base.LeakyBucketConfig{},
+		PersistentConfig:  true,
 	}
 
 	rt := rest.NewRestTester(t, rtConfig)
@@ -325,41 +324,48 @@ func TestStartMigrationAlreadyRunningProcess(t *testing.T) {
 	ctx := rt.Context()
 	_ = rt.Bucket()
 
-	const (
-		dbName = "db1"
-	)
+	const dbName = "db1"
 
-	ds0, err := tb.GetNamedDataStore(0)
+	ds0, err := rt.TestBucket.GetNamedDataStore(0)
 	require.NoError(t, err)
-	opts := &sgbucket.MutateInOptions{}
 
-	// add some docs (with xattr so they won't be ignored in the background job) to both collections
-	// we want to add large number of docs to stop the migration job from finishing before we can try start the job
-	// again (whilst already running)
-	bodyBytes := []byte(`{"some": "body"}`)
-	for i := range 2000 {
-		key := fmt.Sprintf("%s_%d", t.Name(), i)
-		xattrsInput := map[string][]byte{
-			"_xattr": []byte(`{"some":"xattr"}`),
+	// Write one legacy attachment doc so migration has a real doc to process (calls UpdateXattrs).
+	docKey := t.Name() + "_0"
+	_, writeErr := ds0.WriteWithXattrs(ctx, docKey, 0, 0, []byte(`{"some":"body"}`), map[string][]byte{
+		base.SyncXattrName: []byte(`{"attachments":{"att.txt":{"content_type":"text/plain","digest":"sha1-AABBCCDD","length":3,"revpos":1,"stub":true}}}`),
+	}, nil, &sgbucket.MutateInOptions{})
+	require.NoError(t, writeErr)
+
+	// Block migration at UpdateXattrs for our doc so stop arrives while migration is genuinely in-flight.
+	leakyDS, ok := base.AsLeakyDataStore(ds0)
+	require.True(t, ok, "datastore must be a LeakyDataStore")
+	blocked := make(chan struct{})
+	blockCh := make(chan struct{})
+	leakyDS.SetUpdateXattrsCallback(func(key string) {
+		if key != docKey {
+			return
 		}
-		_, writeErr := ds0.WriteWithXattrs(ctx, key, 0, 0, bodyBytes, xattrsInput, nil, opts)
-		require.NoError(t, writeErr)
-	}
+		close(blocked)
+		<-blockCh
+	})
 
-	scopesConfig := rest.GetCollectionsConfig(t, tb, 1)
+	scopesConfig := rest.GetCollectionsConfig(t, rt.TestBucket, 1)
 	dbConfig := rt.NewDbConfig()
-	// ensure import is off to stop the docs we add from being imported by sync gateway, this could cause extra overhead
-	// on the migration job (more doc writes going to bucket). We want to avoid for purpose of this test
 	dbConfig.AutoImport = false
 	dbConfig.Scopes = scopesConfig
 	resp := rt.CreateDatabase(dbName, dbConfig)
 	rest.RequireStatus(t, resp, http.StatusCreated)
-	// wait for migration job to start
-	waitForAttachmentMigrationState(rt, db.BackgroundProcessStateRunning)
+
+	// Wait until migration is blocked mid-UpdateXattrs, guaranteeing Running state.
+	<-blocked
 
 	err = rt.GetDatabase().AttachmentMigrationManager.Start(ctx, nil)
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "Process already running")
+
+	// Clear the callback so subsequent docs pass through, then release the blocked call.
+	leakyDS.SetUpdateXattrsCallback(nil)
+	close(blockCh)
 }
 
 // getAttachmentMigrationManagerStatusMigrationManagerStatus returns the status of the AttachmentMigrationManager for a single database RestTester.

--- a/rest/attachmentmigrationtest/attachment_migration_test.go
+++ b/rest/attachmentmigrationtest/attachment_migration_test.go
@@ -346,7 +346,7 @@ func TestStartMigrationAlreadyRunningProcess(t *testing.T) {
 			return
 		}
 		close(blocked)
-		<-blockCh
+		base.RequireChanClosed(t, blockCh)
 	})
 
 	scopesConfig := rest.GetCollectionsConfig(t, rt.TestBucket, 1)
@@ -357,7 +357,7 @@ func TestStartMigrationAlreadyRunningProcess(t *testing.T) {
 	rest.RequireStatus(t, resp, http.StatusCreated)
 
 	// Wait until migration is blocked mid-UpdateXattrs, guaranteeing Running state.
-	<-blocked
+	base.RequireChanClosed(t, blocked)
 
 	err = rt.GetDatabase().AttachmentMigrationManager.Start(ctx, nil)
 	assert.Error(t, err)

--- a/testing/sgtest/chan.go
+++ b/testing/sgtest/chan.go
@@ -1,0 +1,37 @@
+// Copyright 2026-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package sgtest
+
+import (
+	"testing"
+	"time"
+)
+
+// ChanCallbackTimeout is the timeout used by RequireChanClosedFromCallback.
+const ChanCallbackTimeout = 30 * time.Second
+
+// RequireChanClosedFromCallback waits for ch to be closed, similar to base.RequireChanClosed, but
+// is safe to call from a goroutine other than the one running the test (e.g. a DCP worker or
+// background manager goroutine invoking a test callback). Unlike base.RequireChanClosed, it
+// reports a timeout via t.Errorf instead of t.FailNow, since FailNow must only be called from the
+// test's own goroutine — calling it elsewhere can hang the test binary instead of failing the test.
+func RequireChanClosedFromCallback[T any](t testing.TB, ch <-chan T) {
+	for {
+		select {
+		case _, ok := <-ch:
+			if ok {
+				continue
+			}
+			return
+		case <-time.After(ChanCallbackTimeout):
+			t.Errorf("timed out after %v waiting for channel to close (called from non-test goroutine)", ChanCallbackTimeout)
+			return
+		}
+	}
+}


### PR DESCRIPTION
CBG-5509: use leakybucket to for background manager tests that require stopping

Some background manager tests require checking for stopped status before resuming. If there are not enough documents written or the DCP processing is fast relative to the REST performance, the background job will complete before expected.

Create a pauser pattern so that the background task pauses until the stop action is called. Then when stop is called, release the lock and the status should be marked as stopped.

We could keep adding to the doc count so it would actually pause but it has been very hard to find an adequate number. This way, the number is reduced and the test is deterministic for what I believe it is testing.

Example failure, but it happens with many tests:

```
2026-07-03T22:29:28.657Z [INF] HTTP: c:#158 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
2026-07-03T22:29:29.159Z [INF] HTTP: c:#159 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
2026-07-03T22:29:29.665Z [INF] HTTP: c:#160 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
2026-07-03T22:29:30.158Z [INF] HTTP: c:#161 db:db GET http://127.0.0.1/db/_attachment_migration (as ADMIN)
    attachment_migration_api_test.go:114: 
        	Error Trace:	/Users/runner/work/sync_gateway/sync_gateway/rest/utilities_testing_resttester.go:461
        	            				/Users/runner/hostedtoolcache/go/1.26.4/arm64/src/runtime/asm_arm64.s:1447
        	Error:      	Not equal: 
        	            	expected: "stopped"
        	            	actual  : "completed"
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,2 +1,2 @@
        	            	-(db.BackgroundProcessState) (len=7) "stopped"
        	            	+(db.BackgroundProcessState) (len=9) "completed"
 ```       	            	 
        	            	 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/928/
