### PR TITLE
[3.3.8 only] CBG-5632 do not touch mou unless CBS is 7.6+

### DIFF
--- a/base/collection_xattr.go
+++ b/base/collection_xattr.go
@@ -13,6 +13,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
 
 	"github.com/couchbase/gocb/v2"
 	"github.com/couchbase/gocbcore/v10"
@@ -428,7 +430,7 @@ func (c *Collection) UpdateXattrs(ctx context.Context, k string, exp uint32, cas
 
 func (c *Collection) updateXattrs(ctx context.Context, k string, exp uint32, cas uint64, xattrs map[string][]byte, xattrsToDelete []string, opts *sgbucket.MutateInOptions) (casOut uint64, err error) {
 	if !c.IsSupported(sgbucket.BucketStoreFeatureMultiXattrSubdocOperations) && len(xattrs) >= 2 {
-		return 0, fmt.Errorf("UpdateXattrs: more than 1 xattr %v not supported in UpdateXattrs in this version of Couchbase Server", xattrs)
+		return 0, fmt.Errorf("UpdateXattrs: more than 1 xattr %v not supported in UpdateXattrs in this version of Couchbase Server", slices.Collect(maps.Keys(xattrs)))
 	}
 	if cas == 0 && len(xattrsToDelete) > 0 {
 		return 0, sgbucket.ErrDeleteXattrOnDocumentInsert

--- a/db/crud.go
+++ b/db/crud.go
@@ -336,15 +336,20 @@ func (c *DatabaseCollection) CompactDocChannelHistory(ctx context.Context, docid
 	opts := &sgbucket.MutateInOptions{}
 	// Only update _sync.cas and _mou.cas if the pre-compaction doc had already been imported by SGW
 	opts.MacroExpansion = []sgbucket.MacroExpansionSpec{
-		sgbucket.NewMacroExpansionSpec(xattrCasPath(base.MouXattrName), sgbucket.MacroCas),
 		sgbucket.NewMacroExpansionSpec(xattrCasPath(base.SyncXattrName), sgbucket.MacroCas),
 	}
 	opts.PreserveExpiry = true // if doc has expiry, we should preserve this
 
 	updatedXattr := map[string][]byte{
 		base.SyncXattrName: rawSyncXattr,
-		base.MouXattrName:  rawMouXattr,
 	}
+
+	if c.useMou() {
+		updatedXattr[base.MouXattrName] = rawMouXattr
+		opts.MacroExpansion = append(opts.MacroExpansion,
+			sgbucket.NewMacroExpansionSpec(xattrCasPath(base.MouXattrName), sgbucket.MacroCas))
+	}
+
 	_, err = c.dataStore.UpdateXattrs(ctx, key, 0, cas, updatedXattr, opts)
 	compactedChannelArray := compactedChannels.ToArray()
 	slices.Sort(compactedChannelArray)

--- a/db/crud.go
+++ b/db/crud.go
@@ -2199,13 +2199,15 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 			}
 
 			updatedDoc.IsTombstone = currentRevFromHistory.Deleted
-			if doc.metadataOnlyUpdate != nil {
-				if doc.metadataOnlyUpdate.CAS != "" {
-					updatedDoc.Spec = append(updatedDoc.Spec, sgbucket.NewMacroExpansionSpec(xattrMouCasPath(), sgbucket.MacroCas))
-				}
-			} else {
-				if currentXattrs[base.MouXattrName] != nil && !isNewDocCreation {
-					updatedDoc.XattrsToDelete = append(updatedDoc.XattrsToDelete, base.MouXattrName)
+			if db.useMou() {
+				if doc.metadataOnlyUpdate != nil {
+					if doc.metadataOnlyUpdate.CAS != "" {
+						updatedDoc.Spec = append(updatedDoc.Spec, sgbucket.NewMacroExpansionSpec(xattrMouCasPath(), sgbucket.MacroCas))
+					}
+				} else {
+					if currentXattrs[base.MouXattrName] != nil && !isNewDocCreation {
+						updatedDoc.XattrsToDelete = append(updatedDoc.XattrsToDelete, base.MouXattrName)
+					}
 				}
 			}
 

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -13,8 +13,10 @@ package db
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
+	"maps"
 	"net/http"
 	"sync/atomic"
 	"testing"
@@ -1030,6 +1032,51 @@ func TestMetadataOnlyUpdate(t *testing.T) {
 
 }
 
+// TestFeedImportExistingMouverifies that a feed-triggered import of a document that
+// already has an _mou xattr will work whether or not the backing store supports _mou.
+func TestFeedImportExistingMou(t *testing.T) {
+	if !base.TestUseXattrs() {
+		t.Skip("This test only works with XATTRS enabled")
+	}
+
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyMigrate, base.KeyImport)
+	db, ctx := setupTestDBWithOptionsAndImport(t, nil, DatabaseContextOptions{})
+	defer db.Close(ctx)
+
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+
+	key := t.Name()
+	initialImportCount := db.DbStats.SharedBucketImport().ImportCount.Value()
+
+	startingPCas := "0x1000000000000001"
+	startingMou := &MetadataOnlyUpdate{CAS: "0x1100000000000001", PreviousCAS: startingPCas}
+	writeCas, err := collection.dataStore.WriteWithXattrs(ctx, key, 0, 0, []byte(`{"foo":"bar"}`), map[string][]byte{
+		base.MouXattrName: base.MustJSONMarshal(t, startingMou),
+	}, nil, nil)
+	require.NoError(t, err)
+
+	base.RequireWaitForStat(t, db.DbStats.SharedBucketImport().ImportCount.Value, initialImportCount+1)
+	_, mou, importCas := getSyncAndMou(t, collection, key)
+	require.NotNil(t, mou, "expected _mou xattr to be written by the first import")
+	if collection.dataStore.IsSupported(sgbucket.BucketStoreFeatureMultiXattrSubdocOperations) {
+		require.Equal(t, base.CasToString(writeCas), mou.PreviousCAS)
+	} else {
+		require.Equal(t, startingPCas, mou.PreviousCAS)
+	}
+
+	// Direct bucket write that carries over the existing _mou xattr unchanged (the _sync xattr is
+	// left as-is) alongside a modified body, simulating an external SDK write that will be picked up
+	// by the DCP import feed.
+	_, err = collection.dataStore.WriteWithXattrs(ctx, key, 0, importCas, []byte(`{"foo":"baz"}`), map[string][]byte{
+		base.MouXattrName: base.MustJSONMarshal(t, mou),
+	}, nil, nil)
+	require.NoError(t, err)
+	base.RequireWaitForStat(t, db.DbStats.SharedBucketImport().ImportCount.Value, initialImportCount+2)
+
+	_, mou, _ = getSyncAndMou(t, collection, key)
+	assert.NotNil(t, mou)
+}
+
 func TestImportResurrectionMou(t *testing.T) {
 	if !base.TestUseXattrs() {
 		t.Skip("This test requires xattrs because it relies on import")
@@ -1154,8 +1201,31 @@ func TestImportConflictWithTombstone(t *testing.T) {
 func getSyncAndMou(t *testing.T, collection *DatabaseCollectionWithUser, key string) (syncData *SyncData, mou *MetadataOnlyUpdate, cas uint64) {
 
 	ctx := base.TestCtx(t)
-	xattrs, cas, err := collection.dataStore.GetXattrs(ctx, key, []string{base.SyncXattrName, base.MouXattrName})
-	require.NoError(t, err)
+
+	var xattrs map[string][]byte
+	var err error
+	if collection.dataStore.IsSupported(sgbucket.BucketStoreFeatureMultiXattrSubdocOperations) {
+		xattrs, cas, err = collection.dataStore.GetXattrs(ctx, key, []string{base.SyncXattrName, base.MouXattrName})
+		require.NoError(t, err)
+	} else {
+		// Servers without multi-xattr subdoc support can't fetch _sync and _mou in a single op, so fetch
+		// them individually and confirm the document wasn't mutated between the two fetches.
+		xattrs = make(map[string][]byte, 2)
+		var syncXattrs, mouXattrs map[string][]byte
+		var syncCas, mouCas uint64
+		syncXattrs, syncCas, err = collection.dataStore.GetXattrs(ctx, key, []string{base.SyncXattrName})
+		if !errors.Is(err, base.ErrXattrNotFound) {
+			require.NoError(t, err)
+		}
+		mouXattrs, mouCas, err = collection.dataStore.GetXattrs(ctx, key, []string{base.MouXattrName})
+		if !errors.Is(err, base.ErrXattrNotFound) {
+			require.NoError(t, err)
+		}
+		require.Equal(t, syncCas, mouCas, "cas mismatch between _sync and _mou xattr fetches for key %s", key)
+		cas = syncCas
+		maps.Copy(xattrs, syncXattrs)
+		maps.Copy(xattrs, mouXattrs)
+	}
 
 	if syncXattr, ok := xattrs[base.SyncXattrName]; ok {
 		require.NoError(t, base.JSONUnmarshal(syncXattr, &syncData))

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -1032,7 +1032,7 @@ func TestMetadataOnlyUpdate(t *testing.T) {
 
 }
 
-// TestFeedImportExistingMouverifies that a feed-triggered import of a document that
+// TestFeedImportExistingMou verifies that a feed-triggered import of a document that
 // already has an _mou xattr will work whether or not the backing store supports _mou.
 func TestFeedImportExistingMou(t *testing.T) {
 	if !base.TestUseXattrs() {

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3323,18 +3323,21 @@ func TestCompactNonImportedDocWithAutoImport(t *testing.T) {
 	doc.SyncData = db.SyncData{History: make(db.RevTree)}
 	unmarshalErr := base.JSONUnmarshal(xattrs[base.SyncXattrName], &doc.SyncData)
 	require.NoError(t, unmarshalErr)
-	var mou db.MetadataOnlyUpdate
-	err = base.JSONUnmarshal(xattrs[base.MouXattrName], &mou)
-	require.NoError(t, err)
+	if rt.GetDatabase().EnableMou {
+		var mou db.MetadataOnlyUpdate
+		err = base.JSONUnmarshal(xattrs[base.MouXattrName], &mou)
+		require.NoError(t, err)
 
-	// History should be compacted
-	assert.Less(t, len(doc.SyncData.ChannelSetHistory), len(syncDataBefore.ChannelSetHistory))
-	// sync cas should be equal to doc cas
-	assert.Equal(t, doc.SyncData.Cas, base.CasToString(cas))
-	// verify _mou.cas
-	mouCAS := base.HexCasToUint64(mou.CAS)
-	assert.Equal(t, mouCAS, cas)
-
+		// History should be compacted
+		assert.Less(t, len(doc.SyncData.ChannelSetHistory), len(syncDataBefore.ChannelSetHistory))
+		// sync cas should be equal to doc cas
+		assert.Equal(t, doc.SyncData.Cas, base.CasToString(cas))
+		// verify _mou.cas
+		mouCAS := base.HexCasToUint64(mou.CAS)
+		assert.Equal(t, mouCAS, cas)
+	} else {
+		require.NotContains(t, xattrs, base.MouXattrName)
+	}
 	// Step 10: Verify document is still accessible and intact
 	docFromBucket, _, err := rt.GetSingleDataStore().GetRaw(nonImportedDocID)
 	require.NoError(t, err)


### PR DESCRIPTION
[CBG-5632](https://jira.issues.couchbase.com/browse/CBG-5632) [do not touch mou unless CBS is 7.6+](https://github.com/couchbase/sync_gateway/commit/20463c344b29e880e6e9deee1678808bf6c0e026) 

If an _mou existed on a document (restored from a 7.6 cluster to a 7.2 cluster), then the import of that document would fail

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)

TestDisableXattrs will be fixed in https://github.com/couchbase/sync_gateway/pull/8474

- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/977/ (CBS 7.2.6)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/978/ (CBS 7.6.8)


[CBG-5632]: https://couchbasecloud.atlassian.net/browse/CBG-5632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ