### PR TITLE
CBG-5655 Fix premature termination on transient heartbeat write errors

### DIFF
--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -161,6 +161,10 @@ type LeakyBucketConfig struct {
 	// TouchCallback issues a callback during touch.
 	TouchCallback func(key string) error
 
+	// GetAndTouchRawCallback issues a callback prior to running GetAndTouchRaw. Useful for injecting
+	// transient errors, e.g. to simulate a heartbeat write failure.
+	GetAndTouchRawCallback func(key string) error
+
 	// AddCallback issues a callback during Add.
 	AddCallback func(key string) (bool, error)
 
@@ -235,6 +239,18 @@ func (b *LeakyBucket) getAddCallback() func(string) (bool, error) {
 	b.configLock.RLock()
 	defer b.configLock.RUnlock()
 	return b._config.AddCallback
+}
+
+func (b *LeakyBucket) getGetAndTouchRawCallback() func(string) error {
+	b.configLock.RLock()
+	defer b.configLock.RUnlock()
+	return b._config.GetAndTouchRawCallback
+}
+
+func (b *LeakyBucket) setGetAndTouchRawCallback(fn func(string) error) {
+	b.configLock.Lock()
+	defer b.configLock.Unlock()
+	b._config.GetAndTouchRawCallback = fn
 }
 
 func (b *LeakyBucket) getForceErrorSetRawKeys() []string {

--- a/base/leaky_datastore.go
+++ b/base/leaky_datastore.go
@@ -98,6 +98,10 @@ func (lds *LeakyDataStore) SetGetWithXattrCallback(callback func(string) error) 
 	lds.bucket.setWithXattrCallback(callback)
 }
 
+func (lds *LeakyDataStore) SetGetAndTouchRawCallback(callback func(string) error) {
+	lds.bucket.setGetAndTouchRawCallback(callback)
+}
+
 func (lds *LeakyDataStore) GetRaw(ctx context.Context, k string) (v []byte, cas uint64, err error) {
 	if cb := lds.bucket.getRawCallback(); cb != nil {
 		if err = cb(k); err != nil {
@@ -117,6 +121,11 @@ func (lds *LeakyDataStore) GetWithXattrs(ctx context.Context, k string, xattrKey
 }
 
 func (lds *LeakyDataStore) GetAndTouchRaw(ctx context.Context, k string, exp uint32) (v []byte, cas uint64, err error) {
+	if cb := lds.bucket.getGetAndTouchRawCallback(); cb != nil {
+		if err := cb(k); err != nil {
+			return nil, 0, err
+		}
+	}
 	return lds.dataStore.GetAndTouchRaw(ctx, k, exp)
 }
 func (lds *LeakyDataStore) Touch(ctx context.Context, k string, exp uint32) (cas uint64, err error) {

--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -809,7 +809,7 @@ func (b *BackgroundManager[O]) UpdateHeartbeatDocClusterAware(ctx context.Contex
 		// If we've hit an error, and we haven't had a successful heartbeat in just under its TTL then we need to quit
 		// out. If we fail to write heartbeat for this time we can no longer ensure that this would be the only process
 		// running and another could end up starting.
-		if time.Now().Sub(time.Unix(b.clusterAwareOptions.lastSuccessfulHeartbeatUnix.Value(), 0)) > (BackgroundManagerHeartbeatExpirySecs - BackgroundManagerHeartbeatIntervalSecs) {
+		if time.Since(time.Unix(b.clusterAwareOptions.lastSuccessfulHeartbeatUnix.Value(), 0)) > (BackgroundManagerHeartbeatExpirySecs-BackgroundManagerHeartbeatIntervalSecs)*time.Second {
 			return err
 		}
 		return nil

--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -393,6 +393,8 @@ func (b *BackgroundManager[O]) markStart(ctx context.Context, previousStatus Bac
 		// We need to instantiate these before we setup the below goroutine as it relies upon the terminator
 		b.terminator = base.NewSafeTerminator()
 
+		b.clusterAwareOptions.lastSuccessfulHeartbeatUnix.Set(time.Now().Unix())
+
 		go func(terminator *base.SafeTerminator) {
 			ticker := time.NewTicker(BackgroundManagerHeartbeatIntervalSecs * time.Second)
 			for {

--- a/db/background_mgr_test.go
+++ b/db/background_mgr_test.go
@@ -1538,49 +1538,81 @@ func TestUpdateStatusClusterAware(t *testing.T) {
 // time comfortably exceeds 29 nanoseconds, a single transient heartbeat write error is treated as if the
 // ~29 second grace period had already elapsed, and the error is propagated (causing the caller to call
 // SetError and terminate the background process) instead of being tolerated.
+//
+// The two subtests differ in how the manager reaches the "just had a successful heartbeat" precondition:
+// "already running" sets lastSuccessfulHeartbeatUnix directly, while "startup" goes through mgr.Start, which
+// exercises markStart recording its own heartbeat-doc write as the initial success (lastSuccessfulHeartbeatUnix
+// otherwise defaults to zero, so a transient error on the very first tick after Start would look like ~56
+// years had passed since the last success).
 func TestUpdateHeartbeatDocClusterAwareTransientError(t *testing.T) {
-	testBucket := base.GetTestBucket(t)
-	ctx := base.TestCtx(t)
-
-	metaKeys := base.NewMetadataKeys("test-heartbeat-transient-error")
-	processSuffix := "heartbeat-transient-error"
-	heartbeatDocID := metaKeys.BackgroundProcessHeartbeatPrefix(processSuffix)
-
-	var injectError atomic.Bool
-	injectError.Store(true)
-	leakyBucket := testBucket.LeakyBucketClone(base.LeakyBucketConfig{
-		GetAndTouchRawCallback: func(key string) error {
-			if key == heartbeatDocID && injectError.Load() {
-				return fmt.Errorf("injected transient heartbeat write error")
-			}
-			return nil
+	tests := []struct {
+		name string
+		// setup gets the manager into a state where a heartbeat has just succeeded, before the injected error
+		// is armed.
+		setup func(t *testing.T, ctx context.Context, mgr *BackgroundManager[map[string]any], metadataStore base.DataStore, heartbeatDocID string)
+	}{
+		{
+			name: "already running",
+			setup: func(t *testing.T, ctx context.Context, mgr *BackgroundManager[map[string]any], metadataStore base.DataStore, heartbeatDocID string) {
+				// Write the heartbeat doc up front, as markStart would, so a heartbeat update that isn't
+				// intercepted by the injected error can succeed for real against the underlying bucket.
+				require.NoError(t, metadataStore.SetRaw(ctx, heartbeatDocID, BackgroundManagerHeartbeatExpirySecs, nil, []byte("{}")))
+				mgr.terminator = base.NewSafeTerminator()
+				mgr.clusterAwareOptions.lastSuccessfulHeartbeatUnix.Set(time.Now().Unix())
+			},
 		},
-	})
-	defer leakyBucket.Close(ctx)
-	metadataStore := leakyBucket.DefaultDataStore(ctx)
-
-	// Write the heartbeat doc up front, as markStart would, so a heartbeat update that isn't intercepted by
-	// the injected error above can succeed for real against the underlying bucket.
-	require.NoError(t, metadataStore.SetRaw(ctx, heartbeatDocID, BackgroundManagerHeartbeatExpirySecs, nil, []byte("{}")))
-
-	mgr := &BackgroundManager[map[string]any]{
-		name:    "test-heartbeat-transient-error-mgr",
-		Process: &MockProcess{},
-		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
-			metadataStore: metadataStore,
-			metaKeys:      metaKeys,
-			processSuffix: processSuffix,
+		{
+			name: "startup",
+			setup: func(t *testing.T, ctx context.Context, mgr *BackgroundManager[map[string]any], metadataStore base.DataStore, heartbeatDocID string) {
+				// Start performs the real (uninjected) WriteCas that writes the heartbeat doc for the first
+				// time; this must count as the most recent successful heartbeat even though
+				// UpdateHeartbeatDocClusterAware itself has not yet been called.
+				require.NoError(t, mgr.Start(ctx, map[string]any{}))
+				t.Cleanup(func() { _ = mgr.Stop(ctx) })
+			},
 		},
-		terminator: base.NewSafeTerminator(),
 	}
 
-	// Simulate a heartbeat that succeeded moments ago, well within the ~29 second grace period.
-	mgr.clusterAwareOptions.lastSuccessfulHeartbeatUnix.Set(time.Now().Unix())
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			testBucket := base.GetTestBucket(t)
+			ctx := base.TestCtx(t)
 
-	err := mgr.UpdateHeartbeatDocClusterAware(ctx)
-	require.NoError(t, err, "a transient heartbeat write error should be tolerated within the grace period")
+			metaKeys := base.NewMetadataKeys("test-heartbeat-transient-error")
+			processSuffix := "heartbeat-transient-error"
+			heartbeatDocID := metaKeys.BackgroundProcessHeartbeatPrefix(processSuffix)
 
-	// Once the injected error clears, the next heartbeat should succeed for real and record a new success time.
-	injectError.Store(false)
-	require.NoError(t, mgr.UpdateHeartbeatDocClusterAware(ctx))
+			var injectError atomic.Bool
+			leakyBucket := testBucket.LeakyBucketClone(base.LeakyBucketConfig{
+				GetAndTouchRawCallback: func(key string) error {
+					if key == heartbeatDocID && injectError.Load() {
+						return fmt.Errorf("injected transient heartbeat write error")
+					}
+					return nil
+				},
+			})
+			defer leakyBucket.Close(ctx)
+			metadataStore := leakyBucket.DefaultDataStore(ctx)
+
+			mgr := &BackgroundManager[map[string]any]{
+				name:    "test-heartbeat-transient-error-mgr",
+				Process: &MockProcess{},
+				clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
+					metadataStore: metadataStore,
+					metaKeys:      metaKeys,
+					processSuffix: processSuffix,
+				},
+			}
+
+			test.setup(t, ctx, mgr, metadataStore, heartbeatDocID)
+
+			injectError.Store(true)
+			err := mgr.UpdateHeartbeatDocClusterAware(ctx)
+			require.NoError(t, err, "a transient heartbeat write error should be tolerated within the grace period")
+
+			// Once the injected error clears, the next heartbeat should succeed for real and record a new success time.
+			injectError.Store(false)
+			require.NoError(t, mgr.UpdateHeartbeatDocClusterAware(ctx))
+		})
+	}
 }

--- a/db/background_mgr_test.go
+++ b/db/background_mgr_test.go
@@ -1530,3 +1530,57 @@ func TestUpdateStatusClusterAware(t *testing.T) {
 		})
 	}
 }
+
+// TestUpdateHeartbeatDocClusterAwareTransientError reproduces a bug in UpdateHeartbeatDocClusterAware: the
+// grace-period check compares an elapsed time.Duration (nanoseconds) against
+// (BackgroundManagerHeartbeatExpirySecs - BackgroundManagerHeartbeatIntervalSecs), which is an untyped
+// constant representing *seconds* (29) that is never multiplied by time.Second. Since any measurable elapsed
+// time comfortably exceeds 29 nanoseconds, a single transient heartbeat write error is treated as if the
+// ~29 second grace period had already elapsed, and the error is propagated (causing the caller to call
+// SetError and terminate the background process) instead of being tolerated.
+func TestUpdateHeartbeatDocClusterAwareTransientError(t *testing.T) {
+	testBucket := base.GetTestBucket(t)
+	ctx := base.TestCtx(t)
+
+	metaKeys := base.NewMetadataKeys("test-heartbeat-transient-error")
+	processSuffix := "heartbeat-transient-error"
+	heartbeatDocID := metaKeys.BackgroundProcessHeartbeatPrefix(processSuffix)
+
+	var injectError atomic.Bool
+	injectError.Store(true)
+	leakyBucket := testBucket.LeakyBucketClone(base.LeakyBucketConfig{
+		GetAndTouchRawCallback: func(key string) error {
+			if key == heartbeatDocID && injectError.Load() {
+				return fmt.Errorf("injected transient heartbeat write error")
+			}
+			return nil
+		},
+	})
+	defer leakyBucket.Close(ctx)
+	metadataStore := leakyBucket.DefaultDataStore(ctx)
+
+	// Write the heartbeat doc up front, as markStart would, so a heartbeat update that isn't intercepted by
+	// the injected error above can succeed for real against the underlying bucket.
+	require.NoError(t, metadataStore.SetRaw(ctx, heartbeatDocID, BackgroundManagerHeartbeatExpirySecs, nil, []byte("{}")))
+
+	mgr := &BackgroundManager[map[string]any]{
+		name:    "test-heartbeat-transient-error-mgr",
+		Process: &MockProcess{},
+		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
+			metadataStore: metadataStore,
+			metaKeys:      metaKeys,
+			processSuffix: processSuffix,
+		},
+		terminator: base.NewSafeTerminator(),
+	}
+
+	// Simulate a heartbeat that succeeded moments ago, well within the ~29 second grace period.
+	mgr.clusterAwareOptions.lastSuccessfulHeartbeatUnix.Set(time.Now().Unix())
+
+	err := mgr.UpdateHeartbeatDocClusterAware(ctx)
+	require.NoError(t, err, "a transient heartbeat write error should be tolerated within the grace period")
+
+	// Once the injected error clears, the next heartbeat should succeed for real and record a new success time.
+	injectError.Store(false)
+	require.NoError(t, mgr.UpdateHeartbeatDocClusterAware(ctx))
+}


### PR DESCRIPTION
CBG-5655 Fix premature termination on transient heartbeat write errors

The BackgroundManager running a process writes heartbeat documents every 1s in a ticker loop. If any of those writes failed, then the whole background manager process would abort. I suspect errors could occur like a circuit breaker flip, overload, momentary network outage.

I don't believe this was the intention but rather: UpdateHeartbeatDocClusterAware compared an elapsed time.Duration (nanoseconds) against BackgroundManagerHeartbeatExpirySecs - BackgroundManagerHeartbeatIntervalSecs (29), an untyped constant representing seconds that was never converted with * time.Second. Go converts the untyped constant to Duration(29ns) for the comparison, so any measurable elapsed time already exceeded the intended ~29s grace period.

Add a GetAndTouchRawCallback hook to LeakyBucket/LeakyDataStore so tests can inject errors into heartbeat touches, and add a regression test that reproduces the bug directly against
UpdateHeartbeatDocClusterAware.

As an alternate approach, we could just remove this if statement and return - there is probably already a retry built in for all idempotent kv ops via the global gocb RetryStrategy that is going to be 10-30s, and this bug has existed for a long time and removing this call would just make the code as it exists. It is probably impossible to ever hit the 29ns window.

## Pre-review checklist
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/1003/
