### PR TITLE
CBG-5574 fix an issue with fetching alternate branch

### DIFF
--- a/integration-test/e2e/run_e2e_tests.sh
+++ b/integration-test/e2e/run_e2e_tests.sh
@@ -40,7 +40,8 @@ rm -rf couchbase-lite-tests
 
 git clone --recurse-submodules https://github.com/couchbaselabs/couchbase-lite-tests.git
 cd couchbase-lite-tests
-git checkout --detach "${COUCHBASE_LITE_TESTS_COMMIT}"
+git fetch origin "${COUCHBASE_LITE_TESTS_COMMIT}"
+git checkout --detach FETCH_HEAD
 git submodule sync --recursive
 git submodule update --init --recursive --force
 

--- a/integration-test/e2e/run_e2e_tests.sh
+++ b/integration-test/e2e/run_e2e_tests.sh
@@ -40,7 +40,7 @@ rm -rf couchbase-lite-tests
 
 git clone --recurse-submodules https://github.com/couchbaselabs/couchbase-lite-tests.git
 cd couchbase-lite-tests
-git fetch origin "${COUCHBASE_LITE_TESTS_COMMIT}"
+git fetch origin -- "${COUCHBASE_LITE_TESTS_COMMIT}"
 git checkout --detach FETCH_HEAD
 git submodule sync --recursive
 git submodule update --init --recursive --force


### PR DESCRIPTION
CBG-5574 fix an issue with fetching alternate branch

Use git fetch origin <REMOTE NAME> && git checkout --detach FETCH_HEAD to work with lightweight jenkins checkouts

Used when testing https://github.com/couchbaselabs/couchbase-lite-tests/pull/441