### PR TITLE
CBG-5631 fix TestResyncRegenerateCorruptDocumentSequence

### DIFF
--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -678,17 +678,27 @@ func TestDCPResyncCollectionsStatus(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			rt := rest.NewRestTesterMultipleCollections(t, nil, 3)
+			rt := rest.NewRestTesterMultipleCollections(t, &rest.RestTesterConfig{
+				LeakyBucketConfig: &base.LeakyBucketConfig{},
+			}, 3)
 			defer rt.Close()
 			scopeName := "sg_test_0"
 
-			// create documents in DB to cause resync to take a few seconds
-			for i := range 1000 {
-				resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace1}}/"+fmt.Sprint(i), `{"value":1}`)
+			// All docs on vBucket 0 so a single DCP worker processes them serially, avoiding a
+			// double-close panic from concurrent callback invocations.
+			docKeys := base.VBucket0DocIDs(t, rt.Bucket(), 3)
+			for _, key := range docKeys {
+				resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace1}}/"+key, `{"value":1}`)
 				rest.RequireStatus(t, resp, http.StatusCreated)
 			}
 
 			rt.TakeDbOffline()
+
+			// Pause resync at the first user document so stop arrives while genuinely in-flight,
+			// letting us reliably observe "running" before it completes.
+			pauser := newResyncPauser(rt)
+			defer pauser.Close()
+			pauser.Pause()
 
 			if !testCase.specifyCollection {
 				resp := rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
@@ -698,8 +708,10 @@ func TestDCPResyncCollectionsStatus(t *testing.T) {
 				resp := rt.SendAdminRequest("POST", "/db/_resync?action=start", payload)
 				rest.RequireStatus(t, resp, http.StatusOK)
 			}
+			pauser.WaitUntilBlocked()
 			statusResponse := rt.WaitForResyncDCPStatus(db.BackgroundProcessStateRunning)
 			assert.ElementsMatch(t, statusResponse.CollectionsProcessing[scopeName], testCase.expectedResult[scopeName])
+			pauser.Release()
 
 			statusResponse = rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
 			assert.ElementsMatch(t, statusResponse.CollectionsProcessing[scopeName], testCase.expectedResult[scopeName])
@@ -4285,8 +4297,17 @@ type resyncPauser struct {
 	callbackSet atomic.Bool
 }
 
+// newResyncPauser binds to the first collection (lexicographically, matching {{.keyspace1}}) so it
+// also works against multi-collection databases where GetSingleDataStore doesn't apply.
 func newResyncPauser(rt *rest.RestTester) *resyncPauser {
-	leakyDS, ok := base.AsLeakyDataStore(rt.GetSingleDataStore())
+	collections := rt.GetDbCollections()
+	require.NotEmpty(rt.TB(), collections, "database must have at least one collection")
+	ds, err := rt.GetDatabase().Bucket.NamedDataStore(rt.Context(), base.ScopeAndCollectionName{
+		Scope:      collections[0].ScopeName,
+		Collection: collections[0].Name,
+	})
+	require.NoError(rt.TB(), err)
+	leakyDS, ok := base.AsLeakyDataStore(ds)
 	require.True(rt.TB(), ok, "datastore must be a LeakyDataStore")
 	return &resyncPauser{
 		t:  rt.TB(),

--- a/rest/adminapitest/resync_test.go
+++ b/rest/adminapitest/resync_test.go
@@ -103,11 +103,8 @@ func TestResyncRegenerateSequencesCorruptDocumentSequence(t *testing.T) {
 	rest.RequireStatus(t, response, http.StatusOK)
 	rt.WaitForDBState(db.RunStateString[db.DBOffline])
 
-	// we need to wait for the resync to start and not finish
 	resp := rt.SendAdminRequest("POST", "/{{.db}}/_resync?action=start&regenerate_sequences=true", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
-	_ = rt.WaitForResyncDCPStatus(db.BackgroundProcessStateRunning)
-
 	_ = rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
 
 	collection, ctx := rt.GetSingleTestDatabaseCollection()


### PR DESCRIPTION
CBG-5631 fix TestResyncRegenerateCorruptDocumentSequence

Drop a wait for running status, we do not need to see that it passes through running before completed. If the test runs
quickly, the transition to running might be missed before completion.

Add pauser pattern to TestResyncDCPCollectionsStatus which had a wait for Running before Completed, but in this case it was trying to stop the test.


Original test flake:

```
09:39:03 2026-07-21T06:35:49.377-07:00 [INF] t:TestResyncRegenerateSequencesCorruptDocumentSequence db:db Attachment Migration: Starting new migration run with migration ID: 819bedd6-f4e6-470c-97c9-92dd36b3b448
09:39:03 2026-07-21T06:35:49.380-07:00 [INF] t:TestResyncRegenerateSequencesCorruptDocumentSequence db:db [Migration: 819bedd6-f4e6-470c-97c9-92dd36b3b448] Finished migrating attachment metadata from sync data to global sync data. 0/0 docs changed
09:39:03 2026-07-21T06:35:49.390-07:00 [INF] CRUD: c:#5529 db:db col:sg_test_0 	Doc "<ud>doc0</ud>" / "1-45ca73d819d5b1c9b8eea95290e79004" in channels "{<ud>sg_test_0</ud>}"
09:39:03 2026-07-21T06:35:49.392-07:00 [INF] CRUD: c:#5530 db:db col:sg_test_0 	Doc "<ud>doc1</ud>" / "1-45ca73d819d5b1c9b8eea95290e79004" in channels "{<ud>sg_test_0</ud>}"
09:39:03 2026-07-21T06:35:49.393-07:00 [INF] CRUD: c:#5531 db:db col:sg_test_0 	Doc "<ud>doc2</ud>" / "1-45ca73d819d5b1c9b8eea95290e79004" in channels "{<ud>sg_test_0</ud>}"
09:39:03 2026-07-21T06:35:49.395-07:00 [INF] CRUD: c:#5532 db:db col:sg_test_0 	Doc "<ud>doc3</ud>" / "1-45ca73d819d5b1c9b8eea95290e79004" in channels "{<ud>sg_test_0</ud>}"
09:39:03 2026-07-21T06:35:49.397-07:00 [INF] CRUD: c:#5533 db:db col:sg_test_0 	Doc "<ud>doc4</ud>" / "1-45ca73d819d5b1c9b8eea95290e79004" in channels "{<ud>sg_test_0</ud>}"
09:39:03 2026-07-21T06:35:49.398-07:00 [INF] CRUD: c:#5534 db:db col:sg_test_0 	Doc "<ud>doc5</ud>" / "1-45ca73d819d5b1c9b8eea95290e79004" in channels "{<ud>sg_test_0</ud>}"
09:39:03 2026-07-21T06:35:49.400-07:00 [INF] CRUD: c:#5535 db:db col:sg_test_0 	Doc "<ud>doc6</ud>" / "1-45ca73d819d5b1c9b8eea95290e79004" in channels "{<ud>sg_test_0</ud>}"
09:39:03 2026-07-21T06:35:49.401-07:00 [INF] CRUD: c:#5536 db:db col:sg_test_0 	Doc "<ud>doc7</ud>" / "1-45ca73d819d5b1c9b8eea95290e79004" in channels "{<ud>sg_test_0</ud>}"
09:39:03 2026-07-21T06:35:49.403-07:00 [INF] CRUD: c:#5537 db:db col:sg_test_0 	Doc "<ud>doc8</ud>" / "1-45ca73d819d5b1c9b8eea95290e79004" in channels "{<ud>sg_test_0</ud>}"
09:39:03 2026-07-21T06:35:49.405-07:00 [INF] CRUD: c:#5538 db:db col:sg_test_0 	Doc "<ud>doc9</ud>" / "1-45ca73d819d5b1c9b8eea95290e79004" in channels "{<ud>sg_test_0</ud>}"
09:39:03 2026-07-21T06:35:49.408-07:00 [INF] db:db Closing db /db (bucket "rosmar1")
09:39:03 2026-07-21T06:35:49.422-07:00 [INF] db:db delta_sync enabled=false with rev_max_age_seconds=86400 for database db
09:39:03 2026-07-21T06:35:49.422-07:00 [WRN] db:db Deprecation notice: setting database configuration option "disable_public_all_docs" to false is deprecated. In the future, public access to the all_docs API will be disabled by default. -- rest.dbcOptionsFromConfig() at server_context.go:1597
09:39:03 2026-07-21T06:35:49.422-07:00 [INF] db:db Opening db /db as bucket "rosmar1", pool "default", server <rosmar:/?mode=memory>
09:39:03 2026-07-21T06:35:49.422-07:00 [INF] db:db Opening rosmar database rosmar1 on <rosmar:/?mode=memory>
09:39:03 2026-07-21T06:35:49.422-07:00 [INF] db:db Design docs for current SG view version (2.1) found.
09:39:03 2026-07-21T06:35:49.422-07:00 [INF] db:db Verifying view availability for bucket
09:39:03 2026-07-21T06:35:49.493-07:00 [INF] db:db Views ready for bucket
09:39:03 2026-07-21T06:35:49.494-07:00 [INF] db:db Design docs for current SG view version (2.1) found.
09:39:03 2026-07-21T06:35:49.494-07:00 [INF] db:db Verifying view availability for bucket
09:39:03 2026-07-21T06:35:49.763-07:00 [INF] db:db Views ready for bucket
09:39:03 2026-07-21T06:35:49.766-07:00 [INF] c:CleanAgedItems db:db Created background task: "CleanAgedItems" with interval 1m0s
09:39:03 2026-07-21T06:35:49.767-07:00 [INF] db:db col:sg_test_0 Using default sync function "function(doc){channel(\"sg_test_0\");}" for database db.sg_test_0.sg_test_0
09:39:03 2026-07-21T06:35:50.003-07:00 [INF] c:#5541 db:db Running new resync process with ID: "fc930d26-caca-45df-b603-0cf1397af14c" - no previous run found
09:39:03 2026-07-21T06:35:50.004-07:00 [INF] c:fc930d26-caca-45df-b603-0cf1397af14c db:db running resync against all collections
09:39:03 2026-07-21T06:35:50.004-07:00 [INF] c:fc930d26-caca-45df-b603-0cf1397af14c db:db Starting DCP resync
09:39:03 2026-07-21T06:35:50.019-07:00 [WRN] c:fc930d26-caca-45df-b603-0cf1397af14c db:db col:sg_test_0 Unable to assign a sequence number: Maximum number of sequences to release to catch up with document sequence exceeded -- db.(*DatabaseCollectionWithUser).getResyncedDocument.func1() at database.go:1934
09:39:03 2026-07-21T06:35:50.020-07:00 [INF] c:fc930d26-caca-45df-b603-0cf1397af14c db:db Finished running resync. 10/10 docs changed
09:39:03 2026/07/21 06:35:51 TEST: Memory high water mark increased to 487.09 MB (heap: 485.75 MB stack: 1.34 MB)
09:39:03 2026/07/21 06:35:56 TEST: Memory high water mark increased to 495.05 MB (heap: 493.71 MB stack: 1.34 MB)
09:39:03 2026/07/21 06:36:01 TEST: Memory high water mark increased to 503.12 MB (heap: 501.75 MB stack: 1.38 MB)
09:39:03 2026/07/21 06:36:06 TEST: Memory high water mark increased to 512.02 MB (heap: 510.64 MB stack: 1.38 MB)
09:39:03 2026/07/21 06:36:11 TEST: Memory high water mark increased to 519.87 MB (heap: 518.49 MB stack: 1.38 MB)
09:39:03 2026/07/21 06:36:16 TEST: Memory high water mark increased to 527.74 MB (heap: 526.37 MB stack: 1.38 MB)
09:39:03 2026/07/21 06:36:21 TEST: Memory high water mark increased to 536.27 MB (heap: 534.89 MB stack: 1.38 MB)
09:39:03 2026/07/21 06:36:26 TEST: Memory high water mark increased to 544.21 MB (heap: 542.84 MB stack: 1.38 MB)
09:39:03 2026/07/21 06:36:31 TEST: Memory high water mark increased to 552.90 MB (heap: 551.52 MB stack: 1.38 MB)
09:39:03 2026/07/21 06:36:36 TEST: Memory high water mark increased to 562.25 MB (heap: 560.88 MB stack: 1.38 MB)
09:39:03 2026/07/21 06:36:41 TEST: Memory high water mark increased to 569.83 MB (heap: 568.45 MB stack: 1.38 MB)
09:39:03 2026/07/21 06:36:46 TEST: Memory high water mark increased to 577.93 MB (heap: 576.55 MB stack: 1.38 MB)
09:39:03 2026-07-21T06:36:50.197-07:00 [INF] adminapitest.TestResyncRegenerateSequencesCorruptDocumentSequence: Reset logging
09:39:03 
--- FAIL: TestResyncRegenerateSequencesCorruptDocumentSequence (60.85s)
09:39:03     resync_test.go:109: 
09:39:03         	Error Trace:	/Users/couchbase/workspace/sgw-unix-build/4.2.0/enterprise/sync_gateway/rest/utilities_testing_resttester.go:494
09:39:03         	            				/Users/couchbase/cbdeps/go1.26.5/src/runtime/asm_amd64.s:1771
09:39:03         	Error:      	Not equal: 
09:39:03         	            	expected: "running"
09:39:03         	            	actual  : "completed"
09:39:03         	            	
09:39:03         	            	Diff:
09:39:03         	            	--- Expected
09:39:03         	            	+++ Actual
09:39:03         	            	@@ -1,2 +1,2 @@
09:39:03         	            	-(db.BackgroundProcessState) (len=7) "running"
09:39:03         	            	+(db.BackgroundProcessState) (len=9) "completed"
09:39:03         	            	 
09:39:03     resync_test.go:109: 
09:39:03         	Error Trace:	/Users/couchbase/workspace/sgw-unix-build/4.2.0/enterprise/sync_gateway/rest/utilities_testing_resttester.go:486
09:39:03         	            				/Users/couchbase/workspace/sgw-unix-build/4.2.0/enterprise/sync_gateway/rest/utilities_testing_resttester.go:501
09:39:03         	            				/Users/couchbase/workspace/sgw-unix-build/4.2.0/enterprise/sync_gateway/rest/utilities_testing_resttester.go:460
09:39:03         	            				/Users/couchbase/workspace/sgw-unix-build/4.2.0/enterprise/sync_gateway/rest/adminapitest/resync_test.go:109
09:39:03         	            				/Users/couchbase/cbdeps/go1.26.5/src/runtime/asm_amd64.s:1771
09:39:03         	Error:      	Condition never satisfied
09:39:03         	Test:       	TestResyncRegenerateSequencesCorruptDocumentSequence
09:39:03         	Messages:   	waiting for /{{.db}}/_resync to reach state "running"
```

