### PR TITLE
CBG-5628 BackgroundManager: improve status update error

### DIFF
--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -692,7 +692,7 @@ func (b *BackgroundManager[O]) UpdateSingleNodeClusterAwareStatus(ctx context.Co
 		return err
 	}
 
-	doc := map[string]any{
+	doc := map[string]json.RawMessage{
 		"status": status,
 		"meta":   metadata,
 	}

--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -681,31 +681,23 @@ func (b *BackgroundManager[O]) UpdateStatusClusterAware(ctx context.Context) err
 	}
 }
 
-// UpdateSingleNodeClusterAwareStatus gets the current local status from the running process and updates the status document in
-// the bucket. Implements a retry. Used for Cluster Aware operations
+// UpdateSingleNodeClusterAwareStatus gets the current local status from the running process and writes the status
+// document in the bucket. Used for Cluster Aware operations
 func (b *BackgroundManager[O]) UpdateSingleNodeClusterAwareStatus(ctx context.Context) error {
 	if b.clusterAwareOptions == nil {
 		return nil
 	}
-	err, _ := base.RetryLoop(ctx, "UpdateStatusClusterAware", func() (shouldRetry bool, err error, value any) {
-		status, metadata, err := b.getStatusLocalWithoutPrevious()
-		if err != nil {
-			return true, err, nil
-		}
+	status, metadata, err := b.getStatusLocalWithoutPrevious()
+	if err != nil {
+		return err
+	}
 
-		_, err = b.clusterAwareOptions.metadataStore.WriteSubDoc(ctx, b.clusterAwareOptions.StatusDocID(), "status", 0, status)
-		if err != nil {
-			return true, err, nil
-		}
+	doc := map[string]any{
+		"status": status,
+		"meta":   metadata,
+	}
 
-		_, err = b.clusterAwareOptions.metadataStore.WriteSubDoc(ctx, b.clusterAwareOptions.StatusDocID(), "meta", 0, metadata)
-		if err != nil {
-			return true, err, nil
-		}
-
-		return false, nil, nil
-	}, base.CreateSleeperFunc(5, 100))
-	return err
+	return b.clusterAwareOptions.metadataStore.Set(ctx, b.clusterAwareOptions.StatusDocID(), 0, nil, doc)
 }
 
 // updateMultiNodeClusterAwareStatus updates the cluster status document with the current local status.

--- a/db/background_mgr_test.go
+++ b/db/background_mgr_test.go
@@ -17,9 +17,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/couchbase/gocb/v2"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/testing/assert"
 	"github.com/couchbase/sync_gateway/testing/require"
+	"github.com/couchbaselabs/rosmar"
 )
 
 type MockProcess struct {
@@ -1475,4 +1477,106 @@ func TestBackgroundManagerMultiNodePollingAvoidsOverwrite(t *testing.T) {
 	var status BackgroundManagerStatus
 	require.NoError(t, base.JSONUnmarshal(rawStatus, &status))
 	assert.Equal(t, BackgroundProcessStateCompleted, status.State, "expected the bucket status to remain completed and NOT be overwritten")
+}
+
+// TestUpdateStatusClusterAwareOLD is a scratch copy of the pre-shared-bucket version, for timing comparison only.
+func TestUpdateStatusClusterAwareOLD(t *testing.T) {
+	testCases := []struct {
+		name                string
+		clusterAwareOptions *ClusterAwareBackgroundManagerOptions
+	}{
+		{
+			name: "single node",
+			clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
+				processSuffix: "update-status-closed-bucket-single-node",
+			},
+		},
+		{
+			name: "multi node",
+			clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
+				processSuffix: "update-status-closed-bucket-multi-node",
+				multiNode:     true,
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			testBucket := base.GetTestBucket(t)
+			ctx := base.TestCtx(t)
+			defer testBucket.Close(ctx)
+
+			mgr := &BackgroundManager[map[string]any]{
+				name:                testCase.name + "-mgr",
+				Process:             &MockProcess{},
+				clusterAwareOptions: testCase.clusterAwareOptions,
+				terminator:          base.NewSafeTerminator(),
+			}
+			if mgr.clusterAwareOptions != nil {
+				mgr.clusterAwareOptions.metadataStore = testBucket.DefaultDataStore(ctx)
+				mgr.clusterAwareOptions.metaKeys = base.NewMetadataKeys("test-update-status-closed-bucket")
+			}
+
+			testBucket.Close(ctx)
+
+			err := mgr.UpdateStatusClusterAware(ctx)
+			if base.TestUseCouchbaseServer() {
+				require.ErrorIs(t, err, gocb.ErrShutdown)
+			} else {
+				require.ErrorIs(t, err, rosmar.ErrBucketClosed)
+			}
+		})
+	}
+}
+
+// TestUpdateStatusClusterAware checks that UpdateStatusClusterAware surfaces the underlying bucket-closed
+// error for single-node and multi-node managers.
+func TestUpdateStatusClusterAware(t *testing.T) {
+	testBucket := base.GetTestBucket(t)
+	ctx := base.TestCtx(t)
+	metadataStore := testBucket.DefaultDataStore(ctx)
+	metaKeys := base.NewMetadataKeys("test-update-status-closed-bucket")
+
+	expectedErrBucketClosed := rosmar.ErrBucketClosed
+	if base.TestUseCouchbaseServer() {
+		expectedErrBucketClosed = gocb.ErrShutdown
+	}
+
+	testCases := []struct {
+		name                string
+		clusterAwareOptions *ClusterAwareBackgroundManagerOptions
+	}{
+		{
+			name: "single node",
+			clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
+				metadataStore: metadataStore,
+				metaKeys:      metaKeys,
+				processSuffix: "update-status-closed-bucket-single-node",
+			},
+		},
+		{
+			name: "multi node",
+			clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
+				metadataStore: metadataStore,
+				metaKeys:      metaKeys,
+				processSuffix: "update-status-closed-bucket-multi-node",
+				multiNode:     true,
+			},
+		},
+	}
+
+	testBucket.Close(ctx)
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			mgr := &BackgroundManager[map[string]any]{
+				name:                testCase.name + "-mgr",
+				Process:             &MockProcess{},
+				clusterAwareOptions: testCase.clusterAwareOptions,
+				terminator:          base.NewSafeTerminator(),
+			}
+
+			err := mgr.UpdateStatusClusterAware(ctx)
+			require.ErrorIs(t, err, expectedErrBucketClosed)
+		})
+	}
 }

--- a/db/background_mgr_test.go
+++ b/db/background_mgr_test.go
@@ -1479,55 +1479,6 @@ func TestBackgroundManagerMultiNodePollingAvoidsOverwrite(t *testing.T) {
 	assert.Equal(t, BackgroundProcessStateCompleted, status.State, "expected the bucket status to remain completed and NOT be overwritten")
 }
 
-// TestUpdateStatusClusterAwareOLD is a scratch copy of the pre-shared-bucket version, for timing comparison only.
-func TestUpdateStatusClusterAwareOLD(t *testing.T) {
-	testCases := []struct {
-		name                string
-		clusterAwareOptions *ClusterAwareBackgroundManagerOptions
-	}{
-		{
-			name: "single node",
-			clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
-				processSuffix: "update-status-closed-bucket-single-node",
-			},
-		},
-		{
-			name: "multi node",
-			clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
-				processSuffix: "update-status-closed-bucket-multi-node",
-				multiNode:     true,
-			},
-		},
-	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			testBucket := base.GetTestBucket(t)
-			ctx := base.TestCtx(t)
-			defer testBucket.Close(ctx)
-
-			mgr := &BackgroundManager[map[string]any]{
-				name:                testCase.name + "-mgr",
-				Process:             &MockProcess{},
-				clusterAwareOptions: testCase.clusterAwareOptions,
-				terminator:          base.NewSafeTerminator(),
-			}
-			if mgr.clusterAwareOptions != nil {
-				mgr.clusterAwareOptions.metadataStore = testBucket.DefaultDataStore(ctx)
-				mgr.clusterAwareOptions.metaKeys = base.NewMetadataKeys("test-update-status-closed-bucket")
-			}
-
-			testBucket.Close(ctx)
-
-			err := mgr.UpdateStatusClusterAware(ctx)
-			if base.TestUseCouchbaseServer() {
-				require.ErrorIs(t, err, gocb.ErrShutdown)
-			} else {
-				require.ErrorIs(t, err, rosmar.ErrBucketClosed)
-			}
-		})
-	}
-}
-
 // TestUpdateStatusClusterAware checks that UpdateStatusClusterAware surfaces the underlying bucket-closed
 // error for single-node and multi-node managers.
 func TestUpdateStatusClusterAware(t *testing.T) {
@@ -1535,11 +1486,6 @@ func TestUpdateStatusClusterAware(t *testing.T) {
 	ctx := base.TestCtx(t)
 	metadataStore := testBucket.DefaultDataStore(ctx)
 	metaKeys := base.NewMetadataKeys("test-update-status-closed-bucket")
-
-	expectedErrBucketClosed := rosmar.ErrBucketClosed
-	if base.TestUseCouchbaseServer() {
-		expectedErrBucketClosed = gocb.ErrShutdown
-	}
 
 	testCases := []struct {
 		name                string
@@ -1576,7 +1522,11 @@ func TestUpdateStatusClusterAware(t *testing.T) {
 			}
 
 			err := mgr.UpdateStatusClusterAware(ctx)
-			require.ErrorIs(t, err, expectedErrBucketClosed)
+			if base.TestUseCouchbaseServer() {
+				require.ErrorIs(t, err, gocb.ErrShutdown)
+			} else {
+				require.ErrorIs(t, err, rosmar.ErrBucketClosed)
+			}
 		})
 	}
 }


### PR DESCRIPTION
CBG-5628 BackgroundManager: improve status update error

- Drop the RetryLoop which existed when the SDK did not do retries for intermittent failures to simplify code
- Specifically handle the closed bucket case which will log ambiguously that the RetryLoop timed out

Removes this message (from test, but occurs with real Background Managers), and relies on the determination of caller whether or not to log the error.

```
[WRN] t:TestUpdateStatusClusterAware RetryLoop for UpdateStatusClusterAware giving up after 6 attempts -- base.RetryLoop[...]() at util.go:468
```

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/971/
