### PR TITLE
CBG-5019 test-only: fix flaky revocation replicator tests

### DIFF
--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -1812,43 +1812,21 @@ func TestReplicatorRevocationsMultipleAlternateAccess(t *testing.T) {
 		RequireStatus(t, resp, http.StatusOK)
 		rt2.WaitForPendingChanges()
 
-		err = rt1.WaitForCondition(func() bool {
-			resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docC", "")
-			return resp.Code == http.StatusNotFound
-		})
-		require.NoError(t, err)
+		rt1.WaitForNotFound("docC")
 
 		// Revoke B and ensure docB gets purged from local
 		resp = rt2.SendAdminRequest("PUT", "/db/_role/"+revocationTestRole, GetRolePayload(t, "", rt2ds, []string{"A"}))
 		RequireStatus(t, resp, http.StatusOK)
 
-		err = rt1.WaitForCondition(func() bool {
-			resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docB", "")
-			return resp.Code == http.StatusNotFound
-		})
-		require.NoError(t, err)
+		rt1.WaitForNotFound("docB")
 
 		// Revoke A and ensure docA, docAB, docABC gets purged from local
 		resp = rt2.SendAdminRequest("PUT", "/db/_role/"+revocationTestRole, GetRolePayload(t, "", rt2ds, []string{}))
 		RequireStatus(t, resp, http.StatusOK)
 
-		err = rt1.WaitForCondition(func() bool {
-			resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docA", "")
-			return resp.Code == http.StatusNotFound
-		})
-		require.NoError(t, err)
-
-		err = rt1.WaitForCondition(func() bool {
-			resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docAB", "")
-			return resp.Code == http.StatusNotFound
-		})
-		require.NoError(t, err)
-
-		err = rt1.WaitForCondition(func() bool {
-			resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docABC", "")
-			return resp.Code == http.StatusNotFound
-		})
-		require.NoError(t, err)
+		rt1.WaitForNotFound("docA")
+		rt1.WaitForNotFound("docAB")
+		rt1.WaitForNotFound("docABC")
 	})
 }
 
@@ -1934,23 +1912,11 @@ func TestReplicatorRevocationsWithTombstoneResurrection(t *testing.T) {
 			assert.NoError(t, ar.Stop())
 		}()
 
-		err = rt1.WaitForCondition(func() bool {
-			resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docA", "")
-			return resp.Code == http.StatusNotFound
-		})
-		assert.NoError(t, err)
+		rt1.WaitForNotFound("docA")
 
-		err = rt1.WaitForCondition(func() bool {
-			resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docA1", "")
-			return resp.Code == http.StatusNotFound
-		})
-		assert.NoError(t, err)
+		rt1.WaitForNotFound("docA1")
 
-		err = rt1.WaitForCondition(func() bool {
-			resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docA2", "")
-			return resp.Code == http.StatusNotFound
-		})
-		assert.NoError(t, err)
+		rt1.WaitForNotFound("docA2")
 	})
 }
 
@@ -2032,11 +1998,7 @@ func TestReplicatorRevocationsWithChannelFilter(t *testing.T) {
 
 		require.NoError(t, ar.Start(ctx1))
 
-		err = rt1.WaitForCondition(func() bool {
-			resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docA", "")
-			return resp.Code == http.StatusNotFound
-		})
-		assert.NoError(t, err)
+		rt1.WaitForNotFound("docA")
 	})
 }
 
@@ -2119,23 +2081,11 @@ func TestReplicatorRevocationsWithStarChannel(t *testing.T) {
 
 		require.NoError(t, ar.Start(ctx1))
 
-		err = rt1.WaitForCondition(func() bool {
-			resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docA", "")
-			return resp.Code == http.StatusNotFound
-		})
-		assert.NoError(t, err)
+		rt1.WaitForNotFound("docA")
 
-		err = rt1.WaitForCondition(func() bool {
-			resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docAB", "")
-			return resp.Code == http.StatusNotFound
-		})
-		assert.NoError(t, err)
+		rt1.WaitForNotFound("docAB")
 
-		err = rt1.WaitForCondition(func() bool {
-			resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docABC", "")
-			return resp.Code == http.StatusNotFound
-		})
-		assert.NoError(t, err)
+		rt1.WaitForNotFound("docABC")
 	})
 }
 
@@ -2196,9 +2146,9 @@ func TestReplicatorRevocationsFromZero(t *testing.T) {
 		ar, err := db.NewActiveReplicator(ctx1, activeReplCfg)
 		require.NoError(t, err)
 
-		_ = rt2.PutDoc("docA", `{"channels": ["A"]}`)
-		_ = rt2.PutDoc("docA1", `{"channels": ["A"]}`)
-		_ = rt2.PutDoc("docA2", `{"channels": ["A"]}`)
+		docAVersion := rt2.PutDoc("docA", `{"channels": ["A"]}`)
+		docA1Version := rt2.PutDoc("docA1", `{"channels": ["A"]}`)
+		docA2Version := rt2.PutDoc("docA2", `{"channels": ["A"]}`)
 		rt2.WaitForPendingChanges()
 
 		require.NoError(t, ar.Start(ctx1))
@@ -2208,23 +2158,9 @@ func TestReplicatorRevocationsFromZero(t *testing.T) {
 		rt1.WaitForReplicationStatus(ar.ID, db.ReplicationStateStopped)
 
 		// Be sure docs have arrived
-		err = rt1.WaitForCondition(func() bool {
-			resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docA", "")
-			return resp.Code == http.StatusOK
-		})
-		assert.NoError(t, err)
-
-		err = rt1.WaitForCondition(func() bool {
-			resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docA1", "")
-			return resp.Code == http.StatusOK
-		})
-		assert.NoError(t, err)
-
-		err = rt1.WaitForCondition(func() bool {
-			resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docA2", "")
-			return resp.Code == http.StatusOK
-		})
-		assert.NoError(t, err)
+		sgrRunner.WaitForVersion("docA", rt1, docAVersion)
+		sgrRunner.WaitForVersion("docA1", rt1, docA1Version)
+		sgrRunner.WaitForVersion("docA2", rt1, docA2Version)
 
 		// Reset checkpoint (since 0)
 		require.NoError(t, ar.Reset())
@@ -2237,23 +2173,11 @@ func TestReplicatorRevocationsFromZero(t *testing.T) {
 
 		rt1.WaitForReplicationStatus(ar.ID, db.ReplicationStateStopped)
 
-		err = rt1.WaitForCondition(func() bool {
-			resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docA", "")
-			return resp.Code == http.StatusNotFound
-		})
-		assert.NoError(t, err)
+		rt1.WaitForNotFound("docA")
 
-		err = rt1.WaitForCondition(func() bool {
-			resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docA1", "")
-			return resp.Code == http.StatusNotFound
-		})
-		assert.NoError(t, err)
+		rt1.WaitForNotFound("docA1")
 
-		err = rt1.WaitForCondition(func() bool {
-			resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docA2", "")
-			return resp.Code == http.StatusNotFound
-		})
-		assert.NoError(t, err)
+		rt1.WaitForNotFound("docA2")
 	})
 }
 

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -2026,6 +2026,7 @@ func TestReplicatorRevocationsWithChannelFilter(t *testing.T) {
 		// Revoke A and ensure ABC chanel access and ensure DocA is purged from local
 		resp = rt2.SendAdminRequest("PUT", "/{{.db}}/_user/user", GetUserPayload(t, username, password, "", rt2ds, []string{}, nil))
 		RequireStatus(t, resp, http.StatusOK)
+		rt2.WaitForPendingChanges()
 
 		require.NoError(t, ar.Stop())
 
@@ -2112,6 +2113,7 @@ func TestReplicatorRevocationsWithStarChannel(t *testing.T) {
 		// Revoke A and ensure docA, docAB, docABC get purged from local
 		resp = rt2.SendAdminRequest("PUT", "/db/_user/user", GetUserPayload(t, "user", RestTesterDefaultUserPassword, "", rt2ds, []string{}, nil))
 		RequireStatus(t, resp, http.StatusOK)
+		rt2.WaitForPendingChanges()
 
 		assert.NoError(t, ar.Stop())
 
@@ -2229,6 +2231,7 @@ func TestReplicatorRevocationsFromZero(t *testing.T) {
 
 		resp = rt2.SendAdminRequest("PUT", "/db/_user/user", GetUserPayload(t, "user", "letmein", "", rt2ds, []string{"B"}, nil))
 		RequireStatus(t, resp, http.StatusOK)
+		rt2.WaitForPendingChanges()
 
 		require.NoError(t, ar.Start(ctx1))
 

--- a/rest/utilities_testing_isgr.go
+++ b/rest/utilities_testing_isgr.go
@@ -140,9 +140,10 @@ func (runner *SGRTestRunner) IsV4Protocol() bool {
 	return slices.Contains(runner.SupportedSubprotocols, db.CBMobileReplicationV4.SubprotocolString())
 }
 
+// WaitForVersion will wait for revtree if v3 protocol or full version otherwise.
 func (runner *SGRTestRunner) WaitForVersion(docID string, rt *RestTester, version DocVersion) {
 	rt.TB().Helper()
-	if !slices.Contains(runner.SupportedSubprotocols, db.CBMobileReplicationV4.SubprotocolString()) {
+	if !runner.IsV4Protocol() {
 		// only assert on rev tree IDs when we're not replicating using v4 protocol
 		rt.WaitForVersionRevIDOnly(docID, version)
 		return

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -80,6 +80,15 @@ func (rt *RestTester) GetDoc(docID string) (DocVersion, db.Body) {
 	return DocVersion{RevTreeID: body[db.BodyRev].(string)}, body
 }
 
+// WaitForNotFound waits for a GET request for the given docID to return 404 Not Found.
+func (rt *RestTester) WaitForNotFound(docID string) {
+	rt.TB().Helper()
+	require.EventuallyWithT(rt.TB(), func(c *assert.CollectT) {
+		resp := rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/"+docID, "")
+		assert.Equal(c, http.StatusNotFound, resp.Code, "expected doc %q to be not found, got status %d: %s", docID, resp.Code, resp.Body.String())
+	}, 20*time.Second, 100*time.Millisecond)
+}
+
 // TriggerOnDemandImport will use the REST API to trigger on an demand import via GET. This function intentionally does not check error codes in case the document does not exist or is invalid to be imported.
 func (rt *RestTester) TriggerOnDemandImport(docID string) {
 	_ = rt.SendAdminRequest(http.MethodGet, fmt.Sprintf("/{{.keyspace}}/%s", docID), "")


### PR DESCRIPTION
CBG-5019 test-only: fix flaky revocation replicator tests

Wait for pending changes before restarting one-shot replicators after revoking access, so the run doesn't race the channel cache and miss the revocation.

Replace WaitForCondition loops in revocation tests

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/983/

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>