### PR TITLE
CBG-5509 test flakes fix: add missing pauser pattern

### DIFF
--- a/rest/attachmentcompactiontest/attachment_compaction_api_test.go
+++ b/rest/attachmentcompactiontest/attachment_compaction_api_test.go
@@ -137,7 +137,7 @@ func TestAttachmentCompactionPersistence(t *testing.T) {
 		CustomTestBucket: noCloseTB,
 	})
 	rt2 := rest.NewRestTesterDefaultCollection(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb,
+		CustomTestBucket: tb.LeakyBucketClone(base.LeakyBucketConfig{}),
 	})
 	defer rt2.Close()
 	defer rt1.Close()
@@ -184,14 +184,30 @@ func TestAttachmentCompactionPersistence(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, db.BackgroundProcessStateStopped, rt2AttachmentStatus.State)
 
+	// Add a second legacy attachment now that the run is genuinely stopped. On a real cluster,
+	// stopping isn't instant, so the first attachment may already be marked by this point (the
+	// blocked mark call completes once Release lets it through) -- a fresh doc created after
+	// Stopped is confirmed is guaranteed unmarked, giving the resumed run below something to
+	// genuinely block on.
+	rest.CreateLegacyAttachmentDoc(t, ctx, collection, t.Name()+"_resume", []byte("{}"), "att-resume", []byte("att body 2"))
+
+	// Pause again, bound to rt2's own leaky datastore this time -- the resumed run below performs
+	// its writes through rt2, so a pauser bound to rt1 wouldn't intercept them.
+	pauser2 := newCompactionPauser(rt2)
+	defer pauser2.Close()
+	pauser2.Pause()
+
 	// Attempt to start again from rt2 --> Should resume based on aborted state (same compactionID)
 	resp = rt2.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
+	pauser2.WaitUntilBlocked()
 	status := rt2.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateRunning)
 	assert.Equal(t, compactID, status.CompactID)
+	pauser2.Release()
 
 	// Wait for compaction to complete
-	_ = rt1.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateCompleted)
+	status = rt1.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateCompleted)
+	assert.Equal(t, compactID, status.CompactID)
 }
 
 func TestAttachmentCompactionDryRun(t *testing.T) {

--- a/rest/attachmentmigrationtest/attachment_migration_api_test.go
+++ b/rest/attachmentmigrationtest/attachment_migration_api_test.go
@@ -30,6 +30,7 @@ func TestAttachmentMigrationAPI(t *testing.T) {
 		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
 			AutoImport: false, // turn off import feed to stop the feed migrating attachments
 		}},
+		LeakyBucketConfig: &base.LeakyBucketConfig{},
 	})
 	defer rt.Close()
 	collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
@@ -51,15 +52,24 @@ func TestAttachmentMigrationAPI(t *testing.T) {
 	_ = rt.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateCompleted)
 
 	// add some docs for migration
-	numDocs, _ := addDocsForMigrationProcess(t, ctx, collection, rt.Bucket())
+	numDocs, legacyKeys := addDocsForMigrationProcess(t, ctx, collection, rt.Bucket())
+
+	// Pause migration at the first legacy doc so the duplicate start request below is
+	// guaranteed to arrive while the run is genuinely still in progress.
+	pauser := newMigrationPauser(rt)
+	defer pauser.Close()
+	pauser.Pause(legacyKeys[0])
 
 	// kick off migration
 	resp = rt.SendAdminRequest("POST", "/{{.db}}/_attachment_migration", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
+	pauser.WaitUntilBlocked()
 
 	// attempt to kick off again, should error
 	resp = rt.SendAdminRequest("POST", "/{{.db}}/_attachment_migration", "")
 	rest.RequireStatus(t, resp, http.StatusServiceUnavailable)
+
+	pauser.Release()
 
 	// Wait for run to complete
 	_ = rt.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateCompleted)

--- a/rest/attachmentmigrationtest/attachment_migration_api_test.go
+++ b/rest/attachmentmigrationtest/attachment_migration_api_test.go
@@ -201,7 +201,7 @@ func TestAttachmentMigrationMultiNode(t *testing.T) {
 		DatabaseConfig:   dbCfg,
 	})
 	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb,
+		CustomTestBucket: tb.LeakyBucketClone(base.LeakyBucketConfig{}),
 		DatabaseConfig:   dbCfg,
 	})
 	defer rt2.Close()
@@ -252,12 +252,26 @@ func TestAttachmentMigrationMultiNode(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, db.BackgroundProcessStateStopped, rt2MigrationStatus.State)
 
+	// Add a fresh legacy attachment now that the run is genuinely stopped. On a real cluster (and
+	// even Rosmar), stopping isn't instant, so the original vBucket 0 docs may already be migrated
+	// by this point -- a doc created after Stopped is confirmed is guaranteed unmigrated, giving the
+	// resumed run below something to genuinely block on.
+	resumeDocID := base.VBucket0DocIDs(t, rt1.Bucket(), 6)[5]
+	rest.CreateLegacyAttachmentDoc(t, ctx, collection, resumeDocID, []byte(`{}`), "att", []byte("att body"))
+
+	// Pause again, bound to rt2's own leaky datastore this time -- the resumed run below performs
+	// its writes through rt2, so a pauser bound to rt1 wouldn't intercept them.
+	pauser2 := newMigrationPauser(rt2)
+	defer pauser2.Close()
+	pauser2.Pause(resumeDocID)
+
 	// kick off migration run again on node 2. Should resume and have same migration id.
-	// Note: with the small Rosmar test dataset the resumed migration can finish before the
-	// transient Running state is observable, so we don't poll for it here — the resume is
-	// instead verified by the migrationID equality check on the final Completed status below.
 	resp = rt2.SendAdminRequest("POST", "/{{.db}}/_attachment_migration?action=start", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
+	pauser2.WaitUntilBlocked()
+	status = rt2.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateRunning)
+	assert.Equal(t, migrationID, status.MigrationID)
+	pauser2.Release()
 
 	// Wait for run to be marked as complete on both nodes
 	status = rt1.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateCompleted)


### PR DESCRIPTION
CBG-5509 test flakes fix: add missing pauser pattern to Attachment Compaction and Attachment Migration

As found in mobilejenkins mostly https://github.com/couchbase/sync_gateway/pull/8414 was not enough to fix the underlying problems.

I tried to find the issues before when running the tests locally, but I couldn't see the flakes like we can in CI. They got worse because I reduced the number of documents, but I think fixing these two will make it better again.

