### PR TITLE
CBG-5556 fix TestDCPCheckpointCleanup panic

### DIFF
--- a/base/dcp_client_test.go
+++ b/base/dcp_client_test.go
@@ -937,8 +937,7 @@ func TestDCPCheckpointCleanup(t *testing.T) {
 	foundDocs := make(chan string, len(dataStores))
 	callback := func(event sgbucket.FeedEvent) bool {
 		if strings.HasSuffix(string(event.Key), "_doc") {
-			mutationCount.Add(1)
-			if mutationCount.Load() == uint64(len(dataStores)) {
+			if mutationCount.Add(1) == uint64(len(dataStores)) {
 				close(foundDocs)
 			}
 		}


### PR DESCRIPTION
CBG-5556 fix TestDCPCheckpointCleanup panic

Fix a super unlikely panic where two goroutines both call Add() and then Load() and in between Add() and Load() the value was incremented. In this case, this could be called twice.

Panic:

```
=== RUN   TestDCPCheckpointCleanup
panic: close of closed channel

goroutine 26651 [running]:
github.com/couchbase/sync_gateway/base.TestDCPCheckpointCleanup.func1({{0xc28b0b00d7f840c3, 0x6629a0c88, 0x2f7c280}, {0xc00013f410, 0x30, 0x30}, {0xc0005b31d0, 0xd, 0x10}, 0x18bfb8049c300000, ...})
	/home/ubuntu/workspace/Pipeline_main/base/dcp_client_test.go:942 +0x99
github.com/couchbaselabs/rosmar.(*Bucket).StartDCPFeed.func1({{0xc28b0b00d7f840c3, 0x6629a0c88, 0x2f7c280}, {0xc00013f410, 0x30, 0x30}, {0xc0005b31d0, 0xd, 0x10}, 0x18bfb8049c300000, ...})
	/home/ubuntu/go/pkg/mod/github.com/couchbaselabs/rosmar@v0.0.0-20260625145110-3e0b3eaeb1b1/feeds.go:53 +0x98
github.com/couchbaselabs/rosmar.(*dcpFeed).run(0xc0000fe370)
	/home/ubuntu/go/pkg/mod/github.com/couchbaselabs/rosmar@v0.0.0-20260625145110-3e0b3eaeb1b1/feeds.go:289 +0x3a2
created by github.com/couchbaselabs/rosmar.(*Collection).StartDCPFeed in goroutine 26648
	/home/ubuntu/go/pkg/mod/github.com/couchbaselabs/rosmar@v0.0.0-20260625145110-3e0b3eaeb1b1/feeds.go:120 +0xb6b
```