### PR TITLE
[4.1.1 backport] CBG-5552 ensure activeOnly+limit return all results with channel removals

### DIFF
--- a/db/changes.go
+++ b/db/changes.go
@@ -478,7 +478,9 @@ func (db *DatabaseCollectionWithUser) changesFeed(ctx context.Context, singleCha
 		var lastSeq uint64
 		// Pagination based on ChannelQueryLimit.  This loop may terminated in three ways (see return statements):
 		//   1. Query returns fewer rows than ChannelQueryLimit
-		//   2. A limit is specified on the incoming ChangesOptions, and that limit is reached
+		//   2. A limit is specified on the incoming ChangesOptions, and that limit is reached. Not applicable to
+		//      ActiveOnly feeds - the query always runs at ChannelQueryLimit, and requestLimit is instead enforced
+		//      by the main changes loop after cache entries have been appended.
 		//   3. An error is returned when calling singleChannelCache.GetChanges
 		for {
 			if options.ChangesCtx.Err() != nil {
@@ -486,7 +488,7 @@ func (db *DatabaseCollectionWithUser) changesFeed(ctx context.Context, singleCha
 				return
 			}
 			// Calculate limit for this iteration
-			if requestLimit == 0 {
+			if requestLimit == 0 || options.ActiveOnly {
 				paginationOptions.Limit = queryLimit
 			} else {
 				remainingLimit := requestLimit - itemsSent
@@ -543,12 +545,14 @@ func (db *DatabaseCollectionWithUser) changesFeed(ctx context.Context, singleCha
 				return
 			}
 
-			// If we've reached the request limit, we're done
-			itemsSent += sentChanges
-			if requestLimit > 0 && itemsSent >= requestLimit {
-				return
+			// If we've reached the request limit we're done.  If this is an ActiveOnly changes feed there
+			// is additional filtering in the main changes loop, so we can't apply the requestLimit here.
+			if !options.ActiveOnly {
+				itemsSent += sentChanges
+				if requestLimit > 0 && itemsSent >= requestLimit {
+					return
+				}
 			}
-
 			paginationOptions.Since.Seq = lastSeq
 		}
 	}()

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -9,6 +9,7 @@
 package db
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"reflect"
@@ -17,6 +18,7 @@ import (
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -516,4 +518,803 @@ func TestCurrentVersionPopulationOnChannelCache(t *testing.T) {
 	assert.Equal(t, sourceID, entries[0].SourceID)
 	assert.Equal(t, doc.HLV.SourceID, entries[0].SourceID)
 	assert.Equal(t, doc.HLV.Version, entries[0].Version)
+}
+
+// TestActiveOnlyWithLimit verifies that when querying with ActiveOnly: true and a Limit,
+// the pagination inside changesFeed does not terminate prematurely due to counting inactive/deleted
+// entries as "sent", ensuring the client receives the requested number of active changes when available.
+func TestActiveOnlyWithLimit(t *testing.T) {
+	cacheOptions := DefaultCacheOptions()
+	cacheOptions.ChannelQueryLimit = 3
+	db, ctx := setupTestDBWithCacheOptions(t, cacheOptions)
+	defer db.Close(ctx)
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyCache)
+
+	// 1. Create 6 documents that we will subsequently delete
+	revs := make(map[string]string)
+	for i := 1; i <= 6; i++ {
+		key := fmt.Sprintf("doc_del_%d", i)
+		body := Body{"foo": "bar"}
+		revId, _, err := collection.Put(ctx, key, body)
+		require.NoError(t, err)
+		revs[key] = revId
+	}
+
+	// 2. Delete those 6 documents so we have 6 deleted sequences at the start of the feed
+	for i := 1; i <= 6; i++ {
+		key := fmt.Sprintf("doc_del_%d", i)
+		_, _, err := collection.DeleteDoc(ctx, key, DocVersion{RevTreeID: revs[key]})
+		require.NoError(t, err)
+	}
+
+	// 3. Create 4 active documents
+	for i := 1; i <= 4; i++ {
+		key := fmt.Sprintf("doc_act_%d", i)
+		body := Body{"foo": "bar"}
+		_, _, err := collection.Put(ctx, key, body)
+		require.NoError(t, err)
+	}
+
+	db.WaitForPendingChanges(t)
+
+	// Get changes with active_only=true and Limit=3
+	changesOptions := ChangesOptions{
+		Since:      SequenceID{Seq: 0},
+		ActiveOnly: true,
+		Limit:      3,
+		ChangesCtx: base.TestCtx(t),
+	}
+
+	changes := getChanges(t, collection, base.SetOf("*"), changesOptions)
+	// We should receive exactly 3 active changes ("doc_act_1", "doc_act_2", "doc_act_3")
+	require.Len(t, changes, 3)
+	assert.Equal(t, "doc_act_1", changes[0].ID)
+	assert.Equal(t, "doc_act_2", changes[1].ID)
+	assert.Equal(t, "doc_act_3", changes[2].ID)
+}
+
+// stubSingleChannelCache is a minimal SingleChannelCache test double that serves entries from a
+// fixed, sequence-ordered list, honoring Since and Limit the way a real channel cache would. This
+// lets tests drive changesFeed's own pagination bookkeeping directly, without needing real
+// documents, DCP, or a backing query/view implementation, while still having changesFeed's actual
+// Since/Limit choices (not a pre-scripted call count) determine what gets returned. Only GetChanges
+// and ChannelID are exercised by changesFeed; the remaining methods are unused stubs to satisfy the
+// interface.
+type stubSingleChannelCache struct {
+	channelID channels.ID
+	entries   []*LogEntry // full ordered set of entries in the channel, by sequence
+	calls     int
+}
+
+func (s *stubSingleChannelCache) GetChanges(_ context.Context, options ChangesOptions) ([]*LogEntry, error) {
+	s.calls++
+	var result []*LogEntry
+	for _, entry := range s.entries {
+		if entry.Sequence <= options.Since.Seq {
+			continue
+		}
+		result = append(result, entry)
+		if options.Limit > 0 && len(result) >= options.Limit {
+			break
+		}
+	}
+	return result, nil
+}
+
+func (s *stubSingleChannelCache) GetCachedChanges(_ ChangesOptions) (uint64, []*LogEntry) {
+	return 0, nil
+}
+
+func (s *stubSingleChannelCache) ChannelID() channels.ID {
+	return s.channelID
+}
+
+func (s *stubSingleChannelCache) SupportsLateFeed() bool {
+	return false
+}
+
+func (s *stubSingleChannelCache) LateSequenceUUID() uuid.UUID {
+	return uuid.UUID{}
+}
+
+func (s *stubSingleChannelCache) GetLateSequencesSince(_ uint64) ([]*LogEntry, uint64, error) {
+	return nil, 0, nil
+}
+
+func (s *stubSingleChannelCache) RegisterLateSequenceClient() uint64 {
+	return 0
+}
+
+func (s *stubSingleChannelCache) ReleaseLateSequenceClient(_ uint64) bool {
+	return false
+}
+
+// drainChangesFeed reads a changesFeed's output channel to completion, failing the test on any
+// error entry.
+func drainChangesFeed(t *testing.T, feed <-chan *ChangeEntry) []*ChangeEntry {
+	var received []*ChangeEntry
+	for entry := range feed {
+		require.NoError(t, entry.Err)
+		received = append(received, entry)
+	}
+	return received
+}
+
+// TestChangesFeedActiveOnlyContinuesPastInactiveBatch verifies that ActiveOnly feeds correctly page
+// past inactive/deleted entries and don't prematurely terminate when a user-requested limit is specified.
+// For ActiveOnly feeds, changesFeed must query using the database query pagination limit (ChannelQueryLimit)
+// rather than the user-requested limit, since the number of raw entries and active entries differ.
+// The test ensures changesFeed continues to iterate over the result set to retrieve all active entries
+// even when an inactive page precedes them.
+func TestChangesFeedActiveOnlyContinuesPastInactiveBatch(t *testing.T) {
+	cacheOptions := DefaultCacheOptions()
+	cacheOptions.ChannelQueryLimit = 3
+	ctx, _, collection := setupDBWithChannelCacheSettings(t, cacheOptions)
+	collectionID := collection.GetCollectionID()
+	channelID := channels.NewID("active", collectionID)
+
+	stub := &stubSingleChannelCache{
+		channelID: channelID,
+		entries: []*LogEntry{
+			{DocID: "removed1", RevID: "1-a", Sequence: 1, Flags: channels.Removed, CollectionID: collectionID},
+			{DocID: "removed2", RevID: "1-a", Sequence: 2, Flags: channels.Removed, CollectionID: collectionID},
+			{DocID: "removed3", RevID: "1-a", Sequence: 3, Flags: channels.Removed, CollectionID: collectionID},
+			{DocID: "active1", RevID: "1-a", Sequence: 4, CollectionID: collectionID},
+			{DocID: "active2", RevID: "1-a", Sequence: 5, CollectionID: collectionID},
+		},
+	}
+
+	options := ChangesOptions{
+		Since:      SequenceID{Seq: 0},
+		ActiveOnly: true,
+		Limit:      1,
+		ChangesCtx: base.TestCtx(t),
+	}
+
+	received := drainChangesFeed(t, collection.changesFeed(ctx, stub, options, "test"))
+
+	// changesFeed forwards every entry it sees, active or not - ActiveOnly filtering happens
+	// upstream in SimpleMultiChangesFeed. What matters here is that all 5 entries were retrieved,
+	// including active2, which the buggy version dropped.
+	require.Len(t, received, 5)
+	assert.Equal(t, "removed1", received[0].ID)
+	assert.Equal(t, "removed2", received[1].ID)
+	assert.Equal(t, "removed3", received[2].ID)
+	assert.Equal(t, "active1", received[3].ID)
+	assert.Equal(t, "active2", received[4].ID)
+	assert.Equal(t, 2, stub.calls, "changesFeed should page by ChannelQueryLimit, not the much smaller requested Limit, for ActiveOnly feeds")
+}
+
+// TestChangesFeedActiveOnlyMultipleInactiveBatches is the same shape as
+// TestChangesFeedActiveOnlyContinuesPastInactiveBatch but spans three all-inactive, full-page batches
+// before four active entries appear - more than the requested Limit of 2. The buggy version stopped
+// as soon as it had sent Limit-many active entries, so it would give up after active2 and never see
+// active3 or active4, even though the channel has more data.
+func TestChangesFeedActiveOnlyMultipleInactiveBatches(t *testing.T) {
+	cacheOptions := DefaultCacheOptions()
+	cacheOptions.ChannelQueryLimit = 3
+	ctx, _, collection := setupDBWithChannelCacheSettings(t, cacheOptions)
+	collectionID := collection.GetCollectionID()
+	channelID := channels.NewID("active", collectionID)
+
+	var entries []*LogEntry
+	for seq := uint64(1); seq <= 9; seq++ {
+		entries = append(entries, &LogEntry{DocID: fmt.Sprintf("removed%d", seq), RevID: "1-a", Sequence: seq, Flags: channels.Removed, CollectionID: collectionID})
+	}
+	for i, seq := 1, uint64(10); seq <= 13; i, seq = i+1, seq+1 {
+		entries = append(entries, &LogEntry{DocID: fmt.Sprintf("active%d", i), RevID: "1-a", Sequence: seq, CollectionID: collectionID})
+	}
+
+	stub := &stubSingleChannelCache{
+		channelID: channelID,
+		entries:   entries,
+	}
+
+	options := ChangesOptions{
+		Since:      SequenceID{Seq: 0},
+		ActiveOnly: true,
+		Limit:      2,
+		ChangesCtx: base.TestCtx(t),
+	}
+
+	received := drainChangesFeed(t, collection.changesFeed(ctx, stub, options, "test"))
+
+	require.Len(t, received, 13)
+	assert.Equal(t, "active1", received[9].ID)
+	assert.Equal(t, "active2", received[10].ID)
+	assert.Equal(t, "active3", received[11].ID)
+	assert.Equal(t, "active4", received[12].ID)
+	assert.Equal(t, 5, stub.calls, "changesFeed should have paged through all three inactive batches and kept going to find all four active entries")
+}
+
+// TestChangesFeedActiveOnlyStopsWhenChannelExhausted verifies changesFeed terminates (rather than
+// looping forever) when the channel runs out of data before satisfying the requested ActiveOnly
+// Limit: the final batch is shorter than the pagination limit requested for that call, which is
+// changesFeed's signal that the channel has no more data.
+func TestChangesFeedActiveOnlyStopsWhenChannelExhausted(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+	collectionID := collection.GetCollectionID()
+	channelID := channels.NewID("active", collectionID)
+
+	stub := &stubSingleChannelCache{
+		channelID: channelID,
+		entries: []*LogEntry{
+			{DocID: "removed1", RevID: "1-a", Sequence: 1, Flags: channels.Removed, CollectionID: collectionID},
+		},
+	}
+
+	options := ChangesOptions{
+		Since:      SequenceID{Seq: 0},
+		ActiveOnly: true,
+		Limit:      5,
+		ChangesCtx: base.TestCtx(t),
+	}
+
+	received := drainChangesFeed(t, collection.changesFeed(ctx, stub, options, "test"))
+
+	require.Len(t, received, 1)
+	assert.Equal(t, "removed1", received[0].ID)
+	assert.Equal(t, 1, stub.calls, "changesFeed should stop after a short batch signals the channel is exhausted")
+}
+
+// docMutation names one write-order step in a single-channel feed: whether the doc written at that
+// step is left active in the channel, or removed from it (shows up with the Removed flag). A []docMutation
+// list documents a test case's write sequence directly, without needing to decode a pattern string.
+type docMutation int
+
+const (
+	// iota+1 so the zero value is never a valid mutation - an unset docMutation fails loudly
+	// (removedFlagsFromMutations) instead of silently behaving like docActive.
+	docActive docMutation = iota + 1
+	docRemoved
+)
+
+func (m docMutation) String() string {
+	switch m {
+	case docActive:
+		return "docActive"
+	case docRemoved:
+		return "docRemoved"
+	default:
+		return fmt.Sprintf("docMutation(%d)", int(m))
+	}
+}
+
+// channelFeedEntry is a compact description of one document to materialize in a target channel's feed.
+// Lets stub-style scenarios run against a real channel cache instead.
+type channelFeedEntry struct {
+	docID   string
+	removed bool
+}
+
+// seedChannelFeed writes entries into targetChannel in order, moving removed entries into otherChannel
+// so they show up as removals. Writes happen before the cache is primed, so a since=0 request backfills
+// through real query pagination rather than an already-warm cache.
+func seedChannelFeed(t *testing.T, ctx context.Context, collection *DatabaseCollectionWithUser, targetChannel, otherChannel string, entries []channelFeedEntry) {
+	for _, e := range entries {
+		if e.removed {
+			revID, _, err := collection.Put(ctx, e.docID, Body{"channels": targetChannel})
+			require.NoError(t, err)
+			_, _, err = collection.Put(ctx, e.docID, Body{"channels": otherChannel, "_rev": revID})
+			require.NoError(t, err)
+		} else {
+			_, _, err := collection.Put(ctx, e.docID, Body{"channels": targetChannel})
+			require.NoError(t, err)
+		}
+	}
+}
+
+// removedFlagsFromMutations converts a []docMutation into a per-index removed slice.
+func removedFlagsFromMutations(t testing.TB, mutations []docMutation) []bool {
+	removed := make([]bool, len(mutations))
+	for i, m := range mutations {
+		switch m {
+		case docActive:
+			removed[i] = false
+		case docRemoved:
+			removed[i] = true
+		default:
+			t.Fatalf("unknown %v at index %d", m, i)
+		}
+	}
+	return removed
+}
+
+// expectedActiveOnlyDocIDs derives the expected result ("doc<i+1>" per write-order entry) from the same
+// removed/write-order data used to seed the feed, so the assertion can't drift from the seed: drop
+// removed docs when activeOnly, then cap at limit.
+func expectedActiveOnlyDocIDs(removed []bool, activeOnly bool, limit int) []string {
+	var expected []string
+	for i, r := range removed {
+		if activeOnly && r {
+			continue
+		}
+		expected = append(expected, fmt.Sprintf("doc%d", i+1))
+	}
+	if limit > 0 && len(expected) > limit {
+		expected = expected[:limit]
+	}
+	return expected
+}
+
+// TestChangesQueryLimitBoundaries is TestActiveOnlyWithLimit run against a real database/collection
+// changes feed, verifying that database query pagination limit (ChannelQueryLimit) boundary combinations
+// correctly return active entries without premature termination.
+//
+// It ensures that inactive/deleted entries are not counted toward the user-requested limit, preventing
+// the feed from stopping early.
+//
+// Note: This end-to-end test does not verify that we avoid shrinking the database query pagination limit
+// for ActiveOnly feeds; if it were shrunk, the queries would still return correct results but with more
+// round trips. The stub-based tests instead verify that we query with the full ChannelQueryLimit.
+func TestChangesQueryLimitBoundaries(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyCache)
+
+	const targetChannel = "target"
+	const otherChannel = "other"
+
+	testCases := []struct {
+		name         string
+		queryLimit   int  // CacheOptions.ChannelQueryLimit (database query pagination limit)
+		requestLimit int  // ChangesOptions.Limit (user-requested limit, 0 == no limit)
+		activeOnly   bool // ChangesOptions.ActiveOnly
+		mutations    []docMutation
+	}{
+		// --- ActiveOnly=false: every entry (active + removal) is returned, capped by requestLimit ---
+		{ // active run spans batches; requestLimit stops mid-second-batch (pagination limit 3, request 4)
+			name: "false/active_across_batches_request_lt_total", queryLimit: 3, requestLimit: 4, activeOnly: false,
+			mutations: []docMutation{docActive, docActive, docActive, docActive, docActive, docActive},
+		},
+		{ // requestLimit > queryLimit and > total: full result, having paged through several batches
+			name: "false/request_gt_total_multi_batch", queryLimit: 3, requestLimit: 100, activeOnly: false,
+			mutations: []docMutation{docActive, docRemoved, docActive, docRemoved, docActive, docRemoved, docActive, docRemoved},
+		},
+		{ // requestLimit == queryLimit, more data than one batch: must page past the first batch
+			name: "false/request_eq_query_limit", queryLimit: 3, requestLimit: 3, activeOnly: false,
+			mutations: []docMutation{docActive, docActive, docActive, docActive, docActive},
+		},
+		{ // no requestLimit: drain everything across many small batches
+			name: "false/no_limit_many_batches", queryLimit: 2, requestLimit: 0, activeOnly: false,
+			mutations: []docMutation{docActive, docRemoved, docActive, docRemoved, docActive, docRemoved, docActive, docRemoved},
+		},
+		{ // total is an exact multiple of the query pagination limit (boundary lands exactly at end of data)
+			name: "false/exact_multiple_of_query_limit", queryLimit: 3, requestLimit: 0, activeOnly: false,
+			mutations: []docMutation{docActive, docActive, docActive, docActive, docActive, docActive},
+		},
+
+		// --- ActiveOnly=true: removals are filtered out; changesFeed must keep paging past
+		//     all-inactive batches to reach the requested number of active entries ---
+		{ // a full leading batch of removals (zero active), then active entries - request < active available
+			name: "true/removals_fill_first_batch", queryLimit: 3, requestLimit: 3, activeOnly: true,
+			mutations: []docMutation{docRemoved, docRemoved, docRemoved, docActive, docActive, docActive, docActive},
+		},
+		{ // active entries straddle a query-batch boundary; requestLimit lands mid-run
+			name: "true/active_straddles_batch_boundary", queryLimit: 3, requestLimit: 3, activeOnly: true,
+			mutations: []docMutation{docActive, docActive, docRemoved, docRemoved, docActive, docActive, docActive},
+		},
+		{ // multiple all-removal batches before any active entry (like the stub multi-inactive-batch test)
+			name: "true/multiple_removal_batches", queryLimit: 3, requestLimit: 2, activeOnly: true,
+			mutations: []docMutation{
+				docRemoved, docRemoved, docRemoved, docRemoved, docRemoved, docRemoved, docRemoved,
+				docActive, docActive, docActive, docActive,
+			},
+		},
+		{ // requestLimit > queryLimit: active limit exceeds a single query page
+			name: "true/request_gt_query_limit", queryLimit: 2, requestLimit: 5, activeOnly: true,
+			mutations: []docMutation{
+				docActive, docRemoved, docActive, docRemoved, docActive, docRemoved,
+				docActive, docRemoved, docActive, docRemoved, docActive, docRemoved,
+			},
+		},
+		{ // requestLimit < queryLimit: single page satisfies the request, no extra paging needed
+			name: "true/request_lt_query_limit", queryLimit: 5, requestLimit: 2, activeOnly: true,
+			mutations: []docMutation{docActive, docActive, docActive, docActive, docActive, docActive},
+		},
+		{ // no requestLimit: every active entry must be returned regardless of interleaved removals
+			name: "true/no_limit_interleaved", queryLimit: 3, requestLimit: 0, activeOnly: true,
+			mutations: []docMutation{
+				docRemoved, docActive, docRemoved, docActive, docRemoved, docActive,
+				docRemoved, docActive, docRemoved, docActive, docRemoved,
+			},
+		},
+		{ // channel exhausted before requestLimit is met: return the few active entries and stop
+			name: "true/exhausted_before_limit", queryLimit: 3, requestLimit: 10, activeOnly: true,
+			mutations: []docMutation{docRemoved, docRemoved, docActive, docActive, docRemoved, docRemoved, docActive},
+		},
+		{ // all removals: active-only feed is empty even though the channel has entries to page through
+			name: "true/all_removed_empty", queryLimit: 2, requestLimit: 5, activeOnly: true,
+			mutations: []docMutation{docRemoved, docRemoved, docRemoved, docRemoved, docRemoved},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cacheOptions := DefaultCacheOptions()
+			cacheOptions.ChannelQueryLimit = tc.queryLimit
+			ctx, db, collection := setupDBWithChannelCacheSettings(t, cacheOptions)
+
+			removed := removedFlagsFromMutations(t, tc.mutations)
+			entries := make([]channelFeedEntry, 0, len(removed))
+			for i, r := range removed {
+				entries = append(entries, channelFeedEntry{docID: fmt.Sprintf("doc%d", i+1), removed: r})
+			}
+			seedChannelFeed(t, ctx, collection, targetChannel, otherChannel, entries)
+			db.WaitForPendingChanges(t)
+
+			changesOptions := ChangesOptions{
+				Since:      SequenceID{Seq: 0},
+				ActiveOnly: tc.activeOnly,
+				Limit:      tc.requestLimit,
+				ChangesCtx: base.TestCtx(t),
+			}
+			changes := getChanges(t, collection, base.SetOf(targetChannel), changesOptions)
+
+			expected := expectedActiveOnlyDocIDs(removed, tc.activeOnly, tc.requestLimit)
+
+			require.Len(t, changes, len(expected))
+			for i, exp := range expected {
+				assert.Equal(t, exp, changes[i].ID, "unexpected doc at feed index %d", i)
+				if tc.activeOnly {
+					assert.Empty(t, changes[i].Removed, "active-only feed should not contain removals (index %d)", i)
+				}
+			}
+		})
+	}
+}
+
+// TestChangesQueryCacheConcatenationBoundaries is the counterpart to TestChangesQueryLimitBoundaries,
+// verifying correct merging and deduplication of query results (pruned prefix) and cache results (retained suffix)
+// at the cache validFrom boundary.
+//
+// Like TestChangesQueryLimitBoundaries, this end-to-end test does not directly verify the optimization
+// that avoids shrinking the database query pagination limit (ChannelQueryLimit) during pagination. This is because
+// any active entries omitted in an iteration would still be retrieved in a subsequent query iteration as changesFeed
+// continues to iterate over the resultset using ChannelQueryLimit.
+func TestChangesQueryCacheConcatenationBoundaries(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyCache)
+
+	const targetChannel = "target"
+	const otherChannel = "other"
+
+	testCases := []struct {
+		name           string
+		cacheMaxLength int  // CacheOptions.ChannelCacheMaxLength (query/cache split point: last N entries stay cached)
+		queryLimit     int  // CacheOptions.ChannelQueryLimit (database query pagination limit within the pruned/query-only prefix)
+		requestLimit   int  // ChangesOptions.Limit (user-requested limit, 0 == no limit)
+		activeOnly     bool // ChangesOptions.ActiveOnly
+		mutations      []docMutation
+	}{
+		{ // active run straddles the prune boundary: docs 1-3 pruned to query-only, docs 4-6 stay cached
+			name: "active_run_straddles_prune_boundary", cacheMaxLength: 3, queryLimit: 2, requestLimit: 4, activeOnly: true,
+			mutations: []docMutation{docActive, docActive, docActive, docActive, docActive, docActive},
+		},
+		{ // pruned (query-only) prefix is all removals; every active entry lives in the cached suffix
+			name: "removals_pruned_actives_cached", cacheMaxLength: 3, queryLimit: 2, requestLimit: 0, activeOnly: true,
+			mutations: []docMutation{docRemoved, docRemoved, docRemoved, docActive, docActive, docActive},
+		},
+		{ // same as removals_pruned_actives_cached but with a non-zero requestLimit (the original failure case)
+			name: "removals_pruned_actives_cached_with_limit", cacheMaxLength: 3, queryLimit: 2, requestLimit: 2, activeOnly: true,
+			mutations: []docMutation{docRemoved, docRemoved, docRemoved, docActive, docActive, docActive},
+		},
+		{ // requestLimit fully satisfied within the pruned prefix; cache boundary is never reached
+			name: "request_satisfied_before_prune_boundary", cacheMaxLength: 2, queryLimit: 2, requestLimit: 2, activeOnly: true,
+			mutations: []docMutation{docActive, docActive, docActive, docActive, docActive, docActive},
+		},
+		{ // pruned prefix needs multiple query pages (queryLimit small relative to prefix) before the
+			// cache boundary is reached and the cached suffix gets appended
+			name: "multi_page_query_then_cache_append", cacheMaxLength: 2, queryLimit: 2, requestLimit: 0, activeOnly: true,
+			mutations: []docMutation{docRemoved, docRemoved, docRemoved, docRemoved, docRemoved, docActive, docActive},
+		},
+		{ // same as multi_page_query_then_cache_append but with a non-zero requestLimit
+			name: "multi_page_query_then_cache_append_with_limit", cacheMaxLength: 2, queryLimit: 2, requestLimit: 1, activeOnly: true,
+			mutations: []docMutation{docRemoved, docRemoved, docRemoved, docRemoved, docRemoved, docActive, docActive},
+		},
+		{ // no requestLimit: every active entry must be returned across the query/cache split with no
+			// duplication of the overlap entry at the cache's validFrom boundary
+			name: "no_limit_full_span", cacheMaxLength: 3, queryLimit: 3, requestLimit: 0, activeOnly: true,
+			mutations: []docMutation{
+				docActive, docRemoved, docActive, docRemoved, docActive,
+				docRemoved, docActive, docRemoved, docActive, docRemoved,
+			},
+		},
+		{ // ActiveOnly=false: plain concatenation across a prune boundary that doesn't align with the
+			// query pagination limit, to check for off-by-one duplication/loss at the query/cache seam
+			name: "activeOnly_false_misaligned_boundary", cacheMaxLength: 4, queryLimit: 3, requestLimit: 0, activeOnly: false,
+			mutations: []docMutation{
+				docActive, docRemoved, docActive, docRemoved, docActive,
+				docRemoved, docActive, docRemoved, docActive, docRemoved,
+			},
+		},
+		{ // cache boundary and query pagination limit coincide exactly (aligned case)
+			name: "aligned_boundary", cacheMaxLength: 3, queryLimit: 3, requestLimit: 0, activeOnly: true,
+			mutations: []docMutation{docActive, docActive, docActive, docRemoved, docRemoved, docRemoved, docActive, docActive, docActive},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cacheOptions := DefaultCacheOptions()
+			cacheOptions.ChannelCacheMaxLength = tc.cacheMaxLength
+			cacheOptions.ChannelQueryLimit = tc.queryLimit
+			ctx, db, collection := setupDBWithChannelCacheSettings(t, cacheOptions)
+
+			// Prime the cache before writing so live writes populate it directly (and get pruned live
+			// once ChannelCacheMaxLength is exceeded), rather than requiring a query to backfill it.
+			primingOptions := ChangesOptions{Since: SequenceID{Seq: 0}, ChangesCtx: base.TestCtx(t)}
+			_ = getChanges(t, collection, base.SetOf(targetChannel), primingOptions)
+
+			removed := removedFlagsFromMutations(t, tc.mutations)
+			entries := make([]channelFeedEntry, 0, len(removed))
+			for i, r := range removed {
+				entries = append(entries, channelFeedEntry{docID: fmt.Sprintf("doc%d", i+1), removed: r})
+			}
+			seedChannelFeed(t, ctx, collection, targetChannel, otherChannel, entries)
+			db.WaitForPendingChanges(t)
+
+			changesOptions := ChangesOptions{
+				Since:      SequenceID{Seq: 0},
+				ActiveOnly: tc.activeOnly,
+				Limit:      tc.requestLimit,
+				ChangesCtx: base.TestCtx(t),
+			}
+			changes := getChanges(t, collection, base.SetOf(targetChannel), changesOptions)
+
+			expected := expectedActiveOnlyDocIDs(removed, tc.activeOnly, tc.requestLimit)
+
+			require.Len(t, changes, len(expected))
+			for i, exp := range expected {
+				assert.Equal(t, exp, changes[i].ID, "unexpected doc at feed index %d", i)
+				if tc.activeOnly {
+					assert.Empty(t, changes[i].Removed, "active-only feed should not contain removals (index %d)", i)
+				}
+			}
+		})
+	}
+}
+
+// multiChannelFeedEntry seeds one doc across one or more channels at once. removedFrom is the subset
+// of channels it's later removed from: if it covers every channel, the doc is fully inactive; if it's a
+// strict subset, the doc stays active via the remaining channel(s) - see fullyRemoved.
+type multiChannelFeedEntry struct {
+	channels    []string
+	removedFrom []string
+}
+
+// fullyRemoved reports whether the doc was removed from every channel it's in.
+func (e multiChannelFeedEntry) fullyRemoved() bool {
+	return len(e.removedFrom) > 0 && len(e.removedFrom) == len(e.channels)
+}
+
+// seedMultiChannelFeed is seedChannelFeed generalized to multiple (and shared) channels: entries are
+// written in slice order, so write order equals global sequence order. A fully-removed doc moves to
+// otherChannel; a partially-removed doc just drops the removedFrom channels, staying live elsewhere.
+func seedMultiChannelFeed(t *testing.T, ctx context.Context, collection *DatabaseCollectionWithUser, otherChannel string, entries []multiChannelFeedEntry) {
+	for i, e := range entries {
+		docID := fmt.Sprintf("doc%d", i+1)
+		revID, _, err := collection.Put(ctx, docID, Body{"channels": e.channels})
+		require.NoError(t, err)
+		if len(e.removedFrom) == 0 {
+			continue
+		}
+		removedSet := make(map[string]bool, len(e.removedFrom))
+		for _, c := range e.removedFrom {
+			removedSet[c] = true
+		}
+		var newChannels []string
+		for _, c := range e.channels {
+			if !removedSet[c] {
+				newChannels = append(newChannels, c)
+			}
+		}
+		if len(newChannels) == 0 {
+			// Fully removed: move to a channel outside the requested set rather than leaving the doc
+			// with an empty channel list, mirroring seedChannelFeed's single-channel convention.
+			newChannels = []string{otherChannel}
+		}
+		_, _, err = collection.Put(ctx, docID, Body{"channels": newChannels, "_rev": revID})
+		require.NoError(t, err)
+	}
+}
+
+// multiChannelMutation names one write-order step across two channels (ch1/ch2 in this test): which
+// channel(s) a doc is written to, and whether/how it's later removed. The "both" values cover a single
+// doc shared by both channels at once; bothRemoveCh1Only/bothRemoveCh2Only remove it from just one of
+// the two, leaving it active via the other.
+type multiChannelMutation int
+
+const (
+	// iota+1 so the zero value is never a valid mutation - an unset multiChannelMutation fails loudly
+	// (entriesFromMultiChannelMutations) instead of silently being dropped from the seed.
+	ch1Active         multiChannelMutation = iota + 1 // active in ch1 only
+	ch1Removed                                        // removed from ch1 (was ch1-only)
+	ch2Active                                         // active in ch2 only
+	ch2Removed                                        // removed from ch2 (was ch2-only)
+	bothActive                                        // written to both channels, stays active in both
+	bothRemoved                                       // removed from both channels at once (fully inactive)
+	bothRemoveCh1Only                                 // written to both, removed from ch1 only
+	bothRemoveCh2Only                                 // written to both, removed from ch2 only
+)
+
+func (m multiChannelMutation) String() string {
+	switch m {
+	case ch1Active:
+		return "ch1Active"
+	case ch1Removed:
+		return "ch1Removed"
+	case ch2Active:
+		return "ch2Active"
+	case ch2Removed:
+		return "ch2Removed"
+	case bothActive:
+		return "bothActive"
+	case bothRemoved:
+		return "bothRemoved"
+	case bothRemoveCh1Only:
+		return "bothRemoveCh1Only"
+	case bothRemoveCh2Only:
+		return "bothRemoveCh2Only"
+	default:
+		return fmt.Sprintf("multiChannelMutation(%d)", int(m))
+	}
+}
+
+// entriesFromMultiChannelMutations converts a []multiChannelMutation into multiChannelFeedEntry values.
+func entriesFromMultiChannelMutations(t testing.TB, mutations []multiChannelMutation, ch1, ch2 string) []multiChannelFeedEntry {
+	entries := make([]multiChannelFeedEntry, len(mutations))
+	for i, m := range mutations {
+		switch m {
+		case ch1Active:
+			entries[i] = multiChannelFeedEntry{channels: []string{ch1}}
+		case ch1Removed:
+			entries[i] = multiChannelFeedEntry{channels: []string{ch1}, removedFrom: []string{ch1}}
+		case ch2Active:
+			entries[i] = multiChannelFeedEntry{channels: []string{ch2}}
+		case ch2Removed:
+			entries[i] = multiChannelFeedEntry{channels: []string{ch2}, removedFrom: []string{ch2}}
+		case bothActive:
+			entries[i] = multiChannelFeedEntry{channels: []string{ch1, ch2}}
+		case bothRemoved:
+			entries[i] = multiChannelFeedEntry{channels: []string{ch1, ch2}, removedFrom: []string{ch1, ch2}}
+		case bothRemoveCh1Only:
+			entries[i] = multiChannelFeedEntry{channels: []string{ch1, ch2}, removedFrom: []string{ch1}}
+		case bothRemoveCh2Only:
+			entries[i] = multiChannelFeedEntry{channels: []string{ch1, ch2}, removedFrom: []string{ch2}}
+		default:
+			t.Fatalf("unknown %v at index %d", m, i)
+		}
+	}
+	return entries
+}
+
+// TestChangesMultiChannelActiveOnlyLimit exercises MultiChangesFeed's cross-channel merge with
+// ActiveOnly+Limit across two real channels, verifying correct global write order and deduplication of
+// multi-channel documents.
+//
+// It ensures that inactive/deleted entries on one channel do not incorrectly starve or block active
+// entries on another channel, and that we correctly page past inactive entries across channel merges.
+func TestChangesMultiChannelActiveOnlyLimit(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyCache)
+
+	const ch1 = "ch1"
+	const ch2 = "ch2"
+	const otherChannel = "other"
+
+	testCases := []struct {
+		name         string
+		queryLimit   int
+		requestLimit int
+		activeOnly   bool
+		mutations    []multiChannelMutation
+	}{
+		{ // simple alternation between channels, all active: verifies merge preserves global write order
+			name: "interleaved_actives_request_lt_total", queryLimit: 2, requestLimit: 3, activeOnly: true,
+			mutations: []multiChannelMutation{ch1Active, ch2Active, ch1Active, ch2Active, ch1Active, ch2Active},
+		},
+		{ // ch1 has a long removal run while ch2 keeps producing actives: ch1's inactive backlog must
+			// not starve or misorder ch2's actives in the merged, globally-ordered output
+			name: "one_channel_removed_run_other_active", queryLimit: 2, requestLimit: 3, activeOnly: true,
+			mutations: []multiChannelMutation{
+				ch1Removed, ch1Removed, ch1Removed, ch2Active, ch1Removed, ch2Active, ch2Active, ch1Active,
+			},
+		},
+		{ // both channels have enough entries to require multiple internal query batches each
+			// (queryLimit=2); no requestLimit, so the full merged result must be complete and ordered
+			name: "both_channels_paginate_independently", queryLimit: 2, requestLimit: 0, activeOnly: true,
+			mutations: []multiChannelMutation{
+				ch1Active, ch1Removed, ch2Active, ch2Removed, ch1Active,
+				ch1Removed, ch2Active, ch2Removed, ch1Active, ch2Active,
+			},
+		},
+		{ // requestLimit lands exactly between two actives contributed by different channels
+			name: "limit_lands_at_cross_channel_boundary", queryLimit: 3, requestLimit: 2, activeOnly: true,
+			mutations: []multiChannelMutation{ch1Active, ch2Removed, ch2Removed, ch2Removed, ch1Active, ch2Active},
+		},
+		{ // ActiveOnly=false across channels: plain merge/limit behavior with removals present
+			name: "activeOnly_false_multichannel", queryLimit: 2, requestLimit: 5, activeOnly: false,
+			mutations: []multiChannelMutation{
+				ch1Active, ch2Removed, ch1Removed, ch2Active, ch1Active, ch2Removed, ch2Active, ch1Removed,
+			},
+		},
+		{ // ch1 exhausts after a single entry while ch2 continues; the merge loop must keep draining
+			// ch2 correctly after ch1's changesFeed goroutine has already finished
+			name: "channel_exhausted_early_other_continues", queryLimit: 2, requestLimit: 4, activeOnly: true,
+			mutations: []multiChannelMutation{
+				ch1Active, ch2Active, ch2Removed, ch2Active, ch2Removed, ch2Active, ch2Removed, ch2Active,
+			},
+		},
+
+		// --- shared docs: a single doc written to both channels at once, exercising MultiChangesFeed's
+		//     per-sequence allRemoved dedup across channel feeds ---
+		{ // doc removed from only one of its two channels stays active via the other; must still be
+			// returned under ActiveOnly, not dropped as if fully removed
+			name: "partial_removal_stays_active", queryLimit: 2, requestLimit: 0, activeOnly: true,
+			mutations: []multiChannelMutation{bothRemoveCh1Only, ch1Active, ch2Active},
+		},
+		{ // same, removing the *other* channel first, to rule out any asymmetry in which channel-feed
+			// slot the allRemoved dedup happens to inspect first
+			name: "partial_removal_other_direction_stays_active", queryLimit: 2, requestLimit: 0, activeOnly: true,
+			mutations: []multiChannelMutation{bothRemoveCh2Only, ch1Active, ch2Active},
+		},
+		{ // doc removed from both of its channels (in the same write) is fully inactive, unlike the
+			// partial-removal cases above - the dedup must correctly distinguish the two
+			name: "full_removal_of_shared_doc_is_inactive", queryLimit: 2, requestLimit: 0, activeOnly: true,
+			mutations: []multiChannelMutation{bothRemoved, ch1Active, ch2Active},
+		},
+		{ // a partially-removed shared doc mixed with an ordinary single-channel removal run and a
+			// requestLimit landing after both, forced through multi-batch pagination on each channel
+			name: "partial_removal_mixed_with_limit", queryLimit: 2, requestLimit: 3, activeOnly: true,
+			mutations: []multiChannelMutation{
+				ch1Removed, ch1Removed, bothRemoveCh1Only, ch2Active, ch1Active, ch2Removed, bothRemoveCh2Only, ch2Active,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cacheOptions := DefaultCacheOptions()
+			cacheOptions.ChannelQueryLimit = tc.queryLimit
+			ctx, db, collection := setupDBWithChannelCacheSettings(t, cacheOptions)
+
+			entries := entriesFromMultiChannelMutations(t, tc.mutations, ch1, ch2)
+			seedMultiChannelFeed(t, ctx, collection, otherChannel, entries)
+			db.WaitForPendingChanges(t)
+
+			changesOptions := ChangesOptions{
+				Since:      SequenceID{Seq: 0},
+				ActiveOnly: tc.activeOnly,
+				Limit:      tc.requestLimit,
+				ChangesCtx: base.TestCtx(t),
+			}
+			changes := getChanges(t, collection, base.SetOf(ch1, ch2), changesOptions)
+
+			removed := make([]bool, len(entries))
+			entriesByDocID := make(map[string]multiChannelFeedEntry, len(entries))
+			for i, e := range entries {
+				removed[i] = e.fullyRemoved()
+				entriesByDocID[fmt.Sprintf("doc%d", i+1)] = e
+			}
+			expected := expectedActiveOnlyDocIDs(removed, tc.activeOnly, tc.requestLimit)
+
+			require.Len(t, changes, len(expected))
+			for i, exp := range expected {
+				assert.Equal(t, exp, changes[i].ID, "unexpected doc at feed index %d", i)
+				if !tc.activeOnly {
+					continue
+				}
+				// A doc partially removed (still active via another channel) legitimately carries a
+				// non-empty Removed set recording which channel(s) it left, even though it wasn't
+				// filtered out - so check it matches removedFrom exactly, rather than requiring empty.
+				entry := entriesByDocID[exp]
+				if len(entry.removedFrom) == 0 {
+					assert.Empty(t, changes[i].Removed, "expected no partial removals for %s (index %d)", exp, i)
+				} else {
+					assert.Equal(t, base.SetOf(entry.removedFrom...), changes[i].Removed, "unexpected partial removal set for %s (index %d)", exp, i)
+				}
+			}
+		})
+	}
 }

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -597,4 +598,649 @@ func TestChannelCacheBackgroundTaskWithIllegalTimeInterval(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "CleanAgedItems", backgroundTaskError.TaskName)
 	assert.Equal(t, options.ChannelCacheAge, backgroundTaskError.Interval)
+}
+
+// - The channel cache is validFrom sequence n, with one active mutation resident in the cache
+// - There are channel removals (only) in the bucket with m < sequence < n
+// - Client issues a GetChanges request with since=m
+func TestChannelCacheActiveOnlyAndLimit(t *testing.T) {
+	ctx, db, collection := setupDBWithChannelCacheSize(t, 2)
+
+	const (
+		activeChannel   = "active"
+		inactiveChannel = "inactive"
+		doc1            = "doc1"
+		doc2            = "doc2"
+		doc3            = "doc3"
+	)
+
+	// doc1 rev1: channel active
+	// doc1 rev2: channel inactive
+	// doc2 rev1: channel active
+	// doc2 rev2: channel inactive
+	// doc3 rev1: channel active
+	revID, _, err := collection.Put(ctx, doc1, Body{"channels": activeChannel})
+	require.NoError(t, err)
+	_, _, err = collection.Put(ctx, doc1, Body{"channels": inactiveChannel, "_rev": revID})
+	require.NoError(t, err)
+	revID, _, err = collection.Put(ctx, doc2, Body{"channels": activeChannel})
+	require.NoError(t, err)
+	_, _, err = collection.Put(ctx, doc2, Body{"channels": inactiveChannel, "_rev": revID})
+	require.NoError(t, err)
+
+	_, _, err = collection.Put(ctx, doc3, Body{"channels": activeChannel})
+	require.NoError(t, err)
+
+	db.WaitForPendingChanges(t)
+
+	// prime channel cache, doc2 and doc3 should be in cache
+	changesOptions := ChangesOptions{
+		Since:      SequenceID{Seq: 0},
+		ActiveOnly: false,
+		ChangesCtx: base.TestCtx(t),
+	}
+	require.Len(t, getChanges(t, collection, base.SetOf(activeChannel), changesOptions), 3)
+
+	// whether limit or no limit, should only be 1 active entry
+	for _, limit := range []int{0, 1} {
+		t.Run("limit="+fmt.Sprint(limit), func(t *testing.T) {
+			changesOptions = ChangesOptions{
+				Since:      SequenceID{Seq: 0},
+				ActiveOnly: true,
+				ChangesCtx: base.TestCtx(t),
+				Limit:      limit,
+			}
+			require.Len(t, getChanges(t, collection, base.SetOf(activeChannel), changesOptions), 1)
+		})
+	}
+}
+
+func TestChannelCacheActiveOnlyScenarios(t *testing.T) {
+	const activeChannel = "active"
+
+	t.Run("query returns an active rev, cache is all removals", func(t *testing.T) {
+		ctx, db, collection := setupDBWithChannelCacheSize(t, 2)
+
+		// doc1: active (seq 1) - will be in backing store, not cache
+		_, _, err := collection.Put(ctx, "doc1", Body{"channels": activeChannel})
+		require.NoError(t, err)
+
+		// doc2: active (seq 2) -> inactive (seq 3) - seq 3 in cache
+		revID2, _, err := collection.Put(ctx, "doc2", Body{"channels": activeChannel})
+		require.NoError(t, err)
+		_, _, err = collection.Put(ctx, "doc2", Body{"channels": "other", "_rev": revID2})
+		require.NoError(t, err)
+
+		// doc3: active (seq 4) -> inactive (seq 5) - seq 5 in cache
+		revID3, _, err := collection.Put(ctx, "doc3", Body{"channels": activeChannel})
+		require.NoError(t, err)
+		_, _, err = collection.Put(ctx, "doc3", Body{"channels": "other", "_rev": revID3})
+		require.NoError(t, err)
+
+		db.WaitForPendingChanges(t)
+
+		// With limit 1 (before)
+		changesOptions := ChangesOptions{Since: SequenceID{Seq: 0}, ActiveOnly: true, Limit: 1, ChangesCtx: base.TestCtx(t)}
+		changes := getChanges(t, collection, base.SetOf(activeChannel), changesOptions)
+		require.Len(t, changes, 1)
+		assert.Equal(t, "doc1", changes[0].ID)
+
+		// No limit
+		changesOptions.Limit = 0
+		changes = getChanges(t, collection, base.SetOf(activeChannel), changesOptions)
+		require.Len(t, changes, 1)
+		assert.Equal(t, "doc1", changes[0].ID)
+
+		// With limit 1 (after)
+		changesOptions.Limit = 1
+		changes = getChanges(t, collection, base.SetOf(activeChannel), changesOptions)
+		require.Len(t, changes, 1)
+		assert.Equal(t, "doc1", changes[0].ID)
+	})
+
+	t.Run("query returns an active rev, cache also has an active rev", func(t *testing.T) {
+		ctx, db, collection := setupDBWithChannelCacheSize(t, 2)
+
+		// doc1: active (seq 1) - backing store
+		_, _, err := collection.Put(ctx, "doc1", Body{"channels": activeChannel})
+		require.NoError(t, err)
+
+		// doc2: active (seq 2) -> inactive (seq 3) - cache
+		revID2, _, err := collection.Put(ctx, "doc2", Body{"channels": activeChannel})
+		require.NoError(t, err)
+		_, _, err = collection.Put(ctx, "doc2", Body{"channels": "other", "_rev": revID2})
+		require.NoError(t, err)
+
+		// doc3: active (seq 4) - cache
+		_, _, err = collection.Put(ctx, "doc3", Body{"channels": activeChannel})
+		require.NoError(t, err)
+
+		db.WaitForPendingChanges(t)
+
+		// With limit 1 (before)
+		changesOptions := ChangesOptions{Since: SequenceID{Seq: 0}, ActiveOnly: true, Limit: 1, ChangesCtx: base.TestCtx(t)}
+		changes := getChanges(t, collection, base.SetOf(activeChannel), changesOptions)
+		require.Len(t, changes, 1)
+		assert.Equal(t, "doc1", changes[0].ID)
+
+		// No limit: should get doc1 and doc3
+		changesOptions.Limit = 0
+		changes = getChanges(t, collection, base.SetOf(activeChannel), changesOptions)
+		require.Len(t, changes, 2)
+		assert.Equal(t, "doc1", changes[0].ID)
+		assert.Equal(t, "doc3", changes[1].ID)
+
+		// With limit 1 (after)
+		changesOptions.Limit = 1
+		changes = getChanges(t, collection, base.SetOf(activeChannel), changesOptions)
+		require.Len(t, changes, 1)
+		assert.Equal(t, "doc1", changes[0].ID)
+	})
+
+	t.Run("query has no active revs, cache has no active revs", func(t *testing.T) {
+		ctx, db, collection := setupDBWithChannelCacheSize(t, 2)
+
+		// doc1: active (seq 1) -> inactive (seq 2)
+		revID1, _, err := collection.Put(ctx, "doc1", Body{"channels": activeChannel})
+		require.NoError(t, err)
+		_, _, err = collection.Put(ctx, "doc1", Body{"channels": "other", "_rev": revID1})
+		require.NoError(t, err)
+
+		// doc2: active (seq 3) -> inactive (seq 4)
+		revID2, _, err := collection.Put(ctx, "doc2", Body{"channels": activeChannel})
+		require.NoError(t, err)
+		_, _, err = collection.Put(ctx, "doc2", Body{"channels": "other", "_rev": revID2})
+		require.NoError(t, err)
+
+		db.WaitForPendingChanges(t)
+
+		// With limit 1 (before)
+		changesOptions := ChangesOptions{Since: SequenceID{Seq: 0}, ActiveOnly: true, Limit: 1, ChangesCtx: base.TestCtx(t)}
+		changes := getChanges(t, collection, base.SetOf(activeChannel), changesOptions)
+		require.Len(t, changes, 0)
+
+		// No limit: should get nothing
+		changesOptions.Limit = 0
+		changes = getChanges(t, collection, base.SetOf(activeChannel), changesOptions)
+		require.Len(t, changes, 0)
+
+		// With limit 1 (after)
+		changesOptions.Limit = 1
+		changes = getChanges(t, collection, base.SetOf(activeChannel), changesOptions)
+		require.Len(t, changes, 0)
+	})
+	t.Run("cache populated, query requires pagination", func(t *testing.T) {
+		cacheOptions := DefaultCacheOptions()
+		cacheOptions.ChannelCacheMaxLength = 5
+		cacheOptions.ChannelQueryLimit = 5
+		ctx, db, collection := setupDBWithChannelCacheSettings(t, cacheOptions)
+		// seed activeChannel in the cache prior to writing docs
+		changesOptions := ChangesOptions{Since: SequenceID{Seq: 0}, ChangesCtx: base.TestCtx(t)}
+		_ = getChanges(t, collection, base.SetOf(activeChannel), changesOptions)
+		// Write 20 docs to the channel.  5 should be cached, 15 require query
+		for i := range 20 {
+			docID := fmt.Sprintf("doc%d", i+1)
+			_, _, err := collection.Put(ctx, docID, Body{"channels": activeChannel})
+			require.NoError(t, err)
+		}
+		db.WaitForPendingChanges(t)
+		changesOptions = ChangesOptions{Since: SequenceID{Seq: 0}, ActiveOnly: true, Limit: 0, ChangesCtx: base.TestCtx(t)}
+		changes := getChanges(t, collection, base.SetOf(activeChannel), changesOptions)
+		require.Len(t, changes, 20)
+		for i, change := range changes {
+			assert.Equal(t, fmt.Sprintf("doc%d", i+1), change.ID, "change at index %d", i)
+		}
+	})
+	t.Run("cache populated, query requires pagination with limit", func(t *testing.T) {
+		// With ChannelQueryLimit=5 and Limit=10, each GetChanges call returns 5 entries from the
+		// query range, which equals the requested limit, so there's no room to also append the
+		// cache (docs 16-20) - if there were, the first call would skip docs 6-15.
+		cacheOptions := DefaultCacheOptions()
+		cacheOptions.ChannelCacheMaxLength = 5
+		cacheOptions.ChannelQueryLimit = 5
+		ctx, db, collection := setupDBWithChannelCacheSettings(t, cacheOptions)
+		changesOptions := ChangesOptions{Since: SequenceID{Seq: 0}, ChangesCtx: base.TestCtx(t)}
+		_ = getChanges(t, collection, base.SetOf(activeChannel), changesOptions)
+		for i := 1; i <= 20; i++ {
+			_, _, err := collection.Put(ctx, fmt.Sprintf("doc%d", i), Body{"channels": activeChannel})
+			require.NoError(t, err)
+		}
+		db.WaitForPendingChanges(t)
+		// Limit=10 spans two query batches (5+5) before reaching cache. The pagination loop must
+		// not prematurely append cache after the first batch hits the active limit.
+		changesOptions = ChangesOptions{Since: SequenceID{Seq: 0}, ActiveOnly: true, Limit: 10, ChangesCtx: base.TestCtx(t)}
+		changes := getChanges(t, collection, base.SetOf(activeChannel), changesOptions)
+		require.Len(t, changes, 10)
+		for i, change := range changes {
+			assert.Equal(t, fmt.Sprintf("doc%d", i+1), change.ID, "change at index %d", i)
+		}
+	})
+}
+
+func setupDBWithChannelCacheSize(t *testing.T, maxLength int) (context.Context, *Database, *DatabaseCollectionWithUser) {
+	cacheOptions := DefaultCacheOptions()
+	cacheOptions.ChannelCacheMaxLength = maxLength
+	return setupDBWithChannelCacheSettings(t, cacheOptions)
+}
+
+func setupDBWithChannelCacheSettings(t *testing.T, cacheOptions CacheOptions) (context.Context, *Database, *DatabaseCollectionWithUser) {
+	db, ctx := setupTestDBWithCacheOptions(t, cacheOptions)
+	t.Cleanup(func() { db.Close(ctx) })
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+	_, err := collection.UpdateSyncFun(ctx, channels.DocChannelsSyncFunction)
+	require.NoError(t, err)
+	return ctx, db, collection
+}
+
+// FuzzChannelCacheActiveOnly verifies that GetChanges with ActiveOnly=true returns every active entry
+// exactly once, in sequence order, regardless of how results are split between backing-store query
+// batches and the in-memory cache.
+func FuzzChannelCacheActiveOnly(f *testing.F) {
+	// --- SEED CORPUS FOR EXPLICIT BOUNDARY CASES ---
+
+	// 1. request limit (R) aligns exactly with query pagination limit (Q) (R == Q, or R == k * Q)
+	f.Add(uint8(15), uint8(5), uint8(5), uint8(5))  // R == Q (both 5)
+	f.Add(uint8(20), uint8(5), uint8(5), uint8(10)) // R == 2 * Q (request 10, page size 5)
+	f.Add(uint8(10), uint8(2), uint8(2), uint8(4))  // R == 2 * Q with tiny limits (request 4, page size 2, cache size 2)
+
+	// 2. single query, no cache (cache validFrom is high, so all historical entries must be fetched from DB)
+	// (cacheMaxLength=1 means cache is effectively empty for other sequences; query limit is large enough to fetch all in one page)
+	f.Add(uint8(20), uint8(1), uint8(15), uint8(5))
+
+	// 3. Query gap before boundary, cache at boundary (query limit restricts DB page size, cacheMaxLength=1 keeps cache minimal)
+	f.Add(uint8(15), uint8(1), uint8(2), uint8(10)) // request limit 10, database page size 2, no cache
+
+	// 4. single query + partial cache (cacheMaxLength is large enough to hold some but not all docs, single DB query)
+	f.Add(uint8(10), uint8(5), uint8(10), uint8(8))
+
+	// 5. multiple queries + partial cache (cache holds part, DB pagination requested to get the rest over multiple pages)
+	f.Add(uint8(12), uint8(4), uint8(3), uint8(10))
+
+	// 6. single query + full cache (cacheMaxLength is large enough to hold all doc sequences, query limit is large)
+	f.Add(uint8(10), uint8(10), uint8(15), uint8(10))
+
+	// 7. multiple queries + full cache (cacheMaxLength is large, but query limit is small)
+	f.Add(uint8(15), uint8(10), uint8(3), uint8(12))
+
+	// 8. Other general permutations
+	f.Add(uint8(5), uint8(5), uint8(5), uint8(0))  // all docs fit in cache, no request limit
+	f.Add(uint8(1), uint8(5), uint8(5), uint8(1))  // single doc, limit=1
+	f.Add(uint8(0), uint8(5), uint8(5), uint8(5))  // no docs
+	f.Add(uint8(15), uint8(5), uint8(5), uint8(5)) // request limit < cache boundary
+
+	f.Fuzz(func(t *testing.T, numDocs, cacheMaxLength, queryLimit, requestLimit uint8) {
+		if cacheMaxLength == 0 {
+			cacheMaxLength = 1
+		}
+		if queryLimit == 0 {
+			queryLimit = 1
+		}
+		const maxDocs = 30
+		n := int(numDocs)
+		if n > maxDocs {
+			n = maxDocs
+		}
+
+		cacheOptions := DefaultCacheOptions()
+		cacheOptions.ChannelCacheMaxLength = int(cacheMaxLength)
+		cacheOptions.ChannelQueryLimit = int(queryLimit)
+		ctx, db, collection := setupDBWithChannelCacheSettings(t, cacheOptions)
+
+		// Seed the channel in the cache before writing docs so subsequent writes land
+		// in the cache from sequence 1.
+		_ = getChanges(t, collection, base.SetOf("active"), ChangesOptions{
+			Since: SequenceID{Seq: 0}, ChangesCtx: base.TestCtx(t),
+		})
+
+		type docState struct {
+			id     string
+			revID  string
+			seq    uint64
+			active bool
+		}
+
+		docsMap := make(map[string]*docState)
+		var docIDs []string
+
+		// Deterministic random generator based on inputs to ensure reproducibility
+		rng := rand.New(rand.NewSource(int64(numDocs) + int64(cacheMaxLength)*100 + int64(queryLimit)*10000 + int64(requestLimit)*1000000))
+
+		nextDocID := 1
+		for i := 1; i <= n; i++ {
+			// Choose action:
+			// 0: Create new active doc
+			// 1: Create new other (inactive) doc
+			// 2: Update existing to active
+			// 3: Update existing to other (inactive)
+			action := rng.Intn(4)
+			if len(docIDs) == 0 {
+				action = rng.Intn(2) // Only create actions are possible initially
+			}
+
+			var docID string
+			var body Body
+			var active bool
+
+			switch action {
+			case 0:
+				docID = fmt.Sprintf("doc_act_%d", nextDocID)
+				nextDocID++
+				body = Body{"channels": "active"}
+				active = true
+			case 1:
+				docID = fmt.Sprintf("doc_oth_%d", nextDocID)
+				nextDocID++
+				body = Body{"channels": "other"}
+				active = false
+			case 2:
+				// Update existing to active
+				idx := rng.Intn(len(docIDs))
+				docID = docIDs[idx]
+				state := docsMap[docID]
+				body = Body{"channels": "active", "_rev": state.revID}
+				active = true
+			case 3:
+				// Update existing to other
+				idx := rng.Intn(len(docIDs))
+				docID = docIDs[idx]
+				state := docsMap[docID]
+				body = Body{"channels": "other", "_rev": state.revID}
+				active = false
+			}
+
+			newRevID, doc, err := collection.Put(ctx, docID, body)
+			require.NoError(t, err)
+
+			if state, exists := docsMap[docID]; exists {
+				state.revID = newRevID
+				state.seq = doc.Sequence
+				state.active = active
+			} else {
+				docsMap[docID] = &docState{
+					id:     docID,
+					revID:  newRevID,
+					seq:    doc.Sequence,
+					active: active,
+				}
+				docIDs = append(docIDs, docID)
+				sort.Strings(docIDs) // maintain sorted order for deterministic selection
+			}
+		}
+
+		db.WaitForPendingChanges(t)
+
+		changes := getChanges(t, collection, base.SetOf("active"), ChangesOptions{
+			Since:      SequenceID{Seq: 0},
+			ActiveOnly: true,
+			Limit:      int(requestLimit),
+			ChangesCtx: base.TestCtx(t),
+		})
+
+		// Collect the expected active docs at their final sequence numbers
+		var activeDocs []*docState
+		for _, state := range docsMap {
+			if state.active {
+				activeDocs = append(activeDocs, state)
+			}
+		}
+		sort.Slice(activeDocs, func(i, j int) bool {
+			return activeDocs[i].seq < activeDocs[j].seq
+		})
+
+		// Correct count: all active docs, or exactly requestLimit if that is smaller
+		limit := int(requestLimit)
+		expectedCount := len(activeDocs)
+		if limit > 0 && limit < len(activeDocs) {
+			expectedCount = limit
+		}
+
+		// No duplicates in the returned changes
+		seen := make(map[string]bool, len(changes))
+		for _, c := range changes {
+			require.False(t, seen[c.ID], "duplicate entry %s", c.ID)
+			seen[c.ID] = true
+		}
+		require.Len(t, changes, expectedCount)
+
+		// Entries must be the first expectedCount active docs in final sequence order
+		for i, c := range changes {
+			require.Equal(t, activeDocs[i].id, c.ID, "wrong doc ID at index %d", i)
+			require.Equal(t, activeDocs[i].seq, c.Seq.Seq, "wrong sequence at index %d", i)
+		}
+	})
+}
+
+// TestChannelCacheActiveOnlyLimitWithCrossChannelGap reproduces a scenario where the cache's
+// validFrom sequence doesn't correspond to any entry in the queried channel, because the
+// intervening sequence(s) belong to a *different* channel. The query's last returned entry can
+// then be well below cacheValidFrom (e.g. N), while the cache's first entry starts above it
+// (e.g. N+2), even though the query fully scanned through to the cache boundary with no gap.
+func TestChannelCacheActiveOnlyLimitWithCrossChannelGap(t *testing.T) {
+	cacheOptions := DefaultCacheOptions()
+	cacheOptions.ChannelCacheMaxLength = 2
+	ctx, db, collection := setupDBWithChannelCacheSettings(t, cacheOptions)
+
+	const activeChannel = "active"
+	const otherChannel = "other"
+
+	// Prime the cache *before* any writes so subsequent docs are appended live (and pruned
+	// live via _pruneCacheLength), which is the path where validFrom can land on a sequence
+	// that isn't an entry in this channel at all (see _pruneCacheLength).
+	primingOptions := ChangesOptions{Since: SequenceID{Seq: 0}, ChangesCtx: base.TestCtx(t)}
+	_ = getChanges(t, collection, base.SetOf(activeChannel), primingOptions)
+
+	// doc1: active (seq1) -> removed from channel (seq2)
+	revID, _, err := collection.Put(ctx, "doc1", Body{"channels": activeChannel})
+	require.NoError(t, err)
+	_, _, err = collection.Put(ctx, "doc1", Body{"channels": otherChannel, "_rev": revID})
+	require.NoError(t, err)
+
+	// doc2: active (seq3) -> removed from channel (seq4)
+	revID, _, err = collection.Put(ctx, "doc2", Body{"channels": activeChannel})
+	require.NoError(t, err)
+	_, _, err = collection.Put(ctx, "doc2", Body{"channels": otherChannel, "_rev": revID})
+	require.NoError(t, err)
+
+	// docGap: seq5, entirely in a different channel - creates a sequence gap for activeChannel.
+	_, _, err = collection.Put(ctx, "docGap", Body{"channels": otherChannel})
+	require.NoError(t, err)
+
+	// doc3, doc4: active (seq6, seq7) - stay active. With ChannelCacheMaxLength=2 these live
+	// appends prune doc1/doc2's entries out of the cache, pushing validFrom to 5 (docGap's
+	// sequence), which isn't an entry in activeChannel at all.
+	_, _, err = collection.Put(ctx, "doc3", Body{"channels": activeChannel})
+	require.NoError(t, err)
+	_, _, err = collection.Put(ctx, "doc4", Body{"channels": activeChannel})
+	require.NoError(t, err)
+
+	db.WaitForPendingChanges(t)
+
+	changesOptions := ChangesOptions{
+		Since:      SequenceID{Seq: 0},
+		ActiveOnly: true,
+		Limit:      1,
+		ChangesCtx: base.TestCtx(t),
+	}
+	changes := getChanges(t, collection, base.SetOf(activeChannel), changesOptions)
+	require.Len(t, changes, 1)
+	assert.Equal(t, "doc3", changes[0].ID)
+}
+
+func TestChannelCacheActiveOnlyBoundariesAndGaps(t *testing.T) {
+	const activeChannel = "active"
+	const otherChannel = "other"
+
+	t.Run("Query and cache both exactly at boundary (No Gap)", func(t *testing.T) {
+		cacheOptions := DefaultCacheOptions()
+		cacheOptions.ChannelCacheMaxLength = 2
+		ctx, db, collection := setupDBWithChannelCacheSettings(t, cacheOptions)
+
+		// Prime cache
+		_ = getChanges(t, collection, base.SetOf(activeChannel), ChangesOptions{
+			Since: SequenceID{Seq: 0}, ChangesCtx: base.TestCtx(t),
+		})
+
+		_, _, err := collection.Put(ctx, "doc1", Body{"channels": activeChannel})
+		require.NoError(t, err)
+		_, _, err = collection.Put(ctx, "doc2", Body{"channels": activeChannel})
+		require.NoError(t, err)
+		_, _, err = collection.Put(ctx, "doc3", Body{"channels": activeChannel})
+		require.NoError(t, err)
+
+		db.WaitForPendingChanges(t)
+
+		// Since doc1 is pruned (cache length 2), validFrom is 2 (doc2's sequence is 2).
+		// Querying with Limit=10 should return all 3 docs: doc1 (Seq 1), doc2 (Seq 2), and doc3 (Seq 3).
+		// Since query reached boundary (Seq 2 >= 2), the cache should be appended, deduplicating doc2.
+		changes := getChanges(t, collection, base.SetOf(activeChannel), ChangesOptions{
+			Since:      SequenceID{Seq: 0},
+			ActiveOnly: true,
+			Limit:      10,
+			ChangesCtx: base.TestCtx(t),
+		})
+		require.Len(t, changes, 3)
+		assert.Equal(t, "doc1", changes[0].ID)
+		assert.Equal(t, "doc2", changes[1].ID)
+		assert.Equal(t, "doc3", changes[2].ID)
+	})
+
+	t.Run("Query gap before boundary, cache at boundary", func(t *testing.T) {
+		cacheOptions := DefaultCacheOptions()
+		cacheOptions.ChannelCacheMaxLength = 2
+		ctx, db, collection := setupDBWithChannelCacheSettings(t, cacheOptions)
+
+		// Prime cache
+		_ = getChanges(t, collection, base.SetOf(activeChannel), ChangesOptions{
+			Since: SequenceID{Seq: 0}, ChangesCtx: base.TestCtx(t),
+		})
+
+		_, _, err := collection.Put(ctx, "doc1", Body{"channels": activeChannel}) // Seq 1
+		require.NoError(t, err)
+		_, _, err = collection.Put(ctx, "docGap", Body{"channels": otherChannel}) // Seq 2
+		require.NoError(t, err)
+		_, _, err = collection.Put(ctx, "doc2", Body{"channels": activeChannel}) // Seq 3
+		require.NoError(t, err)
+		_, _, err = collection.Put(ctx, "doc3", Body{"channels": activeChannel}) // Seq 4
+		require.NoError(t, err)
+
+		db.WaitForPendingChanges(t)
+
+		// doc1 is pruned, cache contains doc2 and doc3. validFrom is 2 (doc1.Seq + 1 = 2).
+		// For ActiveOnly feeds the query always runs at ChannelQueryLimit rather than the request
+		// limit, so the query for doc1 (Seq 1) has room left over and the cache entries (doc2, doc3)
+		// are appended too. It's the main changes loop, not this query, that then trims the combined
+		// result down to the requested Limit=1, leaving only doc1.
+		changes := getChanges(t, collection, base.SetOf(activeChannel), ChangesOptions{
+			Since:      SequenceID{Seq: 0},
+			ActiveOnly: true,
+			Limit:      1,
+			ChangesCtx: base.TestCtx(t),
+		})
+		require.Len(t, changes, 1)
+		assert.Equal(t, "doc1", changes[0].ID)
+	})
+
+	t.Run("Query at boundary, cache gap after boundary", func(t *testing.T) {
+		cacheOptions := DefaultCacheOptions()
+		cacheOptions.ChannelCacheMaxLength = 2
+		ctx, db, collection := setupDBWithChannelCacheSettings(t, cacheOptions)
+
+		// Prime cache
+		_ = getChanges(t, collection, base.SetOf(activeChannel), ChangesOptions{
+			Since: SequenceID{Seq: 0}, ChangesCtx: base.TestCtx(t),
+		})
+
+		_, _, err := collection.Put(ctx, "doc1", Body{"channels": activeChannel}) // Seq 1
+		require.NoError(t, err)
+		_, _, err = collection.Put(ctx, "doc2", Body{"channels": activeChannel}) // Seq 2
+		require.NoError(t, err)
+		_, _, err = collection.Put(ctx, "docGap", Body{"channels": otherChannel}) // Seq 3
+		require.NoError(t, err)
+		_, _, err = collection.Put(ctx, "doc3", Body{"channels": activeChannel}) // Seq 4
+		require.NoError(t, err)
+		_, _, err = collection.Put(ctx, "doc4", Body{"channels": activeChannel}) // Seq 5
+		require.NoError(t, err)
+
+		db.WaitForPendingChanges(t)
+
+		// doc1 and doc2 are pruned. Cache contains doc3 and doc4. validFrom is 3 (doc2.Seq + 1 = 3).
+		// Querying with Limit=2 gets doc1 (Seq 1) and doc2 (Seq 2) and stops early (highSeq = 2 < 3).
+		// The query returns exactly `limit` (2) rows, so there's no room left to append the cache.
+		changes := getChanges(t, collection, base.SetOf(activeChannel), ChangesOptions{
+			Since:      SequenceID{Seq: 0},
+			ActiveOnly: true,
+			Limit:      2,
+			ChangesCtx: base.TestCtx(t),
+		})
+		require.Len(t, changes, 2)
+		assert.Equal(t, "doc1", changes[0].ID)
+		assert.Equal(t, "doc2", changes[1].ID)
+
+		// Querying with Limit=10 gets doc1, doc2 (2 rows, under the limit), leaving room to append
+		// the cache (doc3, doc4), so all 4 are returned.
+		changes10 := getChanges(t, collection, base.SetOf(activeChannel), ChangesOptions{
+			Since:      SequenceID{Seq: 0},
+			ActiveOnly: true,
+			Limit:      10,
+			ChangesCtx: base.TestCtx(t),
+		})
+		require.Len(t, changes10, 4)
+		assert.Equal(t, "doc1", changes10[0].ID)
+		assert.Equal(t, "doc2", changes10[1].ID)
+		assert.Equal(t, "doc3", changes10[2].ID)
+		assert.Equal(t, "doc4", changes10[3].ID)
+	})
+
+	t.Run("Gaps in both directions", func(t *testing.T) {
+		cacheOptions := DefaultCacheOptions()
+		cacheOptions.ChannelCacheMaxLength = 2
+		ctx, db, collection := setupDBWithChannelCacheSettings(t, cacheOptions)
+
+		// Prime cache
+		_ = getChanges(t, collection, base.SetOf(activeChannel), ChangesOptions{
+			Since: SequenceID{Seq: 0}, ChangesCtx: base.TestCtx(t),
+		})
+
+		_, _, err := collection.Put(ctx, "doc1", Body{"channels": activeChannel}) // Seq 1
+		require.NoError(t, err)
+		_, _, err = collection.Put(ctx, "docGap1", Body{"channels": otherChannel}) // Seq 2
+		require.NoError(t, err)
+		_, _, err = collection.Put(ctx, "doc2", Body{"channels": activeChannel}) // Seq 3
+		require.NoError(t, err)
+		_, _, err = collection.Put(ctx, "docGap2", Body{"channels": otherChannel}) // Seq 4
+		require.NoError(t, err)
+		_, _, err = collection.Put(ctx, "doc3", Body{"channels": activeChannel}) // Seq 5
+		require.NoError(t, err)
+		_, _, err = collection.Put(ctx, "doc4", Body{"channels": activeChannel}) // Seq 6
+		require.NoError(t, err)
+
+		db.WaitForPendingChanges(t)
+
+		// doc1 and doc2 are pruned. Cache contains doc3 and doc4. validFrom is 4 (doc2.Seq + 1 = 4).
+		// Querying with Limit=2 gets doc1 (Seq 1) and doc2 (Seq 3) and stops early (highSeq = 3 < 4).
+		// The query returns exactly `limit` (2) rows, so there's no room left to append the cache.
+		changes := getChanges(t, collection, base.SetOf(activeChannel), ChangesOptions{
+			Since:      SequenceID{Seq: 0},
+			ActiveOnly: true,
+			Limit:      2,
+			ChangesCtx: base.TestCtx(t),
+		})
+		require.Len(t, changes, 2)
+		assert.Equal(t, "doc1", changes[0].ID)
+		assert.Equal(t, "doc2", changes[1].ID)
+
+		// Querying with Limit=10 gets doc1, doc2 (2 rows, under the limit), leaving room to append
+		// the cache (doc3, doc4), so all 4 are returned.
+		changes10 := getChanges(t, collection, base.SetOf(activeChannel), ChangesOptions{
+			Since:      SequenceID{Seq: 0},
+			ActiveOnly: true,
+			Limit:      10,
+			ChangesCtx: base.TestCtx(t),
+		})
+		require.Len(t, changes10, 4)
+		assert.Equal(t, "doc1", changes10[0].ID)
+		assert.Equal(t, "doc2", changes10[1].ID)
+		assert.Equal(t, "doc3", changes10[2].ID)
+		assert.Equal(t, "doc4", changes10[3].ID)
+	})
 }


### PR DESCRIPTION
[4.1.1 backport] CBG-5552 ensure activeOnly+limit return all results with channel removals

## Summary
- Cherry-pick of 265bf2cd8943657d0b5560b2a78b7227ec9a788d onto release/4.1.1.

## Integration tests

[x] - https://jenkins.sgwdev.com/job/SyncGatewayIntegration/916/
