### PR TITLE
CBG-5578 fix flake in TestISGRRunAsNonExistentUserPushesAsAdmin

### DIFF
--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -474,7 +474,7 @@ func (dbc *DatabaseContext) startReplications(ctx context.Context) {
 				return
 			}
 
-			err := dbc.SGReplicateMgr.startReplications(dbc.SGReplicateMgr.loggingCtx) // TODO: use dbc.SGReplicateMgr.loggingCtx, if that is not removed ?
+			err := dbc.SGReplicateMgr.startReplications(dbc.SGReplicateMgr.loggingCtx)
 			if err != nil {
 				base.ErrorfCtx(dbc.SGReplicateMgr.loggingCtx, "Error starting %q Inter-Sync Gateway Replications: %v", dbc.Name, err)
 			}

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -474,7 +474,7 @@ func (dbc *DatabaseContext) startReplications(ctx context.Context) {
 				return
 			}
 
-			err := dbc.SGReplicateMgr.StartReplications(dbc.SGReplicateMgr.loggingCtx) // TODO: use dbc.SGReplicateMgr.loggingCtx, if that is not removed ?
+			err := dbc.SGReplicateMgr.startReplications(dbc.SGReplicateMgr.loggingCtx) // TODO: use dbc.SGReplicateMgr.loggingCtx, if that is not removed ?
 			if err != nil {
 				base.ErrorfCtx(dbc.SGReplicateMgr.loggingCtx, "Error starting %q Inter-Sync Gateway Replications: %v", dbc.Name, err)
 			}
@@ -526,9 +526,9 @@ func (m *sgReplicateManager) StartLocalNode(nodeUUID string, heartbeater base.He
 	return heartbeater.RegisterListener(m.heartbeatListener)
 }
 
-// StartReplications performs an initial retrieval of the cluster config, starts any replications
+// startReplications performs an initial retrieval of the cluster config, starts any replications
 // assigned to this node, and starts the process to monitor future changes to the cluster config.
-func (m *sgReplicateManager) StartReplications(ctx context.Context) error {
+func (m *sgReplicateManager) startReplications(ctx context.Context) error {
 
 	replications, err := m.GetReplications()
 	if err != nil {

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -7437,11 +7437,7 @@ function (doc) {
 			adminSrv := httptest.NewServer(passiveRT.TestAdminHandler())
 			defer adminSrv.Close()
 
-			activeRTConfig := &rest.RestTesterConfig{
-				SyncFn:             syncFunc,
-				SgReplicateEnabled: true,
-			}
-			activeRT := rest.NewRestTester(t, activeRTConfig)
+			activeRT := rest.NewRestTester(t, &rest.RestTesterConfig{SyncFn: rtConfig.SyncFn, SgReplicateEnabled: true})
 			defer activeRT.Close()
 
 			for _, rt := range []*rest.RestTester{passiveRT, activeRT} {

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -7166,12 +7166,8 @@ func TestReplicatorDeprecatedCredentials(t *testing.T) {
 	adminSrv := httptest.NewServer(passiveRT.TestPublicHandler())
 	defer adminSrv.Close()
 
-	activeRT := rest.NewRestTester(t, nil)
+	activeRT := rest.NewRestTester(t, &rest.RestTesterConfig{SgReplicateEnabled: true})
 	defer activeRT.Close()
-	activeCtx := activeRT.Context()
-
-	err := activeRT.GetDatabase().SGReplicateMgr.StartReplications(activeCtx)
-	require.NoError(t, err)
 
 	docID := "test"
 	version := activeRT.PutDoc(docID, `{"prop":true}`)
@@ -7198,7 +7194,7 @@ func TestReplicatorDeprecatedCredentials(t *testing.T) {
 	rest.RequireStatus(t, resp, 200)
 
 	var config db.ReplicationConfig
-	err = json.Unmarshal(resp.BodyBytes(), &config)
+	err := json.Unmarshal(resp.BodyBytes(), &config)
 	require.NoError(t, err)
 	assert.Equal(t, "alice", config.Username)
 	assert.Equal(t, base.RedactedStr, config.Password)
@@ -7441,7 +7437,11 @@ function (doc) {
 			adminSrv := httptest.NewServer(passiveRT.TestAdminHandler())
 			defer adminSrv.Close()
 
-			activeRT := rest.NewRestTester(t, rtConfig)
+			activeRTConfig := &rest.RestTesterConfig{
+				SyncFn:             syncFunc,
+				SgReplicateEnabled: true,
+			}
+			activeRT := rest.NewRestTester(t, activeRTConfig)
 			defer activeRT.Close()
 
 			for _, rt := range []*rest.RestTester{passiveRT, activeRT} {
@@ -7499,9 +7499,6 @@ function (doc) {
 			resp = activeRT.SendAdminRequest("PUT", "/{{.db}}/_replication/"+replName, replConf)
 			rest.RequireStatus(t, resp, http.StatusCreated)
 
-			activeCtx := activeRT.Context()
-			err := activeRT.GetDatabase().SGReplicateMgr.StartReplications(activeCtx)
-			require.NoError(t, err)
 			activeRT.WaitForReplicationStatus(replName, db.ReplicationStateRunning)
 
 			base.RequireWaitForStat(t, receiverRT.GetDatabase().DbStats.Database().NumDocWrites.Value, 6)
@@ -7515,7 +7512,7 @@ function (doc) {
 			}
 
 			// Stop and remove replicator (to stop checkpointing after teardown causing panic)
-			_, _, err = activeRT.GetDatabase().SGReplicateMgr.PutReplicationStatus(activeRT.Context(), replName, "stop")
+			_, _, err := activeRT.GetDatabase().SGReplicateMgr.PutReplicationStatus(activeRT.Context(), replName, "stop")
 			require.NoError(t, err)
 			activeRT.WaitForReplicationStatus(replName, db.ReplicationStateStopped)
 			err = activeRT.GetDatabase().SGReplicateMgr.DeleteReplication(replName)
@@ -8092,9 +8089,6 @@ func TestISGRRunAsNonExistentUserPushesAsAdmin(t *testing.T) {
 		"/{{.db}}/_replication/"+repl1Name, replConf)
 	rest.RequireStatus(t, configResp, http.StatusCreated)
 
-	// StartReplications will error initialising the replicator but will not return an error
-	require.NoError(t, activeRT.GetDatabase().SGReplicateMgr.StartReplications(activeRT.Context()))
-
 	activeRT.WaitForReplicationStatus(repl1Name, db.ReplicationStateError)
 
 	resp := passiveRT.SendAdminRequest(http.MethodGet,
@@ -8183,9 +8177,8 @@ func TestISGRRunAsNonExistentUserReplicationConfigInDbConfig(t *testing.T) {
 
 	// Define the replication inline in the DatabaseConfig
 	// rather than creating it through the admin REST API.
-	// initial_state "stopped" prevents it from running before we call
-	// StartReplications, while still exercising the initialisation path that
-	// validates run_as.
+	// initial_state "stopped" prevents it from running, while still exercising
+	// the initialisation path that validates run_as.
 	activeRT := rest.NewRestTester(t, &rest.RestTesterConfig{
 		SyncFn:             syncFn,
 		SgReplicateEnabled: true,
@@ -8212,10 +8205,6 @@ func TestISGRRunAsNonExistentUserReplicationConfigInDbConfig(t *testing.T) {
 	docID := "private_doc_" + rest.SafeDocumentName(t, t.Name())
 	activeRT.PutDoc(docID, `{"channels":["`+privateChannel+`"],"content":"secret"}`)
 	activeRT.WaitForPendingChanges()
-
-	// StartReplications initialises the replicator; it errors on the missing
-	// run_as user but does not surface an error to the caller.
-	require.NoError(t, activeRT.GetDatabase().SGReplicateMgr.StartReplications(activeRT.Context()))
 
 	activeRT.WaitForReplicationStatus(replName, db.ReplicationStateError)
 


### PR DESCRIPTION
CBG-5578 fix flake in TestISGRRunAsNonExistentUserPushesAsAdmin

`sgReplicateManager.StartReplications` was called twice for the same manager: once automatically by DatabaseContext.startReplications() at db startup (whenever SgReplicateEnabled is true), and once explicitly by several ISGR tests trying to force synchronous initialisation. Each call unconditionally (re)initialises and (re)starts every replication assigned to the node with no check for an already-running instance, and registers its own independent cfg-change subscription. 

Fix: remove the redundant explicit StartReplications calls from the affected tests (adding SgReplicateEnabled: true where it was missing, so the automatic path still runs), and rename StartReplications to the unexported startReplications so it can't be called a second time by mistake.

I've considered a future enhancement to make SgReplicateEnabled: true default for RestTester to match the default behavior of a database but I considered it out of scope.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/930/ (unrelated test failure)
