### PR TITLE
CBG-5472: Make the stats logger independent of the database lock

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -15,6 +15,7 @@ import (
 	"expvar"
 	"fmt"
 	"log"
+	"maps"
 	"math"
 	"slices"
 	"strconv"
@@ -106,13 +107,24 @@ const (
 	StatStabilityInternal  = "internal"
 )
 
-type SgwStats struct {
+// sgwStatsFields holds every serialized field of SgwStats. String() copies this struct whole, so a
+// stat added here reaches the output without String() having to name it.
+type sgwStatsFields struct {
 	GlobalStats     *GlobalStat         `json:"global"`
 	DbStats         map[string]*DbStats `json:"per_db"`
 	ReplicatorStats *ReplicatorStats    `json:"per_replication,omitempty"`
+}
+
+// SgwStats is the root of the stats tree serialized to the expvar/stats log output.
+// Declare new serialized stats in sgwStatsFields, not here.
+type SgwStats struct {
+	sgwStatsFields
 
 	dbStatsMapMutex sync.Mutex
 }
+
+// Compile-time interface check.
+var _ expvar.Var = &SgwStats{}
 
 var SyncGatewayStats *SgwStats
 
@@ -128,8 +140,10 @@ func NewSyncGatewayStats() (*SgwStats, error) {
 		return nil, err
 	}
 	sgwStats := SgwStats{
-		GlobalStats: globalStats,
-		DbStats:     map[string]*DbStats{},
+		sgwStatsFields: sgwStatsFields{
+			GlobalStats: globalStats,
+			DbStats:     map[string]*DbStats{},
+		},
 	}
 
 	err = sgwStats.initReplicationStats()
@@ -162,11 +176,20 @@ func init() {
 	expvar.Publish(StatsGroupKeySyncGateway, SyncGatewayStats)
 }
 
+// cloneDbStatsMap returns a shallow copy of the DbStats map, to hold the map lock for as short a time as possible.
+func (s *SgwStats) cloneDbStatsMap() map[string]*DbStats {
+	s.dbStatsMapMutex.Lock()
+	defer s.dbStatsMapMutex.Unlock()
+	return maps.Clone(s.DbStats)
+}
+
 // This String() is to satisfy the expvar.Var interface which is used to produce the expvar endpoint output.
 func (s *SgwStats) String() string {
-	s.dbStatsMapMutex.Lock()
-	bytes, err := JSONMarshalCanonical(s)
-	s.dbStatsMapMutex.Unlock()
+	// Copy every serialized field, then swap in a clone of the map that cannot be read unguarded.
+	statsCopy := s.sgwStatsFields
+	statsCopy.DbStats = s.cloneDbStatsMap()
+
+	bytes, err := JSONMarshalCanonical(statsCopy)
 	if err != nil {
 		ErrorfCtx(context.Background(), "Unable to Marshal SgwStats: %v", err)
 		return "null"
@@ -1355,8 +1378,7 @@ type QueryStat struct {
 }
 
 func (s *SgwStats) NewDBStats(name string, deltaSyncEnabled bool, importEnabled bool, viewsEnabled bool, metadataMigrationEnabled bool, queryNames []string, collections []string) (*DbStats, error) {
-	s.dbStatsMapMutex.Lock()
-	defer s.dbStatsMapMutex.Unlock()
+	// Build and register dbStats before taking the map lock, so Prometheus registration stays outside it.
 	dbStats := &DbStats{
 		dbName:            name,
 		DbReplicatorStats: make(map[string]*DbReplicatorStats),
@@ -1425,51 +1447,62 @@ func (s *SgwStats) NewDBStats(name string, deltaSyncEnabled bool, importEnabled 
 		return nil, err
 	}
 
+	s.dbStatsMapMutex.Lock()
+	defer s.dbStatsMapMutex.Unlock()
 	s.DbStats[name] = dbStats
+
 	return dbStats, nil
 }
 
 func (s *SgwStats) ClearDBStats(name string) {
-	s.dbStatsMapMutex.Lock()
-	defer s.dbStatsMapMutex.Unlock()
-
-	if _, ok := s.DbStats[name]; !ok {
+	dbStats, ok := s.popDbStats(name)
+	if !ok {
 		return
 	}
 
-	for scopeAndCollectionName := range s.DbStats[name].CollectionStats {
-		s.DbStats[name].unregisterCollectionStats(scopeAndCollectionName)
+	for scopeAndCollectionName := range dbStats.CollectionStats {
+		dbStats.unregisterCollectionStats(scopeAndCollectionName)
 	}
 
-	s.DbStats[name].unregisterCacheStats()
-	s.DbStats[name].unregisterCBLReplicationPullStats()
-	s.DbStats[name].unregisterCBLReplicationPushStats()
-	for replName := range s.DbStats[name].DbReplicatorStats {
-		s.DbStats[name].unregisterReplicationStats(replName)
+	dbStats.unregisterCacheStats()
+	dbStats.unregisterCBLReplicationPullStats()
+	dbStats.unregisterCBLReplicationPushStats()
+	// DBReplicatorStats() writes this map lazily, and can run while the database is torn down. Hold
+	// the mutex so iterating here cannot hit "concurrent map read and map write".
+	dbStats.dbReplicatorStatsMutex.Lock()
+	for replName := range dbStats.DbReplicatorStats {
+		dbStats.unregisterReplicationStats(replName)
 	}
-	s.DbStats[name].unregisterDatabaseStats()
-	s.DbStats[name].unregisterSecurityStats()
+	dbStats.dbReplicatorStatsMutex.Unlock()
+	dbStats.unregisterDatabaseStats()
+	dbStats.unregisterSecurityStats()
 
-	if s.DbStats[name].DeltaSyncStats != nil {
-		s.DbStats[name].unregisterDeltaSyncStats()
-	}
-
-	if s.DbStats[name].SharedBucketImportStats != nil {
-		s.DbStats[name].unregisterSharedBucketImportStats()
-	}
-
-	if s.DbStats[name].MigrationStats != nil {
-		s.DbStats[name].unregisterMigrationStats()
+	if dbStats.DeltaSyncStats != nil {
+		dbStats.unregisterDeltaSyncStats()
 	}
 
-	s.DbStats[name].unregisterQueryStats()
-	delete(s.DbStats, name)
+	if dbStats.SharedBucketImportStats != nil {
+		dbStats.unregisterSharedBucketImportStats()
+	}
+
+	if dbStats.MigrationStats != nil {
+		dbStats.unregisterMigrationStats()
+	}
+
+	dbStats.unregisterQueryStats()
 }
 
 // Removes the per-database stats for this database by removing the database from the map
 func RemovePerDbStats(dbName string) {
 	// Clear out the stats for this db since they will no longer be updated.
 	SyncGatewayStats.ClearDBStats(dbName)
+}
+
+// popDbStats removes the named database's stats from the map, and reports whether they were present.
+func (s *SgwStats) popDbStats(name string) (*DbStats, bool) {
+	s.dbStatsMapMutex.Lock()
+	defer s.dbStatsMapMutex.Unlock()
+	return PopMapEntry(s.DbStats, name)
 }
 
 func (d *DbStats) initCacheStats() error {
@@ -2366,15 +2399,18 @@ func (d *DbStats) InitCollectionStats(scopeAndCollectionNames ...string) error {
 	return nil
 }
 
+// DBReplicatorStats returns the stats for replicationID, building and registering them on first
+// use. The mutex is held throughout so the entry is only published once every stat is set.
 func (d *DbStats) DBReplicatorStats(replicationID string) (*DbReplicatorStats, error) {
 	d.dbReplicatorStatsMutex.Lock()
 	defer d.dbReplicatorStatsMutex.Unlock()
 
-	if _, ok := d.DbReplicatorStats[replicationID]; ok {
-		return d.DbReplicatorStats[replicationID], nil
+	if existing, ok := d.DbReplicatorStats[replicationID]; ok {
+		return existing, nil
 	}
-	var err error
+
 	resUtil := &DbReplicatorStats{}
+	var err error
 	labelKeys := []string{DatabaseLabelKey, ReplicationLabelKey}
 	labelVals := []string{d.dbName, replicationID}
 
@@ -2492,8 +2528,7 @@ func (d *DbStats) DBReplicatorStats(replicationID string) (*DbReplicatorStats, e
 	}
 
 	d.DbReplicatorStats[replicationID] = resUtil
-
-	return d.DbReplicatorStats[replicationID], nil
+	return resUtil, nil
 }
 
 // Reset replication stats to zero

--- a/base/stats.go
+++ b/base/stats.go
@@ -15,6 +15,7 @@ import (
 	"expvar"
 	"fmt"
 	"log"
+	"maps"
 	"math"
 	"slices"
 	"strconv"
@@ -106,13 +107,24 @@ const (
 	StatStabilityInternal  = "internal"
 )
 
-type SgwStats struct {
+// sgwStatsFields holds every serialized field of SgwStats. String() copies this struct whole, so a
+// stat added here reaches the output without String() having to name it.
+type sgwStatsFields struct {
 	GlobalStats     *GlobalStat         `json:"global"`
 	DbStats         map[string]*DbStats `json:"per_db"`
 	ReplicatorStats *ReplicatorStats    `json:"per_replication,omitempty"`
+}
+
+// SgwStats is the root of the stats tree serialized to the expvar/stats log output.
+// Declare new serialized stats in sgwStatsFields, not here.
+type SgwStats struct {
+	sgwStatsFields
 
 	dbStatsMapMutex sync.Mutex
 }
+
+// Compile-time interface check.
+var _ expvar.Var = &SgwStats{}
 
 var SyncGatewayStats *SgwStats
 
@@ -128,8 +140,10 @@ func NewSyncGatewayStats() (*SgwStats, error) {
 		return nil, err
 	}
 	sgwStats := SgwStats{
-		GlobalStats: globalStats,
-		DbStats:     map[string]*DbStats{},
+		sgwStatsFields: sgwStatsFields{
+			GlobalStats: globalStats,
+			DbStats:     map[string]*DbStats{},
+		},
 	}
 
 	err = sgwStats.initReplicationStats()
@@ -162,11 +176,20 @@ func init() {
 	expvar.Publish(StatsGroupKeySyncGateway, SyncGatewayStats)
 }
 
+// cloneDbStatsMap returns a shallow copy of the DbStats map, to hold the map lock for as short a time as possible.
+func (s *SgwStats) cloneDbStatsMap() map[string]*DbStats {
+	s.dbStatsMapMutex.Lock()
+	defer s.dbStatsMapMutex.Unlock()
+	return maps.Clone(s.DbStats)
+}
+
 // This String() is to satisfy the expvar.Var interface which is used to produce the expvar endpoint output.
 func (s *SgwStats) String() string {
-	s.dbStatsMapMutex.Lock()
-	bytes, err := JSONMarshalCanonical(s)
-	s.dbStatsMapMutex.Unlock()
+	// Copy every serialized field, then swap in a clone of the map that cannot be read unguarded.
+	statsCopy := s.sgwStatsFields
+	statsCopy.DbStats = s.cloneDbStatsMap()
+
+	bytes, err := JSONMarshalCanonical(statsCopy)
 	if err != nil {
 		ErrorfCtx(context.Background(), "Unable to Marshal SgwStats: %v", err)
 		return "null"
@@ -1350,8 +1373,7 @@ type QueryStat struct {
 }
 
 func (s *SgwStats) NewDBStats(name string, deltaSyncEnabled bool, importEnabled bool, viewsEnabled bool, metadataMigrationEnabled bool, queryNames []string, collections []string) (*DbStats, error) {
-	s.dbStatsMapMutex.Lock()
-	defer s.dbStatsMapMutex.Unlock()
+	// Build and register dbStats before taking the map lock, so Prometheus registration stays outside it.
 	dbStats := &DbStats{
 		dbName:            name,
 		DbReplicatorStats: make(map[string]*DbReplicatorStats),
@@ -1420,51 +1442,62 @@ func (s *SgwStats) NewDBStats(name string, deltaSyncEnabled bool, importEnabled 
 		return nil, err
 	}
 
+	s.dbStatsMapMutex.Lock()
+	defer s.dbStatsMapMutex.Unlock()
 	s.DbStats[name] = dbStats
+
 	return dbStats, nil
 }
 
 func (s *SgwStats) ClearDBStats(name string) {
-	s.dbStatsMapMutex.Lock()
-	defer s.dbStatsMapMutex.Unlock()
-
-	if _, ok := s.DbStats[name]; !ok {
+	dbStats, ok := s.popDbStats(name)
+	if !ok {
 		return
 	}
 
-	for scopeAndCollectionName := range s.DbStats[name].CollectionStats {
-		s.DbStats[name].unregisterCollectionStats(scopeAndCollectionName)
+	for scopeAndCollectionName := range dbStats.CollectionStats {
+		dbStats.unregisterCollectionStats(scopeAndCollectionName)
 	}
 
-	s.DbStats[name].unregisterCacheStats()
-	s.DbStats[name].unregisterCBLReplicationPullStats()
-	s.DbStats[name].unregisterCBLReplicationPushStats()
-	for replName := range s.DbStats[name].DbReplicatorStats {
-		s.DbStats[name].unregisterReplicationStats(replName)
+	dbStats.unregisterCacheStats()
+	dbStats.unregisterCBLReplicationPullStats()
+	dbStats.unregisterCBLReplicationPushStats()
+	// DBReplicatorStats() writes this map lazily, and can run while the database is torn down. Hold
+	// the mutex so iterating here cannot hit "concurrent map read and map write".
+	dbStats.dbReplicatorStatsMutex.Lock()
+	for replName := range dbStats.DbReplicatorStats {
+		dbStats.unregisterReplicationStats(replName)
 	}
-	s.DbStats[name].unregisterDatabaseStats()
-	s.DbStats[name].unregisterSecurityStats()
+	dbStats.dbReplicatorStatsMutex.Unlock()
+	dbStats.unregisterDatabaseStats()
+	dbStats.unregisterSecurityStats()
 
-	if s.DbStats[name].DeltaSyncStats != nil {
-		s.DbStats[name].unregisterDeltaSyncStats()
-	}
-
-	if s.DbStats[name].SharedBucketImportStats != nil {
-		s.DbStats[name].unregisterSharedBucketImportStats()
-	}
-
-	if s.DbStats[name].MigrationStats != nil {
-		s.DbStats[name].unregisterMigrationStats()
+	if dbStats.DeltaSyncStats != nil {
+		dbStats.unregisterDeltaSyncStats()
 	}
 
-	s.DbStats[name].unregisterQueryStats()
-	delete(s.DbStats, name)
+	if dbStats.SharedBucketImportStats != nil {
+		dbStats.unregisterSharedBucketImportStats()
+	}
+
+	if dbStats.MigrationStats != nil {
+		dbStats.unregisterMigrationStats()
+	}
+
+	dbStats.unregisterQueryStats()
 }
 
 // Removes the per-database stats for this database by removing the database from the map
 func RemovePerDbStats(dbName string) {
 	// Clear out the stats for this db since they will no longer be updated.
 	SyncGatewayStats.ClearDBStats(dbName)
+}
+
+// popDbStats removes the named database's stats from the map, and reports whether they were present.
+func (s *SgwStats) popDbStats(name string) (*DbStats, bool) {
+	s.dbStatsMapMutex.Lock()
+	defer s.dbStatsMapMutex.Unlock()
+	return PopMapEntry(s.DbStats, name)
 }
 
 func (d *DbStats) initCacheStats() error {
@@ -2351,15 +2384,18 @@ func (d *DbStats) InitCollectionStats(scopeAndCollectionNames ...string) error {
 	return nil
 }
 
+// DBReplicatorStats returns the stats for replicationID, building and registering them on first
+// use. The mutex is held throughout so the entry is only published once every stat is set.
 func (d *DbStats) DBReplicatorStats(replicationID string) (*DbReplicatorStats, error) {
 	d.dbReplicatorStatsMutex.Lock()
 	defer d.dbReplicatorStatsMutex.Unlock()
 
-	if _, ok := d.DbReplicatorStats[replicationID]; ok {
-		return d.DbReplicatorStats[replicationID], nil
+	if existing, ok := d.DbReplicatorStats[replicationID]; ok {
+		return existing, nil
 	}
-	var err error
+
 	resUtil := &DbReplicatorStats{}
+	var err error
 	labelKeys := []string{DatabaseLabelKey, ReplicationLabelKey}
 	labelVals := []string{d.dbName, replicationID}
 
@@ -2477,8 +2513,7 @@ func (d *DbStats) DBReplicatorStats(replicationID string) (*DbReplicatorStats, e
 	}
 
 	d.DbReplicatorStats[replicationID] = resUtil
-
-	return d.DbReplicatorStats[replicationID], nil
+	return resUtil, nil
 }
 
 // Reset replication stats to zero

--- a/base/stats.go
+++ b/base/stats.go
@@ -1467,13 +1467,7 @@ func (s *SgwStats) ClearDBStats(name string) {
 	dbStats.unregisterCacheStats()
 	dbStats.unregisterCBLReplicationPullStats()
 	dbStats.unregisterCBLReplicationPushStats()
-	// DBReplicatorStats() writes this map lazily, and can run while the database is torn down. Hold
-	// the mutex so iterating here cannot hit "concurrent map read and map write".
-	dbStats.dbReplicatorStatsMutex.Lock()
-	for replName := range dbStats.DbReplicatorStats {
-		dbStats.unregisterReplicationStats(replName)
-	}
-	dbStats.dbReplicatorStatsMutex.Unlock()
+	dbStats.unregisterAllReplicationStats()
 	dbStats.unregisterDatabaseStats()
 	dbStats.unregisterSecurityStats()
 
@@ -2253,6 +2247,17 @@ func (d *DbStats) initSecurityStats() error {
 		d.SecurityStats = resUtil
 	}
 	return nil
+}
+
+// unregisterAllReplicationStats unregisters the stats of every replication on this database.
+// DBReplicatorStats writes the map lazily, and can run while the database is torn down, so the
+// mutex is held for the whole iteration.
+func (d *DbStats) unregisterAllReplicationStats() {
+	d.dbReplicatorStatsMutex.Lock()
+	defer d.dbReplicatorStatsMutex.Unlock()
+	for replicationID := range d.DbReplicatorStats {
+		d.unregisterReplicationStats(replicationID)
+	}
 }
 
 func (d *DbStats) unregisterReplicationStats(replicationID string) {

--- a/base/stats.go
+++ b/base/stats.go
@@ -12,6 +12,7 @@ package base
 
 import (
 	"context"
+	"encoding/json"
 	"expvar"
 	"fmt"
 	"log"
@@ -447,8 +448,9 @@ type AuditStat struct {
 	NumAuditsFilteredByRole *SgwIntStat `json:"num_audits_filtered_by_role"`
 }
 
-type DbStats struct {
-	dbName                  string
+// dbStatsFields holds every serialized field of DbStats. MarshalJSON copies this struct whole, so a
+// stat added here reaches the output without MarshalJSON having to name it.
+type dbStatsFields struct {
 	CacheStats              *CacheStats                   `json:"cache,omitempty"`
 	CBLReplicationPullStats *CBLReplicationPullStats      `json:"cbl_replication_pull,omitempty"`
 	CBLReplicationPushStats *CBLReplicationPushStats      `json:"cbl_replication_push,omitempty"`
@@ -460,7 +462,37 @@ type DbStats struct {
 	SharedBucketImportStats *SharedBucketImportStats      `json:"shared_bucket_import,omitempty"`
 	MigrationStats          *MigrationStats               `json:"metadata_migration,omitempty"`
 	CollectionStats         map[string]*CollectionStats   `json:"per_collection,omitempty"`
-	dbReplicatorStatsMutex  sync.Mutex
+}
+
+// DbStats is the per-database stats tree.
+// Declare new serialized stats in dbStatsFields, not here.
+type DbStats struct {
+	dbStatsFields
+
+	dbName                 string
+	dbReplicatorStatsMutex sync.Mutex
+}
+
+// Compile-time interface check.
+var _ json.Marshaler = &DbStats{}
+
+// cloneDbReplicatorStatsMap returns a shallow copy of the DbReplicatorStats map, to hold the
+// replicator lock for as short a time as possible.
+func (d *DbStats) cloneDbReplicatorStatsMap() map[string]*DbReplicatorStats {
+	d.dbReplicatorStatsMutex.Lock()
+	defer d.dbReplicatorStatsMutex.Unlock()
+	return maps.Clone(d.DbReplicatorStats)
+}
+
+// MarshalJSON serializes the database stats. DBReplicatorStats writes DbReplicatorStats lazily
+// whenever a replication first reports a stat, so the map is swapped for a clone that no other
+// goroutine can write.
+func (d *DbStats) MarshalJSON() ([]byte, error) {
+	// Copy every serialized field, then swap in a clone of the map that cannot be read unguarded.
+	statsCopy := d.dbStatsFields
+	statsCopy.DbReplicatorStats = d.cloneDbReplicatorStatsMap()
+
+	return JSONMarshalCanonical(statsCopy)
 }
 
 type CacheStats struct {
@@ -1380,8 +1412,10 @@ type QueryStat struct {
 func (s *SgwStats) NewDBStats(name string, deltaSyncEnabled bool, importEnabled bool, viewsEnabled bool, metadataMigrationEnabled bool, queryNames []string, collections []string) (*DbStats, error) {
 	// Build and register dbStats before taking the map lock, so Prometheus registration stays outside it.
 	dbStats := &DbStats{
-		dbName:            name,
-		DbReplicatorStats: make(map[string]*DbReplicatorStats),
+		dbName: name,
+		dbStatsFields: dbStatsFields{
+			DbReplicatorStats: make(map[string]*DbReplicatorStats),
+		},
 	}
 
 	// These have a pretty good chance of being used so we'll initialise these for every database stat struct created

--- a/base/stats_test.go
+++ b/base/stats_test.go
@@ -13,11 +13,13 @@ package base
 import (
 	"expvar"
 	"fmt"
+	"maps"
 	"math"
 	"reflect"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/couchbase/sync_gateway/testing/require"
 
@@ -267,7 +269,7 @@ func TestStatsSerializationConcurrentWithDBRegistration(t *testing.T) {
 			}
 		})
 	}
-	wg.Wait()
+	WaitWithTimeout(t, &wg, time.Minute)
 }
 
 // TestClearDBStatsConcurrentWithReplicatorRegistration is a regression test for ClearDBStats
@@ -287,6 +289,7 @@ func TestClearDBStatsConcurrentWithReplicatorRegistration(t *testing.T) {
 	}
 
 	var wg sync.WaitGroup
+	defer WaitWithTimeout(t, &wg, time.Minute)
 	wg.Go(func() {
 		for i := range 100 {
 			_, err := dbStats.DBReplicatorStats(fmt.Sprintf("repl_%d", i))
@@ -296,7 +299,6 @@ func TestClearDBStatsConcurrentWithReplicatorRegistration(t *testing.T) {
 
 	// Iterates DbReplicatorStats concurrently with the registrations above.
 	stats.ClearDBStats(dbName)
-	wg.Wait()
 }
 
 // newTestDbStats returns a DbStats holding only the replicator map, bypassing NewDBStats so a test
@@ -306,8 +308,8 @@ func newTestDbStats(dbName string) *DbStats {
 }
 
 // TestDBReplicatorStatsFailedRegistrationNotCached checks that a DBReplicatorStats call which fails
-// partway through registration leaves nothing usable-looking behind. The entry is added to the map
-// before its stats are populated, so a retry returns a struct of nil stats and no error.
+// partway through registration caches nothing, so a caller can never be handed a half-populated
+// entry - the failure is reported again instead.
 func TestDBReplicatorStatsFailedRegistrationNotCached(t *testing.T) {
 	// TestMain sets this true, which would skip registration and so never produce a failure.
 	defer func(skip bool) { SkipPrometheusStatsRegistration = skip }(SkipPrometheusStatsRegistration)
@@ -328,17 +330,15 @@ func TestDBReplicatorStatsFailedRegistrationNotCached(t *testing.T) {
 	_, err = second.DBReplicatorStats(replicationID)
 	require.Error(t, err, "expected the duplicate Prometheus registration to fail")
 
-	retry, err := second.DBReplicatorStats(replicationID)
-	if err != nil {
-		return // reporting the failure to the caller is the correct behaviour
-	}
-	require.NotNil(t, retry.NumAttachmentBytesPushed,
-		"retry returned a cached half-initialized entry with no error")
+	require.NotContains(t, maps.Keys(second.DbReplicatorStats), replicationID,
+		"a failed registration was cached")
+
+	_, err = second.DBReplicatorStats(replicationID)
+	require.Error(t, err, "expected the retry to report the registration failure again")
 }
 
 // TestDBReplicatorStatsConcurrentSameID checks that concurrent callers for one replication ID never
-// see the entry before its stats are populated. The entry is published to the map before the fields
-// are set, so a caller that arrives during that window receives a struct of nil stats.
+// see the entry before its stats are populated.
 func TestDBReplicatorStatsConcurrentSameID(t *testing.T) {
 	dbStats := newTestDbStats("TestDBReplicatorStatsConcurrentSameID_db")
 
@@ -355,8 +355,8 @@ func TestDBReplicatorStatsConcurrentSameID(t *testing.T) {
 				if !assert.NoError(t, err) {
 					return
 				}
-				// The last field DBReplicatorStats populates, so it stays nil for the whole
-				// window between publishing the entry and finishing it.
+				// The last field DBReplicatorStats populates, so it is the one left nil by an
+				// entry published before it was finished.
 				if replicatorStats.ProcessedSequenceLenPostCleanup == nil {
 					partial.Add(1)
 				}
@@ -364,7 +364,7 @@ func TestDBReplicatorStatsConcurrentSameID(t *testing.T) {
 		}
 		close(start)
 	}
-	wg.Wait()
+	WaitWithTimeout(t, &wg, time.Minute)
 
 	require.Zero(t, partial.Load(),
 		"%d callers received an entry before its stats were populated", partial.Load())

--- a/base/stats_test.go
+++ b/base/stats_test.go
@@ -11,11 +11,13 @@ licenses/APL2.txt.
 package base
 
 import (
+	"encoding/json"
 	"expvar"
 	"fmt"
 	"maps"
 	"math"
 	"reflect"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -211,16 +213,24 @@ func newTestSgwStats() *SgwStats {
 	return &SgwStats{sgwStatsFields: sgwStatsFields{DbStats: map[string]*DbStats{}}}
 }
 
-// TestSgwStatsSerializedFieldsAreEmbedded fails when an exported field is declared on SgwStats
-// instead of sgwStatsFields, because String() copies only sgwStatsFields and would drop it.
-func TestSgwStatsSerializedFieldsAreEmbedded(t *testing.T) {
-	for _, field := range reflect.VisibleFields(reflect.TypeFor[SgwStats]()) {
-		if !field.IsExported() {
-			continue
-		}
-		// Promoted fields have an index path through the embedded struct, declared fields do not.
-		assert.Greater(t, len(field.Index), 1,
-			"SgwStats.%s must be declared in sgwStatsFields so String() serializes it", field.Name)
+// TestSerializedStatFieldsAreEmbedded fails when an exported field is declared on SgwStats or
+// DbStats instead of its embedded fields struct, because the marshaller copies only the embedded
+// struct and would drop it.
+func TestSerializedStatFieldsAreEmbedded(t *testing.T) {
+	for outer, inner := range map[reflect.Type]string{
+		reflect.TypeFor[SgwStats](): "sgwStatsFields",
+		reflect.TypeFor[DbStats]():  "dbStatsFields",
+	} {
+		t.Run(outer.Name(), func(t *testing.T) {
+			for _, field := range reflect.VisibleFields(outer) {
+				if !field.IsExported() {
+					continue
+				}
+				// Promoted fields have an index path through the embedded struct, declared fields do not.
+				assert.Greater(t, len(field.Index), 1,
+					"%s.%s must be declared in %s so it is serialized", outer.Name(), field.Name, inner)
+			}
+		})
 	}
 }
 
@@ -301,10 +311,65 @@ func TestClearDBStatsConcurrentWithReplicatorRegistration(t *testing.T) {
 	stats.ClearDBStats(dbName)
 }
 
+// TestStatsSerializationConcurrentWithReplicatorRegistration is a regression test for the stats
+// output iterating DbReplicatorStats without dbReplicatorStatsMutex, which crashed the process with
+// "concurrent map iteration and map write" when a replication registered mid-serialization. Fails
+// without -race too.
+func TestStatsSerializationConcurrentWithReplicatorRegistration(t *testing.T) {
+	stats := newTestSgwStats()
+	const dbName = "TestStatsSerializationConcurrentWithReplicatorRegistration_db"
+
+	dbStats, err := stats.NewDBStats(dbName, false, false, false, false, nil, nil)
+	require.NoError(t, err)
+
+	// The map is cheapest to marshal, and the window widest, while it is still small.
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		for i := range 500 {
+			_, err := dbStats.DBReplicatorStats(fmt.Sprintf("repl_%d", i))
+			if !assert.NoError(t, err) {
+				return
+			}
+		}
+	})
+	wg.Go(func() {
+		for range 500 {
+			_ = stats.String()
+		}
+	})
+	WaitWithTimeout(t, &wg, time.Minute)
+}
+
+// TestDbStatsSerializedShape pins the stat groups DbStats.MarshalJSON emits, since a hand-written
+// marshaller can silently drop one.
+func TestDbStatsSerializedShape(t *testing.T) {
+	stats := newTestSgwStats()
+	const dbName = "TestDbStatsSerializedShape_db"
+
+	dbStats, err := stats.NewDBStats(dbName, true, true, false, true, []string{"queryName"}, []string{"scope.collection"})
+	require.NoError(t, err)
+	_, err = dbStats.DBReplicatorStats("repl")
+	require.NoError(t, err)
+
+	marshalled, err := JSONMarshalCanonical(dbStats)
+	require.NoError(t, err)
+
+	var groups map[string]json.RawMessage
+	require.NoError(t, JSONUnmarshal(marshalled, &groups))
+	require.ElementsMatch(t, []string{
+		"cache", "cbl_replication_pull", "cbl_replication_push", "database", "delta_sync",
+		"gsi_views", "replications", "security", "shared_bucket_import", "metadata_migration",
+		"per_collection",
+	}, slices.Collect(maps.Keys(groups)))
+}
+
 // newTestDbStats returns a DbStats holding only the replicator map, bypassing NewDBStats so a test
 // can use the same dbName twice.
 func newTestDbStats(dbName string) *DbStats {
-	return &DbStats{dbName: dbName, DbReplicatorStats: map[string]*DbReplicatorStats{}}
+	return &DbStats{
+		dbName:        dbName,
+		dbStatsFields: dbStatsFields{DbReplicatorStats: map[string]*DbReplicatorStats{}},
+	}
 }
 
 // TestDBReplicatorStatsFailedRegistrationNotCached checks that a DBReplicatorStats call which fails

--- a/base/stats_test.go
+++ b/base/stats_test.go
@@ -12,7 +12,11 @@ package base
 
 import (
 	"expvar"
+	"fmt"
 	"math"
+	"reflect"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/testing/require"
@@ -198,4 +202,170 @@ func TestSgwFloatStatMarshalNonFinite(t *testing.T) {
 			require.Equal(t, 0.0, viaString)
 		})
 	}
+}
+
+// newTestSgwStats returns an empty stats tree, separate from the package-level SyncGatewayStats.
+func newTestSgwStats() *SgwStats {
+	return &SgwStats{sgwStatsFields: sgwStatsFields{DbStats: map[string]*DbStats{}}}
+}
+
+// TestSgwStatsSerializedFieldsAreEmbedded fails when an exported field is declared on SgwStats
+// instead of sgwStatsFields, because String() copies only sgwStatsFields and would drop it.
+func TestSgwStatsSerializedFieldsAreEmbedded(t *testing.T) {
+	for _, field := range reflect.VisibleFields(reflect.TypeFor[SgwStats]()) {
+		if !field.IsExported() {
+			continue
+		}
+		// Promoted fields have an index path through the embedded struct, declared fields do not.
+		assert.Greater(t, len(field.Index), 1,
+			"SgwStats.%s must be declared in sgwStatsFields so String() serializes it", field.Name)
+	}
+}
+
+// TestClearDBStatsRemovesFromSerialization checks that a database removed by ClearDBStats no longer
+// appears in the expvar/stats log output.
+func TestClearDBStatsRemovesFromSerialization(t *testing.T) {
+	stats := newTestSgwStats()
+	const dbName = "TestClearDBStatsRemovesFromSerialization_db"
+
+	_, err := stats.NewDBStats(dbName, false, false, false, false, nil, nil)
+	require.NoError(t, err)
+	assert.Contains(t, stats.String(), dbName)
+
+	stats.ClearDBStats(dbName)
+	require.NotContains(t, stats.String(), dbName)
+}
+
+// TestStatsSerializationConcurrentWithDBRegistration is a -race guard on the narrowed
+// dbStatsMapMutex section (CBG-5472): String() marshals a shallow copy of the map outside the lock,
+// so it can read a *DbStats that ClearDBStats is unregistering from Prometheus. This is not a
+// reproducer for the stats logger stall - that was on _databasesLock, see
+// rest.TestStatsLoggerIndependentOfDatabaseLock.
+func TestStatsSerializationConcurrentWithDBRegistration(t *testing.T) {
+	// TestMain sets this true, which would skip the Prometheus path this test wants to exercise.
+	defer func(skip bool) { SkipPrometheusStatsRegistration = skip }(SkipPrometheusStatsRegistration)
+	SkipPrometheusStatsRegistration = false
+
+	stats := newTestSgwStats()
+
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Go(func() {
+			for range 1000 {
+				_ = stats.String()
+			}
+		})
+	}
+	for i := range 10 {
+		wg.Go(func() {
+			// Distinct db name per goroutine so concurrent registrations never collide in Prometheus.
+			name := fmt.Sprintf("TestStatsSerializationConcurrentWithDBRegistration_db_%d", i)
+			for range 100 {
+				_, err := stats.NewDBStats(name, false, false, false, false, nil, nil)
+				assert.NoError(t, err)
+				stats.ClearDBStats(name)
+			}
+		})
+	}
+	wg.Wait()
+}
+
+// TestClearDBStatsConcurrentWithReplicatorRegistration is a regression test for ClearDBStats
+// iterating DbReplicatorStats without dbReplicatorStatsMutex, which panicked with "concurrent map
+// read and map write" when a replication registered during teardown. Fails without -race too.
+func TestClearDBStatsConcurrentWithReplicatorRegistration(t *testing.T) {
+	stats := newTestSgwStats()
+	const dbName = "TestClearDBStatsConcurrentWithReplicatorRegistration_db"
+
+	dbStats, err := stats.NewDBStats(dbName, false, false, false, false, nil, nil)
+	require.NoError(t, err)
+
+	// Pre-populate the map so ClearDBStats takes longer to iterate, widening the race window.
+	for i := range 100 {
+		_, err := dbStats.DBReplicatorStats(fmt.Sprintf("seed_%d", i))
+		require.NoError(t, err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		for i := range 100 {
+			_, err := dbStats.DBReplicatorStats(fmt.Sprintf("repl_%d", i))
+			assert.NoError(t, err)
+		}
+	})
+
+	// Iterates DbReplicatorStats concurrently with the registrations above.
+	stats.ClearDBStats(dbName)
+	wg.Wait()
+}
+
+// newTestDbStats returns a DbStats holding only the replicator map, bypassing NewDBStats so a test
+// can use the same dbName twice.
+func newTestDbStats(dbName string) *DbStats {
+	return &DbStats{dbName: dbName, DbReplicatorStats: map[string]*DbReplicatorStats{}}
+}
+
+// TestDBReplicatorStatsFailedRegistrationNotCached checks that a DBReplicatorStats call which fails
+// partway through registration leaves nothing usable-looking behind. The entry is added to the map
+// before its stats are populated, so a retry returns a struct of nil stats and no error.
+func TestDBReplicatorStatsFailedRegistrationNotCached(t *testing.T) {
+	// TestMain sets this true, which would skip registration and so never produce a failure.
+	defer func(skip bool) { SkipPrometheusStatsRegistration = skip }(SkipPrometheusStatsRegistration)
+	SkipPrometheusStatsRegistration = false
+
+	const dbName = "TestDBReplicatorStatsFailedRegistrationNotCached_db"
+	const replicationID = "repl"
+
+	// Two DbStats sharing a dbName describe identical Prometheus metrics, so the second
+	// registration of the same replication ID collides and fails.
+	first, second := newTestDbStats(dbName), newTestDbStats(dbName)
+
+	firstStats, err := first.DBReplicatorStats(replicationID)
+	require.NoError(t, err)
+	require.NotNil(t, firstStats.NumAttachmentBytesPushed)
+	defer first.unregisterReplicationStats(replicationID)
+
+	_, err = second.DBReplicatorStats(replicationID)
+	require.Error(t, err, "expected the duplicate Prometheus registration to fail")
+
+	retry, err := second.DBReplicatorStats(replicationID)
+	if err != nil {
+		return // reporting the failure to the caller is the correct behaviour
+	}
+	require.NotNil(t, retry.NumAttachmentBytesPushed,
+		"retry returned a cached half-initialized entry with no error")
+}
+
+// TestDBReplicatorStatsConcurrentSameID checks that concurrent callers for one replication ID never
+// see the entry before its stats are populated. The entry is published to the map before the fields
+// are set, so a caller that arrives during that window receives a struct of nil stats.
+func TestDBReplicatorStatsConcurrentSameID(t *testing.T) {
+	dbStats := newTestDbStats("TestDBReplicatorStatsConcurrentSameID_db")
+
+	var partial atomic.Int64
+	var wg sync.WaitGroup
+	// Each replication ID is one chance to observe the window, so use plenty.
+	for i := range 50 {
+		replicationID := fmt.Sprintf("repl_%d", i)
+		start := make(chan struct{})
+		for range 4 {
+			wg.Go(func() {
+				<-start
+				replicatorStats, err := dbStats.DBReplicatorStats(replicationID)
+				if !assert.NoError(t, err) {
+					return
+				}
+				// The last field DBReplicatorStats populates, so it stays nil for the whole
+				// window between publishing the entry and finishing it.
+				if replicatorStats.ProcessedSequenceLenPostCleanup == nil {
+					partial.Add(1)
+				}
+			})
+		}
+		close(start)
+	}
+	wg.Wait()
+
+	require.Zero(t, partial.Load(),
+		"%d callers received an entry before its stats were populated", partial.Load())
 }

--- a/base/util.go
+++ b/base/util.go
@@ -1827,6 +1827,16 @@ func KeysPresent[K comparable, V any](m map[K]V, keys []K) []K {
 	return result
 }
 
+// PopMapEntry removes key from m and returns the value it held, and whether it was present.
+// Popping from a nil map returns the zero value and false.
+func PopMapEntry[M ~map[K]V, K comparable, V any](m M, key K) (V, bool) {
+	value, ok := m[key]
+	if ok {
+		delete(m, key)
+	}
+	return value, ok
+}
+
 // IsRevTreeID checks if the string looks like a RevTree ID.
 func IsRevTreeID(s string) bool {
 	// If we scan forwards past each digit until we hit `-`, we know this is a RevTree ID.

--- a/base/util.go
+++ b/base/util.go
@@ -1864,6 +1864,16 @@ func KeysPresent[K comparable, V any](m map[K]V, keys []K) []K {
 	return result
 }
 
+// PopMapEntry removes key from m and returns the value it held, and whether it was present.
+// Popping from a nil map returns the zero value and false.
+func PopMapEntry[M ~map[K]V, K comparable, V any](m M, key K) (V, bool) {
+	value, ok := m[key]
+	if ok {
+		delete(m, key)
+	}
+	return value, ok
+}
+
 // IsRevTreeID checks if the string looks like a RevTree ID.
 func IsRevTreeID(s string) bool {
 	// If we scan forwards past each digit until we hit `-`, we know this is a RevTree ID.

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -1921,6 +1921,48 @@ func TestKeysPresent(t *testing.T) {
 	}
 }
 
+func TestPopMapEntry(t *testing.T) {
+	t.Run("present", func(t *testing.T) {
+		m := map[string]int{"a": 1, "b": 2}
+		value, ok := PopMapEntry(m, "a")
+		assert.True(t, ok)
+		assert.Equal(t, 1, value)
+		assert.Equal(t, map[string]int{"b": 2}, m)
+	})
+
+	t.Run("absent leaves map untouched", func(t *testing.T) {
+		m := map[string]int{"a": 1}
+		value, ok := PopMapEntry(m, "x")
+		assert.False(t, ok)
+		assert.Equal(t, 0, value, "expected zero value for an absent key")
+		assert.Equal(t, map[string]int{"a": 1}, m)
+	})
+
+	t.Run("zero value stored for key", func(t *testing.T) {
+		// ok has to tell a stored zero value apart from an absent key.
+		m := map[string]int{"a": 0}
+		value, ok := PopMapEntry(m, "a")
+		assert.True(t, ok)
+		assert.Equal(t, 0, value)
+		assert.Empty(t, m)
+	})
+
+	t.Run("nil map", func(t *testing.T) {
+		var m map[string]*int
+		value, ok := PopMapEntry(m, "a")
+		assert.False(t, ok)
+		assert.Nil(t, value)
+	})
+
+	t.Run("named map type", func(t *testing.T) {
+		type stringSet map[string]struct{}
+		m := stringSet{"a": {}}
+		_, ok := PopMapEntry(m, "a")
+		assert.True(t, ok)
+		assert.Empty(t, m)
+	})
+}
+
 func TestIsRevTreeID(t *testing.T) {
 	tests := []struct {
 		value    string

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -1882,6 +1882,48 @@ func TestKeysPresent(t *testing.T) {
 	}
 }
 
+func TestPopMapEntry(t *testing.T) {
+	t.Run("present", func(t *testing.T) {
+		m := map[string]int{"a": 1, "b": 2}
+		value, ok := PopMapEntry(m, "a")
+		assert.True(t, ok)
+		assert.Equal(t, 1, value)
+		assert.Equal(t, map[string]int{"b": 2}, m)
+	})
+
+	t.Run("absent leaves map untouched", func(t *testing.T) {
+		m := map[string]int{"a": 1}
+		value, ok := PopMapEntry(m, "x")
+		assert.False(t, ok)
+		assert.Equal(t, 0, value, "expected zero value for an absent key")
+		assert.Equal(t, map[string]int{"a": 1}, m)
+	})
+
+	t.Run("zero value stored for key", func(t *testing.T) {
+		// ok has to tell a stored zero value apart from an absent key.
+		m := map[string]int{"a": 0}
+		value, ok := PopMapEntry(m, "a")
+		assert.True(t, ok)
+		assert.Equal(t, 0, value)
+		assert.Empty(t, m)
+	})
+
+	t.Run("nil map", func(t *testing.T) {
+		var m map[string]*int
+		value, ok := PopMapEntry(m, "a")
+		assert.False(t, ok)
+		assert.Nil(t, value)
+	})
+
+	t.Run("named map type", func(t *testing.T) {
+		type stringSet map[string]struct{}
+		m := stringSet{"a": {}}
+		_, ok := PopMapEntry(m, "a")
+		assert.True(t, ok)
+		assert.Empty(t, m)
+	})
+}
+
 func TestIsRevTreeID(t *testing.T) {
 	tests := []struct {
 		value    string

--- a/db/database.go
+++ b/db/database.go
@@ -804,6 +804,9 @@ func (db *DatabaseContext) _stopOnlineProcesses(ctx context.Context) {
 }
 
 func (context *DatabaseContext) Close(ctx context.Context) {
+	// Mark offline before teardown so the lock-free stats reader skips this database (CBG-5472).
+	atomic.StoreUint32(&context.State, DBOffline)
+
 	context.BucketLock.Lock()
 	defer context.BucketLock.Unlock()
 

--- a/db/database.go
+++ b/db/database.go
@@ -809,8 +809,8 @@ func (db *DatabaseContext) _stopOnlineProcesses(ctx context.Context) {
 }
 
 func (context *DatabaseContext) Close(ctx context.Context) {
-	// Mark offline before teardown so the lock-free stats reader skips this database (CBG-5472).
-	atomic.StoreUint32(&context.State, DBOffline)
+	// Mark stopping before teardown so the lock-free stats reader skips this database.
+	atomic.StoreUint32(&context.State, DBStopping)
 
 	context.BucketLock.Lock()
 	defer context.BucketLock.Unlock()

--- a/db/database.go
+++ b/db/database.go
@@ -842,6 +842,15 @@ func (context *DatabaseContext) Close(ctx context.Context) {
 
 }
 
+// BucketIfOpen returns the database's bucket, or false if the database has been closed. Callers
+// holding a DatabaseContext they didn't resolve under a lock need this rather than reading Bucket
+// directly, since Close nils it.
+func (context *DatabaseContext) BucketIfOpen() (base.Bucket, bool) {
+	context.BucketLock.RLock()
+	defer context.BucketLock.RUnlock()
+	return context.Bucket, context.Bucket != nil
+}
+
 // stopBackgroundManagers stops any running BackgroundManager.
 // Returns a list of StoppableBackgroundManager it signalled to stop.
 func (dbCtx *DatabaseContext) stopBackgroundManagers(ctx context.Context) (stopped []StoppableBackgroundManager) {

--- a/db/database.go
+++ b/db/database.go
@@ -809,6 +809,9 @@ func (db *DatabaseContext) _stopOnlineProcesses(ctx context.Context) {
 }
 
 func (context *DatabaseContext) Close(ctx context.Context) {
+	// Mark offline before teardown so the lock-free stats reader skips this database (CBG-5472).
+	atomic.StoreUint32(&context.State, DBOffline)
+
 	context.BucketLock.Lock()
 	defer context.BucketLock.Unlock()
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -178,6 +178,29 @@ func assertHTTPError(t *testing.T, err error, status int) bool {
 		assert.Equal(t, status, httpErr.Status)
 }
 
+// TestBucketIfOpenAfterClose checks that BucketIfOpen reports a closed database rather than handing
+// back the nil Bucket that Close leaves behind.
+func TestBucketIfOpenAfterClose(t *testing.T) {
+	ctx := base.TestCtx(t)
+	tBucket := base.GetTestBucket(t)
+	defer tBucket.Close(ctx)
+
+	dbCtx, err := NewDatabaseContext(ctx, "db", tBucket, true, DatabaseContextOptions{
+		Scopes: GetScopesOptions(t, tBucket, 1),
+	})
+	require.NoError(t, err)
+
+	bucket, open := dbCtx.BucketIfOpen()
+	require.True(t, open)
+	require.NotNil(t, bucket)
+
+	dbCtx.Close(ctx)
+
+	bucket, open = dbCtx.BucketIfOpen()
+	require.False(t, open)
+	require.Nil(t, bucket)
+}
+
 func TestDatabaseStartOnlineProcessesWhileClosing(t *testing.T) {
 	timeout := 30 * time.Second
 	go func() {

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -263,6 +263,13 @@ func (h *handler) handleDbOnline() error {
 		return base.HTTPErrorf(http.StatusServiceUnavailable, "Database _resync is in progress, this may take some time, try again later")
 	}
 
+	// This handler runs offline, so the state check in validateAndWriteHeaders doesn't apply. A
+	// database being torn down can't be brought back online - the caller needs to retry against the
+	// database that replaces it.
+	if dbState == db.DBStopping {
+		return base.HTTPErrorf(http.StatusServiceUnavailable, "Database is stopping, try again later")
+	}
+
 	body, err := h.readBody()
 	if err != nil {
 		return err
@@ -290,7 +297,8 @@ func (h *handler) handleDbOnline() error {
 		defer func() {
 			if err != nil {
 				// Reset DB state back to Offline on setup failure to avoid being stuck in DBStarting.
-				atomic.StoreUint32(&h.db.State, db.DBOffline)
+				// CAS rather than store, so a reload that closed this context keeps DBStopping.
+				atomic.CompareAndSwapUint32(&h.db.State, db.DBStarting, db.DBOffline)
 			}
 		}()
 		// If the server was closed during the delay, skip the reload entirely.

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -263,13 +263,6 @@ func (h *handler) handleDbOnline() error {
 		return base.HTTPErrorf(http.StatusServiceUnavailable, "Database _resync is in progress, this may take some time, try again later")
 	}
 
-	// This handler runs offline, so the state check in validateAndWriteHeaders doesn't apply. A
-	// database being torn down can't be brought back online - the caller needs to retry against the
-	// database that replaces it.
-	if dbState == db.DBStopping {
-		return base.HTTPErrorf(http.StatusServiceUnavailable, "Database is stopping, try again later")
-	}
-
 	body, err := h.readBody()
 	if err != nil {
 		return err
@@ -328,7 +321,14 @@ func (h *handler) handleDbOnline() error {
 		} else {
 			var oldConfig DbConfig
 			// persistent config here
-			bucket := h.db.Bucket.GetName()
+			// Close doesn't take AccessLock, so it can nil the bucket after the CAS above succeeded.
+			bucketRef, open := h.db.BucketIfOpen()
+			if !open {
+				err = base.RedactErrorf("database %q was closed while being brought online", base.MD(h.db.Name))
+				base.InfofCtx(contextNoCancel.Ctx, base.KeyCRUD, "%v", err)
+				return
+			}
+			bucket := bucketRef.GetName()
 			dbName := h.db.Name
 			var cas uint64
 			var updatedDbConfig *DatabaseConfig

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -484,6 +484,13 @@ func (h *handler) handlePostIndexInit() error {
 		return base.HTTPErrorf(http.StatusBadRequest, "action %q not supported... must be either 'start' or 'stop'", action)
 	}
 
+	// This handler runs offline, so the state check in validateAndWriteHeaders doesn't apply. There's
+	// no point initialising indexes for a database that is being torn down. Stopping an init is still
+	// allowed above, since that doesn't touch the bucket.
+	if atomic.LoadUint32(&h.db.State) == db.DBStopping {
+		return base.HTTPErrorf(http.StatusServiceUnavailable, "Database is stopping, try again later")
+	}
+
 	var req PostIndexInitRequest
 	if err := h.readJSONInto(&req); err != nil {
 		return err
@@ -529,8 +536,14 @@ func (h *handler) handlePostIndexInit() error {
 	// Skip metadata index initialization on _default._default if it has been dropped (e.g. after a
 	// completed metadata migration) — building indexes on a missing collection would retry until the
 	// op times out. Default to attempting init on _default if existence can't be determined.
+	// The state check above is a point-in-time read and this handler holds no AccessLock, so the
+	// database can still be closed underneath us before we get here.
+	bucket, open := h.db.BucketIfOpen()
+	if !open {
+		return base.HTTPErrorf(http.StatusServiceUnavailable, "Database is stopping, try again later")
+	}
 	defaultCollectionPresent := true
-	if exists, existsErr := defaultCollectionExists(h.ctx(), h.db.Bucket); existsErr != nil {
+	if exists, existsErr := defaultCollectionExists(h.ctx(), bucket); existsErr != nil {
 		base.WarnfCtx(h.ctx(), "db:%s unable to determine whether _default._default exists while reinitializing indexes: %v — will attempt index init on _default", base.MD(h.db.Name), existsErr)
 	} else {
 		defaultCollectionPresent = exists

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -1495,18 +1495,23 @@ func TestDBOnlineSingle(t *testing.T) {
 	assert.True(t, body["state"].(string) == "Online")
 }
 
-// TestDBOnlineWhileStopping checks that _online reports a failure for a database that is being torn
-// down, rather than returning 200 and silently giving up in the background goroutine.
+// TestDBOnlineWhileStopping checks that _online on a database context being torn down reports
+// success and leaves it alone. A concurrent _online reloads the database, which closes the context
+// the second request already resolved, and that request must not fail - see TestDBOnlineConcurrent.
 func TestDBOnlineWhileStopping(t *testing.T) {
 	rt := rest.NewRestTester(t, nil)
 	defer rt.Close()
 
+	dbc := rt.GetDatabase()
 	// _online runs offline, so the state check in validateAndWriteHeaders doesn't reject this.
-	atomic.StoreUint32(&rt.GetDatabase().State, db.DBStopping)
+	atomic.StoreUint32(&dbc.State, db.DBStopping)
 
-	response := rt.SendAdminRequest(http.MethodPost, "/db/_online", "")
-	rest.RequireStatus(t, response, http.StatusServiceUnavailable)
-	require.Contains(t, response.Body.String(), "Database is stopping")
+	rest.RequireStatus(t, rt.SendAdminRequest(http.MethodPost, "/db/_online", ""), http.StatusOK)
+
+	// The background goroutine only transitions an Offline database, so the state stays put.
+	require.Never(t, func() bool {
+		return atomic.LoadUint32(&dbc.State) != db.DBStopping
+	}, time.Second, 10*time.Millisecond)
 }
 
 // Take DB online concurrently using two goroutines

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -1495,6 +1495,20 @@ func TestDBOnlineSingle(t *testing.T) {
 	assert.True(t, body["state"].(string) == "Online")
 }
 
+// TestDBOnlineWhileStopping checks that _online reports a failure for a database that is being torn
+// down, rather than returning 200 and silently giving up in the background goroutine.
+func TestDBOnlineWhileStopping(t *testing.T) {
+	rt := rest.NewRestTester(t, nil)
+	defer rt.Close()
+
+	// _online runs offline, so the state check in validateAndWriteHeaders doesn't reject this.
+	atomic.StoreUint32(&rt.GetDatabase().State, db.DBStopping)
+
+	response := rt.SendAdminRequest(http.MethodPost, "/db/_online", "")
+	rest.RequireStatus(t, response, http.StatusServiceUnavailable)
+	require.Contains(t, response.Body.String(), "Database is stopping")
+}
+
 // Take DB online concurrently using two goroutines
 // Both should return success and DB should be online
 // once both goroutines return

--- a/rest/indextest/index_init_api_test.go
+++ b/rest/indextest/index_init_api_test.go
@@ -15,6 +15,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -331,6 +332,23 @@ func TestChangeIndexPartitionsWithViews(t *testing.T) {
 	resp := rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_index_init", `{"num_partitions":2}`)
 	rest.RequireStatus(t, resp, http.StatusBadRequest)
 	rest.AssertHTTPErrorReason(t, resp, http.StatusBadRequest, "_index_init is a GSI-only feature and is not supported when using views")
+}
+
+// TestIndexInitWhileStopping checks that starting an index init against a database being torn down
+// is rejected. _index_init runs offline, so the state check in validateAndWriteHeaders doesn't cover
+// it, and it used to reach h.db.Bucket and panic into a 500 once Close had nilled it.
+func TestIndexInitWhileStopping(t *testing.T) {
+	rt := rest.NewRestTester(t, nil)
+	defer rt.Close()
+
+	atomic.StoreUint32(&rt.GetDatabase().State, db.DBStopping)
+
+	resp := rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_index_init", `{"num_partitions":2}`)
+	rest.AssertHTTPErrorReason(t, resp, http.StatusServiceUnavailable, "Database is stopping, try again later")
+
+	// Stopping an init doesn't touch the bucket, so it stays available.
+	resp = rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_index_init?action=stop", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
 }
 
 func TestChangeIndexSeparatePrincipalIndexes(t *testing.T) {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -78,7 +78,7 @@ type ServerContext struct {
 
 	// databasesSnapshot holds the values of _databases for the stats logger to read without taking
 	// _databasesLock, which a config update can hold for a long time while it waits on index
-	// readiness (CBG-5472). Kept in step with _databases by the mutation helpers.
+	// readiness. Kept in step with _databases by the mutation helpers.
 	databasesSnapshot atomic.Pointer[[]*db.DatabaseContext]
 
 	// serverCtx is cancelled by Close() to broadcast server shutdown to all background
@@ -1979,7 +1979,7 @@ func (sc *ServerContext) _updateDatabasesSnapshot() {
 }
 
 // Updates stats that are more efficient to calculate at stats collection time. Reads
-// databasesSnapshot rather than _databases, so it never blocks on _databasesLock (CBG-5472).
+// databasesSnapshot rather than _databases, so it never blocks on _databasesLock.
 func (sc *ServerContext) updateCalculatedStats(ctx context.Context) {
 	snapshot := sc.databasesSnapshot.Load()
 	if snapshot == nil {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -73,8 +73,13 @@ type ServerContext struct {
 	_dbRegistry         map[string]struct{}               // _dbRegistry is a map of db names, used to ensure uniqueness even when db isn't active
 	_collectionRegistry map[string]string                 // _collectionRegistry is a map of fully qualified collection name to db name, used for local uniqueness checks
 	_dbConfigs          map[string]*RuntimeDatabaseConfig // _dbConfigs is a map of db name to the RuntimeDatabaseConfig
-	_databases          map[string]*db.DatabaseContext    // _databases is a map of dbname to db.DatabaseContext
+	_databases          map[string]*db.DatabaseContext    // _databases is a map of dbname to db.DatabaseContext. Mutations must call _updateDatabasesSnapshot
 	_databasesLock      sync.RWMutex                      // Lock for _databases and other db-specific maps above
+
+	// databasesSnapshot holds the values of _databases for the stats logger to read without taking
+	// _databasesLock, which a config update can hold for a long time while it waits on index
+	// readiness (CBG-5472). Refreshed by _updateDatabasesSnapshot under the write lock.
+	databasesSnapshot atomic.Pointer[[]*db.DatabaseContext]
 
 	// serverCtx is cancelled by Close() to broadcast server shutdown to all background
 	// goroutines that hold a reference to this ServerContext (e.g. handleDbOnline).
@@ -321,6 +326,7 @@ func (sc *ServerContext) Close(ctx context.Context) {
 		_ = db.EventMgr.RaiseDBStateChangeEvent(ctx, db.Name, "offline", "Database context closed", &sc.Config.API.AdminInterface)
 	}
 	sc._databases = nil
+	sc._updateDatabasesSnapshot()
 	sc.invalidDatabaseConfigTracking.dbNames = nil
 }
 
@@ -1218,6 +1224,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 
 	// Register it so HTTP handlers can find it:
 	sc._databases[dbcontext.Name] = dbcontext
+	sc._updateDatabasesSnapshot()
 	sc._dbConfigs[dbcontext.Name] = &RuntimeDatabaseConfig{DatabaseConfig: config}
 	sc._dbRegistry[dbName] = struct{}{}
 	for _, name := range fqCollections {
@@ -1818,8 +1825,10 @@ func (sc *ServerContext) _unloadDatabase(ctx context.Context, dbName string) boo
 		return false
 	}
 	base.InfofCtx(ctx, base.KeyAll, "Closing db /%s (bucket %q)", base.MD(dbCtx.Name), base.MD(dbCtx.Bucket.GetName()))
-	dbCtx.Close(ctx)
+	// Drop it from the snapshot before teardown, so the stats logger stops seeing it first.
 	delete(sc._databases, dbName)
+	sc._updateDatabasesSnapshot()
+	dbCtx.Close(ctx)
 	return true
 }
 
@@ -1936,17 +1945,23 @@ func (sc *ServerContext) logNetworkInterfaceStats(ctx context.Context) {
 
 }
 
-// Updates stats that are more efficient to calculate at stats collection time
+// _updateDatabasesSnapshot refreshes databasesSnapshot. The caller must hold sc._databasesLock for write.
+func (sc *ServerContext) _updateDatabasesSnapshot() {
+	sc.databasesSnapshot.Store(base.Ptr(slices.Collect(maps.Values(sc._databases))))
+}
+
+// Updates stats that are more efficient to calculate at stats collection time. Reads
+// databasesSnapshot rather than _databases, so it never blocks on _databasesLock (CBG-5472).
 func (sc *ServerContext) updateCalculatedStats(ctx context.Context) {
-	sc._databasesLock.RLock()
-	defer sc._databasesLock.RUnlock()
-	for _, dbContext := range sc._databases {
-		dbState := atomic.LoadUint32(&dbContext.State)
-		if dbState == db.DBOnline {
+	snapshot := sc.databasesSnapshot.Load()
+	if snapshot == nil {
+		return
+	}
+	for _, dbContext := range *snapshot {
+		if atomic.LoadUint32(&dbContext.State) == db.DBOnline {
 			dbContext.UpdateCalculatedStats(ctx)
 		}
 	}
-
 }
 
 // initializeGoCBAgent Obtains a gocb agent from the current server connection. Requires the agent to be closed after use.

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -73,8 +73,13 @@ type ServerContext struct {
 	_dbRegistry         map[string]struct{}               // _dbRegistry is a map of db names, used to ensure uniqueness even when db isn't active
 	_collectionRegistry map[string]string                 // _collectionRegistry is a map of fully qualified collection name to db name, used for local uniqueness checks
 	_dbConfigs          map[string]*RuntimeDatabaseConfig // _dbConfigs is a map of db name to the RuntimeDatabaseConfig
-	_databases          map[string]*db.DatabaseContext    // _databases is a map of dbname to db.DatabaseContext
+	_databases          map[string]*db.DatabaseContext    // _databases is a map of dbname to db.DatabaseContext. Mutations must call _updateDatabasesSnapshot
 	_databasesLock      sync.RWMutex                      // Lock for _databases and other db-specific maps above
+
+	// databasesSnapshot holds the values of _databases for the stats logger to read without taking
+	// _databasesLock, which a config update can hold for a long time while it waits on index
+	// readiness (CBG-5472). Refreshed by _updateDatabasesSnapshot under the write lock.
+	databasesSnapshot atomic.Pointer[[]*db.DatabaseContext]
 
 	// serverCtx is cancelled by Close() to broadcast server shutdown to all background
 	// goroutines that hold a reference to this ServerContext (e.g. handleDbOnline).
@@ -321,6 +326,7 @@ func (sc *ServerContext) Close(ctx context.Context) {
 		_ = db.EventMgr.RaiseDBStateChangeEvent(ctx, db.Name, "offline", "Database context closed", &sc.Config.API.AdminInterface)
 	}
 	sc._databases = nil
+	sc._updateDatabasesSnapshot()
 	sc.invalidDatabaseConfigTracking.dbNames = nil
 }
 
@@ -1221,6 +1227,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 
 	// Register it so HTTP handlers can find it:
 	sc._databases[dbcontext.Name] = dbcontext
+	sc._updateDatabasesSnapshot()
 	sc._dbConfigs[dbcontext.Name] = &RuntimeDatabaseConfig{DatabaseConfig: config}
 	sc._dbRegistry[dbName] = struct{}{}
 	for _, name := range fqCollections {
@@ -1821,8 +1828,10 @@ func (sc *ServerContext) _unloadDatabase(ctx context.Context, dbName string) boo
 		return false
 	}
 	base.InfofCtx(ctx, base.KeyAll, "Closing db /%s (bucket %q)", base.MD(dbCtx.Name), base.MD(dbCtx.Bucket.GetName()))
-	dbCtx.Close(ctx)
+	// Drop it from the snapshot before teardown, so the stats logger stops seeing it first.
 	delete(sc._databases, dbName)
+	sc._updateDatabasesSnapshot()
+	dbCtx.Close(ctx)
 	return true
 }
 
@@ -1939,17 +1948,23 @@ func (sc *ServerContext) logNetworkInterfaceStats(ctx context.Context) {
 
 }
 
-// Updates stats that are more efficient to calculate at stats collection time
+// _updateDatabasesSnapshot refreshes databasesSnapshot. The caller must hold sc._databasesLock for write.
+func (sc *ServerContext) _updateDatabasesSnapshot() {
+	sc.databasesSnapshot.Store(base.Ptr(slices.Collect(maps.Values(sc._databases))))
+}
+
+// Updates stats that are more efficient to calculate at stats collection time. Reads
+// databasesSnapshot rather than _databases, so it never blocks on _databasesLock (CBG-5472).
 func (sc *ServerContext) updateCalculatedStats(ctx context.Context) {
-	sc._databasesLock.RLock()
-	defer sc._databasesLock.RUnlock()
-	for _, dbContext := range sc._databases {
-		dbState := atomic.LoadUint32(&dbContext.State)
-		if dbState == db.DBOnline {
+	snapshot := sc.databasesSnapshot.Load()
+	if snapshot == nil {
+		return
+	}
+	for _, dbContext := range *snapshot {
+		if atomic.LoadUint32(&dbContext.State) == db.DBOnline {
 			dbContext.UpdateCalculatedStats(ctx)
 		}
 	}
-
 }
 
 // initializeGoCBAgent Obtains a gocb agent from the current server connection. Requires the agent to be closed after use.

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1315,7 +1315,14 @@ func (sc *ServerContext) asyncDatabaseOnline(nonCancelCtx base.NonCancellableCon
 
 	if !atomic.CompareAndSwapUint32(&dbc.State, db.DBStarting, db.DBOnline) {
 		// 2nd atomic might end up being Starting here if there's a legitimate race, but it's the most we can do for CAS
-		base.PanicfCtx(ctx, "database state wasn't Starting during asyncDatabaseOnline Online transition... now %q", db.RunStateString[atomic.LoadUint32(&dbc.State)])
+		state := atomic.LoadUint32(&dbc.State)
+		// StartOnlineProcesses only takes BucketLock for read, so a Close can mark the database
+		// Stopping while it runs. Losing the transition to a teardown is expected, not a bug.
+		if state == db.DBStopping {
+			base.InfofCtx(ctx, base.KeyAll, "Database was closed while starting online processes, not bringing it online")
+			return
+		}
+		base.PanicfCtx(ctx, "database state wasn't Starting during asyncDatabaseOnline Online transition... now %q", db.RunStateString[state])
 	}
 
 	_ = dbc.EventMgr.RaiseDBStateChangeEvent(ctx, dbc.Name, "online", dbLoadedStateChangeMsg, &sc.Config.API.AdminInterface)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -73,12 +73,12 @@ type ServerContext struct {
 	_dbRegistry         map[string]struct{}               // _dbRegistry is a map of db names, used to ensure uniqueness even when db isn't active
 	_collectionRegistry map[string]string                 // _collectionRegistry is a map of fully qualified collection name to db name, used for local uniqueness checks
 	_dbConfigs          map[string]*RuntimeDatabaseConfig // _dbConfigs is a map of db name to the RuntimeDatabaseConfig
-	_databases          map[string]*db.DatabaseContext    // _databases is a map of dbname to db.DatabaseContext. Mutations must call _updateDatabasesSnapshot
+	_databases          map[string]*db.DatabaseContext    // _databases is a map of dbname to db.DatabaseContext. Mutate via _addDatabase/_deleteDatabase/_clearDatabases
 	_databasesLock      sync.RWMutex                      // Lock for _databases and other db-specific maps above
 
 	// databasesSnapshot holds the values of _databases for the stats logger to read without taking
 	// _databasesLock, which a config update can hold for a long time while it waits on index
-	// readiness (CBG-5472). Refreshed by _updateDatabasesSnapshot under the write lock.
+	// readiness (CBG-5472). Kept in step with _databases by the mutation helpers.
 	databasesSnapshot atomic.Pointer[[]*db.DatabaseContext]
 
 	// serverCtx is cancelled by Close() to broadcast server shutdown to all background
@@ -325,8 +325,7 @@ func (sc *ServerContext) Close(ctx context.Context) {
 		db.Close(ctx)
 		_ = db.EventMgr.RaiseDBStateChangeEvent(ctx, db.Name, "offline", "Database context closed", &sc.Config.API.AdminInterface)
 	}
-	sc._databases = nil
-	sc._updateDatabasesSnapshot()
+	sc._clearDatabases()
 	sc.invalidDatabaseConfigTracking.dbNames = nil
 }
 
@@ -1226,8 +1225,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	}
 
 	// Register it so HTTP handlers can find it:
-	sc._databases[dbcontext.Name] = dbcontext
-	sc._updateDatabasesSnapshot()
+	sc._addDatabase(dbcontext)
 	sc._dbConfigs[dbcontext.Name] = &RuntimeDatabaseConfig{DatabaseConfig: config}
 	sc._dbRegistry[dbName] = struct{}{}
 	for _, name := range fqCollections {
@@ -1829,8 +1827,7 @@ func (sc *ServerContext) _unloadDatabase(ctx context.Context, dbName string) boo
 	}
 	base.InfofCtx(ctx, base.KeyAll, "Closing db /%s (bucket %q)", base.MD(dbCtx.Name), base.MD(dbCtx.Bucket.GetName()))
 	// Drop it from the snapshot before teardown, so the stats logger stops seeing it first.
-	delete(sc._databases, dbName)
-	sc._updateDatabasesSnapshot()
+	sc._deleteDatabase(dbName)
 	dbCtx.Close(ctx)
 	return true
 }
@@ -1948,7 +1945,28 @@ func (sc *ServerContext) logNetworkInterfaceStats(ctx context.Context) {
 
 }
 
-// _updateDatabasesSnapshot refreshes databasesSnapshot. The caller must hold sc._databasesLock for write.
+// _addDatabase registers a database. The caller must hold sc._databasesLock for write.
+func (sc *ServerContext) _addDatabase(dbContext *db.DatabaseContext) {
+	sc._databases[dbContext.Name] = dbContext
+	sc._updateDatabasesSnapshot()
+}
+
+// _deleteDatabase removes a database. The caller must hold sc._databasesLock for write.
+func (sc *ServerContext) _deleteDatabase(dbName string) {
+	delete(sc._databases, dbName)
+	sc._updateDatabasesSnapshot()
+}
+
+// _clearDatabases removes every database and marks the server context closed, so that
+// _getOrAddDatabaseFromConfig can tell a closed server apart from one with no databases. The caller
+// must hold sc._databasesLock for write.
+func (sc *ServerContext) _clearDatabases() {
+	sc._databases = nil
+	sc._updateDatabasesSnapshot()
+}
+
+// _updateDatabasesSnapshot refreshes databasesSnapshot to match _databases. The caller must hold
+// sc._databasesLock for write.
 func (sc *ServerContext) _updateDatabasesSnapshot() {
 	sc.databasesSnapshot.Store(base.Ptr(slices.Collect(maps.Values(sc._databases))))
 }

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -377,6 +377,102 @@ func TestStatsLoggerStopped(t *testing.T) {
 	time.Sleep(time.Millisecond * 10)
 }
 
+// TestStatsLoggerIndependentOfDatabaseLock is a regression test for CBG-5472. A config update can
+// hold _databasesLock for write across a long index-readiness wait. updateCalculatedStats must
+// still complete during that time, because it reads databasesSnapshot instead of the map.
+func TestStatsLoggerIndependentOfDatabaseLock(t *testing.T) {
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+
+	sc := rt.ServerContext()
+	ctx := base.TestCtx(t)
+	require.Len(t, sc.AllDatabases(), 1)
+
+	// Simulate a config update holding the write lock for a long time.
+	sc._databasesLock.Lock()
+	defer sc._databasesLock.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		sc.updateCalculatedStats(ctx)
+		close(done)
+	}()
+
+	// updateCalculatedStats no longer takes _databasesLock, so it returns immediately.
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("updateCalculatedStats blocked on _databasesLock held by a simulated config update (CBG-5472)")
+	}
+}
+
+// TestDatabasesSnapshotTracksDatabases checks that databasesSnapshot stays in sync with _databases
+// as databases are added and removed (CBG-5472).
+func TestDatabasesSnapshotTracksDatabases(t *testing.T) {
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+
+	sc := rt.ServerContext()
+	dbName := rt.GetDatabase().Name
+
+	snapshot := sc.databasesSnapshot.Load()
+	require.NotNil(t, snapshot)
+	require.Len(t, *snapshot, 1)
+
+	require.True(t, sc.RemoveDatabase(base.TestCtx(t), dbName, "test cleanup"))
+
+	snapshot = sc.databasesSnapshot.Load()
+	require.NotNil(t, snapshot)
+	require.Empty(t, *snapshot)
+}
+
+// TestStatsLoggerConcurrentWithDatabaseRemoval runs the lock-free stats reader against a concurrent
+// database removal. The reader no longer holds _databasesLock, so it can see a database that is
+// closing, which must stay memory-safe. Most valuable under -race.
+func TestStatsLoggerConcurrentWithDatabaseRemoval(t *testing.T) {
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+
+	sc := rt.ServerContext()
+	ctx := base.TestCtx(t)
+	dbName := rt.GetDatabase().Name
+
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		for range 2000 {
+			sc.updateCalculatedStats(ctx)
+		}
+	})
+
+	require.True(t, sc.RemoveDatabase(ctx, dbName, "concurrent stats test"))
+	wg.Wait()
+}
+
+// TestStatsSnapshotExcludesClosedDatabase checks that a database the stats logger can still reach is
+// never one that has been closed. updateCalculatedStats loads the snapshot pointer and then iterates
+// it without a lock, so a removal running alongside leaves it holding a closed DatabaseContext.
+// Close() does not change State, so the DBOnline guard does not skip it.
+func TestStatsSnapshotExcludesClosedDatabase(t *testing.T) {
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+
+	sc := rt.ServerContext()
+	ctx := base.TestCtx(t)
+	dbName := rt.GetDatabase().Name
+
+	// A stats logger iteration that started before the removal holds this pointer.
+	snapshot := sc.databasesSnapshot.Load()
+	require.NotNil(t, snapshot)
+	require.Len(t, *snapshot, 1)
+
+	require.True(t, sc.RemoveDatabase(ctx, dbName, "closed database stats test"))
+
+	for _, dbContext := range *snapshot {
+		require.NotEqual(t, db.DBOnline, atomic.LoadUint32(&dbContext.State),
+			"closed database %q still reports DBOnline, so updateCalculatedStats operates on it", dbContext.Name)
+	}
+}
+
 func TestObtainManagementEndpointsFromServerContext(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("Test requires Couchbase Server")

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -438,6 +438,7 @@ func TestStatsLoggerConcurrentWithDatabaseRemoval(t *testing.T) {
 	dbName := rt.GetDatabase().Name
 
 	var wg sync.WaitGroup
+	defer base.WaitWithTimeout(t, &wg, time.Minute)
 	wg.Go(func() {
 		for range 2000 {
 			sc.updateCalculatedStats(ctx)
@@ -445,13 +446,12 @@ func TestStatsLoggerConcurrentWithDatabaseRemoval(t *testing.T) {
 	})
 
 	require.True(t, sc.RemoveDatabase(ctx, dbName, "concurrent stats test"))
-	wg.Wait()
 }
 
 // TestStatsSnapshotExcludesClosedDatabase checks that a database the stats logger can still reach is
 // never one that has been closed. updateCalculatedStats loads the snapshot pointer and then iterates
-// it without a lock, so a removal running alongside leaves it holding a closed DatabaseContext.
-// Close() does not change State, so the DBOnline guard does not skip it.
+// it without a lock, so a removal running alongside leaves it holding a closed DatabaseContext - the
+// DBOnline guard is what stops it collecting stats from one.
 func TestStatsSnapshotExcludesClosedDatabase(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -473,6 +473,27 @@ func TestStatsSnapshotExcludesClosedDatabase(t *testing.T) {
 	}
 }
 
+// TestAsyncDatabaseOnlineClosedDatabase covers asyncDatabaseOnline losing the race with a database
+// teardown. StartOnlineProcesses only takes BucketLock for read, so a Close can mark the database
+// Stopping while it runs, and the online transition then has nothing to do. It used to panic.
+func TestAsyncDatabaseOnlineClosedDatabase(t *testing.T) {
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+
+	sc := rt.ServerContext()
+	// Offline first, so StartOnlineProcesses has something to start.
+	rt.TakeDbOffline()
+
+	dbc := rt.GetDatabase()
+	atomic.StoreUint32(&dbc.State, db.DBStopping)
+
+	// Version must match, or asyncDatabaseOnline returns before reaching the online transition.
+	sc.asyncDatabaseOnline(base.NewNonCancelCtxForDatabase(base.TestCtx(t)), dbc, nil, sc.GetDbVersion(dbc.Name))
+
+	require.Equal(t, db.DBStopping, atomic.LoadUint32(&dbc.State),
+		"a closing database was brought online by asyncDatabaseOnline")
+}
+
 func TestObtainManagementEndpointsFromServerContext(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("Test requires Couchbase Server")


### PR DESCRIPTION
CBG-5472

Avoid blocking stats logger from database updates and initialisations. Access lock-free version of databases on ServerContext to build stats and minimise the locking required inside DbStats.

## Pre-review checklist
- [x] Self-review @bbrks 

## Dependencies (if applicable)
- [x] #8430 

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/959/
  - (fixed failing unit test)
