### PR TITLE
CBG-5435 switch names from Resume -> Join

### DIFF
--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -89,7 +89,7 @@ const (
 
 // BackgroundManager this is the over-arching type which is exposed in DatabaseContext.
 // O is the type of the options struct passed to BackgroundManagerProcessI.Init and BackgroundManagerProcessI.Run - this allows BackgroundManager to unmarshal the options as
-// the (process-specific) options struct during Resume.
+// the (process-specific) options struct during Join.
 type BackgroundManager[O any] struct {
 	status                                 BackgroundManagerStatus
 	statusLock                             sync.RWMutex
@@ -99,7 +99,7 @@ type BackgroundManager[O any] struct {
 	clusterAwareOptions                    *ClusterAwareBackgroundManagerOptions
 	lock                                   sync.Mutex
 	Process                                BackgroundManagerProcessI[O]
-	// updateDatabaseState, when non-nil, is called from UpdateStatusClusterAware and from Resume
+	// updateDatabaseState, when non-nil, is called from UpdateStatusClusterAware and from Join
 	// (when the cluster is not running) to mirror the local run state into the DatabaseState document.
 	// running is true when the process is locally active, false otherwise.
 	updateDatabaseState func(ctx context.Context, running bool) error
@@ -120,10 +120,12 @@ type ClusterAwareBackgroundManagerOptions struct {
 	lastSuccessfulHeartbeatUnix base.AtomicInt
 }
 
+// HeartbeatDocID returns the document name for the heartbeat document associated with this BackgroundManager.
 func (b *ClusterAwareBackgroundManagerOptions) HeartbeatDocID() string {
 	return b.metaKeys.BackgroundProcessHeartbeatPrefix(b.processSuffix)
 }
 
+// StatusDocID returns the document name for the status document associated with this BackgroundManager.
 func (b *ClusterAwareBackgroundManagerOptions) StatusDocID() string {
 	return b.metaKeys.BackgroundProcessStatusPrefix(b.processSuffix)
 }
@@ -164,6 +166,8 @@ type StoppableBackgroundManager interface {
 	Stop(ctx context.Context) error
 }
 
+// updateStatusCallbackFunc is used inside a background process to signal that stats should be serialized to the
+// bucket separately from the standard BackgroundManagerStatusUpdateIntervalSecs interval.
 type updateStatusCallbackFunc func(ctx context.Context) error
 
 // GetName returns name of the background manager
@@ -181,13 +185,14 @@ func (b *BackgroundManager[O]) callUpdateDatabaseState(ctx context.Context, runn
 	}
 }
 
-// Resume joins an already-running multi-node background process on this node using the options stored in
+// Join an already-running multi-node background process using the options stored in
 // the status document.  It only starts the local process when the cluster state is
-// BackgroundProcessStateRunning; any other state (including no status document) returns
-// errBackgroundManagerStatusNotRunning.  Only supported for multi-node background managers.
-func (b *BackgroundManager[O]) Resume(ctx context.Context) error {
+// BackgroundProcessStateRunning; if there is no status document it returns
+// errBackgroundManagerStatusNotRunning, and for any other terminal state it returns nil
+// without starting the local process.  Only supported for multi-node background managers.
+func (b *BackgroundManager[O]) Join(ctx context.Context) error {
 	if b.mode() != backgroundManagerModeMultiNode {
-		err := fmt.Errorf("Resume is only supported for multi-node background managers (process %q)", b.name)
+		err := fmt.Errorf("Join is only supported for multi-node background managers (process %q)", b.name)
 		base.WarnfCtx(ctx, "%v", err)
 		return err
 	}
@@ -223,6 +228,13 @@ func (b *BackgroundManager[O]) Resume(ctx context.Context) error {
 	return b.start(ctx, doc.Meta.Options, raw, true)
 }
 
+// Start starts a background manager with the given process-specific options and returns once the background
+// process is started.
+//
+// Returns:
+//   - errBackgroundManagerProcessAlreadyRunning if already running in local or single node cluster aware mode
+//   - errBackgroundManagerStatusAlreadyStopping if in the process of stopping
+//   - an error from Process.Init
 func (b *BackgroundManager[O]) Start(ctx context.Context, options O) error {
 	var processClusterStatus []byte
 	if b.mode() != backgroundManagerModeLocal {
@@ -235,7 +247,16 @@ func (b *BackgroundManager[O]) Start(ctx context.Context, options O) error {
 	return b.start(ctx, options, processClusterStatus, false)
 }
 
-func (b *BackgroundManager[O]) start(ctx context.Context, options O, processClusterStatus []byte, isResume bool) error {
+// start marks the process as running, calls Process.Init, and launches Process.Run in a goroutine. options are
+// process-specific and passed through to Init/Run, processClusterStatus is the last known status document (nil if
+// none), and isJoin is true when this node is joining an already-running multi-node process rather than starting a
+// new one.
+//
+// Returns:
+//   - errBackgroundManagerProcessAlreadyRunning if already running in local or single node cluster aware mode
+//   - errBackgroundManagerStatusAlreadyStopping if in the process of stopping
+//   - an error from Process.Init
+func (b *BackgroundManager[O]) start(ctx context.Context, options O, processClusterStatus []byte, isJoin bool) error {
 	if b.mode() != backgroundManagerModeMultiNode && b.updateDatabaseState != nil {
 		return fmt.Errorf("updateDatabaseState should only be set for multi-node background managers")
 	}
@@ -329,7 +350,7 @@ func (b *BackgroundManager[O]) start(ctx context.Context, options O, processClus
 		var err error
 		if b.mode() == backgroundManagerModeMultiNode {
 			mode := backgroundManagerStatusStart
-			if isResume || initMode == backgroundManagerInitResume {
+			if isJoin || initMode == backgroundManagerInitResume {
 				mode = backgroundManagerStatusResume
 			}
 			err = b.updateMultiNodeClusterAwareStatus(ctx, mode)
@@ -345,11 +366,12 @@ func (b *BackgroundManager[O]) start(ctx context.Context, options O, processClus
 	return nil
 }
 
-// markStart changes the local status to started.
+// markStart changes the local status to started. previousStatus is the last known cluster status, used to check
+// whether a multi-node process is currently stopping.
 //
-// If local or single node process and the bucket status is running, return errBackgroundManagerProcessAlreadyRunning.
-// If the status is stopping, return errBackgroundManagerStatusAlreadyStopping
-// that should be stopping or is already stopped.
+// Returns:
+//   - errBackgroundManagerProcessAlreadyRunning if already running in local or single node cluster aware mode
+//   - errBackgroundManagerStatusAlreadyStopping if in the process of stopping
 func (b *BackgroundManager[O]) markStart(ctx context.Context, previousStatus BackgroundManagerStatus) error {
 	b.lock.Lock()
 	defer b.lock.Unlock()
@@ -450,6 +472,8 @@ func unmarshalBackgroundManagerStatus(statusRaw []byte) (BackgroundManagerStatus
 	return clusterStatus.Status, nil
 }
 
+// GetStatus returns the bytes of the status document, preferring the cluster status if cluster aware and populated,
+// otherwise falling back to the local status.
 func (b *BackgroundManager[O]) GetStatus(ctx context.Context) ([]byte, error) {
 	if b.mode() != backgroundManagerModeLocal {
 		status, err := b.getStatusFromCluster(ctx)
@@ -471,12 +495,17 @@ func (b *BackgroundManager[O]) GetStatus(ctx context.Context) ([]byte, error) {
 	return status, err
 }
 
-func (b *BackgroundManager[O]) getStatusLocalWithoutPrevious() ([]byte, []byte, error) {
+// getStatusLocalWithoutPrevious returns the byte arrays of the status and meta fields of the status document by
+// delegating to underlying background process. This should be called only when the existing status is not populated.
+func (b *BackgroundManager[O]) getStatusLocalWithoutPrevious() (status []byte, meta []byte, err error) {
 	return b.getStatusWithPrevious(nil)
 
 }
 
-func (b *BackgroundManager[O]) getStatusWithPrevious(previous []byte) ([]byte, []byte, error) {
+// getStatusWithPrevious returns the byte arrays of the status and meta fields of the status document by
+// delegating to the underlying background process. previous is the last serialized status document, used to
+// merge/preserve existing stats; pass nil when there is no previous status to merge.
+func (b *BackgroundManager[O]) getStatusWithPrevious(previous []byte) (status []byte, meta []byte, err error) {
 	b.statusLock.Lock()
 	defer b.statusLock.Unlock()
 
@@ -488,6 +517,7 @@ func (b *BackgroundManager[O]) getStatusWithPrevious(previous []byte) ([]byte, [
 	return b.Process.GetProcessStatus(backgroundStatus, previous)
 }
 
+// getStatusFromCluster returns the status subdocument of the status document as bytes by reading it from the cluster.
 func (b *BackgroundManager[O]) getStatusFromCluster(ctx context.Context) ([]byte, error) {
 	status, statusCas, err := b.clusterAwareOptions.metadataStore.GetSubDocRaw(ctx, b.clusterAwareOptions.StatusDocID(), "status")
 	if err != nil {
@@ -550,6 +580,8 @@ func (b *BackgroundManager[O]) getStatusFromCluster(ctx context.Context) ([]byte
 	return status, err
 }
 
+// resetStatus clears the in memory status of the BackgroundManager. Used to reset the state from a
+// previous status.
 func (b *BackgroundManager[O]) resetStatus() {
 	b.lock.Lock()
 	defer b.lock.Unlock()
@@ -590,6 +622,8 @@ func (b *BackgroundManager[O]) Terminate() {
 	b.backgroundManagerStatusUpdateWaitGroup.Wait()
 }
 
+// markStop will change the local state of the background manager and signal to background managers on other Sync
+// Gateway nodes to stop.
 func (b *BackgroundManager[O]) markStop(ctx context.Context) error {
 	b.lock.Lock()
 	defer b.lock.Unlock()
@@ -768,8 +802,8 @@ type HeartbeatDoc struct {
 	ShouldStop bool `json:"should_stop"`
 }
 
-// UpdateHeartbeatDocClusterAware simply performs a touch operation on the heartbeat document to update its expiry.
-// Implements a retry. Used for Cluster Aware operations
+// UpdateHeartbeatDocClusterAware performs a touch operation on the heartbeat document to update its expiry, and
+// stops the process if the doc indicates a stop was requested. Used for Cluster Aware operations.
 func (b *BackgroundManager[O]) UpdateHeartbeatDocClusterAware(ctx context.Context) error {
 	statusRaw, _, err := b.clusterAwareOptions.metadataStore.GetAndTouchRaw(ctx, b.clusterAwareOptions.HeartbeatDocID(), BackgroundManagerHeartbeatExpirySecs)
 	if err != nil {
@@ -867,7 +901,7 @@ const (
 	backgroundManagerModeMultiNode
 )
 
-// mode returns the running mode a BackgroundManager.
+// mode returns the running mode of a BackgroundManager.
 func (b *BackgroundManager[O]) mode() backgroundManagerMode {
 	if b.clusterAwareOptions == nil {
 		return backgroundManagerModeLocal

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -48,7 +48,7 @@ type ResyncManagerDCP struct {
 	VBUUIDs                      []uint64
 	EndSeqNos                    []uint64 // EndSeqNos for resync, stored as a slice to optimize persistence in status doc
 	ResyncedCollections          base.CollectionNames
-	startOptions                 ResyncOptions // options from the most recent Start call, persisted to meta for Resume
+	startOptions                 ResyncOptions // options from the most recent Start call, persisted to meta for Join
 	resyncCollectionInfo
 	lock              sync.RWMutex
 	Distributed       bool
@@ -230,7 +230,7 @@ func (r *ResyncManagerDCP) purgeCheckpoints(ctx context.Context, resyncID string
 	)
 }
 
-// setStartOptions stores the options used to start the current run so that Resume can reconstruct them.
+// setStartOptions stores the options used to start the current run so that Join can reconstruct them.
 func (r *ResyncManagerDCP) setStartOptions(options ResyncOptions) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
@@ -822,8 +822,8 @@ type resyncManagerCompletedVBuckets struct {
 type ResyncManagerMeta struct {
 	VBUUIDs       []uint64      `json:"vbuuids"`
 	CollectionIDs []uint32      `json:"collection_ids,omitempty"`
-	EndSeqNos     []uint64      `json:"end_seq_nos"`       // end seq nos, persisted for Resume
-	Options       ResyncOptions `json:"options,omitempty"` // start options, persisted for Resume
+	EndSeqNos     []uint64      `json:"end_seq_nos"`       // end seq nos, persisted for Join
+	Options       ResyncOptions `json:"options,omitempty"` // start options, persisted for Join
 	resyncManagerCompletedVBuckets
 }
 

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -1081,7 +1081,7 @@ func TestResyncManagerDCPWritesV1SyncInfoAtCcv41(t *testing.T) {
 }
 
 // TestResyncManagerOptionsStoredInMeta verifies that the options passed when starting a resync are embedded
-// in the "options" field of the meta returned by GetProcessStatus, so that BackgroundManager.Resume can
+// in the "options" field of the meta returned by GetProcessStatus, so that BackgroundManager.Join can
 // read them back from the status document.
 func TestResyncManagerOptionsStoredInMeta(t *testing.T) {
 	inputCollections := base.CollectionNames{"scope1": []string{"col1", "col2"}}
@@ -1096,7 +1096,7 @@ func TestResyncManagerOptionsStoredInMeta(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, metaBytes)
 
-	// BackgroundManager.Resume reads "options" from the meta subdoc, deserialising into ResyncOptions.
+	// BackgroundManager.Join reads "options" from the meta subdoc, deserialising into ResyncOptions.
 	var metaDoc ResyncManagerMeta
 	require.NoError(t, base.JSONUnmarshal(metaBytes, &metaDoc))
 
@@ -1127,18 +1127,18 @@ func TestResyncDCPInitStoresOptionsInMeta(t *testing.T) {
 
 	var metaDoc ResyncManagerMeta
 	require.NoError(t, base.JSONUnmarshal(metaBytes, &metaDoc))
-	// Verify Init stored the options so that Resume can recover them via the meta subdoc.
+	// Verify Init stored the options so that Join can recover them via the meta subdoc.
 	require.Equal(t, false, metaDoc.Options.RegenerateSequences)
 	require.Equal(t, false, metaDoc.Options.Reset)
 }
 
-// TestResyncManagerDCPResumeRoundTripsOptions verifies that ResyncOptions survive the full serialisation
-// round-trip performed by BackgroundManager.Resume: options are written to the cluster status document by
-// the first manager and then read back into a fresh ResyncManagerDCP via Resume, without ever being passed
+// TestResyncManagerDCPJoinRoundTripsOptions verifies that ResyncOptions survive the full serialisation
+// round-trip performed by BackgroundManager.Join: options are written to the cluster status document by
+// the first manager and then read back into a fresh ResyncManagerDCP via Join, without ever being passed
 // to the second manager's Start call directly.
-func TestResyncManagerDCPResumeRoundTripsOptions(t *testing.T) {
+func TestResyncManagerDCPJoinRoundTripsOptions(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
-	// write documents so that Resume() can be called while mgr is already running
+	// write documents so that Join() can be called while mgr is already running
 	docsToCreate := 500
 	if base.UnitTestUrlIsWalrus() {
 		// rosmar runs too quickly, increase doc count
@@ -1182,17 +1182,17 @@ func TestResyncManagerDCPResumeRoundTripsOptions(t *testing.T) {
 	require.NoError(t, mgr1.Start(ctx, inputOptions))
 	RequireBackgroundManagerState(t, mgr1, BackgroundProcessStateRunning)
 
-	// Flush options into the cluster status document before the second manager calls Resume.
+	// Flush options into the cluster status document before the second manager calls Join.
 	require.NoError(t, mgr1.UpdateStatusClusterAware(ctx))
 
-	// A second manager sharing the same metadata store calls Resume: it must recover inputOptions from the
+	// A second manager sharing the same metadata store calls Join: it must recover inputOptions from the
 	// status document without ever having been given them directly.
-	// Init is called synchronously inside Resume before Run is spawned, so startOptions is already set
-	// by the time Resume returns.
+	// Init is called synchronously inside Join before Run is spawned, so startOptions is already set
+	// by the time Join returns.
 	mgr2 := newMgr()
 	defer func() { _ = mgr2.Stop(ctx) }()
 
-	require.NoError(t, mgr2.Resume(ctx))
+	require.NoError(t, mgr2.Join(ctx))
 
 	// Read startOptions from mgr2's process. The field is unexported but accessible within the package.
 	resync2 := mgr2.Process.(*ResyncManagerDCP)

--- a/db/background_mgr_test.go
+++ b/db/background_mgr_test.go
@@ -281,7 +281,7 @@ func TestBackgroundManagerMultiNodeSimultaneousTransitions(t *testing.T) {
 	}, 15*time.Second, 500*time.Millisecond)
 }
 
-func TestBackgroundManagerStartTimePreservedOnResume(t *testing.T) {
+func TestBackgroundManagerStartTimePreservedOnJoin(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	ctx := context.Background()
 	defer testBucket.Close(ctx)
@@ -505,25 +505,25 @@ func (r *ResumableMockProcess) ReceivedOptions() map[string]any {
 	return r.receivedOptions
 }
 
-// TestBackgroundManagerResume verifies that a second multi-node manager can join an already-running process
-// via Resume, picking up the stored options without being given them explicitly.
-func TestBackgroundManagerResume(t *testing.T) {
+// TestBackgroundManagerJoin verifies that a second multi-node manager can join an already-running process
+// via Join, picking up the stored options without being given them explicitly.
+func TestBackgroundManagerJoin(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	ctx := base.TestCtx(t)
 	defer testBucket.Close(ctx)
 	metadataStore := testBucket.DefaultDataStore(ctx)
-	metaKeys := base.NewMetadataKeys("test-resume")
+	metaKeys := base.NewMetadataKeys("test-join")
 
 	clusterOpts := &ClusterAwareBackgroundManagerOptions{
 		metadataStore: metadataStore,
 		metaKeys:      metaKeys,
-		processSuffix: "resume",
+		processSuffix: "join",
 		multiNode:     true,
 	}
 
 	process := &ResumableMockProcess{}
 	mgr := &BackgroundManager[map[string]any]{
-		name:                "test-resume-mgr",
+		name:                "test-join-mgr",
 		Process:             process,
 		clusterAwareOptions: clusterOpts,
 		terminator:          base.NewSafeTerminator(),
@@ -537,16 +537,16 @@ func TestBackgroundManagerResume(t *testing.T) {
 		assert.Equal(c, BackgroundProcessStateRunning, mgr.GetRunState())
 	}, 5*time.Second, 100*time.Millisecond)
 
-	// While cluster state is running, a second manager sharing the same status document should join via Resume.
+	// While cluster state is running, a second manager sharing the same status document should join via Join.
 	process2 := &ResumableMockProcess{}
 	mgr2 := &BackgroundManager[map[string]any]{
-		name:                "test-resume-mgr2",
+		name:                "test-join-mgr2",
 		Process:             process2,
 		clusterAwareOptions: clusterOpts,
 		terminator:          base.NewSafeTerminator(),
 	}
 
-	require.NoError(t, mgr2.Resume(ctx))
+	require.NoError(t, mgr2.Join(ctx))
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		assert.Equal(c, BackgroundProcessStateRunning, mgr2.GetRunState())
 	}, 5*time.Second, 100*time.Millisecond)
@@ -556,73 +556,73 @@ func TestBackgroundManagerResume(t *testing.T) {
 	require.NoError(t, mgr2.Stop(ctx))
 }
 
-// TestBackgroundManagerResumeNoDoc verifies that Resume returns errBackgroundManagerStatusNotRunning when
+// TestBackgroundManagerJoinNoDoc verifies that Join returns errBackgroundManagerStatusNotRunning when
 // no status document exists (i.e. Start has never been called).
-func TestBackgroundManagerResumeNoDoc(t *testing.T) {
+func TestBackgroundManagerJoinNoDoc(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	ctx := base.TestCtx(t)
 	defer testBucket.Close(ctx)
 	metadataStore := testBucket.DefaultDataStore(ctx)
-	metaKeys := base.NewMetadataKeys("test-resume-no-doc")
+	metaKeys := base.NewMetadataKeys("test-join-no-doc")
 
 	mgr := &BackgroundManager[map[string]any]{
-		name:    "test-resume-no-doc-mgr",
+		name:    "test-join-no-doc-mgr",
 		Process: &ResumableMockProcess{},
 		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
 			metadataStore: metadataStore,
 			metaKeys:      metaKeys,
-			processSuffix: "resume-no-doc",
+			processSuffix: "join-no-doc",
 			multiNode:     true,
 		},
 		terminator: base.NewSafeTerminator(),
 	}
 
-	require.ErrorIs(t, mgr.Resume(ctx), errBackgroundManagerStatusNotRunning)
+	require.ErrorIs(t, mgr.Join(ctx), errBackgroundManagerStatusNotRunning)
 }
 
-// TestBackgroundManagerResumeSingleNodeError verifies that Resume returns an error for single-node managers
-// since Resume is only supported for multi-node background managers.
-func TestBackgroundManagerResumeSingleNodeError(t *testing.T) {
+// TestBackgroundManagerJoinSingleNodeError verifies that Join returns an error for single-node managers
+// since Join is only supported for multi-node background managers.
+func TestBackgroundManagerJoinSingleNodeError(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	ctx := base.TestCtx(t)
 	defer testBucket.Close(ctx)
 	metadataStore := testBucket.DefaultDataStore(ctx)
-	metaKeys := base.NewMetadataKeys("test-resume-single-node")
+	metaKeys := base.NewMetadataKeys("test-join-single-node")
 
 	process := &ResumableMockProcess{}
 	mgr := &BackgroundManager[map[string]any]{
-		name:    "test-resume-single-node-mgr",
+		name:    "test-join-single-node-mgr",
 		Process: process,
 		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
 			metadataStore: metadataStore,
 			metaKeys:      metaKeys,
-			processSuffix: "resume-single-node",
+			processSuffix: "join-single-node",
 			multiNode:     false, // single-node
 		},
 		terminator: base.NewSafeTerminator(),
 	}
 
-	err := mgr.Resume(ctx)
+	err := mgr.Join(ctx)
 	require.Error(t, err)
 }
 
-// TestBackgroundManagerResumeWhileRunning verifies that calling Resume on a multi-node manager that is
+// TestBackgroundManagerJoinWhileRunning verifies that calling Join on a multi-node manager that is
 // already running is idempotent: it returns nil and does not start a second instance of the process.
-func TestBackgroundManagerResumeWhileRunning(t *testing.T) {
+func TestBackgroundManagerJoinWhileRunning(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	ctx := base.TestCtx(t)
 	defer testBucket.Close(ctx)
 	metadataStore := testBucket.DefaultDataStore(ctx)
-	metaKeys := base.NewMetadataKeys("test-resume-running")
+	metaKeys := base.NewMetadataKeys("test-join-running")
 
 	process := &ResumableMockProcess{}
 	mgr := &BackgroundManager[map[string]any]{
-		name:    "test-resume-running-mgr",
+		name:    "test-join-running-mgr",
 		Process: process,
 		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
 			metadataStore: metadataStore,
 			metaKeys:      metaKeys,
-			processSuffix: "resume-running",
+			processSuffix: "join-running",
 			multiNode:     true,
 		},
 		terminator: base.NewSafeTerminator(),
@@ -634,32 +634,32 @@ func TestBackgroundManagerResumeWhileRunning(t *testing.T) {
 		assert.Equal(c, BackgroundProcessStateRunning, mgr.GetRunState())
 	}, 5*time.Second, 100*time.Millisecond)
 
-	// Resume while running is idempotent for multi-node managers.
-	require.NoError(t, mgr.Resume(ctx))
+	// Join while running is idempotent for multi-node managers.
+	require.NoError(t, mgr.Join(ctx))
 	require.Equal(t, BackgroundProcessStateRunning, mgr.GetRunState())
 	require.Equal(t, startOptions, process.ReceivedOptions())
 
 	require.NoError(t, mgr.Stop(ctx))
 }
 
-// TestBackgroundManagerResumeWhenNotRunning verifies that Resume returns errBackgroundManagerStatusNotRunning
-// when the cluster state is not running (e.g., after the process has been stopped).
-func TestBackgroundManagerResumeWhenNotRunning(t *testing.T) {
+// TestBackgroundManagerJoinWhenNotRunning verifies that Join returns nil without starting the local process
+// when the cluster state is a terminal, non-running state (e.g., after the process has been stopped).
+func TestBackgroundManagerJoinWhenNotRunning(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	ctx := base.TestCtx(t)
 	defer testBucket.Close(ctx)
 	metadataStore := testBucket.DefaultDataStore(ctx)
-	metaKeys := base.NewMetadataKeys("test-resume-not-running")
+	metaKeys := base.NewMetadataKeys("test-join-not-running")
 
 	clusterOpts := &ClusterAwareBackgroundManagerOptions{
 		metadataStore: metadataStore,
 		metaKeys:      metaKeys,
-		processSuffix: "resume-not-running",
+		processSuffix: "join-not-running",
 		multiNode:     true,
 	}
 
 	mgr := &BackgroundManager[map[string]any]{
-		name:                "test-resume-not-running-mgr",
+		name:                "test-join-not-running-mgr",
 		Process:             &ResumableMockProcess{},
 		clusterAwareOptions: clusterOpts,
 		terminator:          base.NewSafeTerminator(),
@@ -678,32 +678,32 @@ func TestBackgroundManagerResumeWhenNotRunning(t *testing.T) {
 		assert.Contains(c, []BackgroundProcessState{BackgroundProcessStateStopped, BackgroundProcessStateCompleted}, status.State)
 	}, 5*time.Second, 100*time.Millisecond)
 
-	// Cluster state is now stopped; a second manager must not be able to Resume.
+	// Cluster state is now stopped; a second manager must not be able to Join.
 	mgr2 := &BackgroundManager[map[string]any]{
-		name:                "test-resume-not-running-mgr2",
+		name:                "test-join-not-running-mgr2",
 		Process:             &ResumableMockProcess{},
 		clusterAwareOptions: clusterOpts,
 		terminator:          base.NewSafeTerminator(),
 	}
-	require.NoError(t, mgr2.Resume(ctx))
+	require.NoError(t, mgr2.Join(ctx))
 	mgr2State, err := mgr2.getClusterStatusState(ctx)
 	require.NoError(t, err)
 	require.Equal(t, mgr.GetRunState(), mgr2State)
 }
 
-// TestBackgroundManagerResumeLocalModeError verifies that Resume returns an error for a local-mode manager
-// since Resume is only supported for multi-node background managers.
-func TestBackgroundManagerResumeLocalModeError(t *testing.T) {
+// TestBackgroundManagerJoinLocalModeError verifies that Join returns an error for a local-mode manager
+// since Join is only supported for multi-node background managers.
+func TestBackgroundManagerJoinLocalModeError(t *testing.T) {
 	ctx := base.TestCtx(t)
 	process := &ResumableMockProcess{}
 	mgr := &BackgroundManager[map[string]any]{
-		name:       "test-resume-local-mgr",
+		name:       "test-join-local-mgr",
 		Process:    process,
 		terminator: base.NewSafeTerminator(),
 		// no clusterAwareOptions → local mode
 	}
 
-	err := mgr.Resume(ctx)
+	err := mgr.Join(ctx)
 	require.Error(t, err)
 }
 
@@ -797,25 +797,25 @@ func TestBackgroundManagerUpdateDatabaseStateOnCompletion(t *testing.T) {
 	base.RequireChanRecvWithTimeout(t, calledWithFalse, 5*time.Second)
 }
 
-// TestBackgroundManagerResumeCallsUpdateDatabaseStateWhenNotRunning verifies that Resume calls
+// TestBackgroundManagerJoinCallsUpdateDatabaseStateWhenNotRunning verifies that Join calls
 // updateDatabaseState(false) when the cluster has no status document (not running).
-func TestBackgroundManagerResumeCallsUpdateDatabaseStateWhenNotRunning(t *testing.T) {
+func TestBackgroundManagerJoinCallsUpdateDatabaseStateWhenNotRunning(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	ctx := base.TestCtx(t)
 	defer testBucket.Close(ctx)
 	metadataStore := testBucket.DefaultDataStore(ctx)
-	metaKeys := base.NewMetadataKeys("test-resume-db-state-not-running")
+	metaKeys := base.NewMetadataKeys("test-join-db-state-not-running")
 
 	var dbStateCalls []bool
 	var mu sync.Mutex
 
 	mgr := &BackgroundManager[map[string]any]{
-		name:    "test-resume-db-state-not-running",
+		name:    "test-join-db-state-not-running",
 		Process: &ResumableMockProcess{},
 		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
 			metadataStore: metadataStore,
 			metaKeys:      metaKeys,
-			processSuffix: "resume-db-state-not-running",
+			processSuffix: "join-db-state-not-running",
 			multiNode:     true,
 		},
 		terminator: base.NewSafeTerminator(),
@@ -827,8 +827,8 @@ func TestBackgroundManagerResumeCallsUpdateDatabaseStateWhenNotRunning(t *testin
 		},
 	}
 
-	// No status doc exists → Resume must return errBackgroundManagerStatusNotRunning.
-	err := mgr.Resume(ctx)
+	// No status doc exists → Join must return errBackgroundManagerStatusNotRunning.
+	err := mgr.Join(ctx)
 	require.ErrorIs(t, err, errBackgroundManagerStatusNotRunning)
 
 	mu.Lock()
@@ -836,29 +836,29 @@ func TestBackgroundManagerResumeCallsUpdateDatabaseStateWhenNotRunning(t *testin
 	copy(calls, dbStateCalls)
 	mu.Unlock()
 
-	require.Len(t, calls, 1, "expected exactly one updateDatabaseState call from Resume")
+	require.Len(t, calls, 1, "expected exactly one updateDatabaseState call from Join")
 	require.False(t, calls[0], "expected updateDatabaseState(false) when cluster is not running")
 }
 
-// TestBackgroundManagerResumeCallsUpdateDatabaseStateWhenStopped verifies that Resume calls
+// TestBackgroundManagerJoinCallsUpdateDatabaseStateWhenStopped verifies that Join calls
 // updateDatabaseState(false) when the cluster state is stopped (not running).
-func TestBackgroundManagerResumeCallsUpdateDatabaseStateWhenStopped(t *testing.T) {
+func TestBackgroundManagerJoinCallsUpdateDatabaseStateWhenStopped(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	ctx := base.TestCtx(t)
 	defer testBucket.Close(ctx)
 	metadataStore := testBucket.DefaultDataStore(ctx)
-	metaKeys := base.NewMetadataKeys("test-resume-db-state-stopped")
+	metaKeys := base.NewMetadataKeys("test-join-db-state-stopped")
 
 	clusterOpts := &ClusterAwareBackgroundManagerOptions{
 		metadataStore: metadataStore,
 		metaKeys:      metaKeys,
-		processSuffix: "resume-db-state-stopped",
+		processSuffix: "join-db-state-stopped",
 		multiNode:     true,
 	}
 
 	// Start and then stop a manager so the cluster status doc shows Stopped.
 	starter := &BackgroundManager[map[string]any]{
-		name:                "test-resume-db-state-stopped-starter",
+		name:                "test-join-db-state-stopped-starter",
 		Process:             &ResumableMockProcess{},
 		clusterAwareOptions: clusterOpts,
 		terminator:          base.NewSafeTerminator(),
@@ -880,7 +880,7 @@ func TestBackgroundManagerResumeCallsUpdateDatabaseStateWhenStopped(t *testing.T
 	var dbStateCalls []bool
 	var mu sync.Mutex
 	observer := &BackgroundManager[map[string]any]{
-		name:                "test-resume-db-state-stopped-observer",
+		name:                "test-join-db-state-stopped-observer",
 		Process:             &ResumableMockProcess{},
 		clusterAwareOptions: clusterOpts,
 		terminator:          base.NewSafeTerminator(),
@@ -892,7 +892,7 @@ func TestBackgroundManagerResumeCallsUpdateDatabaseStateWhenStopped(t *testing.T
 		},
 	}
 
-	err := observer.Resume(ctx)
+	err := observer.Join(ctx)
 	require.NoError(t, err)
 
 	mu.Lock()
@@ -1072,35 +1072,35 @@ func TestUpdateDatabaseStateConcurrentManagersSharedStateDoc(t *testing.T) {
 	assertResyncRunningEventually(t, dbStateMgr, false, ctx)
 }
 
-// TestUpdateDatabaseStateResumeOverwritesRunningState exercises a design-level race: a node whose
-// Resume fails (stale cluster state) calls updateDatabaseState(false) and can overwrite the true
+// TestUpdateDatabaseStateJoinOverwritesRunningState exercises a design-level race: a node whose
+// Join fails (stale cluster state) calls updateDatabaseState(false) and can overwrite the true
 // written by a concurrently running node. This verifies that the system eventually self-corrects via
 // the DatabaseStateMgr polling loop.
-func TestUpdateDatabaseStateResumeOverwritesRunningState(t *testing.T) {
+func TestUpdateDatabaseStateJoinOverwritesRunningState(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	ctx := base.TestCtx(t)
 	defer testBucket.Close(ctx)
 	metadataStore := testBucket.DefaultDataStore(ctx)
-	metaKeys := base.NewMetadataKeys("test-resume-overwrite")
+	metaKeys := base.NewMetadataKeys("test-join-overwrite")
 
 	// Manager A is the running node.
-	mgrA, dbStateMgr := newTestManagerWithStateDoc(metadataStore, metaKeys, "resume-overwrite", &ResumableMockProcess{})
+	mgrA, dbStateMgr := newTestManagerWithStateDoc(metadataStore, metaKeys, "join-overwrite", &ResumableMockProcess{})
 	require.NoError(t, mgrA.Start(ctx, nil))
 	defer func() { assert.NoError(t, mgrA.Stop(ctx)) }()
 
 	assertResyncRunningEventually(t, dbStateMgr, true, ctx)
 
-	// Manager B is an observer that has a stale cluster status. We simulate Resume seeing
-	// "not running" by stopping the cluster state doc before B calls Resume.
+	// Manager B is an observer that has a stale cluster status. We simulate Join seeing
+	// "not running" by stopping the cluster state doc before B calls Join.
 	// In practice this can happen when B reads the status doc during a brief window between
 	// an old run completing and a new one starting.
 	mgrB := &BackgroundManager[map[string]any]{
-		name:    "test-resume-overwrite-observer",
+		name:    "test-join-overwrite-observer",
 		Process: &ResumableMockProcess{},
 		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
 			metadataStore: metadataStore,
-			metaKeys:      base.NewMetadataKeys("test-resume-overwrite-stale"), // different key → no status doc
-			processSuffix: "resume-overwrite-stale",
+			metaKeys:      base.NewMetadataKeys("test-join-overwrite-stale"), // different key → no status doc
+			processSuffix: "join-overwrite-stale",
 			multiNode:     true,
 		},
 		terminator: base.NewSafeTerminator(),
@@ -1110,8 +1110,8 @@ func TestUpdateDatabaseStateResumeOverwritesRunningState(t *testing.T) {
 		},
 	}
 
-	// B's Resume will see no cluster status doc → errBackgroundManagerStatusNotRunning → callUpdateDatabaseState(false).
-	err := mgrB.Resume(ctx)
+	// B's Join will see no cluster status doc → errBackgroundManagerStatusNotRunning → callUpdateDatabaseState(false).
+	err := mgrB.Join(ctx)
 	require.ErrorIs(t, err, errBackgroundManagerStatusNotRunning)
 
 	// B wrote false to the shared state doc, even though A is still running.
@@ -1177,18 +1177,18 @@ func TestDatabaseStateMgrIsUpdatedConcurrentWithUpdateState(t *testing.T) {
 	t.Logf("handler fired %d times", handlerFires.Load())
 }
 
-func TestBackgroundManagerResumeConcurrentWhileStopping(t *testing.T) {
+func TestBackgroundManagerJoinConcurrentWhileStopping(t *testing.T) {
 	t.Skip("this test might not be valid pending CBG-5435")
 	testBucket := base.GetTestBucket(t)
 	ctx := base.TestCtx(t)
 	defer testBucket.Close(ctx)
 	metadataStore := testBucket.DefaultDataStore(ctx)
-	metaKeys := base.NewMetadataKeys("test-resume-race")
+	metaKeys := base.NewMetadataKeys("test-join-race")
 
 	clusterOpts := &ClusterAwareBackgroundManagerOptions{
 		metadataStore: metadataStore,
 		metaKeys:      metaKeys,
-		processSuffix: "resume-race",
+		processSuffix: "join-race",
 		multiNode:     true,
 	}
 
@@ -1196,7 +1196,7 @@ func TestBackgroundManagerResumeConcurrentWhileStopping(t *testing.T) {
 
 	// mgr1 is the "originating" node that starts the process and then stops it.
 	mgr1 := &BackgroundManager[map[string]any]{
-		name:                "test-resume-race-mgr1",
+		name:                "test-join-race-mgr1",
 		Process:             &ResumableMockProcess{},
 		clusterAwareOptions: clusterOpts,
 		terminator:          base.NewSafeTerminator(),
@@ -1206,49 +1206,49 @@ func TestBackgroundManagerResumeConcurrentWhileStopping(t *testing.T) {
 		assert.Equal(c, BackgroundProcessStateRunning, mgr1.GetRunState())
 	}, 5*time.Second, 100*time.Millisecond)
 
-	// Ensure the running state is persisted to the cluster so that Resume callers can see it.
+	// Ensure the running state is persisted to the cluster so that Join callers can see it.
 	require.NoError(t, mgr1.UpdateStatusClusterAware(ctx))
 
-	const numResumeCallers = 10
+	const numJoinCallers = 10
 
-	// Build a fleet of managers that will all call Resume concurrently.
-	resumeManagers := make([]*BackgroundManager[map[string]any], numResumeCallers)
-	for i := range numResumeCallers {
-		resumeManagers[i] = &BackgroundManager[map[string]any]{
-			name:                fmt.Sprintf("test-resume-race-caller%d", i),
+	// Build a fleet of managers that will all call Join concurrently.
+	joinManagers := make([]*BackgroundManager[map[string]any], numJoinCallers)
+	for i := range numJoinCallers {
+		joinManagers[i] = &BackgroundManager[map[string]any]{
+			name:                fmt.Sprintf("test-join-race-caller%d", i),
 			Process:             &ResumableMockProcess{},
 			clusterAwareOptions: clusterOpts,
 			terminator:          base.NewSafeTerminator(),
 		}
 	}
 
-	// Use a barrier so all goroutines fire Resume at the same instant that Stop is called.
+	// Use a barrier so all goroutines fire Join at the same instant that Stop is called.
 	var barrier sync.WaitGroup
-	barrier.Add(numResumeCallers + 1) // +1 for the Stop goroutine
+	barrier.Add(numJoinCallers + 1) // +1 for the Stop goroutine
 
-	// resumeErrors[i] holds the error returned by resumeManagers[i].Resume.
-	resumeErrors := make([]error, numResumeCallers)
+	// joinErrors[i] holds the error returned by joinManagers[i].Join.
+	joinErrors := make([]error, numJoinCallers)
 
-	var resumeWG sync.WaitGroup
-	for i := range numResumeCallers {
-		resumeWG.Add(1)
+	var joinWG sync.WaitGroup
+	for i := range numJoinCallers {
+		joinWG.Add(1)
 		go func(i int) {
-			defer resumeWG.Done()
+			defer joinWG.Done()
 			barrier.Done()
 			barrier.Wait()
-			resumeErrors[i] = resumeManagers[i].Resume(ctx)
+			joinErrors[i] = joinManagers[i].Join(ctx)
 		}(i)
 	}
 
-	// Stop mgr1 concurrently with the Resume calls.
+	// Stop mgr1 concurrently with the Join calls.
 	go func() {
 		barrier.Done()
 		barrier.Wait()
 		assert.NoError(t, mgr1.Stop(ctx))
 	}()
 
-	// Wait for all Resume callers to finish before reading their results.
-	resumeWG.Wait()
+	// Wait for all Join callers to finish before reading their results.
+	joinWG.Wait()
 
 	// Wait for mgr1 to reach a terminal state.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -1260,24 +1260,24 @@ func TestBackgroundManagerResumeConcurrentWhileStopping(t *testing.T) {
 		}, state)
 	}, 10*time.Second, 100*time.Millisecond)
 
-	// Stop any resume callers that managed to start running.
-	for i := range numResumeCallers {
-		if resumeErrors[i] == nil {
-			// Resume succeeded → process may be running; stop it.
-			_ = resumeManagers[i].Stop(ctx)
+	// Stop any join callers that managed to start running.
+	for i := range numJoinCallers {
+		if joinErrors[i] == nil {
+			// Join succeeded → process may be running; stop it.
+			_ = joinManagers[i].Stop(ctx)
 		}
 	}
 
-	// Wait for all resume callers that started to reach a terminal state.
+	// Wait for all join callers that started to reach a terminal state.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		for i := range numResumeCallers {
-			if resumeErrors[i] != nil {
-				// Resume returned an error — no goroutine running, nothing to wait for.
+		for i := range numJoinCallers {
+			if joinErrors[i] != nil {
+				// Join returned an error — no goroutine running, nothing to wait for.
 				continue
 			}
-			state := resumeManagers[i].GetRunState()
+			state := joinManagers[i].GetRunState()
 			if state == "" {
-				// Resume returned nil but the process never started: the cluster transitioned
+				// Join returned nil but the process never started: the cluster transitioned
 				// out of "running" before this node called start(). Nothing to wait for.
 				continue
 			}
@@ -1337,26 +1337,26 @@ func (s *statsMockProcess) LastPreviousStatus() []byte {
 	return s.lastPreviousStatus
 }
 
-// TestBackgroundManagerResumePreservesPreviousStatus verifies that when a multi-node manager Resume()s,
+// TestBackgroundManagerJoinPreservesPreviousStatus verifies that when a multi-node manager Join()s,
 // it preserves and passes the previous cluster status to the process GetProcessStatus call,
 // allowing it to merge/preserve stats.
-func TestBackgroundManagerResumePreservesPreviousStatus(t *testing.T) {
+func TestBackgroundManagerJoinPreservesPreviousStatus(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	ctx := base.TestCtx(t)
 	defer testBucket.Close(ctx)
 	metadataStore := testBucket.DefaultDataStore(ctx)
-	metaKeys := base.NewMetadataKeys("test-resume-preserve-status")
+	metaKeys := base.NewMetadataKeys("test-join-preserve-status")
 
 	clusterOpts := &ClusterAwareBackgroundManagerOptions{
 		metadataStore: metadataStore,
 		metaKeys:      metaKeys,
-		processSuffix: "resume-preserve-status",
+		processSuffix: "join-preserve-status",
 		multiNode:     true,
 	}
 
 	process1 := &statsMockProcess{}
 	mgr1 := &BackgroundManager[map[string]any]{
-		name:                "test-resume-mgr1",
+		name:                "test-join-mgr1",
 		Process:             process1,
 		clusterAwareOptions: clusterOpts,
 		terminator:          base.NewSafeTerminator(),
@@ -1370,18 +1370,18 @@ func TestBackgroundManagerResumePreservesPreviousStatus(t *testing.T) {
 
 	process2 := &statsMockProcess{}
 	mgr2 := &BackgroundManager[map[string]any]{
-		name:                "test-resume-mgr2",
+		name:                "test-join-mgr2",
 		Process:             process2,
 		clusterAwareOptions: clusterOpts,
 		terminator:          base.NewSafeTerminator(),
 	}
 
-	require.NoError(t, mgr2.Resume(ctx))
+	require.NoError(t, mgr2.Join(ctx))
 	RequireBackgroundManagerState(t, mgr2, BackgroundProcessStateRunning)
 
 	// Assert that process2 received the previous status in its GetProcessStatus call,
-	// which is required to avoid dropping stats on resume.
-	require.NotEmpty(t, process2.LastPreviousStatus(), "expected previous status to be passed to GetProcessStatus on resume")
+	// which is required to avoid dropping stats on join.
+	require.NotEmpty(t, process2.LastPreviousStatus(), "expected previous status to be passed to GetProcessStatus on join")
 
 	// Ensure we can unmarshal it to verify it actually contains the status.
 	var clusterStatus struct {

--- a/db/database.go
+++ b/db/database.go
@@ -638,11 +638,11 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 	dbContext.ResyncManager = NewResyncManagerDCP(dbContext, distributedResync)
 	dbContext.AsyncIndexInitManager = NewAsyncIndexInitManager(metadataStore, dbContext.MetadataKeys)
 
-	var resumeResync resyncResumeFunc
+	var joinResync resyncJoinFunc
 	if distributedResync {
-		resumeResync = dbContext.ResyncManager.Resume
+		joinResync = dbContext.ResyncManager.Join
 	}
-	dbContext.DBStateManager = NewDatabaseStateMgr(metadataStore, metaKeys.DatabaseStateKey(), resumeResync)
+	dbContext.DBStateManager = NewDatabaseStateMgr(metadataStore, metaKeys.DatabaseStateKey(), joinResync)
 
 	return dbContext, nil
 }

--- a/db/database_state.go
+++ b/db/database_state.go
@@ -17,8 +17,8 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 )
 
-// resyncResumeFunc is a callback function to call to resume a resync process.
-type resyncResumeFunc func(ctx context.Context) error
+// resyncJoinFunc is a callback function to call to join a resync process already running in the cluster.
+type resyncJoinFunc func(ctx context.Context) error
 
 type DatabaseState struct {
 	ResyncRunning *bool `json:"resync,omitempty"`
@@ -29,20 +29,20 @@ type DatabaseStateMgr struct {
 	dbStateID       string
 	metadataStore   base.DataStore
 	pollingInterval time.Duration
-	resumeResync    resyncResumeFunc
+	joinResync      resyncJoinFunc
 	lock            sync.Mutex
 	terminator      chan struct{}
 	done            chan struct{}
 }
 
-// NewDatabaseStateMgr creates a DatabaseStateMgr for the given database. If resumeResync is non-nil, it will be invoked when DatabaseState.ResyncRunning is detected as changed on the bucket.
-func NewDatabaseStateMgr(metadataStore base.DataStore, dbStateID string, resumeResync resyncResumeFunc) *DatabaseStateMgr {
+// NewDatabaseStateMgr creates a DatabaseStateMgr for the given database. If joinResync is non-nil, it will be invoked when DatabaseState.ResyncRunning is detected as changed on the bucket.
+func NewDatabaseStateMgr(metadataStore base.DataStore, dbStateID string, joinResync resyncJoinFunc) *DatabaseStateMgr {
 	return &DatabaseStateMgr{
 		dbStateID:       dbStateID,
 		CAS:             0,
 		metadataStore:   metadataStore,
 		pollingInterval: 10 * time.Second,
-		resumeResync:    resumeResync,
+		joinResync:      joinResync,
 	}
 }
 
@@ -121,11 +121,11 @@ func (dbMgr *DatabaseStateMgr) poll(ctx context.Context) {
 	if !ok {
 		return
 	}
-	if dbMgr.resumeResync != nil {
+	if dbMgr.joinResync != nil {
 		if state.ResyncRunning != nil && *state.ResyncRunning {
-			err := dbMgr.resumeResync(ctx)
+			err := dbMgr.joinResync(ctx)
 			if err != nil {
-				base.WarnfCtx(ctx, "failed to resume resync from DatabaseStateMgr: %v, will try again.", err)
+				base.WarnfCtx(ctx, "failed to join resync from DatabaseStateMgr: %v, will try again.", err)
 				return // leave CAS stale so next tick retries
 			}
 		}

--- a/db/database_state_test.go
+++ b/db/database_state_test.go
@@ -97,7 +97,7 @@ func TestGetState(t *testing.T) {
 }
 
 // TestDatabaseStateMgrPolling verifies StartPolling and StopPolling behaviour:
-// the registered resumeResyncFunc is invoked on CAS changes when ResyncRunning is true, skipped
+// the registered joinResync is invoked on CAS changes when ResyncRunning is true, skipped
 // when the CAS is unchanged, and driven automatically by the polling goroutine.
 func TestDatabaseStateMgrPolling(t *testing.T) {
 	ctx := base.TestCtx(t)
@@ -105,7 +105,7 @@ func TestDatabaseStateMgrPolling(t *testing.T) {
 	defer tBucket.Close(ctx)
 	metadataStore := tBucket.GetMetadataStore()
 
-	t.Run("resumeResyncFunc invoked when doc exists and CAS changed", func(t *testing.T) {
+	t.Run("joinResync invoked when doc exists and CAS changed", func(t *testing.T) {
 		docID := base.NewMetadataKeys(t.Name()).DatabaseStateKey()
 		var callCount atomic.Int32
 		mgr := NewDatabaseStateMgr(metadataStore, docID, func(_ context.Context) error {
@@ -141,8 +141,8 @@ func TestDatabaseStateMgrPolling(t *testing.T) {
 		require.Equal(t, int32(0), callCount.Load())
 	})
 
-	t.Run("retries resumeResyncFunc after transient error", func(t *testing.T) {
-		// Regression: when resumeResyncFunc returns an error the CAS must be reset so
+	t.Run("retries joinResync after transient error", func(t *testing.T) {
+		// Regression: when joinResync returns an error the CAS must be reset so
 		// the next polling tick sees a mismatch and retries, rather than treating
 		// the state change as already handled.
 		docID := base.NewMetadataKeys(t.Name()).DatabaseStateKey()
@@ -169,7 +169,7 @@ func TestDatabaseStateMgrPolling(t *testing.T) {
 	t.Run("StopPolling halts the goroutine", func(t *testing.T) {
 		docID := base.NewMetadataKeys(t.Name()).DatabaseStateKey()
 
-		// Register a resumeResyncFunc that signals a channel on each call.
+		// Register a joinResync that signals a channel on each call.
 		// The select/default prevents blocking if the channel is already full.
 		called := make(chan struct{}, 1)
 		var callCount atomic.Int32
@@ -187,7 +187,7 @@ func TestDatabaseStateMgrPolling(t *testing.T) {
 		mgr.StartPolling(ctx)
 
 		// Write a state document directly via the datastore (bypassing mgr.CAS) so that
-		// the poller sees a CAS mismatch and invokes the resumeResyncFunc.
+		// the poller sees a CAS mismatch and invokes the joinResync.
 		_, err := metadataStore.Update(ctx, docID, 0, func(current []byte) (updated []byte, expiry *uint32, delete bool, err error) {
 			bodyBytes, err := base.JSONMarshal(DatabaseState{ResyncRunning: base.Ptr(true)})
 			if err != nil {
@@ -197,7 +197,7 @@ func TestDatabaseStateMgrPolling(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		// Confirm the goroutine is running by waiting for the resumeResyncFunc to fire.
+		// Confirm the goroutine is running by waiting for the joinResync to fire.
 		base.RequireChanRecvWithTimeout(t, called, 2*time.Second)
 		require.Equal(t, int32(1), callCount.Load(), "expected exactly one callback before stopping")
 
@@ -205,7 +205,7 @@ func TestDatabaseStateMgrPolling(t *testing.T) {
 		mgr.StopPolling(ctx)
 
 		// Write a new state change (ResyncRunning=false) directly to the store. The goroutine
-		// must not invoke resumeResyncFunc because ResyncRunning is false, and it must not run at all
+		// must not invoke joinResync because ResyncRunning is false, and it must not run at all
 		// because the poller has been stopped.
 		_, err = metadataStore.Update(ctx, docID, 0, func(current []byte) (updated []byte, expiry *uint32, delete bool, err error) {
 			bodyBytes, err := base.JSONMarshal(DatabaseState{ResyncRunning: base.Ptr(false)})


### PR DESCRIPTION
CBG-5435 switch names from Resume -> Join

This separates the idea that Join represents one background manager joining a cluster of other background managers running. Resume would be called anytime that a user doesn't invoke `/db/_resync?action=start` - though this is not specific to resync and general to any future BackgroundManagers that are multi node cluster aware.

Add and improve docstrings in BackgroundManager.

