### PR TITLE
CBG-5581 don't count tombstones in resync docs targeted

### DIFF
--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -211,7 +211,7 @@ func (r *ResyncManagerDCP) Init(ctx context.Context, options ResyncOptions, clus
 func totalResyncDocs(ctx context.Context, collections DatabaseCollections) (uint64, error) {
 	var total uint64
 	for _, collection := range collections {
-		count, err := collection.CountAllDocs(ctx)
+		count, err := collection.CountAllActiveDocs(ctx)
 		if err != nil {
 			return 0, base.RedactErrorf("failed to count docs for collection %s.%s: %w", base.MD(collection.ScopeName), base.MD(collection.Name), err)
 		}

--- a/db/query.go
+++ b/db/query.go
@@ -371,7 +371,8 @@ var QueryCountDocs = SGQuery{
 			"USE INDEX ($idx) "+
 			"WHERE $sync.`sequence` > 0 AND "+ // Required to use IndexAllDocs
 			"META(%s).id NOT LIKE '%s' "+
-			"AND ($sync.flags IS MISSING OR BITTEST($sync.flags,1) = false)",
+			"AND ($sync.flags IS MISSING OR BITTEST($sync.flags,1) = false) "+
+			"AND ($sync.deleted IS MISSING OR $sync.deleted = false)",
 		base.KeyspaceQueryToken, base.KeyspaceQueryAlias,
 		base.KeyspaceQueryAlias, SyncDocWildcard),
 	adhoc: false,

--- a/db/query.go
+++ b/db/query.go
@@ -361,7 +361,7 @@ var QueryAllDocs = SGQuery{
 	adhoc: false,
 }
 
-// QueryCountDocs finds documents that are tagged with sync metadata, including tombstones. This ignores any metadata
+// QueryCountDocs finds documents that are tagged with sync metadata, excluding tombstones. This ignores any metadata
 // documents starting with _sync:
 var QueryCountDocs = SGQuery{
 	name: QueryTypeCountDocs,
@@ -370,7 +370,8 @@ var QueryCountDocs = SGQuery{
 			"FROM %s AS %s "+
 			"USE INDEX ($idx) "+
 			"WHERE $sync.`sequence` > 0 AND "+ // Required to use IndexAllDocs
-			"META(%s).id NOT LIKE '%s' ",
+			"META(%s).id NOT LIKE '%s' "+
+			"AND ($sync.flags IS MISSING OR BITTEST($sync.flags,1) = false)",
 		base.KeyspaceQueryToken, base.KeyspaceQueryAlias,
 		base.KeyspaceQueryAlias, SyncDocWildcard),
 	adhoc: false,
@@ -798,9 +799,8 @@ func (c *DatabaseCollection) QueryAllDocs(ctx context.Context, startKey string, 
 	return N1QLQueryWithStats(ctx, c.dataStore, QueryTypeAllDocs, allDocsQueryStatement, params, base.RequestPlus, QueryAllDocs.adhoc, c.dbStats(), c.slowQueryWarningThreshold())
 }
 
-// CountAllDocs returns the total number of documents in the collection that contain _sync metadata.
-// When using views, tombstoned documents are excluded.
-func (c *DatabaseCollection) CountAllDocs(ctx context.Context) (uint64, error) {
+// CountAllActiveDocs returns the total number of non-tombstoned documents in the collection that contain _sync metadata.
+func (c *DatabaseCollection) CountAllActiveDocs(ctx context.Context) (uint64, error) {
 	if c.useViews() {
 		opts := Body{"stale": false, "reduce": true}
 		results, err := c.dbCtx.ViewQueryWithStats(ctx, c.dataStore, DesignDocSyncHousekeeping(), ViewAllDocs, opts)

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -545,12 +545,15 @@ func TestCountAllActiveDocs(t *testing.T) {
 
 	// Add some docs
 	numDocs := 5
-	var docToDelete *Document
+	var docToDelete, docToLegacyTombstone *Document
 	for i := range numDocs {
 		_, doc, err := collection.Put(ctx, fmt.Sprintf("doc%d", i), Body{"value": i})
 		require.NoError(t, err)
-		if i == 0 {
+		switch i {
+		case 0:
 			docToDelete = doc
+		case 1:
+			docToLegacyTombstone = doc
 		}
 	}
 
@@ -582,4 +585,19 @@ func TestCountAllActiveDocs(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, uint64(numDocs-1), count)
 
+	// Simulate a legacy tombstone that only sets _sync.deleted, without the sync.flags deleted bit
+	// (the flags-based tombstone marker was introduced after the "deleted" field in commit 4194f81,
+	// 2/17/14). ViewAllDocs already excludes these via `(sync.flags & 1) || sync.deleted`;
+	// CountAllActiveDocs must match that behavior.
+	_, xattrs, _, err := collection.dataStore.GetWithXattrs(ctx, docToLegacyTombstone.ID, []string{base.SyncXattrName})
+	require.NoError(t, err)
+	var legacyTombstoneSyncData map[string]any
+	require.NoError(t, base.JSONUnmarshal(xattrs[base.SyncXattrName], &legacyTombstoneSyncData))
+	legacyTombstoneSyncData["deleted"] = true
+	_, err = collection.dataStore.UpdateXattrs(ctx, docToLegacyTombstone.ID, 0, docToLegacyTombstone.Cas, map[string][]byte{base.SyncXattrName: base.MustJSONMarshal(t, legacyTombstoneSyncData)}, DefaultMutateInOpts())
+	require.NoError(t, err)
+
+	count, err = collection.CountAllActiveDocs(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(numDocs-2), count)
 }

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -534,12 +534,12 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 	checkFlags(entries)
 }
 
-func TestCountAllDocs(t *testing.T) {
+func TestCountAllActiveDocs(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 
-	count, err := collection.CountAllDocs(ctx)
+	count, err := collection.CountAllActiveDocs(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(0), count)
 
@@ -554,7 +554,7 @@ func TestCountAllDocs(t *testing.T) {
 		}
 	}
 
-	count, err = collection.CountAllDocs(ctx)
+	count, err = collection.CountAllActiveDocs(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(numDocs), count)
 
@@ -571,19 +571,14 @@ func TestCountAllDocs(t *testing.T) {
 	_, _, err = collection.DeleteDoc(ctx, "doc0", docToDelete.ExtractDocVersion())
 	require.NoError(t, err)
 
-	count, err = collection.CountAllDocs(ctx)
+	count, err = collection.CountAllActiveDocs(ctx)
 	require.NoError(t, err)
-	// Views exclude tombstoned documents from the map function; N1QL counts them until purged.
-	if base.TestsDisableGSI() {
-		assert.Equal(t, uint64(numDocs-1), count)
-	} else {
-		assert.Equal(t, uint64(numDocs), count)
-	}
+	assert.Equal(t, uint64(numDocs-1), count)
 
 	err = collection.Purge(ctx, "doc0", false)
 	require.NoError(t, err)
 
-	count, err = collection.CountAllDocs(ctx)
+	count, err = collection.CountAllActiveDocs(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(numDocs-1), count)
 


### PR DESCRIPTION
CBG-5581 don't count tombstones in resync docs targeted

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`
