### PR TITLE
[3.3.8 only] CBG-5635 fix TestDisableXattrs

### DIFF
--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -4012,6 +4012,11 @@ func TestDisableXattrs(t *testing.T) {
 
 			dbConfig := rt.NewDbConfig()
 			dbConfig.EnableXattrs = base.Ptr(true)
+			if !persistent {
+				// legacy (non-persistent) config does not inherit bootstrap credentials
+				dbConfig.Username = base.TestClusterUsername()
+				dbConfig.Password = base.TestClusterPassword()
+			}
 
 			rest.RequireStatus(t, rt.CreateDatabase("db1", dbConfig), http.StatusCreated)
 


### PR DESCRIPTION
CBG-5635 fix TestDisableXattrs

This test fails consistently with Couchbase Server, fix the test code to be able to spot regression on 3.3 branch.

