### PR TITLE
avoid bot review

### DIFF
--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -38,7 +38,8 @@ jobs:
       ) || (
         github.event_name == 'pull_request' &&
         github.event.pull_request.draft == false &&
-        github.event.pull_request.head.repo.full_name == github.repository
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        github.event.pull_request.user.type != 'Bot'
       )
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
dependabot is not able to do reviews and it doesn't need to https://github.com/couchbase/sync_gateway/actions/runs/30032109744/job/89290912220?pr=8478