### PR TITLE
CBG-4920 Fix flaky TestActiveReplicatorHLVConflictCustom

### DIFF
--- a/rest/replicatortest/replicator_conflict_test.go
+++ b/rest/replicatortest/replicator_conflict_test.go
@@ -1648,12 +1648,20 @@ func TestActiveReplicatorHLVConflictCustom(t *testing.T) {
 				require.NoError(t, err)
 				defer func() { require.NoError(t, ar.Stop()) }()
 
-				// Start the replicator
-				require.NoError(t, ar.Start(ctx1))
+				// Start push before pull: rt2 has no resolver, so it deterministically 409s the
+				// still-untouched local rev. Starting both together races that against pull
+				// resolving (and overwriting) the local doc first, making DocWriteConflict flaky.
+				require.NoError(t, ar.Push.Start(ctx1))
+				require.EventuallyWithT(t, func(c *assert.CollectT) {
+					status := ar.GetStatus(ctx1)
+					assert.Equal(c, 1, int(status.PushReplicationStatus.DocWriteConflict))
+				}, 10*time.Second, 100*time.Millisecond)
 
+				require.NoError(t, ar.Pull.Start(ctx1))
 				require.EventuallyWithT(t, func(c *assert.CollectT) {
 					status := ar.GetStatus(ctx1)
 					assert.Equal(c, 1, int(status.PullReplicationStatus.DocsRead))
+					// resolving/republishing must not register as a second conflict
 					assert.Equal(c, 1, int(status.PushReplicationStatus.DocWriteConflict))
 					if testCase.expectedDocPushResolved {
 						assert.Equal(c, 1, int(status.PushReplicationStatus.DocsWritten))


### PR DESCRIPTION
CBG-4920 Fix flaky TestActiveReplicatorHLVConflictCustom

Under a single continuous PushAndPull replicator:

pull could resolve the conflict and overwrite rt1's local doc before push got a chance to send the still-conflicting revision. This leaves leaves DocWriteConflict at 0.

Start push and pull sequentially instead so the push-side rejection is deterministic before pull resolves the conflict.


To reproduce, add sleep https://github.com/couchbase/sync_gateway/blob/c2c06d972b1999b00e844f3b4fe2b1c25bf9b7e7/db/active_replicator_push.go#L241

The previous error would be that `DocWriteConflict` would stay at 0 instead of going to 1. The end result of the documents was always identical.


## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`
