### PR TITLE
CBG-4232 test-only: fix test which races with rosmar

### DIFF
--- a/rest/attachmentcompactiontest/attachment_compaction_api_test.go
+++ b/rest/attachmentcompactiontest/attachment_compaction_api_test.go
@@ -293,11 +293,15 @@ func TestAttachmentCompactionReset(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, db.BackgroundProcessStateStopped, attachmentStatus.State)
 
+	pauser.Pause()
+
 	// Start compaction again but with reset=true --> meaning it shouldn't try to resume
 	resp = rt.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment&reset=true", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
+	pauser.WaitUntilBlocked()
 	status := rt.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateRunning)
 	assert.NotEqual(t, compactID, status.CompactID)
+	pauser.Release()
 
 	// Wait for completion and verify the completed run also carries a different compactID
 	status = rt.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateCompleted)


### PR DESCRIPTION
CBG-4232 test-only: fix test which races with rosmar

Now that this test is enabled for rosmar, fix flake:

```
--- FAIL: TestAttachmentCompactionReset (60.58s)
08:21:23     attachment_compaction_api_test.go:299: 
08:21:23         	Error Trace:	/home/ec2-user/workspace/sgw-unix-build/4.2.0/enterprise/sync_gateway/rest/utilities_testing_resttester.go:494
08:21:23         	            				/home/ec2-user/cbdeps/go1.26.5/src/runtime/asm_arm64.s:1447
08:21:23         	Error:      	Not equal: 
08:21:23         	            	expected: "running"
08:21:23         	            	actual  : "completed"
08:21:23         	            	
08:21:23         	            	Diff:
08:21:23         	            	--- Expected
08:21:23         	            	+++ Actual
08:21:23         	            	@@ -1,2 +1,2 @@
08:21:23         	            	-(db.BackgroundProcessState) (len=7) "running"
08:21:23         	            	+(db.BackgroundProcessState) (len=9) "completed"
08:21:23         	            	 
08:21:23     attachment_compaction_api_test.go:299: 
08:21:23         	Error Trace:	/home/ec2-user/workspace/sgw-unix-build/4.2.0/enterprise/sync_gateway/rest/utilities_testing_resttester.go:486
08:21:23         	            				/home/ec2-user/workspace/sgw-unix-build/4.2.0/enterprise/sync_gateway/rest/utilities_testing_attachment.go:28
08:21:23         	            				/home/ec2-user/workspace/sgw-unix-build/4.2.0/enterprise/sync_gateway/rest/attachmentcompactiontest/attachment_compaction_api_test.go:299
08:21:23         	Error:      	Condition never satisfied
08:21:23         	Test:       	TestAttachmentCompactionReset
08:21:23         	Messages:   	waiting for /{{.db}}/_compact?type=attachment to reach state "running"
```
