### PR TITLE
CBG-5557: fix TestReplicationStatusActions flake

### DIFF
--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -736,6 +736,11 @@ func TestReplicationStatusActions(t *testing.T) {
 			status := rt1.GetReplicationStatus(replicationID)
 			assert.Equal(c, db.ReplicationStateStopped, status.Status)
 			assert.Equal(c, "", status.LastSeqPull)
+			replications := rt1.GetReplications()
+			cfg, ok := replications[replicationID]
+			if assert.True(c, ok, "replication %q not found", replicationID) {
+				assert.Equal(c, db.ReplicationStateStopped, cfg.TargetState)
+			}
 		}, 10*time.Second, 100*time.Millisecond)
 
 		// Restart the replication

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1269,6 +1269,7 @@ func RequestByUser(method, resource, body, username string) *http.Request {
 }
 
 func RequireStatus(t testing.TB, response *TestResponse, expectedStatus int) {
+	t.Helper()
 	require.Equalf(t, expectedStatus, response.Code,
 		"Response status %d %q (expected %d %q)\nfor %s <%s> : %s",
 		response.Code, http.StatusText(response.Code),
@@ -1277,6 +1278,7 @@ func RequireStatus(t testing.TB, response *TestResponse, expectedStatus int) {
 }
 
 func AssertStatus(t testing.TB, response *TestResponse, expectedStatus int) bool {
+	t.Helper()
 	return assert.Equalf(t, expectedStatus, response.Code,
 		"Response status %d %q (expected %d %q)\nfor %s <%s> : %s",
 		response.Code, http.StatusText(response.Code),

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -378,6 +378,7 @@ func (rt *RestTester) WaitForActiveReplicatorCount(expCount int) {
 }
 
 func (rt *RestTester) WaitForReplicationStatusForDB(dbName string, replicationID string, targetStatus string) {
+	rt.TB().Helper()
 	var status db.ReplicationStatus
 	successFunc := func() bool {
 		status = rt.GetReplicationStatusForDB(dbName, replicationID)
@@ -387,10 +388,12 @@ func (rt *RestTester) WaitForReplicationStatusForDB(dbName string, replicationID
 }
 
 func (rt *RestTester) WaitForReplicationStatus(replicationID string, targetStatus string) {
+	rt.TB().Helper()
 	rt.WaitForReplicationStatusForDB("{{.db}}", replicationID, targetStatus)
 }
 
 func (rt *RestTester) GetReplications() (replications map[string]db.ReplicationCfg) {
+	rt.TB().Helper()
 	rawResponse := rt.SendAdminRequest("GET", "/{{.db}}/_replication/", "")
 	RequireStatus(rt.TB(), rawResponse, 200)
 	require.NoError(rt.TB(), base.JSONUnmarshal(rawResponse.Body.Bytes(), &replications))
@@ -398,10 +401,12 @@ func (rt *RestTester) GetReplications() (replications map[string]db.ReplicationC
 }
 
 func (rt *RestTester) GetReplicationStatus(replicationID string) (status db.ReplicationStatus) {
+	rt.TB().Helper()
 	return rt.GetReplicationStatusForDB("{{.db}}", replicationID)
 }
 
 func (rt *RestTester) GetReplicationStatusForDB(dbName string, replicationID string) (status db.ReplicationStatus) {
+	rt.TB().Helper()
 	rawResponse := rt.SendAdminRequest("GET", "/"+dbName+"/_replicationStatus/"+replicationID, "")
 	RequireStatus(rt.TB(), rawResponse, 200)
 	require.NoError(rt.TB(), base.JSONUnmarshal(rawResponse.Body.Bytes(), &status))


### PR DESCRIPTION
CBG-5557: fix TestReplicationStatusActions flake

After action=reset, the sgReplicateManager goroutine calls alignState(ctx, resetting) on the local ActiveReplicator, which clears the checkpoint (c.Checkpointer = nil) and removes the persisted status document. At this point the in-memory replicator reports status=stopped and LastSeqPull="". The test's EventuallyWithT saw both conditions satisfied and proceeded to call action=start.

However, the manager hadn't yet called UpdateReplicationState(id, stopped) to persist TargetState=stopped back to the cluster config. That call happens synchronously after alignState returns, but there is a window between the two where TargetState is still "resetting" in the cluster config. UpdateReplicationState (called by action=start) reads the cluster config and passes TargetState to isValidStateChange, which rejects the "resetting -> running" transition with a 400.

