### PR TITLE
Adopt recent best practices for agent files and move some review items into linters

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,6 @@ Describe your PR here...
 - Use bullet points if there's more than one thing changed
 
 ## Pre-review checklist
-- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
 - [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
 - [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`
 
@@ -13,4 +12,10 @@ Describe your PR here...
 - [ ] Update Go module dependencies when merged
 
 ## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
-- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
+- [ ] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
+
+<!--
+Automated review runs on every non-draft PR raised from this repo (forks are not reviewed automatically).
+  - Re-run it, or ask a follow-up, by commenting `@droid <question>`
+  - Suppress it with the `droid-skip` label, or `WIP`/`DO NOT MERGE` in the title
+-->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,7 +1,5 @@
 When performing a code review, if there are any changes to the REST APIs (e.g. REST handler code, query parameters, structs returned via handler functions), ensure the OpenAPI specifications are updated accordingly in the `docs/api` directory.
 
-When performing a code review, if there is any dev-time logging using `log.Printf`, `fmt.Printf`, or similar, ensure it is removed or replaced with appropriate Sync Gateway logging (e.g. `base.Infof`, `base.Warnf`, `base.Debugf`).
-
 When performing a code review, if a log message includes User Data, ensure the value is wrapped with the `base.UD()` helper function to enable redaction. User Data includes: Document IDs, JSON document contents (keys and values), usernames, email addresses, or other personally identifiable information (PII).
 
 When performing a code review, be mindful of performance implications, such as mutex contention, race conditions, and other concurrency-related issues.
@@ -9,7 +7,5 @@ When performing a code review, be mindful of performance implications, such as m
 When performing a code review, ensure code comments explain the _intent_ or _reasoning_ behind an implementation, rather than just restating what the code does.
 
 When performing a code review, ensure `for` loops have sufficient exit conditions and are not prone to infinite loops. Prefer expressing the exit condition in the loop declaration itself, rather than relying on `break` statements within the loop body.
-
-When performing a code review, make sure context.WithCancelCause is used instead of context.WithCancel.
 
 When performing a code review, flag any new code that gates behavior on whether xattrs are enabled (e.g. `UseXattrs` checks, non-xattr write/read branches, or config plumbing that exposes xattr-mode as a choice). Since Sync Gateway 4.0, xattr mode is the only supported mode on `main`; new code must assume xattrs are enabled. The exception is read-side migration logic that handles pre-existing non-xattr documents already in a bucket — that gradual-migration path must still be preserved, but no new write paths or config surfaces should produce non-xattr data.

--- a/.golangci-strict.yml
+++ b/.golangci-strict.yml
@@ -10,6 +10,7 @@ version: "2"
 linters:
   enable:
     - exhaustive
+    - forbidigo # Forbids identifiers - used here to keep dev-time printing out of shipping code
     - gocritic # The most opinionated Go source code linter
     #- goprintffuncname # Checks that printf-like functions are named with `f` at the end
     #- gosec # Inspects source code for security problems
@@ -32,6 +33,13 @@ linters:
       default-signifies-exhaustive: true
       explicit-exhaustive-map: true
       ignore-enum-members: "(auditdSyncGatewayEndID|levelCount)" # these mark end of an enum
+    forbidigo:
+      # Listed explicitly rather than relying on forbidigo's defaults, which don't cover log.Print*.
+      forbid:
+        - pattern: ^fmt\.Print(f|ln)?$
+          msg: use the context-aware base logging wrappers (base.InfofCtx, base.WarnfCtx, base.DebugfCtx, base.TracefCtx) so log keys and redaction are applied
+        - pattern: ^log\.Print(f|ln)?$
+          msg: use the context-aware base logging wrappers (base.InfofCtx, base.WarnfCtx, base.DebugfCtx, base.TracefCtx) so log keys and redaction are applied
     gocritic:
       enabled-checks:
         - ruleguard
@@ -103,6 +111,11 @@ linters:
       - linters:
           - unused
         path: rest/debug.go
+      # The logging implementation itself, the standalone CLIs under tools/, and tests (which print
+      # diagnostics and generate data) write to stdout by design.
+      - linters:
+          - forbidigo
+        path: (base/logging\.go|base/redactor\.go|^tools/|_test.*\.go)
       - text: "ST1000:" # at least one file in a package should have a package comment
         linters:
           - staticcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - bodyclose # checks whether HTTP response body is closed successfully
     - dupl # Tool for code clone detection
     - exhaustive
+    - forbidigo # Forbids identifiers - used here to keep dev-time printing out of shipping code
     - goconst # Finds repeated strings that could be replaced by a constant
     - gocritic # The most opinionated Go source code linter
     - goprintffuncname # Checks that printf-like functions are named with `f` at the end
@@ -30,6 +31,13 @@ linters:
       default-signifies-exhaustive: true
       explicit-exhaustive-map: true
       ignore-enum-members: "(auditdSyncGatewayEndID|levelCount)" # these mark end of an enum
+    forbidigo:
+      # Listed explicitly rather than relying on forbidigo's defaults, which don't cover log.Print*.
+      forbid:
+        - pattern: ^fmt\.Print(f|ln)?$
+          msg: use the context-aware base logging wrappers (base.InfofCtx, base.WarnfCtx, base.DebugfCtx, base.TracefCtx) so log keys and redaction are applied
+        - pattern: ^log\.Print(f|ln)?$
+          msg: use the context-aware base logging wrappers (base.InfofCtx, base.WarnfCtx, base.DebugfCtx, base.TracefCtx) so log keys and redaction are applied
     gocritic:
       enabled-checks:
         - ruleguard
@@ -52,6 +60,11 @@ linters:
           - govet
         path: (_test.*\.go)
         text: fieldalignment # detect Go structs that would take less memory if their fields were sorted
+      # The logging implementation itself, the standalone CLIs under tools/, and tests (which print
+      # diagnostics and generate data) write to stdout by design.
+      - linters:
+          - forbidigo
+        path: (base/logging\.go|base/redactor\.go|^tools/|_test.*\.go)
       - text:  "missing cases in switch"
         linters:
           - exhaustive

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,12 +4,17 @@ Sync Gateway is a horizontally scalable web server that securely manages access 
 
 ## Build & Test
 
-- Git: `main` branch is the current in-development version. Released versions and backports end up in `release/x.y.z` branches. Feature branches are typically just named `CBG-xxxx` after the Jira ticket.
-- Build: `go build -o bin/sync_gateway .`
-- Building or testing EE (requires private repo SSH access) must use the `cb_sg_enterprise, cb_sg_devmode` build tags for all Go commands. E.g: `go build -tags cb_sg_enterprise,cb_sg_devmode .`
-- Run integration tests (requires local Couchbase Server): `SG_TEST_BACKING_STORE=Couchbase go test ./...`
-- Python tooling lint/typecheck: `uv run ruff check tools/ tools-tests/` and `uv run mypy`
-- Python tests: `uv run pytest`
+```sh
+go build -o bin/sync_gateway .   # Community Edition (default)
+go test ./...                    # unit tests, in-memory Rosmar backing store
+```
+
+- **Enterprise Edition** builds and tests need the `cb_sg_enterprise,cb_sg_devmode` build tags on every Go command, plus SSH access to a private repo — see [docs/BUILD.md](docs/BUILD.md). Don't add these tags unless you specifically intend to test EE.
+- **Integration tests** against a real Couchbase Server, the `SG_TEST_*` environment variables, and the bucket pool are covered in [docs/TESTING.md](docs/TESTING.md).
+- **Python tooling** (`tools/`): `uv run ruff check tools/ tools-tests/`, `uv run mypy`, `uv run pytest`.
+- **Lint**: CI enforces `.golangci-strict.yml`; reproduce it locally with `pre-commit run golangci-lint --all-files`. Some conventions are enforced here rather than written down — the linter message explains the fix.
+
+Git: `main` is the current in-development version. Released versions and backports live in `release/x.y.z` branches. Feature branches are named `CBG-xxxx` after the Jira ticket.
 
 ## Architecture Overview
 
@@ -26,76 +31,30 @@ The entry point is `main.go`, which calls `rest.ServerMain()`. The runtime objec
 - **Caching** — `RevisionCache` (LRU, sharded) + `ChannelCache` (per-channel change feeds).
 - **Database states** — Offline → Starting → Online → Stopping (+ Resyncing).
 - **Configuration** — `StartupConfig` (server-level, file/CLI) vs `DbConfig` (per-database); persistent config stored in Couchbase Server.
+- **Editions** — CE is the default; EE is gated behind the `cb_sg_enterprise` build tag. Edition-specific implementations live in paired `*_ce.go` / `*_ee.go` files.
 
-## Editions: CE vs EE
+## Conventions
 
-Sync Gateway ships two editions controlled by the `cb_sg_enterprise` build tag:
-- **CE** (Community Edition): default, no build tag needed. Files: `*_ce.go`
-- **EE** (Enterprise Edition): `go build -tags cb_sg_enterprise`. Files: `*_ee.go`
+### JSON
 
-Never add the `cb_sg_enterprise` tag to test commands unless intentionally testing EE features.
-
-## Conventions & Patterns
-
-### Go style
-- Use `github.com/stretchr/testify` for assertions (`require` for fatal, `assert` for non-fatal).
-- Use stdlib and base utilities where possible unless a module is already referenced by `go.mod`.
-- JSON marshaling uses `base.JSONMarshal`, `base.JSONUnmarshal`, and `base.JSONDecoder` wrappers — never `encoding/json` directly. (EE builds use `jsoniter` under the hood; CE uses the standard library.)
+Call `base.JSONMarshal`, `base.JSONUnmarshal`, and `base.JSONDecoder` rather than `json.Marshal`, `json.Unmarshal`, and `json.NewDecoder` — EE swaps in `jsoniter` underneath, and direct calls silently bypass that. Importing `encoding/json` for types such as `json.RawMessage` or to implement `json.Marshaler` is fine and common.
 
 ### Logging
-- Use `base.InfofCtx`, `base.WarnfCtx`, `base.DebugfCtx`, `base.TracefCtx` — never `fmt.Printf` or `log.Printf`.
-- Wrap User Data (doc IDs, usernames, PII) with `base.UD()`.
-- Wrap Metadata (db names, config keys) with `base.MD()`.
 
-### Testing patterns
-- Default test backing store is **Rosmar** (in-memory). Set `SG_TEST_BACKING_STORE=Couchbase` for CBS.
-- REST tests use `rest.NewRestTester(t, &RestTesterConfig{...})`.
-- Bucket tests use `base.GetTestBucket(t)`.
-- Tests run with `-shuffle=on` by default.
-- Go tests timeout at 10 minutes per package, but should be increased to 45 minutes if using `SG_TEST_BACKING_STORE=Couchbase`
-- If running more than one test, pipe the test output to a temp file for later analysis and ONLY READ SMALL PARTS OF THIS FILE in the event of a failure, it will be very large! Make sure to clean up the temp log file once you're done with it too.
+Use the context-aware wrappers — `base.InfofCtx`, `base.WarnfCtx`, `base.DebugfCtx`, `base.TracefCtx` — so log keys and redaction are applied. Wrap User Data (doc IDs, document contents, usernames, PII) in `base.UD()` and metadata (db names, config keys) in `base.MD()`. Never log credentials, tokens, or keys. Auth flows are basic auth, session-based auth, and OIDC (`auth/oidc.go`).
+
+### Testing
+
+Rosmar (in-memory) is the default backing store. Assertions use testify — `require` to stop the test, `assert` to continue. REST-level tests use `rest.NewRestTester(t, &rest.RestTesterConfig{...})`; bucket-level tests use `base.GetTestBucket(t)`. Rosmar is not fully feature-compatible with Couchbase Server, so anything leaning on server behaviour (DCP, XDCR, GSI, xattrs, collections) should be exercised in both modes.
 
 ### REST API changes
-- When modifying REST handlers, query parameters, or response schemas, update the OpenAPI specs in `docs/api/`.
 
-### Code review conventions
-- Use `context.WithCancelCause` instead of `context.WithCancel` so cancellation reasons propagate.
-- Prefer expressing loop exit conditions in the `for` declaration itself rather than relying on `break` inside the body; ensure loops have a clear termination condition.
-- Comments should explain *why* / intent, not restate *what* the code does.
-- Watch for concurrency hazards (mutex contention, races) when reviewing.
+Changing a handler, query parameter, or response schema means updating the OpenAPI specs in [docs/api/](docs/api/README.md). `redocly lint` and `yamllint` gate this in both pre-commit and CI.
 
 ### Xattrs are mandatory (SG 4.0+)
-- Xattr mode is the only supported mode on `main`. New code must assume xattrs are enabled — do not add `UseXattrs` checks, non-xattr write/read branches, or config surfaces that let xattr-mode be turned off.
-- The one preserved carve-out is **read-side migration of pre-existing non-xattr documents** already present in a bucket: that gradual-migration path must still work so older data is upgraded on access. No new code paths should *produce* non-xattr data.
-- When touching existing `UseXattrs` checks, prefer simplifying toward the xattrs-on branch and deleting the alternative, unless the code is part of the read/migration path described above.
 
-## Security
+Xattr mode is the only supported mode on `main`. New code must assume xattrs are enabled — do not add `UseXattrs` checks, non-xattr write/read branches, or config surfaces that let xattr mode be turned off.
 
-- NEVER log credentials, tokens, or keys.
-- User Data must be redacted via `base.UD()` in all log output.
-- System/Metadata must use `base.MD()`.
-- Auth flows include basic auth, session-based auth, OIDC (`auth/oidc.go`)
+The one preserved carve-out is **read-side migration of pre-existing non-xattr documents** already in a bucket: that gradual-migration path must keep working so older data is upgraded on access. No new code path should *produce* non-xattr data.
 
-## Test Environment Variables
-
-These variables are read by Go test code via `os.Getenv` and work with `go test`.
-
-**Core configuration:**
-
-| Variable | Purpose | Default |
-|----------|---------|---------|
-| `SG_TEST_BACKING_STORE` | Set to `Couchbase` to test against a real CBS cluster instead of Rosmar | Rosmar (in-memory) |
-| `SG_TEST_COUCHBASE_SERVER_URL` | Couchbase Server URL for integration tests | `couchbase://127.0.0.1` |
-
-**Integration test tuning** (only relevant with `SG_TEST_BACKING_STORE=Couchbase`):
-
-| Variable | Purpose | Default |
-|----------|---------|---------|
-| `SG_TEST_BUCKET_POOL_SIZE` | Number of buckets to pre-create in the test pool. Single tests usually only need one or two buckets and will speed up testing. Leave this as default if running more than one test. | `4` |
-
-## Gotchas
-
-- EE build requires SSH access to `github.com/couchbaselabs/go-fleecedelta` private repo.
-- Integration tests must always force `-count=1 -p 1` (serial execution) to avoid cross-package interference.
-- Rosmar is an in-memory Couchbase bucket simulator used for unit tests; it lives in `github.com/couchbaselabs/rosmar`.
-  - It does not have 100% feature-parity, so any features heavily using Couchbase-Server should be tested in both modes to ensure compatibility.
+When touching an existing `UseXattrs` check, prefer simplifying toward the xattrs-on branch and deleting the alternative, unless the code is part of the read/migration path above.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,10 @@ Use the context-aware wrappers — `base.InfofCtx`, `base.WarnfCtx`, `base.Debug
 
 ### Testing
 
-Rosmar (in-memory) is the default backing store. Assertions use testify — `require` to stop the test, `assert` to continue. REST-level tests use `rest.NewRestTester(t, &rest.RestTesterConfig{...})`; bucket-level tests use `base.GetTestBucket(t)`. Rosmar is not fully feature-compatible with Couchbase Server, so anything leaning on server behaviour (DCP, XDCR, GSI, xattrs, collections) should be exercised in both modes.
+Rosmar (in-memory) is the default backing store.
+Assertions use the wrapper packages `github.com/couchbase/sync_gateway/testing/require` and `github.com/couchbase/sync_gateway/testing/assert` (thin wrappers around testify) — `require` to stop the test, `assert` to continue.
+REST-level tests use `rest.NewRestTester(t, &rest.RestTesterConfig{...})`; bucket-level tests use `base.GetTestBucket(t)`.
+Rosmar is not fully feature-compatible with Couchbase Server, so anything leaning on server behaviour (DCP, XDCR, GSI, xattrs, collections) should be exercised in both modes.
 
 ### REST API changes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,30 +7,13 @@ Sync Gateway is a horizontally scalable web server that securely manages access 
 - Git: `main` branch is the current in-development version. Released versions and backports end up in `release/x.y.z` branches. Feature branches are typically just named `CBG-xxxx` after the Jira ticket.
 - Build: `go build -o bin/sync_gateway .`
 - Building or testing EE (requires private repo SSH access) must use the `cb_sg_enterprise, cb_sg_devmode` build tags for all Go commands. E.g: `go build -tags cb_sg_enterprise,cb_sg_devmode .`
-- Run all unit tests (Rosmar/in-memory, no Couchbase Server): `go test ./...`
-- Run a single test: `go test -run ^TestFunctionName$ github.com/couchbase/sync_gateway/rest`
-- Run a single package: `go test github.com/couchbase/sync_gateway/rest`
 - Run integration tests (requires local Couchbase Server): `SG_TEST_BACKING_STORE=Couchbase go test ./...`
-- Run a specific benchmark: `go test -bench=^BenchmarkSomething$ -run=- ./...`
-- Lint: `golangci-lint run`
 - Python tooling lint/typecheck: `uv run ruff check tools/ tools-tests/` and `uv run mypy`
 - Python tests: `uv run pytest`
 
 ## Architecture Overview
 
 The entry point is `main.go`, which calls `rest.ServerMain()`. The runtime object hierarchy is `ServerContext` → `DatabaseContext` → `DatabaseCollection`. Each HTTP request is handled by a short-lived `handler` struct; BLIP (WebSocket) replication uses `BlipSyncContext`/`blipHandler`. Three listener ports: Public (:4984), Admin (:4985), Metrics (:4986).
-
-| Package | Purpose |
-|---------|---------|
-| `rest/` | REST API handlers, routing (gorilla/mux), config management, server context |
-| `db/` | Core database logic: CRUD, documents, revisions, changes feed, BLIP sync, replication, import |
-| `base/` | Shared utilities: logging, bucket abstraction, stats, DCP, test infrastructure |
-| `auth/` | Authentication: users, roles, sessions, OIDC, JWT |
-| `channels/` | Channel mapping, sync function runner, channel sets |
-| `xdcr/` | Cross-datacenter replication (CBS and Rosmar backends) |
-| `topologytest/` | Multi-actor topology integration tests |
-| `service/` | OS service install/upgrade scripts |
-| `tools/` | Python tooling: `sgcollect.py` (log collection), `password_remover.py` |
 
 ## Key Concepts
 
@@ -44,25 +27,6 @@ The entry point is `main.go`, which calls `rest.ServerMain()`. The runtime objec
 - **Database states** — Offline → Starting → Online → Stopping (+ Resyncing).
 - **Configuration** — `StartupConfig` (server-level, file/CLI) vs `DbConfig` (per-database); persistent config stored in Couchbase Server.
 
-## Key Files
-
-| File | Contents |
-|------|----------|
-| `rest/handler.go` | REST handler struct, privilege levels |
-| `rest/routing.go` | Route registration (Gorilla mux) |
-| `rest/server_context.go` | ServerContext |
-| `rest/config.go` | DbConfig |
-| `rest/config_startup.go` | StartupConfig |
-| `db/database.go` | DatabaseContext, database states |
-| `db/database_collection.go` | DatabaseCollection, DatabaseCollectionWithUser |
-| `db/document.go` | Document, SyncData, revision structures |
-| `db/blip_sync_context.go` | BlipSyncContext (BLIP session) |
-| `db/blip_handler.go` | blipHandler (per-message BLIP handling) |
-| `db/active_replicator.go` | ActiveReplicator (inter-SG replication) |
-| `db/changes.go` | Changes feed |
-| `channels/sync_runner.go` | Sync function execution |
-| `base/dcp_receiver.go` | DCP feed processing |
-
 ## Editions: CE vs EE
 
 Sync Gateway ships two editions controlled by the `cb_sg_enterprise` build tag:
@@ -74,8 +38,6 @@ Never add the `cb_sg_enterprise` tag to test commands unless intentionally testi
 ## Conventions & Patterns
 
 ### Go style
-- Use the Go version declared in `go.mod`. Tabs for indentation (standard `goimports`).
-- 120-char soft line limit (`.editorconfig`).
 - Use `github.com/stretchr/testify` for assertions (`require` for fatal, `assert` for non-fatal).
 - Use stdlib and base utilities where possible unless a module is already referenced by `go.mod`.
 - JSON marshaling uses `base.JSONMarshal`, `base.JSONUnmarshal`, and `base.JSONDecoder` wrappers — never `encoding/json` directly. (EE builds use `jsoniter` under the hood; CE uses the standard library.)
@@ -86,7 +48,6 @@ Never add the `cb_sg_enterprise` tag to test commands unless intentionally testi
 - Wrap Metadata (db names, config keys) with `base.MD()`.
 
 ### Testing patterns
-- Each top-level package has a `main_test.go` with `TestMain` that sets up `TestBucketPool`.
 - Default test backing store is **Rosmar** (in-memory). Set `SG_TEST_BACKING_STORE=Couchbase` for CBS.
 - REST tests use `rest.NewRestTester(t, &RestTesterConfig{...})`.
 - Bucket tests use `base.GetTestBucket(t)`.

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -232,6 +232,7 @@ func TestRetryLoopContextCancellation(t *testing.T) {
 		return true, nil, nil
 	}
 
+	//nolint:gocritic // deliberately covers the causeless cancellation path; TestRetryLoopContextCancellationWithCause covers WithCancelCause
 	ctx, cancelFunc := context.WithCancel(TestCtx(t))
 
 	go func() {

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -16,6 +16,41 @@ go build -o bin/sync_gateway_ce .
 SG_EDITION=CE ./build.sh
 ```
 
+Community and Enterprise Editions
+---------------------------------
+
+Sync Gateway ships two editions, selected by the `cb_sg_enterprise` build tag. Edition-specific
+implementations live in `*_ce.go` and `*_ee.go` files.
+
+**Community Edition (CE)** is the default and needs no build tag:
+
+```bash
+go build -o bin/sync_gateway .
+```
+
+**Enterprise Edition (EE)** requires the `cb_sg_enterprise` and `cb_sg_devmode` tags, and the tags must
+be passed to *every* Go command — `build`, `test`, `vet`:
+
+```bash
+go build -tags cb_sg_enterprise,cb_sg_devmode -o bin/sync_gateway .
+go test -tags cb_sg_enterprise,cb_sg_devmode ./...
+```
+
+EE builds depend on [couchbaselabs/go-fleecedelta](https://github.com/couchbaselabs/go-fleecedelta),
+which is a private repository, so you need SSH access to it. Configure Git to use SSH for those
+fetches and mark the module private:
+
+```bash
+git config --global url.git@github.com:couchbaselabs/go-fleecedelta.insteadOf https://github.com/couchbaselabs/go-fleecedelta
+export GOPRIVATE=github.com/couchbaselabs/go-fleecedelta
+```
+
+This is the same rewrite `build.sh` applies. It is scoped to the one repository rather than
+redirecting every GitHub fetch over SSH.
+
+Do not add `cb_sg_enterprise` to a command unless you specifically intend to build or test EE — CE is
+what runs by default in most CI jobs, and a CE-only regression is easy to miss otherwise.
+
 Building Older Versions (via repo)
 ----------------------------------
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,125 @@
+Testing Sync Gateway
+====================
+
+Sync Gateway's Go tests run against one of two backing stores. Which one you pick changes how long the
+tests take, which features are exercised, and which flags you need.
+
+Backing stores
+--------------
+
+**Rosmar (default)** — an in-memory Couchbase bucket simulator ([couchbaselabs/rosmar](https://github.com/couchbaselabs/rosmar)).
+No external dependencies, fast, and what runs by default:
+
+```sh
+go test ./...
+```
+
+Rosmar does not have 100% feature parity with Couchbase Server. Anything that leans heavily on server
+behaviour — DCP, XDCR, GSI/N1QL queries, xattr semantics, collections — should be tested in both modes
+before you trust it.
+
+**Couchbase Server** — requires a local cluster:
+
+```sh
+SG_TEST_BACKING_STORE=Couchbase go test -count=1 -p 1 -timeout 45m ./...
+```
+
+Three flags matter here and are easy to get wrong:
+
+- `-count=1` disables the test result cache.
+- `-p 1` runs packages serially. Integration tests share a pool of real buckets, so parallel packages
+  interfere with each other.
+- `-timeout 45m` — the default is 10 minutes per package, which is not enough against a real server.
+
+Tests run with `-shuffle=on` by default (see `.github/workflows/ci.yml`), so ordering dependencies
+between tests will surface as intermittent failures.
+
+Capturing output
+----------------
+
+Integration runs produce a lot of output. Redirect it to a file and read only the parts you need:
+
+```sh
+SG_TEST_BACKING_STORE=Couchbase go test -count=1 -p 1 -timeout 45m ./... > /tmp/sg-test.log 2>&1
+grep -n "^--- FAIL\|^FAIL\|^panic:" /tmp/sg-test.log
+```
+
+The bucket pool
+---------------
+
+In integration mode a pool of buckets is created up front and leased to tests as they run
+(`base/main_test_bucket_pool.go`). A test that cannot get a bucket waits
+`waitForReadyBucketTimeout` — **2 minutes** — before failing.
+
+This produces a distinctive symptom: if a batch of tests all fail after almost exactly 120 seconds,
+the problem is usually pool starvation (too few buckets, or buckets held by preserved failures), not
+the tests themselves.
+
+When running a single test, shrinking the pool avoids the cost of preparing buckets you will not use:
+
+```sh
+SG_TEST_BACKING_STORE=Couchbase SG_TEST_BUCKET_POOL_SIZE=1 go test -count=1 -run TestFoo ./db/
+```
+
+Leave `SG_TEST_BUCKET_POOL_SIZE` at its default when running more than one test.
+
+Environment variables
+---------------------
+
+Read via `os.Getenv` by test code, so they work with plain `go test`. Defined in `base/constants.go`,
+`base/main_test_bucket_pool_config.go`, and `testing/sgtest/sgtest.go`.
+
+### Choosing a backing store
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `SG_TEST_BACKING_STORE` | Set to `Couchbase` to test against a real cluster instead of Rosmar | `Walrus` (Rosmar, in-memory) |
+| `SG_TEST_COUCHBASE_SERVER_URL` | Couchbase Server connection string | `couchbase://127.0.0.1` |
+| `SG_TEST_ROSMAR_URL` | Override the Rosmar URL | in-memory |
+| `SG_TEST_USERNAME` | Cluster admin username | `Administrator` |
+| `SG_TEST_PASSWORD` | Cluster admin password | `password` |
+
+### Bucket pool (integration mode only)
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `SG_TEST_BUCKET_POOL_SIZE` | Buckets pre-created for the pool. Set to `1` for single-test runs | `4` |
+| `SG_TEST_COLLECTION_POOL_SIZE` | Collections prepared per bucket | `2` |
+| `SG_TEST_BUCKET_QUOTA_MB` | Memory quota per bucket | `200` |
+| `SG_TEST_BUCKET_NUM_REPLICAS` | Replica count for created buckets | `0` |
+| `SG_TEST_BUCKET_POOL_PRESERVE` | Keep buckets from failed tests for inspection. Preserved buckets leave the pool, so remaining tests are skipped once all are consumed | unset |
+| `SG_TEST_BUCKET_POOL_DEBUG` | Verbose logging from the pooling framework | unset |
+| `SG_TEST_USE_EXISTING_BUCKET` | Use a named existing bucket instead of the pool (single bucket only) | unset |
+| `SG_TEST_SKIP_SERVER_VERSION_CHECK` | Allow running against an unsupported server version | unset |
+
+### Feature toggles
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `SG_TEST_USE_GSI` | Set `false` to use views instead of GSI | `true` |
+| `SG_TEST_USE_DEFAULT_COLLECTION` | Run against `_default._default` rather than named collections | unset |
+| `SG_TEST_USE_SYSTEM_METADATA_COLLECTION` | Store SG metadata in `_system._mobile` | `false` |
+| `SG_TEST_DISABLE_REV_CACHE` | Disable the revision cache | unset |
+| `SG_TEST_TLS_SKIP_VERIFY` | Skip TLS certificate verification | `true` |
+| `SG_TEST_USE_AUTH_HANDLER` | Use an auth handler | unset |
+
+### Diagnostics
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `SG_TEST_LOG_LEVEL` | Global log level for all tests | unset |
+| `SG_TEST_GOROUTINE_DUMP` | Capture a goroutine pprof profile at the end of each package and log its location | unset |
+| `SG_TEST_PROFILE_FREQUENCY` | Capture pprof profiles at this interval | unset |
+
+Enterprise Edition
+------------------
+
+EE tests need build tags. See [BUILD.md](BUILD.md).
+
+Writing tests
+-------------
+
+- Assertions use [testify](https://github.com/stretchr/testify): `require` to stop the test, `assert` to
+  continue.
+- REST-level tests use `rest.NewRestTester(t, &rest.RestTesterConfig{...})`.
+- Bucket-level tests use `base.GetTestBucket(t)`.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -119,7 +119,7 @@ EE tests need build tags. See [BUILD.md](BUILD.md).
 Writing tests
 -------------
 
-- Assertions use [testify](https://github.com/stretchr/testify): `require` to stop the test, `assert` to
+- Assertions use the wrapper packages `github.com/couchbase/sync_gateway/testing/require` and `github.com/couchbase/sync_gateway/testing/assert` (thin wrappers around [testify](https://github.com/stretchr/testify)): `require` to stop the test, `assert` to
   continue.
 - REST-level tests use `rest.NewRestTester(t, &rest.RestTesterConfig{...})`.
 - Bucket-level tests use `base.GetTestBucket(t)`.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -4,14 +4,26 @@ This directory contains the OpenAPI specs for the Sync Gateway REST API.
 
 The recommended tool to work with these specs is [Redocly](https://redoc.ly/).
 
-## Preview
+The specs are split across `paths/`, `components/`, and per-audience roots (`admin.yaml`,
+`public.yaml`, `metric.yaml`, `diagnostic.yaml`, and their `-capella` variants). Which roots are
+linted, and the decorators applied to each, are declared in `.redocly.yaml` at the repository root.
 
-```sh
-$ redocly preview-docs
-```
+Changing a REST handler, a query parameter, or a response schema means updating these specs.
 
 ## Linting
 
+Validates every API root defined in `.redocly.yaml`:
+
 ```sh
-$ redocly lint
+$ npx --yes @redocly/cli@2 lint --config=.redocly.yaml --format=stylish
+```
+
+This is wired into both the `redocly-lint` pre-commit hook (which fires on any change under
+`docs/api/` or to `.redocly.yaml`) and the `openapi` CI workflow, so it usually runs without you
+invoking it directly. `yamllint` also runs over this directory in both places.
+
+## Preview
+
+```sh
+$ npx --yes @redocly/cli@2 preview-docs --config=.redocly.yaml
 ```

--- a/rest/config.go
+++ b/rest/config.go
@@ -1598,7 +1598,7 @@ func SetupServerContext(ctx context.Context, config *StartupConfig, persistentCo
 		if err := config.SetupAndValidateLogging(ctx); err != nil {
 			// If we didn't set up logging correctly, we *probably* can't log via normal means...
 			// as a best-effort, last-ditch attempt, we'll log to stderr as well.
-			log.Printf("[ERR] Error setting up logging: %v", err)
+			log.Printf("[ERR] Error setting up logging: %v", err) //nolint:forbidigo // the base loggers are what just failed to initialise
 			return nil, fmt.Errorf("error setting up logging: %v", err)
 		}
 		base.FlushLoggerBuffers()

--- a/ruleguard/rules-withcancel.go
+++ b/ruleguard/rules-withcancel.go
@@ -1,0 +1,27 @@
+// Copyright 2026-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+//go:build ruleguard
+// +build ruleguard
+
+//nolint:unused // functions in here are invoked by ruleguard, but aren't imported/used by anything Go can detect.
+package ruleguard
+
+import (
+	"github.com/quasilyte/go-ruleguard/dsl"
+)
+
+// withcancel finds uses of context.WithCancel. WithCancelCause carries a reason through to
+// ctx.Err()/context.Cause(), which is what makes a cancelled operation diagnosable from a log line.
+// Deliberate exceptions (e.g. testing the causeless cancellation path) should carry a //nolint:gocritic
+// with the reason.
+func withcancel(m dsl.Matcher) {
+	m.
+		Match(`context.WithCancel($ctx)`).
+		Report("use context.WithCancelCause instead of context.WithCancel, so the cancellation reason propagates")
+}

--- a/ruleguard/withcancel_test.go
+++ b/ruleguard/withcancel_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+//go:build ruleguard
+// +build ruleguard
+
+//nolint:unused // ruleguard test file
+package ruleguard_test
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// should have 4 valid usages and 3 invalid usages when ruleguard is run on this file/function
+func testwithcancel() {
+	ctx := context.Background()
+
+	// ok
+	ctx1, cancel1 := context.WithCancelCause(ctx)
+	cancel1(errors.New("done"))
+	_ = ctx1
+	ctx2, cancel2 := context.WithTimeout(ctx, 0)
+	cancel2()
+	_ = ctx2
+	ctx3, cancel3 := context.WithDeadlineCause(ctx, time.Now(), errors.New("expired"))
+	cancel3()
+	_ = ctx3
+	_ = context.WithoutCancel(ctx)
+
+	// invalid
+	ctx4, cancel4 := context.WithCancel(ctx)
+	cancel4()
+	_ = ctx4
+	ctx5, cancel5 := context.WithCancel(context.TODO())
+	cancel5()
+	_ = ctx5
+	ctx6, cancel6 := context.WithCancel(derive(ctx))
+	cancel6()
+	_ = ctx6
+}
+
+func derive(ctx context.Context) context.Context { return ctx }


### PR DESCRIPTION
- Move some review guidance into linters (printf-style debugging, context without cause)
- `/doctor` to cleanup AGENTS.md from cheaply/easily discoverable information prone to misdirect for unrelated tasks
- Restructure AGENTS.md to be progressive (i.e. point to other more specific instructions in `./docs`) as per Claude best-practices
- Clean up PR template