### PR TITLE
CBG-5545: add not found error check before warning about error in RecheckPendingBucketMetadataMigrations

### DIFF
--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -2323,6 +2323,11 @@ func (sc *ServerContext) RecheckPendingBucketMetadataMigrations(ctx context.Cont
 			continue
 		}
 		if err := sc.maybeCompleteBucketMetadataMigration(ctx, bucket); err != nil {
+			if base.IsDocNotFoundError(err) {
+				// no migration status doc for this bucket means no metadata migration has ever
+				// been run for any of its databases — not an error worth warning about
+				continue
+			}
 			base.WarnfCtx(ctx, "Re-check of bucket %q metadata migration failed: %v", base.MD(bucket), err)
 		}
 	}


### PR DESCRIPTION

CBG-5545

We were logging warning for not found error on migration status doc. This doc will never exist in the bucket if a db in the bucket never has migration run so can get noisy. 

Before: 
```
2026-07-09T09:40:09.889+01:00 [DBG] Config+: Fetching configs from buckets in cluster for group "default"
2026-07-09T09:40:09.898+01:00 [DBG] Config+: b:sg_int_0_1783524622802650000 Checking for database config (attempt 1/5)
2026-07-09T09:40:09.908+01:00 [DBG] Config+: b:sg_int_0_1783524622802650000 Bucket "sg_int_0_1783524622802650000" did not contain any configs for group "default"
2026-07-09T09:40:09.908+01:00 [DBG] Config+: b:sg_int_1_1783524622802650000 Checking for database config (attempt 1/5)
2026-07-09T09:40:09.919+01:00 [DBG] Config+: b:sg_int_1_1783524622802650000 Bucket "sg_int_1_1783524622802650000" did not contain any configs for group "default"
2026-07-09T09:40:09.919+01:00 [DBG] Config+: b:sg_int_2_1783524622802650000 Checking for database config (attempt 1/5)
2026-07-09T09:40:09.930+01:00 [DBG] Config+: b:sg_int_2_1783524622802650000 Bucket "sg_int_2_1783524622802650000" did not contain any configs for group "default"
2026-07-09T09:40:09.930+01:00 [DBG] Config+: b:test Checking for database config (attempt 1/5)
2026-07-09T09:40:09.933+01:00 [DBG] Config+: b:test Got config for group "default" with cas 1783586348851789824
2026-07-09T09:40:09.933+01:00 [DBG] Config+: Database "db1" bucket "test" config has not changed since last update
2026-07-09T09:40:09.933+01:00 [DBG] SGCluster+: c:test._system._mobile-cfgSG cfg_sg: Get, key: nodeDefs-known, cas: 0
2026-07-09T09:40:09.934+01:00 [DBG] SGCluster+: c:test._system._mobile-cfgSG cfg_sg: Get, key: sgrCluster, cas: 0
2026-07-09T09:40:09.938+01:00 [DBG] Config+: Bucket "test" bootstrap-target refresh: Not Found
2026-07-09T09:40:09.940+01:00 [WRN] Re-check of bucket "test" metadata migration failed: read status doc for bucket "test": Not Found -- rest.(*ServerContext).RecheckPendingBucketMetadataMigrations() at server_context.go:2331
```

After:
```
2026-07-09T09:50:04.230+01:00 [DBG] Config+: Fetching configs from buckets in cluster for group "default"
2026-07-09T09:50:04.237+01:00 [DBG] Config+: b:sg_int_0_1783524622802650000 Checking for database config (attempt 1/5)
2026-07-09T09:50:04.247+01:00 [DBG] Config+: b:sg_int_0_1783524622802650000 Bucket "sg_int_0_1783524622802650000" did not contain any configs for group "default"
2026-07-09T09:50:04.247+01:00 [DBG] Config+: b:sg_int_1_1783524622802650000 Checking for database config (attempt 1/5)
2026-07-09T09:50:04.259+01:00 [DBG] Config+: b:sg_int_1_1783524622802650000 Bucket "sg_int_1_1783524622802650000" did not contain any configs for group "default"
2026-07-09T09:50:04.259+01:00 [DBG] Config+: b:sg_int_2_1783524622802650000 Checking for database config (attempt 1/5)
2026-07-09T09:50:04.267+01:00 [DBG] Config+: b:sg_int_2_1783524622802650000 Bucket "sg_int_2_1783524622802650000" did not contain any configs for group "default"
2026-07-09T09:50:04.267+01:00 [DBG] Config+: b:test Checking for database config (attempt 1/5)
2026-07-09T09:50:04.269+01:00 [DBG] Config+: b:test Got config for group "default" with cas 1783586348851789824
2026-07-09T09:50:04.269+01:00 [DBG] Config+: Database "db1" bucket "test" config has not changed since last update
2026-07-09T09:50:04.270+01:00 [DBG] Config+: Bucket "test" bootstrap-target refresh: Not Found
```

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/920/
