### PR TITLE
CBG-4600 apply networkType to cbgt

### DIFF
--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/couchbase/cbgt"
+	"github.com/couchbase/gocbcore/v10/connstr"
 )
 
 const (
@@ -322,6 +323,42 @@ func getCBGTIndexUUID(manager *cbgt.Manager, indexName string) (previousUUID str
 	}
 }
 
+// cbgtManagerOptions builds the options map passed to cbgt.NewManagerEx for the given DCP connection string.
+func cbgtManagerOptions(ctx context.Context, serverURL string) (map[string]string, error) {
+	// Specify one feed per pindex
+	options := make(map[string]string)
+	options[cbgt.FeedAllotmentOption] = cbgt.FeedAllotmentOnePerPIndex
+	options["managerLoadDataDir"] = "false"
+	// TLS is controlled by the connection string.
+	// cbgt uses this parameter to run in mixed mode - non-TLS for CCCP but TLS for memcached. Sync Gateway does not need to set this parameter.
+	options["feedInitialBootstrapNonTLS"] = "false"
+
+	// Since cbgt initializes a buffer per CBS node per partition in most cases (vbuckets in partitions can't be grouped by CBS node),
+	// setting the small buffer size used in cbgt 1.3.2.  (see CBG-3341 for potential optimization of this value)
+	idealKvConnectionBufferSize := 16384
+	// This value will be overridden by the BucketSpec connection string.
+	options["kvConnectionBufferSize"] = strconv.Itoa(idealKvConnectionBufferSize)
+	connSpec, err := connstr.Parse(serverURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse connection string: %w", err)
+	}
+
+	connStrKvBufferSize, err := getConnSpecOption[int](&connSpec, kvBufferSizeKey)
+	if err == nil && connStrKvBufferSize != nil && *connStrKvBufferSize > idealKvConnectionBufferSize {
+		WarnfCtx(ctx, "DCP sharded import connection string includes %s=%d, which is more than the implicit %s=%d. This will result in increased memory usage.", kvBufferSizeKey, *connStrKvBufferSize, kvBufferSizeKey, idealKvConnectionBufferSize)
+	}
+
+	networkType, err := getConnSpecOption[string](&connSpec, networkKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine network type from connection string: %w", err)
+	}
+	if networkType != nil {
+		options["gocbcoreIOConfigNetworkType"] = *networkType
+	}
+
+	return options, nil
+}
+
 // createCBGTManager creates a new manager for a given bucket and bucketSpec
 // Inline comments below provide additional detail on how cbgt uses each manager
 // parameter, and the implications for SG
@@ -378,6 +415,11 @@ func initCBGTManager(ctx context.Context, bucket Bucket, spec BucketSpec, cfgSG 
 	//   avoids file system usage, in conjunction with managerLoadDataDir=false in options.
 	dataDir := ""
 
+	options, err := cbgtManagerOptions(ctx, serverURL)
+	if err != nil {
+		return nil, err
+	}
+
 	eventHandlersCtx, eventHandlersCancel := context.WithCancelCause(ctx)
 	eventHandlers := &sgMgrEventHandlers{
 		ctx:                    eventHandlersCtx,
@@ -385,24 +427,6 @@ func initCBGTManager(ctx context.Context, bucket Bucket, spec BucketSpec, cfgSG 
 		unregisterFeedCallback: unregisterCallback,
 	}
 
-	// Specify one feed per pindex
-	options := make(map[string]string)
-	options[cbgt.FeedAllotmentOption] = cbgt.FeedAllotmentOnePerPIndex
-	options["managerLoadDataDir"] = "false"
-	// TLS is controlled by the connection string.
-	// cbgt uses this parameter to run in mixed mode - non-TLS for CCCP but TLS for memcached. Sync Gateway does not need to set this parameter.
-	options["feedInitialBootstrapNonTLS"] = "false"
-
-	// Since cbgt initializes a buffer per CBS node per partition in most cases (vbuckets in partitions can't be grouped by CBS node),
-	// setting the small buffer size used in cbgt 1.3.2.  (see CBG-3341 for potential optimization of this value)
-	idealKvConnectionBufferSize := 16384
-	// This value will be overridden by the BucketSpec connection string.
-	options["kvConnectionBufferSize"] = strconv.Itoa(idealKvConnectionBufferSize)
-
-	connStrKvBufferSize, err := getIntFromConnStr(serverURL, kvBufferSizeKey)
-	if err == nil && connStrKvBufferSize != nil && *connStrKvBufferSize > idealKvConnectionBufferSize {
-		WarnfCtx(ctx, "DCP sharded import connection string includes %s=%d, which is more than the implicit %s=%d. This will result in increased memory usage.", kvBufferSizeKey, *connStrKvBufferSize, kvBufferSizeKey, idealKvConnectionBufferSize)
-	}
 	// Creates a new cbgt manager.
 	mgr := cbgt.NewManagerEx(
 		SGCbgtMetadataVersion, // cbgt metadata version, matching 3.0 clients

--- a/base/dcp_test.go
+++ b/base/dcp_test.go
@@ -563,3 +563,107 @@ func TestCBGTKvPoolSize(t *testing.T) {
 	defer cbgtContext.Stop(ctx)
 	require.Contains(t, cbgtContext.Manager.Server(), "kv_pool_size=1")
 }
+
+func TestCBGTManagerOptions(t *testing.T) {
+	testCases := []struct {
+		name            string
+		server          string
+		expectedOptions map[string]string
+	}{
+		{
+			name:   "no options",
+			server: "couchbase://127.0.0.1",
+			expectedOptions: map[string]string{
+				cbgt.FeedAllotmentOption:     cbgt.FeedAllotmentOnePerPIndex,
+				"managerLoadDataDir":         "false",
+				"feedInitialBootstrapNonTLS": "false",
+				"kvConnectionBufferSize":     "16384",
+			},
+		},
+		{
+			name:   "network=default",
+			server: "couchbase://127.0.0.1?network=default",
+			expectedOptions: map[string]string{
+				cbgt.FeedAllotmentOption:      cbgt.FeedAllotmentOnePerPIndex,
+				"managerLoadDataDir":          "false",
+				"feedInitialBootstrapNonTLS":  "false",
+				"kvConnectionBufferSize":      "16384",
+				"gocbcoreIOConfigNetworkType": "default",
+			},
+		},
+		{
+			name:   "network=external",
+			server: "couchbase://127.0.0.1?network=external",
+			expectedOptions: map[string]string{
+				cbgt.FeedAllotmentOption:      cbgt.FeedAllotmentOnePerPIndex,
+				"managerLoadDataDir":          "false",
+				"feedInitialBootstrapNonTLS":  "false",
+				"kvConnectionBufferSize":      "16384",
+				"gocbcoreIOConfigNetworkType": "external",
+			},
+		},
+		{
+			name:   "network=auto",
+			server: "couchbase://127.0.0.1?network=auto",
+			expectedOptions: map[string]string{
+				cbgt.FeedAllotmentOption:      cbgt.FeedAllotmentOnePerPIndex,
+				"managerLoadDataDir":          "false",
+				"feedInitialBootstrapNonTLS":  "false",
+				"kvConnectionBufferSize":      "16384",
+				"gocbcoreIOConfigNetworkType": "auto",
+			},
+		},
+		{
+			// kv_buffer_size never overrides the returned kvConnectionBufferSize option - the connection string is
+			// passed to cbgt.NewManagerEx separately and cbgt applies it there.
+			name:   "kv_buffer_size below implicit size",
+			server: "couchbase://127.0.0.1?kv_buffer_size=100",
+			expectedOptions: map[string]string{
+				cbgt.FeedAllotmentOption:     cbgt.FeedAllotmentOnePerPIndex,
+				"managerLoadDataDir":         "false",
+				"feedInitialBootstrapNonTLS": "false",
+				"kvConnectionBufferSize":     "16384",
+			},
+		},
+		{
+			name:   "kv_buffer_size above implicit size",
+			server: "couchbase://127.0.0.1?kv_buffer_size=20000",
+			expectedOptions: map[string]string{
+				cbgt.FeedAllotmentOption:     cbgt.FeedAllotmentOnePerPIndex,
+				"managerLoadDataDir":         "false",
+				"feedInitialBootstrapNonTLS": "false",
+				"kvConnectionBufferSize":     "16384",
+			},
+		},
+		{
+			// an unparsable kv_buffer_size is silently ignored, rather than failing the manager options build.
+			name:   "kv_buffer_size not an int",
+			server: "couchbase://127.0.0.1?kv_buffer_size=notanumber",
+			expectedOptions: map[string]string{
+				cbgt.FeedAllotmentOption:     cbgt.FeedAllotmentOnePerPIndex,
+				"managerLoadDataDir":         "false",
+				"feedInitialBootstrapNonTLS": "false",
+				"kvConnectionBufferSize":     "16384",
+			},
+		},
+		{
+			// multiple values for a single option is also silently ignored.
+			name:   "multiple kv_buffer_size values",
+			server: "couchbase://127.0.0.1?kv_buffer_size=20000&kv_buffer_size=30000",
+			expectedOptions: map[string]string{
+				cbgt.FeedAllotmentOption:     cbgt.FeedAllotmentOnePerPIndex,
+				"managerLoadDataDir":         "false",
+				"feedInitialBootstrapNonTLS": "false",
+				"kvConnectionBufferSize":     "16384",
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx := TestCtx(t)
+			options, err := cbgtManagerOptions(ctx, testCase.server)
+			require.NoError(t, err)
+			require.Equal(t, testCase.expectedOptions, options)
+		})
+	}
+}

--- a/base/gocb_connection_string.go
+++ b/base/gocb_connection_string.go
@@ -93,7 +93,7 @@ func getConnSpecOption[T string | int](spec *connstr.ConnSpec, key string) (*T, 
 		return nil, nil
 	}
 	if len(arg) > 1 {
-		return nil, fmt.Errorf("multiple %s values found in connection string %q", key, spec.String())
+		return nil, RedactErrorf("multiple %s values found in connection string %q", key, MD(spec.String()))
 	}
 
 	var value any
@@ -101,7 +101,7 @@ func getConnSpecOption[T string | int](spec *connstr.ConnSpec, key string) (*T, 
 	case int:
 		i, err := strconv.Atoi(arg[0])
 		if err != nil {
-			return nil, fmt.Errorf("invalid %s value %s in connection string %q, must be int", key, arg[0], spec.String())
+			return nil, RedactErrorf("invalid %s value %s in connection string %q, must be int", key, arg[0], MD(spec.String()))
 		}
 		value = i
 	case string:

--- a/base/gocb_connection_string.go
+++ b/base/gocb_connection_string.go
@@ -13,13 +13,14 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/couchbaselabs/gocbconnstr"
+	"github.com/couchbase/gocbcore/v10/connstr"
 )
 
 const (
 	dcpBufferSizeKey = "dcp_buffer_size"
 	kvBufferSizeKey  = "kv_buffer_size"
 	kvPoolSizeKey    = "kv_pool_size"
+	networkKey       = "network"
 )
 
 // GoCBConnStringParams represents parameters that are passed to gocb when creating a new connection string.
@@ -39,8 +40,8 @@ func DefaultGoCBConnStringParams() *GoCBConnStringParams {
 }
 
 // getGoCBConnSpec returns a gocb connection spec based on the server string. The provided defaults will be used only when the corresponding property is not set in the connection string.
-func getGoCBConnSpec(server string, defaults *GoCBConnStringParams) (*gocbconnstr.ConnSpec, error) {
-	connSpec, err := gocbconnstr.Parse(server)
+func getGoCBConnSpec(server string, defaults *GoCBConnStringParams) (*connstr.ConnSpec, error) {
+	connSpec, err := connstr.Parse(server)
 	if err != nil {
 		return nil, err
 	}
@@ -83,26 +84,38 @@ func GetGoCBConnStringWithDefaults(server string, defaults *GoCBConnStringParams
 	return connSpec.String(), nil
 }
 
+// getConnSpecOption returns a single query parameter value from a connstr.ConnSpec, converted to type T (string or
+// int). If the option isn't set, returns nil and no error. Returns an error if the option is set more than once, or
+// if the value can't be converted to T.
+func getConnSpecOption[T string | int](spec *connstr.ConnSpec, key string) (*T, error) {
+	arg := spec.Options[key]
+	if len(arg) == 0 {
+		return nil, nil
+	}
+	if len(arg) > 1 {
+		return nil, fmt.Errorf("multiple %s values found in connection string %q", key, spec.String())
+	}
+
+	var value any
+	switch any(*new(T)).(type) {
+	case int:
+		i, err := strconv.Atoi(arg[0])
+		if err != nil {
+			return nil, fmt.Errorf("invalid %s value %s in connection string %q, must be int", key, arg[0], spec.String())
+		}
+		value = i
+	case string:
+		value = arg[0]
+	}
+	typed := value.(T)
+	return &typed, nil
+}
+
 // getIntFromConnStr returns a query parameter from a connection string. If it doesn't exist,  return nil and no error. If there's an error in parsing the connection string, return an error.
-func getIntFromConnStr(connstr, key string) (*int, error) {
-	connSpec, err := getGoCBConnSpec(connstr, nil)
+func getIntFromConnStr(server, key string) (*int, error) {
+	connSpec, err := getGoCBConnSpec(server, nil)
 	if err != nil {
 		return nil, err
 	}
-
-	values := url.Values(connSpec.Options)
-
-	arg := values[key]
-
-	if len(arg) == 0 {
-		return nil, nil
-	} else if len(arg) > 1 {
-		return nil, fmt.Errorf("Multiple %s values found in connection string %s", key, connstr)
-	}
-
-	i, err := strconv.Atoi(arg[0])
-	if err != nil {
-		return nil, fmt.Errorf("Invalid %s value %s in connection string %s, must be int", key, arg[0], connstr)
-	}
-	return &i, nil
+	return getConnSpecOption[int](connSpec, key)
 }

--- a/base/gocb_connection_string_test.go
+++ b/base/gocb_connection_string_test.go
@@ -11,6 +11,7 @@ package base
 import (
 	"testing"
 
+	"github.com/couchbase/gocbcore/v10/connstr"
 	"github.com/couchbase/sync_gateway/testing/require"
 )
 
@@ -73,6 +74,85 @@ func TestGetGoCBConnStringWithDefaults(t *testing.T) {
 			require.Equal(t, testCase.connStr, connStr)
 		})
 	}
+}
+
+func TestGetConnSpecOption(t *testing.T) {
+	t.Run("int", func(t *testing.T) {
+		testCases := []struct {
+			name          string
+			options       map[string][]string
+			expected      *int
+			expectedError bool
+		}{
+			{
+				name:    "not set",
+				options: map[string][]string{},
+			},
+			{
+				name:     "single value",
+				options:  map[string][]string{"kv_pool_size": {"8"}},
+				expected: Ptr(8),
+			},
+			{
+				name:          "multiple values",
+				options:       map[string][]string{"kv_pool_size": {"8", "4"}},
+				expectedError: true,
+			},
+			{
+				name:          "non-int value",
+				options:       map[string][]string{"kv_pool_size": {"notanint"}},
+				expectedError: true,
+			},
+		}
+		for _, testCase := range testCases {
+			t.Run(testCase.name, func(t *testing.T) {
+				spec := &connstr.ConnSpec{Options: testCase.options}
+				value, err := getConnSpecOption[int](spec, "kv_pool_size")
+				if testCase.expectedError {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+					require.Equal(t, testCase.expected, value)
+				}
+			})
+		}
+	})
+
+	t.Run("string", func(t *testing.T) {
+		testCases := []struct {
+			name          string
+			options       map[string][]string
+			expected      *string
+			expectedError bool
+		}{
+			{
+				name:    "not set",
+				options: map[string][]string{},
+			},
+			{
+				name:     "single value",
+				options:  map[string][]string{networkKey: {"external"}},
+				expected: Ptr("external"),
+			},
+			{
+				name:          "multiple values",
+				options:       map[string][]string{networkKey: {"external", "default"}},
+				expectedError: true,
+			},
+		}
+		for _, testCase := range testCases {
+			t.Run(testCase.name, func(t *testing.T) {
+				spec := &connstr.ConnSpec{Options: testCase.options}
+				value, err := getConnSpecOption[string](spec, networkKey)
+				if testCase.expectedError {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+					require.Equal(t, testCase.expected, value)
+				}
+			})
+		}
+	})
 }
 
 func TestGetIntFromConnStr(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/couchbase/sg-bucket v0.0.0-20260706130600-fc995d3ac4be
 	github.com/couchbasedeps/fast-skiplist v0.0.0-20250722125747-e0dd031fe2ac
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338
-	github.com/couchbaselabs/gocbconnstr v1.0.5
 	github.com/couchbaselabs/rosmar v0.0.0-20260706134933-2f0dabde975c
 	github.com/elastic/gosigar v0.14.4
 	github.com/felixge/fgprof v0.9.5

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,6 @@ github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338 h1:xM
 github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338/go.mod h1:0f+dmhfcTKK+4quAe6rwqQUVVWtHX/eztNB8cmBUniQ=
 github.com/couchbaselabs/gocaves/client v0.0.0-20250107114554-f96479220ae8 h1:MQfvw4BiLTuyR69FuA5Kex+tXUeLkH+/ucJfVL1/hkM=
 github.com/couchbaselabs/gocaves/client v0.0.0-20250107114554-f96479220ae8/go.mod h1:AVekAZwIY2stsJOMWLAS/0uA/+qdp7pjO8EHnl61QkY=
-github.com/couchbaselabs/gocbconnstr v1.0.5 h1:e0JokB5qbcz7rfnxEhNRTKz8q1svoRvDoZihsiwNigA=
-github.com/couchbaselabs/gocbconnstr v1.0.5/go.mod h1:KV3fnIKMi8/AzX0O9zOrO9rofEqrRF1d2rG7qqjxC7o=
 github.com/couchbaselabs/gocbconnstr/v2 v2.0.0 h1:HU9DlAYYWR69jQnLN6cpg0fh0hxW/8d5hnglCXXjW78=
 github.com/couchbaselabs/gocbconnstr/v2 v2.0.0/go.mod h1:o7T431UOfFVHDNvMBUmUxpHnhivwv7BziUao/nMl81E=
 github.com/couchbaselabs/rosmar v0.0.0-20260706134933-2f0dabde975c h1:rTggaJZ5WvEizK3YV6B+wFvqlC3pUxHRCqH4oYzff9M=


### PR DESCRIPTION
CBG-4600 apply networkType to cbgt

- move construction of options to a helper function
- replace gocbconnstr with the connstr package in gocb, these are the same packages
- Add networkType if applicable, following how this works https://github.com/couchbase/gocbcore/blob/f6c191fa62dd0fcc97e1219cdc9da2bb5f19891e/agent_config.go#L269 which is called from https://github.com/couchbase/sync_gateway/blob/fefbba485dac34b8bce2ce5e9c2cf6e2761e35b7/base/gocb_dcp_client.go#L360

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/924/
