### PR TITLE
CBG-5600 run Couchbase Lite E2E tests automatically from merges

### DIFF
--- a/.github/slack_usernames.yaml
+++ b/.github/slack_usernames.yaml
@@ -7,7 +7,7 @@
 # the file licenses/APL2.txt.
 
 # Maps GitHub usernames to Slack member IDs (Slack profile -> More -> Copy member ID),
-# so Jenkins can DM the commit author on E2E build results.
+# so Jenkins can DM whoever manually triggered a build with its results.
 DragosPetruTaraban: "U0221MMQKJ9"
 JRascagneres: "UC51SKA66"
 RIT3shSapata: "U04EQ6XLSF5"

--- a/.github/slack_usernames.yaml
+++ b/.github/slack_usernames.yaml
@@ -1,0 +1,21 @@
+# Copyright 2026-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
+# Maps GitHub usernames to Slack member IDs (Slack profile -> More -> Copy member ID),
+# so Jenkins can DM the commit author on E2E build results.
+DragosPetruTaraban: "U0221MMQKJ9"
+JRascagneres: "UC51SKA66"
+RIT3shSapata: "U04EQ6XLSF5"
+adamcfraser: "U03DMET9D"
+bbrks: "UAVMTSQ02"
+borrrden: "U03DAHVP9"
+gregns1: "U03LW9MNHLP"
+syncgatewaybot-alerts: "C0BHQLWP7UL"
+syncgatewaybot: "CCCKUSYLR"
+torcolvin: "U03D1N4373N"
+vipbhardwaj: "U04ESPQSPU4"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -208,6 +208,23 @@ pipeline {
                                 // Queues up an async integration test run using default build params (main branch),
                                 // but waits up to an hour for batches of PR merges before actually running (via quietPeriod)
                                 build job: 'MainIntegration', quietPeriod: 3600, wait: false
+
+                                echo 'Queueing E2E test runs (rosmar/cbs x dev_e2e/QE) for branch "main" ...'
+                                script {
+                                    def e2eModes = [
+                                        [backingStore: 'rosmar', testDirectory: 'tests/dev_e2e'],
+                                        [backingStore: 'rosmar', testDirectory: 'tests/QE'],
+                                        [backingStore: 'cbs', testDirectory: 'tests/dev_e2e'],
+                                        [backingStore: 'cbs', testDirectory: 'tests/QE'],
+                                    ]
+                                    e2eModes.each { mode ->
+                                        build job: 'Couchbase Lite E2E', wait: false, parameters: [
+                                            string(name: 'SG_COMMIT', value: env.SG_COMMIT),
+                                            string(name: 'BACKING_STORE', value: mode.backingStore),
+                                            string(name: 'TEST_DIRECTORY', value: mode.testDirectory),
+                                        ]
+                                    }
+                                }
                             }
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
             steps {
                 sh 'git rev-parse HEAD > .git/commit-id'
                 script {
-                    env.SG_COMMIT = readFile '.git/commit-id'
+                    env.SG_COMMIT = readFile('.git/commit-id').trim()
                     // Set BRANCH variable to target branch if this build is a PR
                     if (env.CHANGE_TARGET) {
                         env.BRANCH = env.CHANGE_TARGET
@@ -254,7 +254,8 @@ pipeline {
             archiveArtifacts excludes: 'verbose_*.out', artifacts: '*.out', fingerprint: false, allowEmptyArchive: true
             script {
                 if ("${env.BRANCH_NAME}" == 'main') {
-                    slackSend color: 'danger', message: "Failed tests in main SGW pipeline: ${currentBuild.fullDisplayName}\nAt least one test failed: ${env.BUILD_URL}"
+                    def slackUtils = load('integration-test/slackUtils.groovy')
+                    slackUtils.slackSendFailure('main SGW pipeline', 'unstable', env.BUILD_URL)
                 }
             }
         }
@@ -263,7 +264,8 @@ pipeline {
             archiveArtifacts excludes: 'verbose_*.out', artifacts: '*.out', fingerprint: false, allowEmptyArchive: true
             script {
                 if ("${env.BRANCH_NAME}" == 'main') {
-                    slackSend color: 'danger', message: "Build failure!!!\nA build failure occurred in the main SGW pipeline: ${currentBuild.fullDisplayName}\nSomething went wrong building: ${env.BUILD_URL}"
+                    def slackUtils = load('integration-test/slackUtils.groovy')
+                    slackUtils.slackSendFailure('main SGW pipeline', 'build failure', env.BUILD_URL)
                 }
             }
         }
@@ -271,7 +273,8 @@ pipeline {
             archiveArtifacts excludes: 'verbose_*.out', artifacts: '*.out', fingerprint: false, allowEmptyArchive: true
             script {
                 if ("${env.BRANCH_NAME}" == 'main') {
-                    slackSend color: 'danger', message: "main SGW pipeline build aborted: ${currentBuild.fullDisplayName}\nCould be due to build timeout: ${env.BUILD_URL}"
+                    def slackUtils = load('integration-test/slackUtils.groovy')
+                    slackUtils.slackSendFailure('main SGW pipeline', 'aborted', env.BUILD_URL)
                 }
             }
         }

--- a/integration-test/e2e/Jenkinsfile
+++ b/integration-test/e2e/Jenkinsfile
@@ -1,63 +1,15 @@
-// Builds a Slack-friendly summary of the JUnit results recorded by the 'junit' step in post.always,
-// including up to 10 failed test names (Jenkins runs post.always before success/failure, so results are available here).
-def testSummary() {
-    def testResultAction = currentBuild.rawBuild.getAction(hudson.tasks.test.AbstractTestResultAction)
-    if (testResultAction == null) {
-        return '_No test results found_'
-    }
-    def summary = "*Tests:* ${testResultAction.totalCount} total, ${testResultAction.failCount} failed, ${testResultAction.skipCount} skipped"
-    if (testResultAction.failCount > 0) {
-        def failedTests = testResultAction.getFailedTests()
-        def names = failedTests.take(10).collect { "• ${it.fullDisplayName}" }.join('\n')
-        summary += "\n*Failed tests:*\n${names}"
-        if (failedTests.size() > 10) {
-            summary += "\n• ...and ${failedTests.size() - 10} more"
-        }
-    }
-    return summary
-}
-
-def slackMessage(String status, String link) {
-    def emoji = status == 'passed' ? ':white_check_mark:' : ':x:'
-    return """
-        ${emoji} *E2E tests ${status}* — ${currentBuild.fullDisplayName}
-
-        *SG_COMMIT:* ${params.SG_COMMIT}
-        *BACKING_STORE:* ${params.BACKING_STORE}
-        *TEST_DIRECTORY:* ${params.TEST_DIRECTORY}
-        *COUCHBASE_LITE_VERSION:* ${params.COUCHBASE_LITE_VERSION}
-        *COUCHBASE_SERVER_VERSION:* ${params.COUCHBASE_SERVER_VERSION}
-
-        ${testSummary()}
-
-        ${link}
-    """.stripIndent().trim()
-}
-
-// Looks up the Slack member ID of whoever manually triggered this build in the UI, via
-// .github/slack_usernames.yaml (Jenkins usernames are identical to GitHub usernames in this org).
-// The 'Run E2E Tests' stage overwrites this file with the latest version from main before this
-// runs, so the map stays current regardless of which SG_COMMIT is under test.
-// Returns null for non-user-triggered builds (e.g. the automatic fan-out from the root Jenkinsfile,
-// which has an UpstreamCause instead) or if the triggering user has no entry/Slack ID in the map.
-def slackUserIdForBuild() {
-    def userIdCauses = currentBuild.getBuildCauses('hudson.model.Cause$UserIdCause')
-    if (!userIdCauses) {
-        echo('No UserIdCause on this build (not manually triggered) - skipping Slack DM')
-        return null
-    }
-    if (!fileExists('.github/slack_usernames.yaml')) {
-        echo('.github/slack_usernames.yaml not present (build likely failed before it could be fetched) - skipping Slack DM')
-        return null
-    }
-    def githubUsername = userIdCauses[0].userId
-    def slackMap = readYaml(file: '.github/slack_usernames.yaml')
-    def slackUserId = slackMap[githubUsername]
-    if (!slackUserId) {
-        echo("No Slack ID mapped for '${githubUsername}' in .github/slack_usernames.yaml")
-        return null
-    }
-    return slackUserId
+// Details block included in every Slack message for this pipeline (see integration-test/slackUtils.groovy).
+// The 'Run E2E Tests' stage overwrites integration-test/slackUtils.groovy and .github/slack_usernames.yaml
+// with the latest versions from main before this runs, so both stay current regardless of which SG_COMMIT
+// is under test.
+def e2eDetails() {
+    return [
+        SG_COMMIT: params.SG_COMMIT,
+        BACKING_STORE: params.BACKING_STORE,
+        TEST_DIRECTORY: params.TEST_DIRECTORY,
+        COUCHBASE_LITE_VERSION: params.COUCHBASE_LITE_VERSION,
+        COUCHBASE_SERVER_VERSION: params.COUCHBASE_SERVER_VERSION,
+    ]
 }
 
 pipeline {
@@ -182,10 +134,10 @@ pipeline {
                 sshagent(credentials: ['CB_SG_Robot_Github_SSH_Key']) {
                     sh '''
                         set -eu
-                        mkdir -p integration-test/e2e
+                        mkdir -p integration-test/e2e .github
                         curl -sSf https://raw.githubusercontent.com/couchbase/sync_gateway/main/integration-test/e2e/run_e2e_tests.sh -o integration-test/e2e/run_e2e_tests.sh
-                        # TODO: point back at main once .github/slack_usernames.yaml is merged there
-                        curl -sSf https://raw.githubusercontent.com/couchbase/sync_gateway/CBG-5600/.github/slack_usernames.yaml -o .github/slack_usernames.yaml
+                        curl -sSf https://raw.githubusercontent.com/couchbase/sync_gateway/main/integration-test/slackUtils.groovy -o integration-test/slackUtils.groovy
+                        curl -sSf https://raw.githubusercontent.com/couchbase/sync_gateway/main/.github/slack_usernames.yaml -o .github/slack_usernames.yaml
                         /bin/bash integration-test/e2e/run_e2e_tests.sh
                     '''
                 }
@@ -199,26 +151,19 @@ pipeline {
         }
         success {
             script {
-                slackSend(channel: 'syncgatewaybot', color: 'good', message: slackMessage('passed', env.BUILD_URL))
-                def dmTarget = slackUserIdForBuild()
+                def slackUtils = load('integration-test/slackUtils.groovy')
+                def message = slackUtils.slackMessage('E2E tests', 'passed', env.BUILD_URL, e2eDetails())
+                slackSend(channel: 'syncgatewaybot', color: 'good', message: message)
+                def dmTarget = slackUtils.slackUserIdForBuild()
                 if (dmTarget) {
-                    slackSend(channel: dmTarget, color: 'good', message: slackMessage('passed', env.BUILD_URL))
+                    slackSend(channel: dmTarget, color: 'good', message: message)
                 }
             }
         }
         failure {
             script {
-                def dmTarget = slackUserIdForBuild()
-                if (dmTarget) {
-                    // A known trigger user exists (this was a manual "Build with Parameters" run):
-                    // DM them privately.
-                    slackSend(channel: dmTarget, color: 'danger', message: slackMessage('failed', "Console: ${env.BUILD_URL}console"))
-                } else {
-                    // This was triggered from a pipeline rather than a user, report to all developers.
-                    slackSend(channel: 'syncgatewaybot-alerts', color: 'danger', message: slackMessage('failed', "Console: ${env.BUILD_URL}console"))
-                }
-                // Always send to #syncgatewaybot
-                slackSend(channel: 'syncgatewaybot', color: 'danger', message: slackMessage('failed', "Console: ${env.BUILD_URL}console"))
+                def slackUtils = load('integration-test/slackUtils.groovy')
+                slackUtils.slackSendFailure('E2E tests', 'failed', "Console: ${env.BUILD_URL}console", e2eDetails())
             }
         }
         cleanup {

--- a/integration-test/e2e/Jenkinsfile
+++ b/integration-test/e2e/Jenkinsfile
@@ -1,3 +1,65 @@
+// Builds a Slack-friendly summary of the JUnit results recorded by the 'junit' step in post.always,
+// including up to 10 failed test names (Jenkins runs post.always before success/failure, so results are available here).
+def testSummary() {
+    def testResultAction = currentBuild.rawBuild.getAction(hudson.tasks.test.AbstractTestResultAction)
+    if (testResultAction == null) {
+        return '_No test results found_'
+    }
+    def summary = "*Tests:* ${testResultAction.totalCount} total, ${testResultAction.failCount} failed, ${testResultAction.skipCount} skipped"
+    if (testResultAction.failCount > 0) {
+        def failedTests = testResultAction.getFailedTests()
+        def names = failedTests.take(10).collect { "• ${it.fullDisplayName}" }.join('\n')
+        summary += "\n*Failed tests:*\n${names}"
+        if (failedTests.size() > 10) {
+            summary += "\n• ...and ${failedTests.size() - 10} more"
+        }
+    }
+    return summary
+}
+
+def slackMessage(String status, String link) {
+    def emoji = status == 'passed' ? ':white_check_mark:' : ':x:'
+    return """
+        ${emoji} *E2E tests ${status}* — ${currentBuild.fullDisplayName}
+
+        *SG_COMMIT:* ${params.SG_COMMIT}
+        *BACKING_STORE:* ${params.BACKING_STORE}
+        *TEST_DIRECTORY:* ${params.TEST_DIRECTORY}
+        *COUCHBASE_LITE_VERSION:* ${params.COUCHBASE_LITE_VERSION}
+        *COUCHBASE_SERVER_VERSION:* ${params.COUCHBASE_SERVER_VERSION}
+
+        ${testSummary()}
+
+        ${link}
+    """.stripIndent().trim()
+}
+
+// Looks up the Slack member ID of whoever manually triggered this build in the UI, via
+// .github/slack_usernames.yaml (Jenkins usernames are identical to GitHub usernames in this org).
+// The 'Run E2E Tests' stage overwrites this file with the latest version from main before this
+// runs, so the map stays current regardless of which SG_COMMIT is under test.
+// Returns null for non-user-triggered builds (e.g. the automatic fan-out from the root Jenkinsfile,
+// which has an UpstreamCause instead) or if the triggering user has no entry/Slack ID in the map.
+def slackUserIdForBuild() {
+    def userIdCauses = currentBuild.getBuildCauses('hudson.model.Cause$UserIdCause')
+    if (!userIdCauses) {
+        echo('No UserIdCause on this build (not manually triggered) - skipping Slack DM')
+        return null
+    }
+    if (!fileExists('.github/slack_usernames.yaml')) {
+        echo('.github/slack_usernames.yaml not present (build likely failed before it could be fetched) - skipping Slack DM')
+        return null
+    }
+    def githubUsername = userIdCauses[0].userId
+    def slackMap = readYaml(file: '.github/slack_usernames.yaml')
+    def slackUserId = slackMap[githubUsername]
+    if (!slackUserId) {
+        echo("No Slack ID mapped for '${githubUsername}' in .github/slack_usernames.yaml")
+        return null
+    }
+    return slackUserId
+}
+
 pipeline {
     agent any
     options {
@@ -122,6 +184,8 @@ pipeline {
                         set -eu
                         mkdir -p integration-test/e2e
                         curl -sSf https://raw.githubusercontent.com/couchbase/sync_gateway/main/integration-test/e2e/run_e2e_tests.sh -o integration-test/e2e/run_e2e_tests.sh
+                        # TODO: point back at main once .github/slack_usernames.yaml is merged there
+                        curl -sSf https://raw.githubusercontent.com/couchbase/sync_gateway/CBG-5600/.github/slack_usernames.yaml -o .github/slack_usernames.yaml
                         /bin/bash integration-test/e2e/run_e2e_tests.sh
                     '''
                 }
@@ -130,8 +194,32 @@ pipeline {
     }
     post {
         always {
-            archiveArtifacts artifacts: 'couchbase-lite-tests/environment/local/sync_gateway.log', followSymlinks: false
-            junit allowEmptyResults: true, testResults: 'couchbase-lite-tests/tests/**/junit*.xml'
+            archiveArtifacts(artifacts: 'couchbase-lite-tests/environment/local/sync_gateway.log', followSymlinks: false)
+            junit(allowEmptyResults: true, testResults: 'couchbase-lite-tests/tests/**/junit*.xml')
+        }
+        success {
+            script {
+                slackSend(channel: 'syncgatewaybot', color: 'good', message: slackMessage('passed', env.BUILD_URL))
+                def dmTarget = slackUserIdForBuild()
+                if (dmTarget) {
+                    slackSend(channel: dmTarget, color: 'good', message: slackMessage('passed', env.BUILD_URL))
+                }
+            }
+        }
+        failure {
+            script {
+                def dmTarget = slackUserIdForBuild()
+                if (dmTarget) {
+                    // A known trigger user exists (this was a manual "Build with Parameters" run):
+                    // DM them privately.
+                    slackSend(channel: dmTarget, color: 'danger', message: slackMessage('failed', "Console: ${env.BUILD_URL}console"))
+                } else {
+                    // This was triggered from a pipeline rather than a user, report to all developers.
+                    slackSend(channel: 'syncgatewaybot-alerts', color: 'danger', message: slackMessage('failed', "Console: ${env.BUILD_URL}console"))
+                }
+                // Always send to #syncgatewaybot
+                slackSend(channel: 'syncgatewaybot', color: 'danger', message: slackMessage('failed', "Console: ${env.BUILD_URL}console"))
+            }
         }
         cleanup {
             cleanWs(disableDeferredWipeout: true)

--- a/integration-test/slackUtils.groovy
+++ b/integration-test/slackUtils.groovy
@@ -1,0 +1,87 @@
+//  Copyright 2026-Present Couchbase, Inc.
+//
+//  Use of this software is governed by the Business Source License included
+//  in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+//  in that file, in accordance with the Business Source License, use of this
+//  software will be governed by the Apache License, Version 2.0, included in
+//  the file licenses/APL2.txt.
+
+// Shared Slack notification helpers, loaded via the `load` step by Jenkinsfiles that want
+// consistent Slack formatting (see Jenkinsfile and integration-test/e2e/Jenkinsfile).
+
+// Builds a Slack-friendly summary of the JUnit results recorded by the 'junit' step in post.always,
+// including up to 10 failed test names (Jenkins runs post.always before success/failure/unstable/aborted,
+// so results are available here).
+def testSummary() {
+    def testResultAction = currentBuild.rawBuild.getAction(hudson.tasks.test.AbstractTestResultAction)
+    if (testResultAction == null) {
+        return '_No test results found_'
+    }
+    def summary = "*Tests:* ${testResultAction.totalCount} total, ${testResultAction.failCount} failed, ${testResultAction.skipCount} skipped"
+    if (testResultAction.failCount > 0) {
+        def failedTests = testResultAction.getFailedTests()
+        def names = failedTests.take(10).collect { "• ${it.fullDisplayName}" }.join('\n')
+        summary += "\n*Failed tests:*\n${names}"
+        if (failedTests.size() > 10) {
+            summary += "\n• ...and ${failedTests.size() - 10} more"
+        }
+    }
+    return summary
+}
+
+// Builds a Slack message: a status emoji/title line, an optional block of key/value details
+// (insertion order preserved, so pass a LinkedHashMap / map literal), the JUnit test summary, and
+// a trailing link.
+def slackMessage(String title, String status, String link, Map details = [:]) {
+    def emoji = status == 'passed' ? ':white_check_mark:' : ':x:'
+    def lines = ["${emoji} *${title} ${status}* — ${currentBuild.fullDisplayName}"]
+    if (details) {
+        lines << ''
+        details.each { key, value -> lines << "*${key}:* ${value}" }
+    }
+    lines << ''
+    lines << testSummary()
+    lines << ''
+    lines << link
+    return lines.join('\n')
+}
+
+// Looks up the Slack member ID of whoever manually triggered this build in the UI, via
+// .github/slack_usernames.yaml (Jenkins usernames are identical to GitHub usernames in this org).
+// Returns null for non-user-triggered builds (e.g. an automatic fan-out from an upstream job,
+// which has an UpstreamCause instead) or if the triggering user has no entry/Slack ID in the map.
+def slackUserIdForBuild() {
+    def userIdCauses = currentBuild.getBuildCauses('hudson.model.Cause$UserIdCause')
+    if (!userIdCauses) {
+        echo('No UserIdCause on this build (not manually triggered) - skipping Slack DM')
+        return null
+    }
+    if (!fileExists('.github/slack_usernames.yaml')) {
+        echo('.github/slack_usernames.yaml not present (build likely failed before it could be fetched) - skipping Slack DM')
+        return null
+    }
+    def githubUsername = userIdCauses[0].userId
+    def slackMap = readYaml(file: '.github/slack_usernames.yaml')
+    def slackUserId = slackMap[githubUsername]
+    if (!slackUserId) {
+        echo("No Slack ID mapped for '${githubUsername}' in .github/slack_usernames.yaml")
+        return null
+    }
+    return slackUserId
+}
+
+// Sends a failure-style Slack notification: always to #syncgatewaybot; additionally either DMs
+// the user who manually triggered the build (if known) or posts to #syncgatewaybot-alerts (if
+// triggered by a pipeline rather than a person).
+def slackSendFailure(String title, String status, String link, Map details = [:]) {
+    def message = slackMessage(title, status, link, details)
+    def dmTarget = slackUserIdForBuild()
+    if (dmTarget) {
+        slackSend(channel: dmTarget, color: 'danger', message: message)
+    } else {
+        slackSend(channel: 'syncgatewaybot-alerts', color: 'danger', message: message)
+    }
+    slackSend(channel: 'syncgatewaybot', color: 'danger', message: message)
+}
+
+return this


### PR DESCRIPTION
CBG-5600 run Couchbase Lite E2E tests automatically from merges

Runs in four modes since these are fast enough:

1. dev_e2e + rosmar
2. dev_e2e + CBS
3. QE + rosmar (this is pretty limited number of tests)
4. QE + CBS (this is still limited compared to QE jenkins runs)

Add notifications:

- DM to user if there was a user who ran build via website, this is from Slackbot. To do a DM, create a mapping of slack user ids to github usernames. the slack / jenkins user doesn't have permission to look up this information, and there is no correlation between github user and slack user anyway.
- always post to #syncgatewaybot
- only post to #syncgatewaybot-alerts new channel if is a failure and it was triggered by an upstream job

I am not at all attached to the formatting of this message. I have a temporary jenkins job for E2E tests you can trigger to run the successful / failing tests https://jenkins.sgwdev.com/job/Couchbase%20Lite%20E2E%20jenkins%20testing/ . I'll delete this jenkins project when this is merged.

## TODOs before merge after reviewers OK
- [ ] If reviewer likes this format, I will apply to MainIntegration.
- [ ] File ticket to apply changes to Sync Gateway Integration and Topology Test jobs. The notifications use pipeline only syntax so I might have to convert those from Freestyle jobs to pipeline jobs
- [ ] I left a TODO that I need to update to main, this is in place so reviewer can trigger this: `# TODO: point back at main once .github/slack_usernames.yaml is merged there`
