### PR TITLE
CBG-5524: collect and send phone home records to collector

### DIFF
--- a/base/collection.go
+++ b/base/collection.go
@@ -555,7 +555,7 @@ func (b *GocbV2Bucket) MgmtRequest(ctx context.Context, method, uri, contentType
 		username, password, _ = b.Spec.Auth.GetCredentials()
 	}
 
-	respBytes, statusCode, err := MgmtRequest(b.HttpClient(ctx), mgmtEp, method, uri, contentType, username, password, body)
+	respBytes, statusCode, err := MgmtRequest(ctx, b.HttpClient(ctx), mgmtEp, method, uri, contentType, username, password, body)
 	if err != nil {
 		return nil, statusCode, err
 	}

--- a/base/fleet_manager_collector.go
+++ b/base/fleet_manager_collector.go
@@ -11,10 +11,13 @@ licenses/APL2.txt.
 package base
 
 import (
+	"context"
+	"os"
 	"runtime"
 	"strconv"
 
 	"github.com/KimMachineGun/automemlimit/memlimit"
+	"github.com/elastic/gosigar"
 )
 
 const ProductInfoName = "sync_gateway"
@@ -37,11 +40,11 @@ type FleetManagerProductInfo struct {
 }
 
 type FleetManagerCollectorSettings struct {
-	IntervalSeconds int  `json:"reportIntervalHours"`
-	Enabled         bool `json:"enabled"`
+	ReportingInterval int  `json:"reportIntervalHours"`
+	Enabled           bool `json:"enabled"`
 }
 
-func CollectSGWFleetManagerMetrics(nodeUID, hostname string) SyncGatewayFleetManagerMetrics {
+func CollectSGWFleetManagerMetrics(ctx context.Context, nodeUID, hostname string) SyncGatewayFleetManagerMetrics {
 	edition := "Enterprise"
 	if !IsEnterpriseEdition() {
 		edition = "Community"
@@ -49,10 +52,10 @@ func CollectSGWFleetManagerMetrics(nodeUID, hostname string) SyncGatewayFleetMan
 	productInfo := FleetManagerProductInfo{
 		Edition: edition,
 		Version: ProductVersion.ReleaseVersionString(),
-		Name:    "sync_gateway",
+		Name:    ProductInfoName,
 	}
 
-	sysInfo := getSystemInfo()
+	sysInfo := getSystemInfo(ctx)
 
 	return SyncGatewayFleetManagerMetrics{
 		InstanceID:    nodeUID,
@@ -74,22 +77,37 @@ type systemInfo struct {
 	uptimeSeconds int64
 }
 
-func getSystemInfo() systemInfo {
-	totalRam := SyncGatewayStats.GlobalStats.ResourceUtilizationStats().SystemMemoryTotal.Value()
-	cgroupLimit, err := memlimit.FromCgroup()
-	if err == nil {
-		// cgroup in place report this instead
-		totalRam = int64(cgroupLimit)
+func getSystemInfo(ctx context.Context) systemInfo {
+	var residentBytes, totalRam int64
+
+	// Sample process/system memory directly here rather than reading the ResourceUtilizationStats
+	// expvars: those are only populated by the stats-logger ticker, so at startup (before its first
+	// tick) and whenever the stats logger is disabled they would still read zero when this report is
+	// sent, yielding a phone-home record with ramBytesUsed/ramBytesTotal of 0.
+	procMem := gosigar.ProcMem{}
+	if err := procMem.Get(os.Getpid()); err != nil {
+		WarnfCtx(ctx, "Could not read process memory for fleet manager metrics: %v", err)
+	} else {
+		residentBytes = int64(procMem.Resident)
 	}
-	goArch := runtime.GOARCH
-	goOS := runtime.GOOS
-	osVersion := goOS + "-" + goArch
+
+	if cgroupLimit, err := memlimit.FromCgroup(); err == nil {
+		// A cgroup memory limit, when present, is the meaningful "total" for this instance.
+		totalRam = int64(cgroupLimit)
+	} else {
+		sysMem := gosigar.Mem{}
+		if err := sysMem.Get(); err != nil {
+			WarnfCtx(ctx, "Could not read system memory for fleet manager metrics: %v", err)
+		} else {
+			totalRam = int64(sysMem.Total)
+		}
+	}
 
 	return systemInfo{
 		uptimeSeconds: SyncGatewayStats.GlobalStats.ResourceUtilizationStats().Uptime.ToSeconds(),
 		cpuCores:      runtime.NumCPU(),
-		ramBytesUsed:  strconv.FormatInt(SyncGatewayStats.GlobalStats.ResourceUtilizationStats().ProcessMemoryResident.Value(), 10),
+		ramBytesUsed:  strconv.FormatInt(residentBytes, 10),
 		ramBytesTotal: strconv.FormatInt(totalRam, 10),
-		osVersion:     osVersion,
+		osVersion:     runtime.GOOS + "-" + runtime.GOARCH,
 	}
 }

--- a/base/fleet_manager_collector.go
+++ b/base/fleet_manager_collector.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/KimMachineGun/automemlimit/memlimit"
 	"github.com/elastic/gosigar"
+	"github.com/shirou/gopsutil/v4/mem"
 )
 
 const ProductInfoName = "sync_gateway"
@@ -78,7 +79,7 @@ type systemInfo struct {
 }
 
 func getSystemInfo(ctx context.Context) systemInfo {
-	var residentBytes, totalRam int64
+	var residentBytes int64
 
 	// Sample process/system memory directly here rather than reading the ResourceUtilizationStats
 	// expvars: those are only populated by the stats-logger ticker, so at startup (before its first
@@ -91,23 +92,38 @@ func getSystemInfo(ctx context.Context) systemInfo {
 		residentBytes = int64(procMem.Resident)
 	}
 
-	if cgroupLimit, err := memlimit.FromCgroup(); err == nil {
-		// A cgroup memory limit, when present, is the meaningful "total" for this instance.
-		totalRam = int64(cgroupLimit)
-	} else {
-		sysMem := gosigar.Mem{}
-		if err := sysMem.Get(); err != nil {
-			WarnfCtx(ctx, "Could not read system memory for fleet manager metrics: %v", err)
-		} else {
-			totalRam = int64(sysMem.Total)
-		}
-	}
-
+	totalRam := GetTotalMemory(ctx, false)
 	return systemInfo{
 		uptimeSeconds: SyncGatewayStats.GlobalStats.ResourceUtilizationStats().Uptime.ToSeconds(),
 		cpuCores:      runtime.NumCPU(),
 		ramBytesUsed:  strconv.FormatInt(residentBytes, 10),
-		ramBytesTotal: strconv.FormatInt(totalRam, 10),
+		ramBytesTotal: strconv.FormatInt(int64(totalRam), 10),
 		osVersion:     runtime.GOOS + "-" + runtime.GOARCH,
 	}
+}
+
+// getTotalMemory returns the total memory available on the system. If a cgroup is detected, it will use the cgroup memory max.
+func GetTotalMemory(ctx context.Context, virtualMem bool) uint64 {
+	memoryTotal, err := memlimit.FromCgroup()
+	if err == nil {
+		return memoryTotal
+	}
+	TracefCtx(ctx, KeyAll, "Did not detect a cgroup for a memory limit")
+	var totalRam uint64
+	if virtualMem {
+		memory, err := mem.VirtualMemory()
+		if err != nil {
+			WarnfCtx(ctx, "Error getting total memory from gopsutil: %v", err)
+			return 0
+		}
+		totalRam = memory.Total
+	} else {
+		sysMem := gosigar.Mem{}
+		if err := sysMem.Get(); err != nil {
+			WarnfCtx(ctx, "Error getting total memory from gosigar: %v", err)
+		} else {
+			totalRam = sysMem.Total
+		}
+	}
+	return totalRam
 }

--- a/base/fleet_manager_collector.go
+++ b/base/fleet_manager_collector.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2026-Present Couchbase, Inc.
+
+Use of this software is governed by the Business Source License included in
+the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+file, in accordance with the Business Source License, use of this software will
+be governed by the Apache License, Version 2.0, included in the file
+licenses/APL2.txt.
+*/
+
+package base
+
+import (
+	"runtime"
+	"strconv"
+
+	"github.com/KimMachineGun/automemlimit/memlimit"
+)
+
+const ProductInfoName = "sync_gateway"
+
+type SyncGatewayFleetManagerMetrics struct {
+	InstanceID    string                  `json:"instanceId"`
+	CpuCores      int                     `json:"cpuCores"`
+	RamBytesTotal string                  `json:"ramBytesTotal"`
+	RamBytesUsed  string                  `json:"ramBytesUsed"`
+	ProductInfo   FleetManagerProductInfo `json:"product"`
+	OSVersion     string                  `json:"osVersion"`
+	Hostname      string                  `json:"hostname"`
+	UptimeSeconds int64                   `json:"uptimeSeconds"`
+}
+
+type FleetManagerProductInfo struct {
+	Edition string `json:"edition"`
+	Version string `json:"version"`
+	Name    string `json:"name"`
+}
+
+type FleetManagerCollectorSettings struct {
+	IntervalSeconds int  `json:"reportIntervalHours"`
+	Enabled         bool `json:"enabled"`
+}
+
+func CollectSGWFleetManagerMetrics(nodeUID, hostname string) SyncGatewayFleetManagerMetrics {
+	edition := "Enterprise"
+	if !IsEnterpriseEdition() {
+		edition = "Community"
+	}
+	productInfo := FleetManagerProductInfo{
+		Edition: edition,
+		Version: ProductVersion.ReleaseVersionString(),
+		Name:    "sync_gateway",
+	}
+
+	sysInfo := getSystemInfo()
+
+	return SyncGatewayFleetManagerMetrics{
+		InstanceID:    nodeUID,
+		CpuCores:      sysInfo.cpuCores,
+		RamBytesTotal: sysInfo.ramBytesTotal,
+		RamBytesUsed:  sysInfo.ramBytesUsed,
+		ProductInfo:   productInfo,
+		OSVersion:     sysInfo.osVersion,
+		Hostname:      hostname,
+		UptimeSeconds: sysInfo.uptimeSeconds,
+	}
+}
+
+type systemInfo struct {
+	cpuCores      int
+	ramBytesTotal string
+	ramBytesUsed  string
+	osVersion     string
+	uptimeSeconds int64
+}
+
+func getSystemInfo() systemInfo {
+	totalRam := SyncGatewayStats.GlobalStats.ResourceUtilizationStats().SystemMemoryTotal.Value()
+	cgroupLimit, err := memlimit.FromCgroup()
+	if err == nil {
+		// cgroup in place report this instead
+		totalRam = int64(cgroupLimit)
+	}
+	goArch := runtime.GOARCH
+	goOS := runtime.GOOS
+	osVersion := goOS + "-" + goArch
+
+	return systemInfo{
+		uptimeSeconds: SyncGatewayStats.GlobalStats.ResourceUtilizationStats().Uptime.ToSeconds(),
+		cpuCores:      runtime.NumCPU(),
+		ramBytesUsed:  strconv.FormatInt(SyncGatewayStats.GlobalStats.ResourceUtilizationStats().ProcessMemoryResident.Value(), 10),
+		ramBytesTotal: strconv.FormatInt(totalRam, 10),
+		osVersion:     osVersion,
+	}
+}

--- a/base/gocb_utils.go
+++ b/base/gocb_utils.go
@@ -176,8 +176,8 @@ func getRootCAs(ctx context.Context, caCertPath string) (*x509.CertPool, error) 
 
 // MgmtRequest makes a request to the http couchbase management api. This function will read the entire contents of
 // the response and return the output bytes, the status code, and an error.
-func MgmtRequest(client *http.Client, mgmtEp, method, uri, contentType, username, password string, body io.Reader) ([]byte, int, error) {
-	req, err := http.NewRequest(method, mgmtEp+uri, body)
+func MgmtRequest(ctx context.Context, client *http.Client, mgmtEp, method, uri, contentType, username, password string, body io.Reader) ([]byte, int, error) {
+	req, err := http.NewRequestWithContext(ctx, method, mgmtEp+uri, body)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/base/main_test_cluster.go
+++ b/base/main_test_cluster.go
@@ -160,6 +160,7 @@ func (c *tbpCluster) MgmtRequest(method, path string, contentType string, body i
 		return nil, 0, fmt.Errorf("no management endpoints available for cluster %q", c.clusterSpec.Server)
 	}
 	return MgmtRequest(
+		context.Background(),
 		c.agent.HTTPClient(),
 		mgmtEps[0],
 		method,
@@ -178,6 +179,7 @@ func GetCouchbaseServerVersion(agent *gocbcore.Agent, clusterSpec CouchbaseClust
 		return nil, false, fmt.Errorf("no management endpoints available")
 	}
 	output, status, err := MgmtRequest(
+		context.Background(),
 		agent.HTTPClient(),
 		mgmtEps[0],
 		http.MethodGet,

--- a/base/stats.go
+++ b/base/stats.go
@@ -1339,6 +1339,10 @@ func (s *SgwDurStat) String() string {
 	return strconv.Itoa(int(time.Since(s.StartTime).Nanoseconds()))
 }
 
+func (s *SgwDurStat) ToSeconds() int64 {
+	return int64(time.Since(s.StartTime).Seconds())
+}
+
 type QueryStat struct {
 	QueryCount      *SgwIntStat
 	QueryErrorCount *SgwIntStat

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -332,6 +332,35 @@ func UnitTestUrlIsWalrus() bool {
 	return sgtest.UnitTestUrlIsWalrus()
 }
 
+// TestClusterVersion returns the Couchbase Server version backing the test bucket pool. It fails the
+// test if there is no cluster connection (i.e. not running against Couchbase Server).
+func TestClusterVersion(t testing.TB) *ComparableBuildVersion {
+	require.NotNil(t, GTestBucketPool, "GTestBucketPool is not initialized")
+	require.NotNil(t, GTestBucketPool.cluster, "no cluster connection available - not running against Couchbase Server")
+	version := GTestBucketPool.cluster.version
+	return &version
+}
+
+// RequireServerVersionForTest skips the test unless the Couchbase Server backing the test bucket pool
+// is at least the minimum version required for its release train. Pass one minimum version per release
+// train the feature shipped in, e.g. RequireServerVersionForTest(t, "7.6.12", "8.0.3", "8.1.0"). This
+// is a no-op when not running against Couchbase Server, since those tests are gated separately.
+func RequireServerVersionForTest(t testing.TB, minReleaseVersions ...string) {
+	if !sgtest.TestUseCouchbaseServer() {
+		return
+	}
+	minVersions := make([]*ComparableBuildVersion, 0, len(minReleaseVersions))
+	for _, v := range minReleaseVersions {
+		parsed, err := NewComparableBuildVersionFromString(v)
+		require.NoError(t, err, "couldn't parse minimum version %q", v)
+		minVersions = append(minVersions, parsed)
+	}
+	serverVersion := TestClusterVersion(t)
+	if !serverVersion.AtLeastReleaseVersion(minVersions...) {
+		t.Skipf("Test requires Couchbase Server %v, but running against %v", minReleaseVersions, serverVersion)
+	}
+}
+
 func TestUseWalrus() bool {
 	backingStore := os.Getenv(TestEnvSyncGatewayBackingStore)
 	return strings.EqualFold(backingStore, TestEnvBackingStoreWalrus)

--- a/base/version_comparable_build.go
+++ b/base/version_comparable_build.go
@@ -168,6 +168,38 @@ func (pv *ComparableBuildVersion) AtLeastMinorVersion(major, minor uint8) bool {
 	return pv.minor >= minor
 }
 
+// AtLeastReleaseVersion reports whether pv is at least the minimum version applicable to its
+// release train, given one minimum version per train. This is for features shipped (or backported)
+// across several release trains at different patch levels - e.g. a feature available in 7.6.12,
+// 8.0.3, and 8.1.0. The rule per train (matched on major.minor):
+//   - 7.6.x qualifies only if >= 7.6.12
+//   - 8.0.x qualifies only if >= 8.0.3
+//   - 8.1.x qualifies (>= 8.1.0, i.e. any 8.1 build)
+//   - anything newer than every listed minimum (e.g. 8.2.0) qualifies
+//   - anything in an older, unlisted train does not qualify
+//
+// Returns false if pv is nil or no minimum versions are provided.
+func (pv *ComparableBuildVersion) AtLeastReleaseVersion(minVersions ...*ComparableBuildVersion) bool {
+	if pv == nil {
+		return false
+	}
+	var newest *ComparableBuildVersion
+	for _, min := range minVersions {
+		if min == nil {
+			continue
+		}
+		if newest == nil || newest.Less(min) {
+			newest = min
+		}
+		// Same release train as this minimum (matched on major.minor): pv must meet it.
+		if pv.major == min.major && pv.minor == min.minor {
+			return !pv.Less(min)
+		}
+	}
+	// pv isn't in any listed train: it only qualifies if it's newer than all of them.
+	return newest != nil && !pv.Less(newest)
+}
+
 // AtLeastMinorDowngrade returns true there is a major or minor downgrade from a to b.
 func (a *ComparableBuildVersion) AtLeastMinorDowngrade(b *ComparableBuildVersion) bool {
 	if a.epoch != b.epoch {

--- a/base/version_comparable_build.go
+++ b/base/version_comparable_build.go
@@ -185,6 +185,25 @@ func (pv ComparableBuildVersion) String() string {
 	return pv.str
 }
 
+// ReleaseVersionString returns the major.minor.patch[.other] release version, omitting epoch,
+// build number, and edition. The optional 4th (other) component is included only when non-zero.
+// e.g. "4.1.0", "4.0.6", or "4.1.0.1"
+func (pv *ComparableBuildVersion) ReleaseVersionString() string {
+	if pv == nil {
+		return "0.0.0"
+	}
+	releaseStr := strconv.FormatUint(uint64(pv.major), 10) +
+		string(comparableBuildVersionSep) +
+		strconv.FormatUint(uint64(pv.minor), 10) +
+		string(comparableBuildVersionSep) +
+		strconv.FormatUint(uint64(pv.patch), 10)
+	if pv.other > 0 {
+		releaseStr += string(comparableBuildVersionSep) +
+			strconv.FormatUint(uint64(pv.other), 10)
+	}
+	return releaseStr
+}
+
 // MarshalJSON implements json.Marshaler for ComparableBuildVersion. The JSON representation is the version string.
 func (pv *ComparableBuildVersion) MarshalJSON() ([]byte, error) {
 	return JSONMarshal(pv.String())

--- a/base/version_comparable_build_test.go
+++ b/base/version_comparable_build_test.go
@@ -258,6 +258,43 @@ func TestAtLeastMinorDowngradeVersion(t *testing.T) {
 	}
 }
 
+func TestAtLeastReleaseVersion(t *testing.T) {
+	// Feature shipped across three release trains at different patch levels.
+	minVersions := []string{"7.6.12", "8.0.3", "8.1.0"}
+	testCases := []struct {
+		version   string
+		qualifies bool
+	}{
+		{version: "7.6.11", qualifies: false},
+		{version: "7.6.12", qualifies: true},
+		{version: "7.6.13", qualifies: true},
+		{version: "8.0.2", qualifies: false},
+		{version: "8.0.3", qualifies: true},
+		{version: "8.0.4", qualifies: true},
+		{version: "8.1.0", qualifies: true},
+		{version: "8.1.5", qualifies: true},
+		{version: "8.2.0", qualifies: true},
+		{version: "9.0.0", qualifies: true},
+		{version: "7.6.0", qualifies: false},
+		{version: "7.2.0", qualifies: false},
+	}
+
+	mins := make([]*ComparableBuildVersion, 0, len(minVersions))
+	for _, v := range minVersions {
+		parsed, err := NewComparableBuildVersionFromString(v)
+		require.NoError(t, err)
+		mins = append(mins, parsed)
+	}
+
+	for _, test := range testCases {
+		t.Run(test.version, func(t *testing.T) {
+			version, err := NewComparableBuildVersionFromString(test.version)
+			require.NoError(t, err)
+			require.Equal(t, test.qualifies, version.AtLeastReleaseVersion(mins...))
+		})
+	}
+}
+
 func BenchmarkComparableBuildVersion(b *testing.B) {
 	const str = "8:7.6.5.4@3-EE"
 

--- a/base/version_comparable_build_test.go
+++ b/base/version_comparable_build_test.go
@@ -134,6 +134,30 @@ func TestComparableBuildVersionEmptyStringJSON(t *testing.T) {
 	require.Equal(t, "0.0.0", version.String())
 }
 
+func TestReleaseVersionString(t *testing.T) {
+	testCases := []struct {
+		version  string
+		expected string
+	}{
+		{version: "4.1.0", expected: "4.1.0"},            // 4th component is 0 → omitted
+		{version: "4.0.6", expected: "4.0.6"},            // patch release
+		{version: "4.1.0.1", expected: "4.1.0.1"},        // 4th component present
+		{version: "4.1.0@123-EE", expected: "4.1.0"},     // build and edition stripped
+		{version: "4.1.0.1@123-CE", expected: "4.1.0.1"}, // build and edition stripped, other kept
+	}
+	for _, test := range testCases {
+		t.Run(test.version, func(t *testing.T) {
+			version, err := NewComparableBuildVersionFromString(test.version)
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, version.ReleaseVersionString())
+		})
+	}
+
+	// nil receiver is safe and yields the zero version.
+	var nilVersion *ComparableBuildVersion
+	assert.Equal(t, "0.0.0", nilVersion.ReleaseVersionString())
+}
+
 func TestAtLeastMinorDowngradeVersion(t *testing.T) {
 	testCases := []struct {
 		versionA       string

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -747,7 +747,7 @@ func GetIndexPartitionCount(t testing.TB, bucket *base.GocbV2Bucket, dsName sgbu
 	}
 	ctx := base.TestCtx(t)
 	uri := "/getIndexStatus"
-	respBytes, statusCode, err := base.MgmtRequest(bucket.HttpClient(ctx), gsiEps[0], http.MethodGet, uri, "application/json", username, password, nil)
+	respBytes, statusCode, err := base.MgmtRequest(ctx, bucket.HttpClient(ctx), gsiEps[0], http.MethodGet, uri, "application/json", username, password, nil)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, statusCode, "unexpected status code for %s", respBytes)
 	var output struct {

--- a/rest/config.go
+++ b/rest/config.go
@@ -1657,6 +1657,15 @@ func SetupServerContext(ctx context.Context, config *StartupConfig, persistentCo
 		return nil, err
 	}
 
+	// Fleet manager metrics are reported to the Couchbase Server management API, which isn't
+	// available when running against Walrus/Rosmar. Whether the connected server actually supports
+	// the collector endpoint is not gated here: reportFleetManagerMetrics attempts the report each
+	// interval and treats an unavailable endpoint as a benign skip, so reporting starts automatically
+	// once the server is upgraded to a supporting version.
+	if !base.ServerIsWalrus(sc.Config.Bootstrap.Server) {
+		sc.reportFleetManagerMetrics(sc.serverCtx)
+	}
+
 	// On successful server context creation, generate startup audit event
 	base.Audit(ctx, base.AuditIDSyncGatewayStartup, sc.StartupAuditFields())
 

--- a/rest/fleet_manager_reporter.go
+++ b/rest/fleet_manager_reporter.go
@@ -1,0 +1,90 @@
+// Copyright 2026-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package rest
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/couchbase/sync_gateway/base"
+)
+
+const fleetManagerMetricsInterval = 1 * time.Hour // todo: CBG-5525 make this configurable
+
+func (sc *ServerContext) reportFleetManagerMetrics(ctx context.Context) {
+	hostname, err := os.Hostname()
+	if err != nil {
+		base.WarnfCtx(ctx, "Could not read hostname for fleet manager metrics: %v", err)
+	}
+
+	report := func() {
+		metrics := base.CollectSGWFleetManagerMetrics(ctx, sc.NodeUID, hostname)
+		if err := sc.sendFleetManagerMetrics(ctx, metrics); err != nil {
+			base.WarnfCtx(ctx, "Could not report fleet manager metrics: %v", err)
+		}
+	}
+
+	ticker := time.NewTicker(fleetManagerMetricsInterval)
+	go func() {
+		defer ticker.Stop()
+		// Report once on startup rather than waiting a full interval for the first tick.
+		report()
+		for {
+			select {
+			case <-ticker.C:
+				report()
+			case <-ctx.Done():
+				base.InfofCtx(ctx, base.KeyAll, "Stopping fleet manager metrics reporting: %v", context.Cause(ctx))
+				return
+			}
+		}
+	}()
+	base.InfofCtx(ctx, base.KeyAll, "Starting fleet manager metrics reporting")
+}
+
+// sendFleetManagerMetrics POSTs the collected metrics to the ns_server fleet manager collector
+// ingest endpoint on the Couchbase Server management API. A 404 means the connected server predates
+// the collector endpoint (or it has been removed); this is treated as a benign skip so reporting
+// starts automatically once the server is upgraded, rather than a hard error.
+func (sc *ServerContext) sendFleetManagerMetrics(ctx context.Context, metrics base.SyncGatewayFleetManagerMetrics) error {
+	endpoints, httpClient, err := sc.ObtainManagementEndpointsAndHTTPClient()
+	if err != nil {
+		return fmt.Errorf("could not obtain management endpoints: %w", err)
+	}
+	if len(endpoints) == 0 {
+		return fmt.Errorf("no management endpoints available")
+	}
+
+	metricsJSON, err := base.JSONMarshal(metrics)
+	if err != nil {
+		return fmt.Errorf("could not marshal fleet manager metrics: %w", err)
+	}
+
+	uri := fmt.Sprintf("/_telemetryCollector/ingest?product_name=%s&instance_id=%s", base.ProductInfoName, url.QueryEscape(metrics.InstanceID))
+	statusCode, _, err := doHTTPAuthRequest(ctx, httpClient, sc.Config.Bootstrap.Username, sc.Config.Bootstrap.Password, http.MethodPost, uri, "application/json", endpoints, metricsJSON)
+	if err != nil {
+		return err
+	}
+	switch statusCode {
+	case http.StatusNoContent:
+		// success
+		return nil
+	case http.StatusNotFound:
+		// Server doesn't expose the collector endpoint (too old, or collector removed). Skip quietly
+		// and retry on the next interval.
+		base.DebugfCtx(ctx, base.KeyAll, "Fleet manager collector endpoint unavailable (status %d); will retry next interval", statusCode)
+		return nil
+	default:
+		return fmt.Errorf("unexpected status %d from fleet manager collector", statusCode)
+	}
+}

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -1155,7 +1155,7 @@ func (h *handler) checkAdminAuthenticationOnly() (bool, error) {
 		return false, ErrLoginRequired
 	}
 
-	statusCode, _, err := doHTTPAuthRequest(h.ctx(), httpClient, username, password, "POST", "/pools/default/checkPermissions", managementEndpoints, nil)
+	statusCode, _, err := doHTTPAuthRequest(h.ctx(), httpClient, username, password, "POST", "/pools/default/checkPermissions", "", managementEndpoints, nil)
 	if err != nil {
 		return false, base.HTTPErrorf(http.StatusInternalServerError, "Error performing HTTP auth request: %v", err)
 	}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -220,7 +220,7 @@ func (sc *ServerContext) sendFleetManagerMetrics(ctx context.Context, metrics ba
 	}
 
 	uri := fmt.Sprintf("/_telemetryCollector/ingest?product_name=%s&instance_id=%s", base.ProductInfoName, url.QueryEscape(metrics.InstanceID))
-	statusCode, respBytes, err := doHTTPAuthRequest(ctx, httpClient, sc.Config.Bootstrap.Username, sc.Config.Bootstrap.Password, http.MethodPost, uri, "application/json", endpoints, metricsJSON)
+	statusCode, _, err := doHTTPAuthRequest(ctx, httpClient, sc.Config.Bootstrap.Username, sc.Config.Bootstrap.Password, http.MethodPost, uri, "application/json", endpoints, metricsJSON)
 	if err != nil {
 		return err
 	}
@@ -234,7 +234,7 @@ func (sc *ServerContext) sendFleetManagerMetrics(ctx context.Context, metrics ba
 		base.DebugfCtx(ctx, base.KeyAll, "Fleet manager collector endpoint unavailable (status %d); will retry next interval", statusCode)
 		return nil
 	default:
-		return fmt.Errorf("unexpected status %d from fleet manager collector: %s", statusCode, respBytes)
+		return fmt.Errorf("unexpected status %d from fleet manager collector", statusCode)
 	}
 }
 
@@ -2245,7 +2245,7 @@ func doHTTPAuthRequest(ctx context.Context, httpClient *http.Client, username, p
 
 	worker := func() (shouldRetry bool, err error, value any) {
 		endpointIdx := retryCount % len(endpoints)
-		responseBody, statusCode, err = base.MgmtRequest(httpClient, endpoints[endpointIdx], method, path, contentType, username, password, bytes.NewBuffer(requestBody))
+		responseBody, statusCode, err = base.MgmtRequest(ctx, httpClient, endpoints[endpointIdx], method, path, contentType, username, password, bytes.NewBuffer(requestBody))
 
 		if err, ok := err.(net.Error); ok && err.Timeout() {
 			retryCount++

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -210,13 +210,16 @@ func (sc *ServerContext) sendFleetManagerMetrics(ctx context.Context, metrics ba
 	if err != nil {
 		return fmt.Errorf("could not obtain management endpoints: %w", err)
 	}
+	if len(endpoints) == 0 {
+		return fmt.Errorf("no management endpoints available")
+	}
 
 	metricsJSON, err := base.JSONMarshal(metrics)
 	if err != nil {
 		return fmt.Errorf("could not marshal fleet manager metrics: %w", err)
 	}
 
-	uri := fmt.Sprintf("/_lighthouseCollector/ingest?product_name=%s&instance_id=%s", base.ProductInfoName, url.QueryEscape(metrics.InstanceID))
+	uri := fmt.Sprintf("/_telemetryCollector/ingest?product_name=%s&instance_id=%s", base.ProductInfoName, url.QueryEscape(metrics.InstanceID))
 	statusCode, respBytes, err := doHTTPAuthRequest(ctx, httpClient, sc.Config.Bootstrap.Username, sc.Config.Bootstrap.Password, http.MethodPost, uri, "application/json", endpoints, metricsJSON)
 	if err != nil {
 		return err

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -19,6 +19,7 @@ import (
 	"maps"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"runtime"
 	"runtime/debug"
@@ -165,6 +166,72 @@ func (sc *ServerContext) CloseCpuPprofFile(ctx context.Context) (filename string
 	sc.cpuPprofFile = nil
 	sc.cpuPprofFileMutex.Unlock()
 	return filename
+}
+
+const fleetManagerMetricsInterval = 1 * time.Hour // todo: CBG-5525 make this configurable
+
+func (sc *ServerContext) reportFleetManagerMetrics(ctx context.Context) {
+	hostname, err := os.Hostname()
+	if err != nil {
+		base.WarnfCtx(ctx, "Could not read hostname for node UID fingerprint: %v", err)
+	}
+
+	report := func() {
+		metrics := base.CollectSGWFleetManagerMetrics(sc.NodeUID, hostname)
+		if err := sc.sendFleetManagerMetrics(ctx, metrics); err != nil {
+			base.WarnfCtx(ctx, "Could not report fleet manager metrics: %v", err)
+		}
+	}
+
+	ticker := time.NewTicker(fleetManagerMetricsInterval)
+	go func() {
+		defer ticker.Stop()
+		// Report once on startup rather than waiting a full interval for the first tick.
+		report()
+		for {
+			select {
+			case <-ticker.C:
+				report()
+			case <-ctx.Done():
+				base.InfofCtx(ctx, base.KeyAll, "Stopping fleet manager metrics reporting: %v", context.Cause(ctx))
+				return
+			}
+		}
+	}()
+	base.InfofCtx(ctx, base.KeyAll, "Starting fleet manager metrics reporting")
+}
+
+// sendFleetManagerMetrics POSTs the collected metrics to the ns_server fleet manager collector
+// ingest endpoint on the Couchbase Server management API. A 404 means the connected server predates
+// the collector endpoint (or it has been removed); this is treated as a benign skip so reporting
+// starts automatically once the server is upgraded, rather than a hard error.
+func (sc *ServerContext) sendFleetManagerMetrics(ctx context.Context, metrics base.SyncGatewayFleetManagerMetrics) error {
+	endpoints, httpClient, err := sc.ObtainManagementEndpointsAndHTTPClient()
+	if err != nil {
+		return fmt.Errorf("could not obtain management endpoints: %w", err)
+	}
+
+	metricsJSON, err := base.JSONMarshal(metrics)
+	if err != nil {
+		return fmt.Errorf("could not marshal fleet manager metrics: %w", err)
+	}
+
+	uri := fmt.Sprintf("/_lighthouseCollector/ingest?product_name=%s&instance_id=%s", base.ProductInfoName, url.QueryEscape(metrics.InstanceID))
+	statusCode, respBytes, err := doHTTPAuthRequest(ctx, httpClient, sc.Config.Bootstrap.Username, sc.Config.Bootstrap.Password, http.MethodPost, uri, "application/json", endpoints, metricsJSON)
+	if err != nil {
+		return err
+	}
+	switch statusCode {
+	case http.StatusNoContent:
+		return nil
+	case http.StatusNotFound:
+		// Server doesn't expose the collector endpoint (too old, or collector removed). Skip quietly
+		// and retry on the next interval.
+		base.DebugfCtx(ctx, base.KeyAll, "Fleet manager collector endpoint unavailable (status %d); will retry next interval", statusCode)
+		return nil
+	default:
+		return fmt.Errorf("unexpected status %d from fleet manager collector: %s", statusCode, respBytes)
+	}
 }
 
 func NewServerContext(ctx context.Context, config *StartupConfig, persistentConfig bool) *ServerContext {
@@ -2074,7 +2141,7 @@ func (sc *ServerContext) ObtainManagementEndpointsAndHTTPClient() ([]string, *ht
 func CheckPermissions(ctx context.Context, httpClient *http.Client, managementEndpoints []string, bucketName, username, password string, accessPermissions []Permission, responsePermissions []Permission) (statusCode int, permissionResults map[string]bool, err error) {
 	combinedPermissions := append(accessPermissions, responsePermissions...)
 	body := []byte(strings.Join(FormatPermissionNames(combinedPermissions, bucketName), ","))
-	statusCode, bodyResponse, err := doHTTPAuthRequest(ctx, httpClient, username, password, "POST", "/pools/default/checkPermissions", managementEndpoints, body)
+	statusCode, bodyResponse, err := doHTTPAuthRequest(ctx, httpClient, username, password, "POST", "/pools/default/checkPermissions", "", managementEndpoints, body)
 	if err != nil {
 		return http.StatusInternalServerError, nil, err
 	}
@@ -2128,7 +2195,7 @@ type WhoAmIResponse struct {
 }
 
 func cbRBACWhoAmI(ctx context.Context, httpClient *http.Client, managementEndpoints []string, username, password string) (response *WhoAmIResponse, statusCode int, err error) {
-	statusCode, bodyResponse, err := doHTTPAuthRequest(ctx, httpClient, username, password, "GET", "/whoami", managementEndpoints, nil)
+	statusCode, bodyResponse, err := doHTTPAuthRequest(ctx, httpClient, username, password, "GET", "/whoami", "", managementEndpoints, nil)
 	if err != nil {
 		return nil, http.StatusInternalServerError, err
 	}
@@ -2169,12 +2236,12 @@ func CheckRoles(ctx context.Context, httpClient *http.Client, managementEndpoint
 	return http.StatusForbidden, nil
 }
 
-func doHTTPAuthRequest(ctx context.Context, httpClient *http.Client, username, password, method, path string, endpoints []string, requestBody []byte) (statusCode int, responseBody []byte, err error) {
+func doHTTPAuthRequest(ctx context.Context, httpClient *http.Client, username, password, method, path, contentType string, endpoints []string, requestBody []byte) (statusCode int, responseBody []byte, err error) {
 	retryCount := 0
 
 	worker := func() (shouldRetry bool, err error, value any) {
 		endpointIdx := retryCount % len(endpoints)
-		responseBody, statusCode, err = base.MgmtRequest(httpClient, endpoints[endpointIdx], method, path, "", username, password, bytes.NewBuffer(requestBody))
+		responseBody, statusCode, err = base.MgmtRequest(httpClient, endpoints[endpointIdx], method, path, contentType, username, password, bytes.NewBuffer(requestBody))
 
 		if err, ok := err.(net.Error); ok && err.Timeout() {
 			retryCount++
@@ -2774,7 +2841,7 @@ func (sc *ServerContext) getClusterUUID(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	statusCode, output, err := doHTTPAuthRequest(ctx, client, sc.Config.Bootstrap.Username, sc.Config.Bootstrap.Password, http.MethodGet, "/pools", eps, nil)
+	statusCode, output, err := doHTTPAuthRequest(ctx, client, sc.Config.Bootstrap.Username, sc.Config.Bootstrap.Password, http.MethodGet, "/pools", "", eps, nil)
 	if err != nil {
 		return "", err
 	}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -19,7 +19,6 @@ import (
 	"maps"
 	"net"
 	"net/http"
-	"net/url"
 	"os"
 	"runtime"
 	"runtime/debug"
@@ -33,14 +32,12 @@ import (
 
 	"github.com/KimMachineGun/automemlimit/memlimit"
 	"github.com/couchbase/gocb/v2"
-	"github.com/couchbase/sync_gateway/auth"
-	"github.com/couchbase/sync_gateway/db/functions"
-	"github.com/shirou/gopsutil/v4/mem"
-
 	"github.com/couchbase/gocbcore/v10"
 	sgbucket "github.com/couchbase/sg-bucket"
+	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
+	"github.com/couchbase/sync_gateway/db/functions"
 )
 
 const kDefaultSlowQueryWarningThreshold uint32 = 500 // ms
@@ -168,76 +165,6 @@ func (sc *ServerContext) CloseCpuPprofFile(ctx context.Context) (filename string
 	return filename
 }
 
-const fleetManagerMetricsInterval = 1 * time.Hour // todo: CBG-5525 make this configurable
-
-func (sc *ServerContext) reportFleetManagerMetrics(ctx context.Context) {
-	hostname, err := os.Hostname()
-	if err != nil {
-		base.WarnfCtx(ctx, "Could not read hostname for fleet manager metrics: %v", err)
-	}
-
-	report := func() {
-		metrics := base.CollectSGWFleetManagerMetrics(ctx, sc.NodeUID, hostname)
-		if err := sc.sendFleetManagerMetrics(ctx, metrics); err != nil {
-			base.WarnfCtx(ctx, "Could not report fleet manager metrics: %v", err)
-		}
-	}
-
-	ticker := time.NewTicker(fleetManagerMetricsInterval)
-	go func() {
-		defer ticker.Stop()
-		// Report once on startup rather than waiting a full interval for the first tick.
-		report()
-		for {
-			select {
-			case <-ticker.C:
-				report()
-			case <-ctx.Done():
-				base.InfofCtx(ctx, base.KeyAll, "Stopping fleet manager metrics reporting: %v", context.Cause(ctx))
-				return
-			}
-		}
-	}()
-	base.InfofCtx(ctx, base.KeyAll, "Starting fleet manager metrics reporting")
-}
-
-// sendFleetManagerMetrics POSTs the collected metrics to the ns_server fleet manager collector
-// ingest endpoint on the Couchbase Server management API. A 404 means the connected server predates
-// the collector endpoint (or it has been removed); this is treated as a benign skip so reporting
-// starts automatically once the server is upgraded, rather than a hard error.
-func (sc *ServerContext) sendFleetManagerMetrics(ctx context.Context, metrics base.SyncGatewayFleetManagerMetrics) error {
-	endpoints, httpClient, err := sc.ObtainManagementEndpointsAndHTTPClient()
-	if err != nil {
-		return fmt.Errorf("could not obtain management endpoints: %w", err)
-	}
-	if len(endpoints) == 0 {
-		return fmt.Errorf("no management endpoints available")
-	}
-
-	metricsJSON, err := base.JSONMarshal(metrics)
-	if err != nil {
-		return fmt.Errorf("could not marshal fleet manager metrics: %w", err)
-	}
-
-	uri := fmt.Sprintf("/_telemetryCollector/ingest?product_name=%s&instance_id=%s", base.ProductInfoName, url.QueryEscape(metrics.InstanceID))
-	statusCode, _, err := doHTTPAuthRequest(ctx, httpClient, sc.Config.Bootstrap.Username, sc.Config.Bootstrap.Password, http.MethodPost, uri, "application/json", endpoints, metricsJSON)
-	if err != nil {
-		return err
-	}
-	switch statusCode {
-	case http.StatusNoContent:
-		// success
-		return nil
-	case http.StatusNotFound:
-		// Server doesn't expose the collector endpoint (too old, or collector removed). Skip quietly
-		// and retry on the next interval.
-		base.DebugfCtx(ctx, base.KeyAll, "Fleet manager collector endpoint unavailable (status %d); will retry next interval", statusCode)
-		return nil
-	default:
-		return fmt.Errorf("unexpected status %d from fleet manager collector", statusCode)
-	}
-}
-
 func NewServerContext(ctx context.Context, config *StartupConfig, persistentConfig bool) *ServerContext {
 	serverCtx, serverCtxCancel := context.WithCancelCause(context.Background())
 	sc := &ServerContext{
@@ -276,7 +203,7 @@ func NewServerContext(ctx context.Context, config *StartupConfig, persistentConf
 	if config.HeapProfileCollectionThreshold != nil {
 		sc.statsContext.heapProfileCollectionThreshold = *config.HeapProfileCollectionThreshold
 	} else {
-		memoryTotal := getTotalMemory(ctx)
+		memoryTotal := base.GetTotalMemory(ctx, true)
 		if memoryTotal != 0 {
 			sc.statsContext.heapProfileCollectionThreshold = uint64(float64(memoryTotal) * 0.85)
 		} else {
@@ -2809,21 +2736,6 @@ func getRuntimeStatus() *RuntimeStatus {
 	}
 
 	return rs
-}
-
-// getTotalMemory returns the total memory available on the system. If a cgroup is detected, it will use the cgroup memory max.
-func getTotalMemory(ctx context.Context) uint64 {
-	memoryTotal, err := memlimit.FromCgroup()
-	if err == nil {
-		return memoryTotal
-	}
-	base.TracefCtx(ctx, base.KeyAll, "Did not detect a cgroup for a memory limit")
-	memory, err := mem.VirtualMemory()
-	if err != nil {
-		base.WarnfCtx(ctx, "Error getting total memory from gopsutil: %v", err)
-		return 0
-	}
-	return memory.Total
 }
 
 // getClusterUUID returns the cluster UUID. rosmar does not have a ClusterUUID, so this will return an empty cluster UUID and no error in this case.

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -173,11 +173,11 @@ const fleetManagerMetricsInterval = 1 * time.Hour // todo: CBG-5525 make this co
 func (sc *ServerContext) reportFleetManagerMetrics(ctx context.Context) {
 	hostname, err := os.Hostname()
 	if err != nil {
-		base.WarnfCtx(ctx, "Could not read hostname for node UID fingerprint: %v", err)
+		base.WarnfCtx(ctx, "Could not read hostname for fleet manager metrics: %v", err)
 	}
 
 	report := func() {
-		metrics := base.CollectSGWFleetManagerMetrics(sc.NodeUID, hostname)
+		metrics := base.CollectSGWFleetManagerMetrics(ctx, sc.NodeUID, hostname)
 		if err := sc.sendFleetManagerMetrics(ctx, metrics); err != nil {
 			base.WarnfCtx(ctx, "Could not report fleet manager metrics: %v", err)
 		}
@@ -223,6 +223,7 @@ func (sc *ServerContext) sendFleetManagerMetrics(ctx context.Context, metrics ba
 	}
 	switch statusCode {
 	case http.StatusNoContent:
+		// success
 		return nil
 	case http.StatusNotFound:
 		// Server doesn't expose the collector endpoint (too old, or collector removed). Skip quietly

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -1116,7 +1116,7 @@ func TestValidateChangesUseSystemMetadataCollection(t *testing.T) {
 }
 
 func TestHeapProfileValuesPopulated(t *testing.T) {
-	totalMemory := uint64(float64(getTotalMemory(base.TestCtx(t))) * 0.85)
+	totalMemory := uint64(float64(base.GetTotalMemory(base.TestCtx(t), true)) * 0.85)
 	testCases := []struct {
 		name                           string
 		startupConfig                  *StartupConfig

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -1286,12 +1286,11 @@ func TestCollectStackTraceFile(t *testing.T) {
 	require.ElementsMatch(t, files, expectedFiles)
 }
 
-/// need ot get these test behind server versiosn that support light house (may get 401 on endpioints that don;t exist on server versions)
-
 func TestSendingMetricsToNsServerCollector(t *testing.T) {
 	if !sgtest.TestUseCouchbaseServer() {
 		t.Skip("Fleet Manager Collector only works on CBS")
 	}
+	base.RequireServerVersionForTest(t, "7.6.12", "8.0.3", "8.1.0")
 	rt := NewRestTesterPersistentConfig(t)
 	defer rt.Close()
 	ctx := rt.Context()
@@ -1330,6 +1329,7 @@ func TestSendingMetricsWhenCollectorDisabled(t *testing.T) {
 	if !sgtest.TestUseCouchbaseServer() {
 		t.Skip("Fleet Manager Collector only works on CBS")
 	}
+	base.RequireServerVersionForTest(t, "7.6.12", "8.0.3", "8.1.0")
 
 	rt := NewRestTesterPersistentConfig(t)
 	defer rt.Close()

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -1299,7 +1299,7 @@ func TestSendingMetricsToNsServerCollector(t *testing.T) {
 	gocbV2Bucket, err := base.AsGocbV2Bucket(bucket)
 	require.NoError(t, err)
 
-	uri := "/internal/settings/lighthouse"
+	uri := "/internal/settings/telemetry"
 	respBytes, _, err := gocbV2Bucket.MgmtRequest(ctx, http.MethodGet, uri, "application/json", nil)
 	require.NoError(t, err)
 	var settings base.FleetManagerCollectorSettings
@@ -1362,28 +1362,53 @@ func TestSendingMetricsWhenCollectorDisabled(t *testing.T) {
 	gocbV2Bucket, err := base.AsGocbV2Bucket(bucket)
 	require.NoError(t, err)
 
-	uri := "/internal/settings/lighthouse"
+	uri := "/internal/settings/telemetry"
 	disableBody := []byte(`{"enabled": false}`)
 	respBytes, statusCode, err := gocbV2Bucket.MgmtRequest(ctx, http.MethodPost, uri, "application/json", bytes.NewReader(disableBody))
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, statusCode, "unexpected response: %s code: %d", string(respBytes), statusCode)
+
+	// Re-enable the cluster-wide collector via defer so we don't leak the disabled state to other
+	// tests on the shared cluster if an assertion below fails before we get to flip it back.
+	defer func() {
+		enableBody := []byte(`{"enabled": true}`)
+		respBytes, statusCode, err := gocbV2Bucket.MgmtRequest(ctx, http.MethodPost, uri, "application/json", bytes.NewReader(enableBody))
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, statusCode)
+
+		// verify enabled is true now
+		settings := base.FleetManagerCollectorSettings{}
+		require.NoError(t, base.JSONUnmarshal(respBytes, &settings))
+		assert.True(t, settings.Enabled)
+	}()
+
 	var settings base.FleetManagerCollectorSettings
 	require.NoError(t, base.JSONUnmarshal(respBytes, &settings))
 	assert.False(t, settings.Enabled)
 
 	metrics := base.CollectSGWFleetManagerMetrics(ctx, "someNodeID", "myHost")
 	require.NoError(t, rt.ServerContext().sendFleetManagerMetrics(ctx, metrics))
+}
 
-	// now flip collector back to enabled for next test
-	enableBody := []byte(`{"enabled": true}`)
-	respBytes, statusCode, err = gocbV2Bucket.MgmtRequest(ctx, http.MethodPost, uri, "application/json", bytes.NewReader(enableBody))
+func TestNoContentResponseForCollector(t *testing.T) {
+	if !sgtest.TestUseCouchbaseServer() {
+		t.Skip("Fleet Manager Collector only works on CBS")
+	}
+	base.RequireServerVersionForTest(t, "7.6.12", "8.0.3", "8.1.0")
+	rt := NewRestTesterPersistentConfig(t)
+	defer rt.Close()
+
+	gocbV2Bucket, err := base.AsGocbV2Bucket(rt.Bucket())
 	require.NoError(t, err)
-	assert.Equal(t, http.StatusOK, statusCode)
 
-	// verify enabled is true now
-	settings = base.FleetManagerCollectorSettings{}
-	require.NoError(t, base.JSONUnmarshal(respBytes, &settings))
-	assert.True(t, settings.Enabled)
+	metrics := base.CollectSGWFleetManagerMetrics(base.TestCtx(t), "someNodeID", "myHost")
+	uri := fmt.Sprintf("/_telemetryCollector/ingest?product_name=%s&instance_id=%s", base.ProductInfoName, "someID")
+	metricsBytes, err := base.JSONMarshal(metrics)
+	require.NoError(t, err)
+	respBytes, statusCode, err := gocbV2Bucket.MgmtRequest(rt.Context(), http.MethodPost, uri, "application/json", bytes.NewReader(metricsBytes))
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, statusCode)
+	assert.Empty(t, respBytes)
 }
 
 func TestAllFleetManagerMetricsPopulated(t *testing.T) {

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbase/sync_gateway/testing/assert"
 	"github.com/couchbase/sync_gateway/testing/require"
+	"github.com/couchbase/sync_gateway/testing/sgtest"
 )
 
 // TestIsPerDBMigrationInProgress verifies the guard that prevents a joining node from marking
@@ -1283,4 +1284,98 @@ func TestCollectStackTraceFile(t *testing.T) {
 	files := getFilenames(t, tempPath)
 	require.Len(t, files, 10)
 	require.ElementsMatch(t, files, expectedFiles)
+}
+
+/// need ot get these test behind server versiosn that support light house (may get 401 on endpioints that don;t exist on server versions)
+
+func TestSendingMetricsToNsServerCollector(t *testing.T) {
+	if !sgtest.TestUseCouchbaseServer() {
+		t.Skip("Fleet Manager Collector only works on CBS")
+	}
+	rt := NewRestTesterPersistentConfig(t)
+	defer rt.Close()
+	ctx := rt.Context()
+	bucket := rt.Bucket()
+
+	gocbV2Bucket, err := base.AsGocbV2Bucket(bucket)
+	require.NoError(t, err)
+
+	serverIsCE := base.TestsUseServerCE()
+
+	SGWorBFArole := MobileSyncGatewayRole.RoleName
+	if serverIsCE {
+		SGWorBFArole = BucketFullAccessRole.RoleName
+	}
+
+	eps, httpClient, err := rt.ServerContext().ObtainManagementEndpointsAndHTTPClient()
+	require.NoError(t, err)
+
+	base.MakeUser(t, httpClient, eps[0], "MobileSyncGatewayUser", "password", []string{fmt.Sprintf("%s[%s]", SGWorBFArole, rt.Bucket().GetName())})
+	defer base.DeleteUser(t, httpClient, eps[0], "MobileSyncGatewayUser")
+
+	uri := fmt.Sprintf("/internal/settings/lighthouse")
+	respBytes, _, err := gocbV2Bucket.MgmtRequest(ctx, http.MethodGet, uri, "application/json", nil)
+	require.NoError(t, err)
+	var settings base.FleetManagerCollectorSettings
+	require.NoError(t, base.JSONUnmarshal(respBytes, &settings))
+	assert.True(t, settings.Enabled) // enabled by default
+	assert.NotEmpty(t, settings.IntervalSeconds)
+
+	// Exercise the production send path rather than re-implementing the POST here.
+	metrics := base.CollectSGWFleetManagerMetrics("someNodeID", "myHost")
+	require.NoError(t, rt.ServerContext().sendFleetManagerMetrics(ctx, metrics))
+}
+
+func TestSendingMetricsWhenCollectorDisabled(t *testing.T) {
+	if !sgtest.TestUseCouchbaseServer() {
+		t.Skip("Fleet Manager Collector only works on CBS")
+	}
+
+	rt := NewRestTesterPersistentConfig(t)
+	defer rt.Close()
+	ctx := rt.Context()
+	bucket := rt.Bucket()
+
+	gocbV2Bucket, err := base.AsGocbV2Bucket(bucket)
+	require.NoError(t, err)
+
+	uri := fmt.Sprintf("/internal/settings/lighthouse")
+	disableBody := []byte(`{"enabled": false}`)
+	respBytes, statusCode, err := gocbV2Bucket.MgmtRequest(ctx, http.MethodPost, uri, "application/json", bytes.NewReader(disableBody))
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, statusCode, "unexpected response: %s code: %d", string(respBytes), statusCode)
+	var settings base.FleetManagerCollectorSettings
+	require.NoError(t, base.JSONUnmarshal(respBytes, &settings))
+	assert.False(t, settings.Enabled)
+
+	metrics := base.CollectSGWFleetManagerMetrics("someNodeID", "myHost")
+	require.NoError(t, rt.ServerContext().sendFleetManagerMetrics(ctx, metrics))
+
+	// now flip collector back to enabled for next test
+	enableBody := []byte(`{"enabled": true}`)
+	respBytes, statusCode, err = gocbV2Bucket.MgmtRequest(ctx, http.MethodPost, uri, "application/json", bytes.NewReader(enableBody))
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, statusCode)
+
+	// verify enabled is true now
+	settings = base.FleetManagerCollectorSettings{}
+	require.NoError(t, base.JSONUnmarshal(respBytes, &settings))
+	assert.True(t, settings.Enabled)
+}
+
+func TestAllFleetManagerMetricsPopulated(t *testing.T) {
+	rt := NewRestTesterPersistentConfig(t)
+	defer rt.Close()
+
+	metrics := base.CollectSGWFleetManagerMetrics("someNodeID", "myHost")
+	assert.NotEmpty(t, metrics.InstanceID)
+	assert.NotZero(t, metrics.CpuCores)
+	assert.NotEmpty(t, metrics.RamBytesTotal)
+	assert.NotEmpty(t, metrics.RamBytesUsed)
+	assert.NotEmpty(t, metrics.OSVersion)
+	assert.NotEmpty(t, metrics.Hostname)
+	assert.GreaterOrEqual(t, metrics.UptimeSeconds, 0)
+	assert.NotEmpty(t, metrics.ProductInfo.Edition)
+	assert.NotEmpty(t, metrics.ProductInfo.Version)
+	assert.NotEmpty(t, metrics.ProductInfo.Name)
 }

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -1299,30 +1299,53 @@ func TestSendingMetricsToNsServerCollector(t *testing.T) {
 	gocbV2Bucket, err := base.AsGocbV2Bucket(bucket)
 	require.NoError(t, err)
 
-	serverIsCE := base.TestsUseServerCE()
-
-	SGWorBFArole := MobileSyncGatewayRole.RoleName
-	if serverIsCE {
-		SGWorBFArole = BucketFullAccessRole.RoleName
-	}
-
-	eps, httpClient, err := rt.ServerContext().ObtainManagementEndpointsAndHTTPClient()
-	require.NoError(t, err)
-
-	base.MakeUser(t, httpClient, eps[0], "MobileSyncGatewayUser", "password", []string{fmt.Sprintf("%s[%s]", SGWorBFArole, rt.Bucket().GetName())})
-	defer base.DeleteUser(t, httpClient, eps[0], "MobileSyncGatewayUser")
-
-	uri := fmt.Sprintf("/internal/settings/lighthouse")
+	uri := "/internal/settings/lighthouse"
 	respBytes, _, err := gocbV2Bucket.MgmtRequest(ctx, http.MethodGet, uri, "application/json", nil)
 	require.NoError(t, err)
 	var settings base.FleetManagerCollectorSettings
 	require.NoError(t, base.JSONUnmarshal(respBytes, &settings))
 	assert.True(t, settings.Enabled) // enabled by default
-	assert.NotEmpty(t, settings.IntervalSeconds)
+	assert.NotEmpty(t, settings.ReportingInterval)
 
 	// Exercise the production send path rather than re-implementing the POST here.
-	metrics := base.CollectSGWFleetManagerMetrics("someNodeID", "myHost")
+	metrics := base.CollectSGWFleetManagerMetrics(ctx, "someNodeID", "myHost")
 	require.NoError(t, rt.ServerContext().sendFleetManagerMetrics(ctx, metrics))
+}
+
+// TestSendingMetricsToNsServerCollectorAsMobileSyncGatewayRole verifies that a user holding only the
+// role Sync Gateway is bootstrapped with (mobile_sync_gateway on Enterprise, bucket_full_access on
+// Community) is authorized to POST to the ns_server collector endpoint. Operators are expected to
+// bootstrap Sync Gateway with such a user, so we point the server's bootstrap credentials at a
+// freshly-created user with that role and run the production send path as it.
+func TestSendingMetricsToNsServerCollectorAsMobileSyncGatewayRole(t *testing.T) {
+	if !sgtest.TestUseCouchbaseServer() {
+		t.Skip("Fleet Manager Collector only works on CBS")
+	}
+	base.RequireServerVersionForTest(t, "7.6.12", "8.0.3", "8.1.0")
+	rt := NewRestTesterPersistentConfig(t)
+	defer rt.Close()
+	ctx := rt.Context()
+	sc := rt.ServerContext()
+
+	eps, httpClient, err := sc.ObtainManagementEndpointsAndHTTPClient()
+	require.NoError(t, err)
+
+	roleName := MobileSyncGatewayRole.RoleName
+	if base.TestsUseServerCE() {
+		roleName = BucketFullAccessRole.RoleName
+	}
+
+	const username, password = "MobileSyncGatewayUser", "password"
+	role := fmt.Sprintf("%s[%s]", roleName, rt.Bucket().GetName())
+	base.MakeUser(t, httpClient, eps[0], username, password, []string{role})
+	defer base.DeleteUser(t, httpClient, eps[0], username)
+
+	// Redirect the send path's authentication to the scoped user for the test;
+	// sendFleetManagerMetrics reads these credentials at call time.
+	sc.Config.Bootstrap.Username, sc.Config.Bootstrap.Password = username, password
+
+	metrics := base.CollectSGWFleetManagerMetrics(ctx, "someNodeID", "myHost")
+	require.NoError(t, sc.sendFleetManagerMetrics(ctx, metrics))
 }
 
 func TestSendingMetricsWhenCollectorDisabled(t *testing.T) {
@@ -1339,7 +1362,7 @@ func TestSendingMetricsWhenCollectorDisabled(t *testing.T) {
 	gocbV2Bucket, err := base.AsGocbV2Bucket(bucket)
 	require.NoError(t, err)
 
-	uri := fmt.Sprintf("/internal/settings/lighthouse")
+	uri := "/internal/settings/lighthouse"
 	disableBody := []byte(`{"enabled": false}`)
 	respBytes, statusCode, err := gocbV2Bucket.MgmtRequest(ctx, http.MethodPost, uri, "application/json", bytes.NewReader(disableBody))
 	require.NoError(t, err)
@@ -1348,7 +1371,7 @@ func TestSendingMetricsWhenCollectorDisabled(t *testing.T) {
 	require.NoError(t, base.JSONUnmarshal(respBytes, &settings))
 	assert.False(t, settings.Enabled)
 
-	metrics := base.CollectSGWFleetManagerMetrics("someNodeID", "myHost")
+	metrics := base.CollectSGWFleetManagerMetrics(ctx, "someNodeID", "myHost")
 	require.NoError(t, rt.ServerContext().sendFleetManagerMetrics(ctx, metrics))
 
 	// now flip collector back to enabled for next test
@@ -1366,12 +1389,15 @@ func TestSendingMetricsWhenCollectorDisabled(t *testing.T) {
 func TestAllFleetManagerMetricsPopulated(t *testing.T) {
 	rt := NewRestTesterPersistentConfig(t)
 	defer rt.Close()
+	ctx := rt.Context()
 
-	metrics := base.CollectSGWFleetManagerMetrics("someNodeID", "myHost")
+	metrics := base.CollectSGWFleetManagerMetrics(ctx, "someNodeID", "myHost")
 	assert.NotEmpty(t, metrics.InstanceID)
 	assert.NotZero(t, metrics.CpuCores)
-	assert.NotEmpty(t, metrics.RamBytesTotal)
-	assert.NotEmpty(t, metrics.RamBytesUsed)
+	// RAM values are sampled directly at collection time, so they must be populated even before the
+	// stats-logger ticker has run (a "0" string passes NotEmpty, which is why we check for non-zero).
+	assert.NotEqual(t, "0", metrics.RamBytesTotal)
+	assert.NotEqual(t, "0", metrics.RamBytesUsed)
 	assert.NotEmpty(t, metrics.OSVersion)
 	assert.NotEmpty(t, metrics.Hostname)
 	assert.GreaterOrEqual(t, metrics.UptimeSeconds, 0)


### PR DESCRIPTION
CBG-5524

Collect and send a phone home record to ns server telemetry collector for fleet manager metrics. 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/905/ (server 8.1.0)
- [x] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/906/ (server 8.0.3) flaked
- [x] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/905/ (server 7.6.12)
