### PR TITLE
CBG-5560 remove EnableXattr from DatabaseContext

### DIFF
--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -43,8 +43,6 @@ import (
 // Code that is test-related that needs to be accessible from non-base packages, and therefore can't live in
 // util_test.go, which is only accessible from the base package.
 
-var TestExternalRevStorage = false
-
 type TestBucket struct {
 	Bucket
 	BucketSpec BucketSpec

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -1790,8 +1790,7 @@ func BenchmarkProcessEntry(b *testing.B) {
 			bucket := base.GetTestBucket(b)
 			defer bucket.Close(ctx)
 			context, err := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{
-				EnableXattr: true,
-				Scopes:      GetScopesOptions(b, bucket, 1),
+				Scopes: GetScopesOptions(b, bucket, 1),
 			})
 			require.NoError(b, err)
 			defer context.Close(ctx)

--- a/db/crud.go
+++ b/db/crud.go
@@ -141,79 +141,61 @@ func (c *DatabaseCollection) GetDocSyncData(ctx context.Context, docid string) (
 		return emptySyncData, base.HTTPErrorf(400, "Invalid doc ID")
 	}
 
-	if c.UseXattrs() {
-		// Retrieve doc and xattr from bucket, unmarshal only xattr.
-		// Triggers on-demand import when document xattr doesn't match cas.
-		rawDoc, xattrs, cas, getErr := c.dataStore.GetWithXattrs(ctx, key, c.syncGlobalSyncAndUserXattrKeys())
+	// Retrieve doc and xattr from bucket, unmarshal only xattr.
+	// Triggers on-demand import when document xattr doesn't match cas.
+	rawDoc, xattrs, cas, getErr := c.dataStore.GetWithXattrs(ctx, key, c.syncGlobalSyncAndUserXattrKeys())
+	if getErr != nil {
+		return emptySyncData, getErr
+	}
+
+	// Unmarshal xattr only
+	doc, unmarshalErr := c.unmarshalDocumentWithXattrs(ctx, docid, nil, xattrs, cas, DocUnmarshalSync)
+	if unmarshalErr != nil {
+		return emptySyncData, unmarshalErr
+	}
+
+	isSgWrite, crc32Match, _ := doc.IsSGWrite(ctx, rawDoc)
+	if crc32Match {
+		c.dbStats().Database().Crc32MatchCount.Add(1)
+	}
+
+	// If existing doc wasn't an SG Write, import the doc.
+	if !isSgWrite {
+		var importErr error
+
+		rawDoc, xattrs, cas, getErr = c.dataStore.GetWithXattrs(ctx, key, c.syncGlobalSyncMouRevSeqNoAndUserXattrKeys())
 		if getErr != nil {
 			return emptySyncData, getErr
 		}
 
-		// Unmarshal xattr only
-		doc, unmarshalErr := c.unmarshalDocumentWithXattrs(ctx, docid, nil, xattrs, cas, DocUnmarshalSync)
+		// Re-unmarshal with the full xattr set so doc.RevSeqNo and doc.MetadataOnlyUpdate
+		// are populated for use by OnDemandImportForGet.
+		doc, unmarshalErr = c.unmarshalDocumentWithXattrs(ctx, docid, nil, xattrs, cas, DocUnmarshalSync)
 		if unmarshalErr != nil {
 			return emptySyncData, unmarshalErr
 		}
 
-		isSgWrite, crc32Match, _ := doc.IsSGWrite(ctx, rawDoc)
+		isSgWriteAfterReload, crc32Match, _ := doc.IsSGWrite(ctx, rawDoc)
 		if crc32Match {
 			c.dbStats().Database().Crc32MatchCount.Add(1)
 		}
 
-		// If existing doc wasn't an SG Write, import the doc.
-		if !isSgWrite {
-			var importErr error
-
-			rawDoc, xattrs, cas, getErr = c.dataStore.GetWithXattrs(ctx, key, c.syncGlobalSyncMouRevSeqNoAndUserXattrKeys())
-			if getErr != nil {
-				return emptySyncData, getErr
-			}
-
-			// Re-unmarshal with the full xattr set so doc.RevSeqNo and doc.MetadataOnlyUpdate
-			// are populated for use by OnDemandImportForGet.
-			doc, unmarshalErr = c.unmarshalDocumentWithXattrs(ctx, docid, nil, xattrs, cas, DocUnmarshalSync)
-			if unmarshalErr != nil {
-				return emptySyncData, unmarshalErr
-			}
-
-			isSgWriteAfterReload, crc32Match, _ := doc.IsSGWrite(ctx, rawDoc)
-			if crc32Match {
-				c.dbStats().Database().Crc32MatchCount.Add(1)
-			}
-
-			if isSgWriteAfterReload {
-				return doc.SyncData, nil
-			}
-
-			doc, importErr = c.OnDemandImportForGet(ctx, docid, doc, rawDoc, xattrs, cas)
-			if importErr != nil {
-				return emptySyncData, importErr
-			}
-			// importDoc swallows ErrImportCancelled (e.g. SG purge race), returning
-			// (nil, nil). Treat that the same as not found.
-			if doc == nil {
-				return emptySyncData, base.ErrNotFound
-			}
+		if isSgWriteAfterReload {
+			return doc.SyncData, nil
 		}
 
-		return doc.SyncData, nil
-
-	} else {
-		// Non-xattr.  Retrieve doc from bucket, unmarshal metadata only.
-		rawDocBytes, _, err := c.dataStore.GetRaw(ctx, key)
-		if err != nil {
-			return emptySyncData, err
+		doc, importErr = c.OnDemandImportForGet(ctx, docid, doc, rawDoc, xattrs, cas)
+		if importErr != nil {
+			return emptySyncData, importErr
 		}
-
-		docRoot := documentRoot{
-			SyncData: &SyncData{History: make(RevTree)},
+		// importDoc swallows ErrImportCancelled (e.g. SG purge race), returning
+		// (nil, nil). Treat that the same as not found.
+		if doc == nil {
+			return emptySyncData, base.ErrNotFound
 		}
-		if err := base.JSONUnmarshal(rawDocBytes, &docRoot); err != nil {
-			return emptySyncData, err
-		}
-
-		return *docRoot.SyncData, nil
 	}
+
+	return doc.SyncData, nil
 
 }
 
@@ -1346,7 +1328,7 @@ func (db *DatabaseCollectionWithUser) Put(ctx context.Context, docid string, bod
 	}
 
 	docUpdateEvent := NewVersion
-	allowImport := db.UseXattrs()
+	allowImport := true
 	updateRevCache := true
 	doc, newRevID, err = db.updateAndReturnDoc(ctx, newDoc.ID, allowImport, &expiry, nil, docUpdateEvent, nil, false, updateRevCache, func(doc *Document) (resultDoc *Document, resultAttachmentData updatedAttachments, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
 		var isSgWrite bool
@@ -1366,7 +1348,7 @@ func (db *DatabaseCollectionWithUser) Put(ctx context.Context, docid string, bod
 		}
 
 		// If the existing doc isn't an SG write, import prior to updating
-		if doc != nil && !isSgWrite && db.UseXattrs() {
+		if doc != nil && !isSgWrite {
 			err := db.OnDemandImportForWrite(ctx, newDoc.ID, doc, deleted)
 			if err != nil {
 				if db.ForceAPIForbiddenErrors() {
@@ -1509,7 +1491,7 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 		}
 
 		// If the existing doc isn't an SG write, import prior to updating
-		if doc != nil && !isSgWrite && db.UseXattrs() {
+		if doc != nil && !isSgWrite {
 			err := db.OnDemandImportForWrite(ctx, opts.NewDoc.ID, doc, opts.NewDoc.Deleted)
 			if err != nil {
 				return nil, nil, false, nil, err
@@ -1753,7 +1735,7 @@ func (db *DatabaseCollectionWithUser) PutExistingRevWithConflictResolution(ctx c
 
 	newDoc := opts.NewDoc
 	docHistory := opts.RevTreeHistory
-	allowImport := db.UseXattrs()
+	allowImport := true
 	updateRevCache := true
 	originalNewDocAtts := maps.Clone(newDoc.Attachments())
 	doc, _, err = db.updateAndReturnDoc(ctx, newDoc.ID, allowImport, &newDoc.DocExpiry, nil, opts.DocUpdateEvent, opts.ExistingDoc, false, updateRevCache, func(doc *Document) (resultDoc *Document, resultAttachmentData updatedAttachments, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
@@ -1772,7 +1754,7 @@ func (db *DatabaseCollectionWithUser) PutExistingRevWithConflictResolution(ctx c
 		}
 
 		// If the existing doc isn't an SG write, import prior to updating
-		if doc != nil && !isSgWrite && db.UseXattrs() {
+		if doc != nil && !isSgWrite {
 			err := db.OnDemandImportForWrite(ctx, newDoc.ID, doc, newDoc.Deleted)
 			if err != nil {
 				return nil, nil, false, nil, err
@@ -2424,10 +2406,10 @@ func (db *DatabaseCollectionWithUser) storeOldBodyInRevTreeAndUpdateCurrent(ctx 
 		if marshalErr != nil {
 			base.WarnfCtx(ctx, "Unable to marshal document body properties for storage in rev tree: %v", marshalErr)
 		}
-		doc.setNonWinningRevisionBody(prevCurrentRev, oldBodyJson, db.AllowExternalRevBodyStorage(), oldDocHasAttachments)
+		doc.setNonWinningRevisionBody(prevCurrentRev, oldBodyJson, oldDocHasAttachments)
 	}
 	// Store the new revision body into the doc:
-	doc.setRevisionBody(ctx, newRevID, newDoc, db.AllowExternalRevBodyStorage(), newDocHasAttachments)
+	doc.setRevisionBody(ctx, newRevID, newDoc, newDocHasAttachments)
 	doc.SetAttachments(newDoc.Attachments())
 	doc.MetadataOnlyUpdate = newDoc.MetadataOnlyUpdate
 
@@ -2884,7 +2866,6 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 
 	// Update the document
 	inConflict := false
-	upgradeInProgress := false
 	docBytes := 0   // Track size of document written, for write stats
 	xattrBytes := 0 // Track size of xattr written, for write stats
 	skipObsoleteAttachmentsRemoval := false
@@ -2895,7 +2876,7 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 		skipObsoleteAttachmentsRemoval = true
 	}
 
-	if db.UseXattrs() || upgradeInProgress {
+	{
 		var casOut uint64
 		// Update the document, storing metadata in extended attribute
 		if opts == nil {
@@ -3211,7 +3192,7 @@ func (db *DatabaseCollectionWithUser) postWriteUpdateHLV(ctx context.Context, do
 	// backup new revision to the bucket now we have a doc assigned a CV (post macro expansion) for future deltaSrc purposes
 	// we don't need to store revision body backups without delta sync in 4.0, since all clients know how to use the sendReplacementRevs feature
 	backupRev := db.deltaSyncEnabled() && db.deltaSyncRevMaxAgeSeconds() != 0
-	if db.UseXattrs() && backupRev {
+	if backupRev {
 		var newBodyWithAtts = doc._rawBody
 		if len(doc.Attachments()) > 0 {
 			var err error
@@ -3538,23 +3519,16 @@ func (db *DatabaseCollectionWithUser) Purge(ctx context.Context, key string, nee
 
 	}
 
-	if db.UseXattrs() {
-		// Clean up _sync and _globalSync (if present). Leave _vv and _mou since they are also shared by XDCR/Eventing.
-		xattrsToDelete := []string{base.SyncXattrName, base.GlobalXattrName}
-		// TODO: CBG-4796 - we currently need to determine a list of present xattrs before we delete to avoid differences
-		// between Rosmar and Couchbase Server implementations of DeleteWithXattrs and GetWithXattrs.
-		var presentXattrsToDelete []string
-		if rawBucketDoc != nil && rawBucketDoc.Xattrs != nil {
-			presentXattrsToDelete = base.KeysPresent(rawBucketDoc.Xattrs, xattrsToDelete)
-		}
-		if err := db.dataStore.DeleteWithXattrs(ctx, key, presentXattrsToDelete); err != nil {
-			return err
-		}
-	} else {
-		err := db.dataStore.Delete(ctx, key)
-		if err != nil {
-			return err
-		}
+	// Clean up _sync and _globalSync (if present). Leave _vv and _mou since they are also shared by XDCR/Eventing.
+	xattrsToDelete := []string{base.SyncXattrName, base.GlobalXattrName}
+	// TODO: CBG-4796 - we currently need to determine a list of present xattrs before we delete to avoid differences
+	// between Rosmar and Couchbase Server implementations of DeleteWithXattrs and GetWithXattrs.
+	var presentXattrsToDelete []string
+	if rawBucketDoc != nil && rawBucketDoc.Xattrs != nil {
+		presentXattrsToDelete = base.KeysPresent(rawBucketDoc.Xattrs, xattrsToDelete)
+	}
+	if err := db.dataStore.DeleteWithXattrs(ctx, key, presentXattrsToDelete); err != nil {
+		return err
 	}
 	if needsAudit {
 		base.Audit(ctx, base.AuditIDDocumentDelete, base.AuditFields{

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -26,44 +26,27 @@ import (
 	"github.com/couchbase/sync_gateway/testing/require"
 )
 
-type treeDoc struct {
-	Meta treeMeta `json:"_sync"`
-}
-
 type treeMeta struct {
 	RevTree revTreeList `json:"history"`
 }
 
 // Retrieve the raw doc from the bucket, and unmarshal sync history as revTreeList, to validate low-level  storage
-func getRevTreeList(ctx context.Context, dataStore sgbucket.DataStore, key string, useXattrs bool) (revTreeList, error) {
-	switch useXattrs {
-	case true:
-		_, xattrs, _, getErr := dataStore.GetWithXattrs(ctx, key, []string{base.SyncXattrName})
-		rawXattr, ok := xattrs[base.SyncXattrName]
-		if !ok {
-			return revTreeList{}, base.ErrXattrNotFound
-		}
-		if getErr != nil {
-			return revTreeList{}, getErr
-		}
-
-		var treeMeta treeMeta
-		err := base.JSONUnmarshal(rawXattr, &treeMeta)
-		if err != nil {
-			return revTreeList{}, err
-		}
-		return treeMeta.RevTree, nil
-
-	default:
-		rawDoc, _, err := dataStore.GetRaw(ctx, key)
-		if err != nil {
-			return revTreeList{}, err
-		}
-		var doc treeDoc
-		err = base.JSONUnmarshal(rawDoc, &doc)
-		return doc.Meta.RevTree, err
+func getRevTreeList(ctx context.Context, dataStore sgbucket.DataStore, key string) (revTreeList, error) {
+	_, xattrs, _, getErr := dataStore.GetWithXattrs(ctx, key, []string{base.SyncXattrName})
+	if getErr != nil {
+		return revTreeList{}, getErr
+	}
+	rawXattr, ok := xattrs[base.SyncXattrName]
+	if !ok {
+		return revTreeList{}, base.ErrXattrNotFound
 	}
 
+	var treeMeta treeMeta
+	err := base.JSONUnmarshal(rawXattr, &treeMeta)
+	if err != nil {
+		return revTreeList{}, err
+	}
+	return treeMeta.RevTree, nil
 }
 
 // TestRevisionCacheLoad
@@ -73,8 +56,6 @@ func TestRevisionCacheLoad(t *testing.T) {
 	db, ctx := setupTestDBWithViewsEnabled(t)
 	defer db.Close(ctx)
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
-
-	base.TestExternalRevStorage = true
 
 	// Create rev 1-a
 	log.Printf("Create rev 1-a")
@@ -113,7 +94,6 @@ func TestHasAttachmentsFlag(t *testing.T) {
 	defer db.Close(ctx)
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 
-	base.TestExternalRevStorage = true
 	prop_1000_bytes := base.CreateProperty(1000)
 
 	// Create rev 1-a
@@ -176,7 +156,7 @@ func TestHasAttachmentsFlag(t *testing.T) {
 
 	// Retrieve the raw document, and verify 2-a isn't stored inline
 	log.Printf("Retrieve doc, verify rev 2-a not inline")
-	revTree, err := getRevTreeList(ctx, collection.dataStore, "doc1", db.UseXattrs())
+	revTree, err := getRevTreeList(ctx, collection.dataStore, "doc1")
 	assert.NoError(t, err, "Couldn't get revtree for raw document")
 	assert.Len(t, revTree.BodyMap, 0)
 	assert.Len(t, revTree.BodyKeyMap, 1)
@@ -190,8 +170,6 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	db, ctx := setupTestDBAllowConflicts(t)
 	defer db.Close(ctx)
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
-
-	base.TestExternalRevStorage = true
 
 	prop_1000_bytes := base.CreateProperty(1000)
 
@@ -241,7 +219,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 
 	// Retrieve the raw document, and verify 2-a isn't stored inline
 	log.Printf("Retrieve doc, verify rev 2-a not inline")
-	revTree, err := getRevTreeList(ctx, collection.dataStore, "doc1", db.UseXattrs())
+	revTree, err := getRevTreeList(ctx, collection.dataStore, "doc1")
 	assert.NoError(t, err, "Couldn't get revtree for raw document")
 	assert.Len(t, revTree.BodyMap, 0)
 	assert.Len(t, revTree.BodyKeyMap, 1)
@@ -293,7 +271,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	base.RequireDocNotFoundError(t, err)
 
 	// Validate the tombstone is stored inline (due to small size)
-	revTree, err = getRevTreeList(ctx, collection.dataStore, "doc1", db.UseXattrs())
+	revTree, err = getRevTreeList(ctx, collection.dataStore, "doc1")
 	assert.NoError(t, err, "Couldn't get revtree for raw document")
 	assert.Len(t, revTree.BodyMap, 1)
 	assert.Len(t, revTree.BodyKeyMap, 0)
@@ -338,7 +316,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 
 	// Validate the tombstone is not stored inline (due to small size)
 	log.Printf("Verify raw revtree w/ tombstone 3-c in key map")
-	newRevTree, err := getRevTreeList(ctx, collection.dataStore, "doc1", db.UseXattrs())
+	newRevTree, err := getRevTreeList(ctx, collection.dataStore, "doc1")
 	assert.NoError(t, err, "Couldn't get revtree for raw document")
 	assert.Len(t, newRevTree.BodyMap, 1)    // tombstone 3-b
 	assert.Len(t, newRevTree.BodyKeyMap, 1) // tombstone 3-c
@@ -362,7 +340,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2c_body, []string{"3-a", "2-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 3-a")
 
-	revTree, err = getRevTreeList(ctx, collection.dataStore, "doc1", db.UseXattrs())
+	revTree, err = getRevTreeList(ctx, collection.dataStore, "doc1")
 	assert.NoError(t, err, "Couldn't get revtree for raw document")
 	assert.Len(t, revTree.BodyMap, 1)    // tombstone 3-b
 	assert.Len(t, revTree.BodyKeyMap, 1) // tombstone 3-c
@@ -374,8 +352,6 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	db, ctx := setupTestDBAllowConflicts(t)
 	defer db.Close(ctx)
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
-
-	base.TestExternalRevStorage = true
 
 	prop_1000_bytes := base.CreateProperty(1000)
 
@@ -425,7 +401,7 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 
 	// Retrieve the raw document, and verify 2-a isn't stored inline
 	log.Printf("Retrieve doc, verify rev 2-a not inline")
-	revTree, err := getRevTreeList(ctx, collection.dataStore, "doc1", db.UseXattrs())
+	revTree, err := getRevTreeList(ctx, collection.dataStore, "doc1")
 	assert.NoError(t, err, "Couldn't get revtree for raw document")
 	assert.Len(t, revTree.BodyMap, 0)
 	assert.Len(t, revTree.BodyKeyMap, 1)
@@ -477,13 +453,13 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 
 	// Retrieve the raw document, and verify 2-a isn't stored inline
 	log.Printf("Retrieve doc, verify rev 2-a not inline")
-	revTree, err = getRevTreeList(ctx, collection.dataStore, "doc1", db.UseXattrs())
+	revTree, err = getRevTreeList(ctx, collection.dataStore, "doc1")
 	assert.NoError(t, err, "Couldn't get revtree for raw document")
 	assert.Len(t, revTree.BodyMap, 0)
 	assert.Len(t, revTree.BodyKeyMap, 1)
 	log.Printf("revTree.BodyKeyMap:%v", revTree.BodyKeyMap)
 
-	revTree, err = getRevTreeList(ctx, collection.dataStore, "doc1", db.UseXattrs())
+	revTree, err = getRevTreeList(ctx, collection.dataStore, "doc1")
 	require.NoError(t, err)
 	log.Printf("revtree before additional revisions: %v", revTree.BodyKeyMap)
 

--- a/db/database.go
+++ b/db/database.go
@@ -205,7 +205,6 @@ type DatabaseContextOptions struct {
 	OIDCOptions                      *auth.OIDCOptions
 	LocalJWTConfig                   auth.LocalJWTConfig
 	ImportOptions                    ImportOptions
-	EnableXattr                      bool             // Use xattr for _sync
 	LocalDocExpirySecs               uint32           // The _local doc expiry time in seconds
 	SecureCookieOverride             bool             // Pass-through DBConfig.SecureCookieOverride
 	SessionCookieName                string           // Pass-through DbConfig.SessionCookieName
@@ -422,7 +421,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 		return nil, err
 	}
 
-	dbStats, statsError := initDatabaseStats(ctx, dbName, autoImport, options)
+	dbStats, statsError := initDatabaseStats(ctx, dbName, options)
 	if statsError != nil {
 		return nil, statsError
 	}
@@ -1597,11 +1596,6 @@ func (db *Database) Compact(ctx context.Context, skipRunningStateCheck bool, opt
 		defer atomic.CompareAndSwapUint32(&db.CompactState, DBCompactRunning, DBCompactNotRunning)
 	}
 
-	// Compact should be a no-op if not running w/ xattrs
-	if !db.UseXattrs() {
-		return 0, nil
-	}
-
 	purgeInterval := db.GetMetadataPurgeInterval(ctx, true)
 	base.InfofCtx(ctx, base.KeyAll, "Tombstone compaction using the metadata purge interval of %.2f days.", purgeInterval.Hours()/24)
 
@@ -2102,10 +2096,6 @@ func (context *DatabaseContext) GetUserViewsEnabled() bool {
 	return false
 }
 
-func (context *DatabaseContext) UseXattrs() bool {
-	return context.Options.EnableXattr
-}
-
 // numIndexPartitions returns the number of index partitions to use for the database's indexes.
 func (context *DatabaseContext) numIndexPartitions() uint32 {
 	if context.Options.NumIndexPartitions != nil {
@@ -2122,15 +2112,6 @@ func (context *DatabaseContext) DeltaSyncEnabled() bool {
 	return context.Options.DeltaSyncOptions.Enabled
 }
 
-func (c *DatabaseCollection) AllowExternalRevBodyStorage() bool {
-
-	// Support unit testing w/out xattrs enabled
-	if base.TestExternalRevStorage {
-		return false
-	}
-	return !c.UseXattrs()
-}
-
 func (context *DatabaseContext) SetUserViewsEnabled(value bool) {
 	if context.Options.UnsupportedOptions == nil {
 		context.Options.UnsupportedOptions = &UnsupportedOptions{}
@@ -2141,10 +2122,10 @@ func (context *DatabaseContext) SetUserViewsEnabled(value bool) {
 	context.Options.UnsupportedOptions.UserViews.Enabled = &value
 }
 
-func initDatabaseStats(ctx context.Context, dbName string, autoImport bool, options DatabaseContextOptions) (*base.DbStats, error) {
+func initDatabaseStats(ctx context.Context, dbName string, options DatabaseContextOptions) (*base.DbStats, error) {
 
 	enabledDeltaSync := options.DeltaSyncOptions.Enabled
-	enabledImport := autoImport || options.EnableXattr
+	enabledImport := true
 	enabledViews := options.UseViews
 	enabledMetadataMigration := options.UseSystemMetadataCollection
 
@@ -2527,36 +2508,33 @@ func (db *DatabaseContext) StartOnlineProcesses(ctx context.Context) (returnedEr
 		db.LocalJWTProviders[name] = cfg.BuildProvider(ctx, name)
 	}
 
-	if db.UseXattrs() {
-		// Log the purge interval for tombstone compaction
-		mpi := db.GetMetadataPurgeInterval(ctx, true)
-		base.InfofCtx(ctx, base.KeyAll, "Using metadata purge interval of %.2f days for tombstone compaction.", mpi.Hours()/24)
+	// Log the purge interval for tombstone compaction
+	mpi := db.GetMetadataPurgeInterval(ctx, true)
+	base.InfofCtx(ctx, base.KeyAll, "Using metadata purge interval of %.2f days for tombstone compaction.", mpi.Hours()/24)
 
-		if db.Options.CompactInterval != 0 {
-			if db.autoImport {
-				db := Database{DatabaseContext: db}
-				// Wrap the dbContext's terminator in a SafeTerminator for the compaction task
-				bgtTerminator := base.NewSafeTerminator()
-				go func() {
-					<-db.terminator
-					bgtTerminator.Close()
-				}()
-				bgt, err := NewBackgroundTask(ctx, "Compact", func(ctx context.Context) error {
-					_, err := db.Compact(ctx, false, nil, bgtTerminator, true)
-					if err != nil {
-						base.WarnfCtx(ctx, "Error trying to compact tombstoned documents for %q with error: %v", db.Name, err)
-					}
-					return nil
-				}, time.Duration(db.Options.CompactInterval)*time.Second, db.terminator)
+	if db.Options.CompactInterval != 0 {
+		if db.autoImport {
+			db := Database{DatabaseContext: db}
+			// Wrap the dbContext's terminator in a SafeTerminator for the compaction task
+			bgtTerminator := base.NewSafeTerminator()
+			go func() {
+				<-db.terminator
+				bgtTerminator.Close()
+			}()
+			bgt, err := NewBackgroundTask(ctx, "Compact", func(ctx context.Context) error {
+				_, err := db.Compact(ctx, false, nil, bgtTerminator, true)
 				if err != nil {
-					return err
+					base.WarnfCtx(ctx, "Error trying to compact tombstoned documents for %q with error: %v", db.Name, err)
 				}
-				db.backgroundTasks = append(db.backgroundTasks, bgt)
-			} else {
-				base.WarnfCtx(ctx, "Automatic compaction can only be enabled on nodes running an Import process")
+				return nil
+			}, time.Duration(db.Options.CompactInterval)*time.Second, db.terminator)
+			if err != nil {
+				return err
 			}
+			db.backgroundTasks = append(db.backgroundTasks, bgt)
+		} else {
+			base.WarnfCtx(ctx, "Automatic compaction can only be enabled on nodes running an Import process")
 		}
-
 	}
 
 	// create a background task to keep track of the number of active replication connections the database has each second

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -333,11 +333,6 @@ func (c *DatabaseCollection) UserXattrKey() string {
 	return c.dbCtx.Options.UserXattrKey
 }
 
-// UseXattrs specifies whether the collection stores metadata in xattars or inline. This is controlled at a database level.
-func (c *DatabaseCollection) UseXattrs() bool {
-	return c.dbCtx.Options.EnableXattr
-}
-
 // numIndexPartitions returns the number of partitions for the collection's indexes. This is controlled at a database level.
 func (c *DatabaseCollection) numIndexPartitions() uint32 {
 	return c.dbCtx.numIndexPartitions()

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -3180,8 +3180,7 @@ func BenchmarkDatabase(b *testing.B) {
 		bucket := base.GetTestBucket(b)
 		defer bucket.Close(ctx)
 		dbCtx, err := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{
-			EnableXattr: true,
-			Scopes:      GetScopesOptions(b, bucket, 1),
+			Scopes: GetScopesOptions(b, bucket, 1),
 		})
 		if err != nil {
 			b.Fatalf("Error creating database context: %v", err)
@@ -3210,8 +3209,7 @@ func BenchmarkPut(b *testing.B) {
 	bucket := base.GetTestBucket(b)
 	defer bucket.Close(ctx)
 	context, _ := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{
-		Scopes:      GetScopesOptions(b, bucket, 1),
-		EnableXattr: true,
+		Scopes: GetScopesOptions(b, bucket, 1),
 	})
 	db, err := CreateDatabase(context)
 	if err != nil {
@@ -4069,7 +4067,6 @@ func Test_resyncDocument(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
-	db.Options.EnableXattr = true
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 
 	testCases := []struct {
@@ -4411,7 +4408,7 @@ func TestUpdateCalculatedStatsPanic(t *testing.T) {
 	dbc.UpdateCalculatedStats(ctx)
 
 	// non-nil DatabaseContext and stats, nil channel cache
-	dbStats, statsError := initDatabaseStats(ctx, "db", false, DatabaseContextOptions{})
+	dbStats, statsError := initDatabaseStats(ctx, "db", DatabaseContextOptions{})
 	require.NoError(t, statsError)
 	dbc.DbStats = dbStats
 	dbc.UpdateCalculatedStats(ctx)

--- a/db/dcp_sharded_upgrade_test.go
+++ b/db/dcp_sharded_upgrade_test.go
@@ -218,9 +218,8 @@ func TestShardedDCPUpgrade(t *testing.T) {
 	require.NoError(t, dataStore.SetRaw(ctx, testDoc1, 0, nil, []byte(`{}`)))
 
 	db, err := NewDatabaseContext(ctx, tb.GetName(), tb.NoCloseClone(), true, DatabaseContextOptions{
-		GroupID:     "",
-		EnableXattr: true,
-		UseViews:    base.TestsDisableGSI(),
+		GroupID:  "",
+		UseViews: base.TestsDisableGSI(),
 		ImportOptions: ImportOptions{
 			ImportPartitions: numPartitions,
 		},

--- a/db/design_doc.go
+++ b/db/design_doc.go
@@ -106,7 +106,7 @@ func (db *Database) PutDesignDoc(ctx context.Context, ddocName string, ddoc sgbu
 		}
 	}
 	if wrap {
-		wrapViews(&ddoc, db.GetUserViewsEnabled(), db.UseXattrs())
+		wrapViews(&ddoc, db.GetUserViewsEnabled())
 	}
 
 	vs, err := getViewStoreForDefaultCollection(db.DatabaseContext)
@@ -219,7 +219,7 @@ const (
 	}`
 )
 
-func wrapViews(ddoc *sgbucket.DesignDoc, enableUserViews bool, useXattrs bool) {
+func wrapViews(ddoc *sgbucket.DesignDoc, enableUserViews bool) {
 	// Wrap the map functions to ignore special docs and strip _sync metadata.  If user views are enabled, also
 	// add channel filtering.
 	for name, view := range ddoc.Views {

--- a/db/document.go
+++ b/db/document.go
@@ -870,20 +870,20 @@ func (doc *Document) pruneRevisions(ctx context.Context, maxDepth uint32, keepRe
 }
 
 // Adds a revision body (as Body) to a document.  Removes special properties first.
-func (doc *Document) setRevisionBody(ctx context.Context, revid string, newDoc *Document, storeInline, hasAttachments bool) {
+func (doc *Document) setRevisionBody(ctx context.Context, revid string, newDoc *Document, hasAttachments bool) {
 	if revid == doc.GetRevTreeID() {
 		doc._body = newDoc._body
 		doc._rawBody = newDoc._rawBody
 	} else {
 		bodyBytes, _ := newDoc.BodyBytes(ctx)
-		doc.setNonWinningRevisionBody(revid, bodyBytes, storeInline, hasAttachments)
+		doc.setNonWinningRevisionBody(revid, bodyBytes, hasAttachments)
 	}
 }
 
 // Adds a revision body (as []byte) to a document.  Flags for external storage when appropriate
-func (doc *Document) setNonWinningRevisionBody(revid string, body []byte, storeInline bool, hasAttachments bool) {
+func (doc *Document) setNonWinningRevisionBody(revid string, body []byte, hasAttachments bool) {
 	revBodyKey := ""
-	if !storeInline && len(body) > MaximumInlineBodySize {
+	if len(body) > MaximumInlineBodySize {
 		revBodyKey = generateRevBodyKey(doc.ID, revid)
 		doc.addedRevisionBodies = append(doc.addedRevisionBodies, revid)
 	}

--- a/db/functions/function_test.go
+++ b/db/functions/function_test.go
@@ -617,8 +617,6 @@ func TestKeyPath(t *testing.T) {
 // If certain environment variables are set, for example to turn on XATTR support, then update
 // the DatabaseContextOptions accordingly
 func AddOptionsFromEnvironmentVariables(dbcOptions *db.DatabaseContextOptions) {
-	dbcOptions.EnableXattr = true
-
 	if base.TestsDisableGSI() {
 		dbcOptions.UseViews = true
 	}

--- a/db/indextest/indextest_dual_metadata_test.go
+++ b/db/indextest/indextest_dual_metadata_test.go
@@ -129,7 +129,6 @@ func TestQueryPrincipalsDualMetadataStore(t *testing.T) {
 	// sync metadata
 	dbOptions := getDatabaseContextOptions(false)
 	dbOptions.Scopes = db.GetScopesOptions(t, bucket, 2)
-	dbOptions.EnableXattr = true
 	dbOptions.MetadataStore = ms
 
 	database, dbCtx := db.CreateTestDatabase(t, bucket, dbOptions)
@@ -249,7 +248,6 @@ func TestQueryUsersRealDocsDualMetadataStore(t *testing.T) {
 	// sync metadata.
 	dbOptions := getDatabaseContextOptions(false)
 	dbOptions.Scopes = db.GetScopesOptions(t, bucket, 2)
-	dbOptions.EnableXattr = true
 	dbOptions.MetadataStore = ms
 
 	database, dbCtx := db.CreateTestDatabase(t, bucket, dbOptions)
@@ -342,7 +340,6 @@ func TestGetUsersPaginationDualMetadataStore(t *testing.T) {
 
 	dbOptions := getDatabaseContextOptions(false)
 	dbOptions.Scopes = db.GetScopesOptions(t, bucket, 2)
-	dbOptions.EnableXattr = true
 	dbOptions.MetadataStore = ms
 	dbOptions.QueryPaginationLimit = paginationLimit
 
@@ -459,7 +456,6 @@ func TestQueryRolesDualMetadataStore(t *testing.T) {
 
 	dbOptions := getDatabaseContextOptions(false)
 	dbOptions.Scopes = db.GetScopesOptions(t, bucket, 2)
-	dbOptions.EnableXattr = true
 	dbOptions.MetadataStore = ms
 
 	database, dbCtx := db.CreateTestDatabase(t, bucket, dbOptions)

--- a/db/indextest/indextest_test.go
+++ b/db/indextest/indextest_test.go
@@ -293,9 +293,7 @@ func TestInitializeIndexes(t *testing.T) {
 			bucket := base.GetTestBucket(t)
 			defer bucket.Close(ctx)
 
-			options := db.DatabaseContextOptions{
-				EnableXattr: true,
-			}
+			options := db.DatabaseContextOptions{}
 			if test.collections {
 				base.TestRequiresCollections(t)
 				options.Scopes = db.GetScopesOptions(t, bucket, 1)

--- a/db/indextest/post_upgrade_test.go
+++ b/db/indextest/post_upgrade_test.go
@@ -31,7 +31,6 @@ func TestPostUpgradeIndexesSimple(t *testing.T) {
 	})
 	database, ctx := db.CreateTestDatabase(t, bucket, db.DatabaseContextOptions{
 		CacheOptions: base.Ptr(db.DefaultCacheOptions()),
-		EnableXattr:  true,
 		Scopes:       db.GetScopesOptionsDefaultCollectionOnly(t),
 	})
 	defer database.Close(ctx)
@@ -111,7 +110,6 @@ func TestPostUpgradeMultipleCollections(t *testing.T) {
 	})
 	database, ctx := db.CreateTestDatabase(t, bucket, db.DatabaseContextOptions{
 		CacheOptions: base.Ptr(db.DefaultCacheOptions()),
-		EnableXattr:  true,
 		Scopes:       db.GetScopesOptions(t, bucket, numCollections),
 	})
 
@@ -172,7 +170,6 @@ func TestRemoveIndexesUseViewsTrueAndFalse(t *testing.T) {
 			})
 			database, ctx := db.CreateTestDatabase(t, bucket, db.DatabaseContextOptions{
 				CacheOptions: base.Ptr(db.DefaultCacheOptions()),
-				EnableXattr:  true,
 				Scopes:       db.GetScopesOptionsDefaultCollectionOnly(t),
 				UseViews:     useViews,
 			})

--- a/db/indextest/util.go
+++ b/db/indextest/util.go
@@ -125,8 +125,6 @@ func setupIndexAndDB(t *testing.T, opts testIndexCreationOptions) *db.Database {
 	} else {
 		dbOptions.Scopes = db.GetScopesOptions(t, bucket, numCollections)
 	}
-	dbOptions.EnableXattr = true
-
 	database, ctx := db.CreateTestDatabase(t, bucket, dbOptions)
 
 	t.Cleanup(func() { database.Close(ctx) })

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -531,8 +531,6 @@ func IsCovered(plan map[string]any) bool {
 // If certain environment variables are set, for example to turn on XATTR support, then update
 // the DatabaseContextOptions accordingly
 func AddOptionsFromEnvironmentVariables(dbcOptions *DatabaseContextOptions) {
-	dbcOptions.EnableXattr = true
-
 	if base.TestsDisableGSI() {
 		dbcOptions.UseViews = true
 	}

--- a/db/utilities_hlv_testing.go
+++ b/db/utilities_hlv_testing.go
@@ -143,9 +143,9 @@ func (db *DatabaseCollectionWithUser) CreateDocNoHLV(t testing.TB, ctx context.C
 	require.NoError(t, err)
 
 	docUpdateEvent := NoHLVUpdateForTest
-	allowImport := db.UseXattrs()
 	// we cannot use rev cache for legacy rev writes, the rev cache is architected to always expect a CV on a Put
 	// here we don't thus we end up with inconsistent rev cache state
+	allowImport := true
 	updateRevCache := false
 
 	doc, newRevID, err = db.updateAndReturnDoc(ctx, newDoc.ID, allowImport, &expiry, nil, docUpdateEvent, nil, false, updateRevCache, func(doc *Document) (resultDoc *Document, resultAttachmentData updatedAttachments, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
@@ -162,7 +162,7 @@ func (db *DatabaseCollectionWithUser) CreateDocNoHLV(t testing.TB, ctx context.C
 
 		// (Be careful: this block can be invoked multiple times if there are races!)
 		// If the existing doc isn't an SG write, import prior to updating
-		if doc != nil && !isSgWrite && db.UseXattrs() {
+		if doc != nil && !isSgWrite {
 			err := db.OnDemandImportForWrite(ctx, newDoc.ID, doc, deleted)
 			if err != nil {
 				if db.ForceAPIForbiddenErrors() {

--- a/rest/config.go
+++ b/rest/config.go
@@ -656,9 +656,6 @@ func (dbConfig *DbConfig) GetBucketName() string {
 
 func (dbConfig *DbConfig) AutoImportEnabled(ctx context.Context) (bool, error) {
 	if dbConfig.AutoImport == nil {
-		if !dbConfig.UseXattrs() {
-			return false, nil
-		}
 		return base.DefaultAutoImport, nil
 	}
 
@@ -875,16 +872,10 @@ func (dbConfig *DbConfig) validateVersion(ctx context.Context, isEnterpriseEditi
 		multiError = multiError.Append(fmt.Errorf("Invalid configuration for Sync Gw. TAP feed type can not be used with auto-import"))
 	}
 
-	if dbConfig.AutoImport != nil && autoImportEnabled && !dbConfig.UseXattrs() {
-		multiError = multiError.Append(fmt.Errorf("Invalid configuration - import_docs enabled, but enable_shared_bucket_access not enabled"))
-	}
-
 	if dbConfig.ImportPartitions != nil {
 		if !isEnterpriseEdition {
 			base.WarnfCtx(ctx, eeOnlyWarningMsg, "import_partitions", *dbConfig.ImportPartitions, nil)
 			dbConfig.ImportPartitions = nil
-		} else if !dbConfig.UseXattrs() {
-			multiError = multiError.Append(fmt.Errorf("Invalid configuration - import_partitions set, but enable_shared_bucket_access not enabled"))
 		} else if !autoImportEnabled {
 			multiError = multiError.Append(fmt.Errorf("Invalid configuration - import_partitions set, but import_docs disabled"))
 		} else if *dbConfig.ImportPartitions < 1 || *dbConfig.ImportPartitions > 1024 {
@@ -1143,8 +1134,6 @@ func (dbConfig *DbConfig) validateVersion(ctx context.Context, isEnterpriseEditi
 		if dbConfig.Index.NumPartitions != nil {
 			if *dbConfig.Index.NumPartitions < 1 {
 				multiError = multiError.Append(fmt.Errorf("index.num_partitions must be greater than 0"))
-			} else if !dbConfig.UseXattrs() {
-				multiError = multiError.Append(fmt.Errorf("index.num_partitions is incompatible with enable_shared_bucket_access=false"))
 			}
 		}
 	}
@@ -1259,13 +1248,6 @@ func (dbConfig *DbConfig) ConflictsAllowed() *bool {
 		return dbConfig.AllowConflicts
 	}
 	return base.Ptr(base.DefaultAllowConflicts)
-}
-
-func (dbConfig *DbConfig) UseXattrs() bool {
-	if dbConfig.EnableXattrs != nil {
-		return *dbConfig.EnableXattrs
-	}
-	return base.DefaultUseXattrs
 }
 
 func (dbConfig *DbConfig) Redacted(ctx context.Context) (*DbConfig, error) {

--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -109,7 +109,7 @@ func DefaultPerDBLogging(bootstrapLoggingCnf base.LoggingConfig) *DbLoggingConfi
 // MergeDatabaseConfigWithDefaults merges the passed in config onto a DefaultDbConfig which results in returned value
 // being populated with defaults when not set
 func MergeDatabaseConfigWithDefaults(sc *StartupConfig, dbConfig *DbConfig) (*DbConfig, error) {
-	defaultDbConfig := DefaultDbConfig(sc, dbConfig.UseXattrs())
+	defaultDbConfig := DefaultDbConfig(sc)
 
 	err := base.ConfigMerge(defaultDbConfig, dbConfig)
 	if err != nil {
@@ -122,7 +122,7 @@ func MergeDatabaseConfigWithDefaults(sc *StartupConfig, dbConfig *DbConfig) (*Db
 // DefaultDbConfig provides a DbConfig with all the default values populated. Used with MergeDatabaseConfigWithDefaults
 // to provide defaults to  include_runtime config endpoints.
 // Note that this does not include unsupported options
-func DefaultDbConfig(sc *StartupConfig, useXattrs bool) *DbConfig {
+func DefaultDbConfig(sc *StartupConfig) *DbConfig {
 	dbConfig := DbConfig{
 		BucketConfig:       BucketConfig{},
 		Name:               "",
@@ -164,7 +164,8 @@ func DefaultDbConfig(sc *StartupConfig, useXattrs bool) *DbConfig {
 		SessionCookieHTTPOnly: base.Ptr(false),
 		AllowConflicts:        base.Ptr(base.DefaultAllowConflicts),
 		Index: &IndexConfig{
-			NumReplicas: base.Ptr(DefaultNumIndexReplicas),
+			NumReplicas:   base.Ptr(DefaultNumIndexReplicas),
+			NumPartitions: base.Ptr(db.DefaultNumIndexPartitions),
 		},
 		UseViews:                    base.Ptr(false),
 		SendWWWAuthenticateHeader:   base.Ptr(true),
@@ -190,18 +191,13 @@ func DefaultDbConfig(sc *StartupConfig, useXattrs bool) *DbConfig {
 		Logging:                           DefaultPerDBLogging(sc.Logging),
 		DisablePublicAllDocs:              base.Ptr(false),
 		UseSystemMobileMetadataCollection: base.Ptr(DefaultUseSystemMetadataCollection),
+		AutoImport:                        base.Ptr(base.DefaultAutoImport),
 	}
 
-	if useXattrs {
-		dbConfig.AutoImport = base.Ptr(base.DefaultAutoImport)
-		if base.IsEnterpriseEdition() {
-			dbConfig.ImportPartitions = base.Ptr[uint16](base.DefaultImportPartitions)
-		} else {
-			dbConfig.ImportPartitions = nil
-		}
-		dbConfig.Index.NumPartitions = base.Ptr(db.DefaultNumIndexPartitions)
+	if base.IsEnterpriseEdition() {
+		dbConfig.ImportPartitions = base.Ptr[uint16](base.DefaultImportPartitions)
 	} else {
-		dbConfig.AutoImport = base.Ptr(false)
+		dbConfig.ImportPartitions = nil
 	}
 
 	revsLimit := db.DefaultRevsLimitNoConflicts

--- a/rest/config_database_test.go
+++ b/rest/config_database_test.go
@@ -24,9 +24,8 @@ import (
 )
 
 func TestDefaultDbConfig(t *testing.T) {
-	useXattrs := true
 	sc := DefaultStartupConfig("")
-	compactIntervalDays := *(DefaultDbConfig(&sc, useXattrs).CompactIntervalDays)
+	compactIntervalDays := *(DefaultDbConfig(&sc).CompactIntervalDays)
 	require.Equal(t, db.DefaultCompactInterval, time.Duration(compactIntervalDays)*time.Hour*24)
 }
 
@@ -38,7 +37,7 @@ func TestDefaultDbConfig(t *testing.T) {
 // they should have a default value exposed in include_runtime=true config output.
 func TestDefaultDbConfigFieldCoverage(t *testing.T) {
 	sc := DefaultStartupConfig("/default/log/file/path")
-	defaultConfig := DefaultDbConfig(&sc, true)
+	defaultConfig := DefaultDbConfig(&sc)
 
 	// Fields that are intentionally left unset in DefaultDbConfig.
 	// When adding a field here, add a comment explaining why it doesn't need a default.
@@ -264,17 +263,6 @@ func TestDatabaseConfigValidation(t *testing.T) {
 				},
 			},
 			expectedError: "num_partitions must be greater than 0",
-		},
-		{
-			name: "partitions with xattrs=false",
-			dbConfig: DbConfig{
-				Name: "db",
-				Index: &IndexConfig{
-					NumPartitions: base.Ptr(uint32(2)),
-				},
-				EnableXattrs: base.Ptr(false),
-			},
-			expectedError: "incompatible with enable_shared_bucket_access=false",
 		},
 		{
 			name: "allowing conflicts with allow_conflicts=true",

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -256,16 +256,6 @@ func TestConfigValidationImportPartitions(t *testing.T) {
 		err    string
 	}{
 		{
-			name:   "Import enabled, shared bucket disabled",
-			config: `{"databases": {"db": {"import_docs":true, "enable_shared_bucket_access":false}}}`,
-			err:    "Invalid configuration - import_docs enabled, but enable_shared_bucket_access not enabled",
-		},
-		{
-			name:   "Import partitions set, shared bucket disabled",
-			config: `{"databases": {"db": {"import_partitions":32, "enable_shared_bucket_access":false}}}`,
-			err:    "Invalid configuration - import_partitions set, but enable_shared_bucket_access not enabled",
-		},
-		{
 			name:   "Import disabled, but partitions set",
 			config: `{"databases": {"db": {"enable_shared_bucket_access":true,"import_docs":false,"import_partitions":32}}}`,
 			err:    "Invalid configuration - import_partitions set, but import_docs disabled",
@@ -2234,37 +2224,6 @@ func TestJSLoadTypeString(t *testing.T) {
 
 	// Test out of bounds JSLoadType
 	assert.Equal(t, "JSLoadType(4294967295)", JSLoadType(math.MaxUint32).String())
-}
-
-func TestUseXattrs(t *testing.T) {
-	testCases := []struct {
-		name           string
-		enableXattrs   *bool
-		expectedXattrs bool
-	}{
-		{
-			name:           "Nil Xattrs",
-			enableXattrs:   nil,
-			expectedXattrs: true, // Expects base.DefaultUseXattrs
-		},
-		{
-			name:           "False Xattrs",
-			enableXattrs:   base.Ptr(false),
-			expectedXattrs: false,
-		},
-		{
-			name:           "True Xattrs",
-			enableXattrs:   base.Ptr(true),
-			expectedXattrs: true,
-		},
-	}
-	for _, test := range testCases {
-		t.Run(test.name, func(t *testing.T) {
-			dbc := &DbConfig{EnableXattrs: test.enableXattrs}
-			result := dbc.UseXattrs()
-			assert.Equal(t, test.expectedXattrs, result)
-		})
-	}
 }
 
 func TestInvalidJavascriptFunctions(t *testing.T) {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1402,7 +1402,7 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 	}
 
 	// In sync gateway version 4.0+ we do not support the disabling of use of xattrs
-	if !config.UseXattrs() {
+	if config.EnableXattrs != nil && !*config.EnableXattrs {
 		return db.DatabaseContextOptions{}, fmt.Errorf("sync gateway requires enable_shared_bucket_access=true")
 	}
 
@@ -1490,10 +1490,6 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 	if config.UserXattrKey != nil && *config.UserXattrKey != "" {
 		if !base.IsEnterpriseEdition() {
 			return db.DatabaseContextOptions{}, fmt.Errorf("user_xattr_key is only supported in enterpise edition")
-		}
-
-		if !config.UseXattrs() {
-			return db.DatabaseContextOptions{}, fmt.Errorf("use of user_xattr_key requires shared_bucket_access to be enabled")
 		}
 
 		userXattrKey = *config.UserXattrKey
@@ -1599,7 +1595,6 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 		OIDCOptions:                   config.OIDCConfig,
 		LocalJWTConfig:                config.LocalJWTConfig,
 		ImportOptions:                 *importOptions,
-		EnableXattr:                   config.UseXattrs(),
 		SecureCookieOverride:          secureCookieOverride,
 		SessionCookieName:             config.SessionCookieName,
 		SessionCookieHttpOnly:         base.ValDefault(config.SessionCookieHTTPOnly, false),

--- a/xdcr/xdcr_test.go
+++ b/xdcr/xdcr_test.go
@@ -694,11 +694,11 @@ func TestXDCRBeforeAttachmentMigration(t *testing.T) {
 	srcBucket, srcDs, dstBucket, _ := getTwoBucketDataStores(t)
 	ctx := base.TestCtx(t)
 
-	srcDB, srcCtx := db.CreateTestDatabase(t, base.NoCloseClone(srcBucket), db.DatabaseContextOptions{EnableXattr: true, Scopes: db.GetScopesOptions(t, srcBucket, 1)})
+	srcDB, srcCtx := db.CreateTestDatabase(t, base.NoCloseClone(srcBucket), db.DatabaseContextOptions{Scopes: db.GetScopesOptions(t, srcBucket, 1)})
 	defer srcDB.Close(srcCtx)
 	srcColl, srcCtx := db.GetSingleDatabaseCollectionWithUser(srcCtx, t, srcDB)
 
-	dstDB, dstCtx := db.CreateTestDatabase(t, base.NoCloseClone(dstBucket), db.DatabaseContextOptions{EnableXattr: true, Scopes: db.GetScopesOptions(t, dstBucket, 1)})
+	dstDB, dstCtx := db.CreateTestDatabase(t, base.NoCloseClone(dstBucket), db.DatabaseContextOptions{Scopes: db.GetScopesOptions(t, dstBucket, 1)})
 	defer dstDB.Close(dstCtx)
 	dstColl, dstCtx := db.GetSingleDatabaseCollectionWithUser(dstCtx, t, dstDB)
 


### PR DESCRIPTION
CBG-5560 remove EnableXattr from DatabaseContext

Since code is no longer in use. Most of the changes are whitespace only.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/941/ (unrelated flake)
