### PR TITLE
CBG-3658: Prevent non-finite CPU stat from corrupting stats serialization

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -1263,12 +1263,24 @@ func (s *SgwFloatStat) Add(delta float64) {
 	}
 }
 
+// formatValue renders the stat's current value as a JSON-safe string. JSON has no representation for
+// non-finite floats (+Inf/-Inf/NaN); emitting them as raw bytes ("+Inf" etc.) produces invalid JSON
+// that aborts the entire stats marshal (and the expvar output), so a single degenerate stat could
+// otherwise corrupt the whole serialized blob. Fall back to "0" in that case (CBG-3658).
+func (s *SgwFloatStat) formatValue() string {
+	val := math.Float64frombits(atomic.LoadUint64(&s.Val))
+	if math.IsInf(val, 0) || math.IsNaN(val) {
+		return "0"
+	}
+	return strconv.FormatFloat(val, 'g', -1, 64)
+}
+
 func (s *SgwFloatStat) MarshalJSON() ([]byte, error) {
-	return []byte(strconv.FormatFloat(math.Float64frombits(atomic.LoadUint64(&s.Val)), 'g', -1, 64)), nil
+	return []byte(s.formatValue()), nil
 }
 
 func (s *SgwFloatStat) String() string {
-	return strconv.FormatFloat(math.Float64frombits(atomic.LoadUint64(&s.Val)), 'g', -1, 64)
+	return s.formatValue()
 }
 
 func (s *SgwFloatStat) Value() float64 {

--- a/base/stats.go
+++ b/base/stats.go
@@ -1266,7 +1266,7 @@ func (s *SgwFloatStat) Add(delta float64) {
 // formatValue renders the stat's current value as a JSON-safe string. JSON has no representation for
 // non-finite floats (+Inf/-Inf/NaN); emitting them as raw bytes ("+Inf" etc.) produces invalid JSON
 // that aborts the entire stats marshal (and the expvar output), so a single degenerate stat could
-// otherwise corrupt the whole serialized blob. Fall back to "0" in that case (CBG-3658).
+// otherwise corrupt the whole serialized blob. Fall back to "0" in that case.
 func (s *SgwFloatStat) formatValue() string {
 	val := math.Float64frombits(atomic.LoadUint64(&s.Val))
 	if math.IsInf(val, 0) || math.IsNaN(val) {

--- a/base/stats_test.go
+++ b/base/stats_test.go
@@ -187,13 +187,15 @@ func TestSgwFloatStatMarshalNonFinite(t *testing.T) {
 			marshalled, err := JSONMarshalCanonical(map[string]*SgwFloatStat{"stat": stat})
 			require.NoError(t, err)
 
-			// The output must be valid, parseable JSON.
+			// The output must be valid, parseable JSON, and non-finite values must fall back to 0.
 			var roundTripped map[string]float64
 			require.NoError(t, JSONUnmarshal(marshalled, &roundTripped))
+			require.Equal(t, 0.0, roundTripped["stat"])
 
 			// String() satisfies expvar.Var, which likewise requires a valid JSON value.
 			var viaString float64
 			require.NoError(t, JSONUnmarshal([]byte(stat.String()), &viaString))
+			require.Equal(t, 0.0, viaString)
 		})
 	}
 }

--- a/base/stats_test.go
+++ b/base/stats_test.go
@@ -12,6 +12,7 @@ package base
 
 import (
 	"expvar"
+	"math"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/testing/require"
@@ -161,4 +162,38 @@ func initExpvarBaseEquivalent() *expvar.Map {
 	expvarMap.Set("per_replication", new(expvar.Map).Init())
 
 	return expvarMap
+}
+
+// TestSgwFloatStatMarshalNonFinite is a regression test for CBG-3658: a non-finite float value
+// (e.g. +Inf produced by a divide-by-zero in the process CPU percentage calculation) must not
+// corrupt stats serialization. Previously MarshalJSON emitted the raw bytes "+Inf"/"NaN", which the
+// JSON encoder rejected ("invalid character '+' looking for beginning of value"), collapsing the
+// entire SgwStats blob to "null".
+func TestSgwFloatStatMarshalNonFinite(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		value float64
+	}{
+		{"positive_infinity", math.Inf(1)},
+		{"negative_infinity", math.Inf(-1)},
+		{"nan", math.NaN()},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			stat := &SgwFloatStat{}
+			stat.Set(test.value)
+
+			// Marshal the stat inside a larger structure: this is the exact path that failed via
+			// SgwStats.String -> JSONMarshalCanonical.
+			marshalled, err := JSONMarshalCanonical(map[string]*SgwFloatStat{"stat": stat})
+			require.NoError(t, err)
+
+			// The output must be valid, parseable JSON.
+			var roundTripped map[string]float64
+			require.NoError(t, JSONUnmarshal(marshalled, &roundTripped))
+
+			// String() satisfies expvar.Var, which likewise requires a valid JSON value.
+			var viaString float64
+			require.NoError(t, JSONUnmarshal([]byte(stat.String()), &viaString))
+		})
+	}
 }

--- a/rest/stats_context.go
+++ b/rest/stats_context.go
@@ -114,28 +114,33 @@ func (statsContext *statsContext) calculateProcessCpuPercentage() (cpuPercentUti
 	}
 
 	// Otherwise calculate the cpu percentage based on current vs previous
-	prevSnapshot := statsContext.cpuStatsSnapshot
-
-	// The delta in user time for the process
-	deltaUserTimeJiffies := float64(currentSnapshot.procUserTimeJiffies - prevSnapshot.procUserTimeJiffies)
-
-	// The delta in system time for the process
-	deltaSystemTimeJiffies := float64(currentSnapshot.procSystemTimeJiffies - prevSnapshot.procSystemTimeJiffies)
-
-	// The combined delta of user + system time for the process
-	deltaSgProcessTimeJiffies := deltaUserTimeJiffies + deltaSystemTimeJiffies
-
-	// The delta in total time for the machine
-	deltaTotalTimeJiffies := float64(currentSnapshot.totalTimeJiffies - prevSnapshot.totalTimeJiffies)
-
-	// Calculate the CPU usage percentage for the SG process
-	cpuPercentUtilization = 100 * deltaSgProcessTimeJiffies / deltaTotalTimeJiffies
+	cpuPercentUtilization = currentSnapshot.cpuPercentageSince(statsContext.cpuStatsSnapshot)
 
 	// Store the current values as the previous values for the next time this function is called
 	statsContext.cpuStatsSnapshot = currentSnapshot
 
 	return cpuPercentUtilization, nil
 
+}
+
+// cpuPercentageSince returns the process CPU utilization percentage between the previous snapshot and
+// the receiver (current) snapshot. It returns 0 when no measurable system time has elapsed between
+// the two snapshots: without that guard the divide-by-zero yields +Inf/NaN, which then breaks stats
+// JSON serialization (CBG-3658). A zero total delta happens when stats are sampled very frequently,
+// or on platforms whose CPU accounting has coarse granularity.
+func (current *cpuStatsSnapshot) cpuPercentageSince(previous *cpuStatsSnapshot) float64 {
+	// The combined delta of user + system time for the process
+	deltaSgProcessTimeJiffies := float64(current.procUserTimeJiffies-previous.procUserTimeJiffies) +
+		float64(current.procSystemTimeJiffies-previous.procSystemTimeJiffies)
+
+	// The delta in total time for the machine
+	deltaTotalTimeJiffies := float64(current.totalTimeJiffies - previous.totalTimeJiffies)
+	if deltaTotalTimeJiffies <= 0 {
+		return 0
+	}
+
+	// Calculate the CPU usage percentage for the SG process
+	return 100 * deltaSgProcessTimeJiffies / deltaTotalTimeJiffies
 }
 
 func (statsContext *statsContext) addProcessCpuPercentage() error {

--- a/rest/stats_context.go
+++ b/rest/stats_context.go
@@ -124,9 +124,7 @@ func (statsContext *statsContext) calculateProcessCpuPercentage() (cpuPercentUti
 }
 
 // cpuPercentageSince returns the process CPU utilization percentage between the previous snapshot and
-// the receiver (current) snapshot. It returns 0 when no measurable system time has elapsed between
-// the two snapshots: without that guard the divide-by-zero yields +Inf/NaN, which then breaks stats
-// JSON serialization (CBG-3658). A zero total delta happens when stats are sampled very frequently,
+// the receiver (current) snapshot. A zero total delta happens when stats are sampled very frequently,
 // or on platforms whose CPU accounting has coarse granularity.
 func (current *cpuStatsSnapshot) cpuPercentageSince(previous *cpuStatsSnapshot) float64 {
 	// The combined delta of user + system time for the process

--- a/rest/stats_context_test.go
+++ b/rest/stats_context_test.go
@@ -13,6 +13,7 @@ package rest
 import (
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -24,6 +25,31 @@ import (
 	"github.com/couchbase/sync_gateway/testing/assert"
 	"github.com/couchbase/sync_gateway/testing/require"
 )
+
+// TestProcessCpuPercentageZeroTotalDelta is a regression test for CBG-3658: when two CPU snapshots
+// report the same total system jiffies (which happens when stats are sampled very frequently, or on
+// platforms with coarse CPU accounting) the percentage calculation must not divide by zero and
+// produce +Inf/NaN - which then breaks stats JSON serialization. It must report 0 instead.
+func TestProcessCpuPercentageZeroTotalDelta(t *testing.T) {
+	previous := &cpuStatsSnapshot{totalTimeJiffies: 1000, procUserTimeJiffies: 10, procSystemTimeJiffies: 5}
+	// Same total jiffies as previous, but the process consumed some time: without a guard this is
+	// 100 * positiveDelta / 0 = +Inf.
+	current := &cpuStatsSnapshot{totalTimeJiffies: 1000, procUserTimeJiffies: 20, procSystemTimeJiffies: 8}
+
+	got := current.cpuPercentageSince(previous)
+	require.False(t, math.IsInf(got, 0), "expected a finite percentage, got +/-Inf")
+	require.False(t, math.IsNaN(got), "expected a finite percentage, got NaN")
+	require.Equal(t, 0.0, got)
+}
+
+// TestProcessCpuPercentageNormal verifies the CPU percentage math over a normal (non-degenerate)
+// sampling interval is unaffected by the CBG-3658 divide-by-zero guard.
+func TestProcessCpuPercentageNormal(t *testing.T) {
+	previous := &cpuStatsSnapshot{totalTimeJiffies: 1000, procUserTimeJiffies: 10, procSystemTimeJiffies: 5}
+	current := &cpuStatsSnapshot{totalTimeJiffies: 1200, procUserTimeJiffies: 40, procSystemTimeJiffies: 15}
+	// deltaProcess = (40-10) + (15-5) = 40, deltaTotal = 200 -> 100 * 40 / 200 = 20.0
+	require.Equal(t, 20.0, current.cpuPercentageSince(previous))
+}
 
 func TestNetworkInterfaceStatsForHostnamePort(t *testing.T) {
 


### PR DESCRIPTION
CBG-3658

A divide-by-zero in the process CPU percentage calculation could produce +Inf/NaN when two CPU snapshots reported identical total system jiffies (very frequent stats sampling, or coarse platform CPU accounting). SgwFloatStat then emitted raw "+Inf"/"NaN" bytes, which the JSON encoder rejected, collapsing the entire SgwStats blob to "null" in sg_stats.log.

- Guard the CPU percentage division: return 0 when no total system time has elapsed. The arithmetic is extracted into cpuStatsSnapshot.cpuPercentageSince so the degenerate case is unit-testable without reading live system state.
- Harden SgwFloatStat rendering (shared formatValue used by MarshalJSON and String) to emit "0" for non-finite values, so no single stat can corrupt the whole serialized blob or the expvar output.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
