### PR TITLE
CBG-5653 switch backgroundmanager options to strong types

### DIFF
--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -161,6 +161,10 @@ type LeakyBucketConfig struct {
 	// TouchCallback issues a callback during touch.
 	TouchCallback func(key string) error
 
+	// GetAndTouchRawCallback issues a callback prior to running GetAndTouchRaw. Useful for injecting
+	// transient errors, e.g. to simulate a heartbeat write failure.
+	GetAndTouchRawCallback func(key string) error
+
 	// AddCallback issues a callback during Add.
 	AddCallback func(key string) (bool, error)
 
@@ -235,6 +239,18 @@ func (b *LeakyBucket) getAddCallback() func(string) (bool, error) {
 	b.configLock.RLock()
 	defer b.configLock.RUnlock()
 	return b._config.AddCallback
+}
+
+func (b *LeakyBucket) getGetAndTouchRawCallback() func(string) error {
+	b.configLock.RLock()
+	defer b.configLock.RUnlock()
+	return b._config.GetAndTouchRawCallback
+}
+
+func (b *LeakyBucket) setGetAndTouchRawCallback(fn func(string) error) {
+	b.configLock.Lock()
+	defer b.configLock.Unlock()
+	b._config.GetAndTouchRawCallback = fn
 }
 
 func (b *LeakyBucket) getForceErrorSetRawKeys() []string {

--- a/base/leaky_datastore.go
+++ b/base/leaky_datastore.go
@@ -98,6 +98,10 @@ func (lds *LeakyDataStore) SetGetWithXattrCallback(callback func(string) error) 
 	lds.bucket.setWithXattrCallback(callback)
 }
 
+func (lds *LeakyDataStore) SetGetAndTouchRawCallback(callback func(string) error) {
+	lds.bucket.setGetAndTouchRawCallback(callback)
+}
+
 func (lds *LeakyDataStore) GetRaw(ctx context.Context, k string) (v []byte, cas uint64, err error) {
 	if cb := lds.bucket.getRawCallback(); cb != nil {
 		if err = cb(k); err != nil {
@@ -117,6 +121,11 @@ func (lds *LeakyDataStore) GetWithXattrs(ctx context.Context, k string, xattrKey
 }
 
 func (lds *LeakyDataStore) GetAndTouchRaw(ctx context.Context, k string, exp uint32) (v []byte, cas uint64, err error) {
+	if cb := lds.bucket.getGetAndTouchRawCallback(); cb != nil {
+		if err := cb(k); err != nil {
+			return nil, 0, err
+		}
+	}
 	return lds.dataStore.GetAndTouchRaw(ctx, k, exp)
 }
 func (lds *LeakyDataStore) Touch(ctx context.Context, k string, exp uint32) (cas uint64, err error) {

--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -809,7 +809,7 @@ func (b *BackgroundManager[O]) UpdateHeartbeatDocClusterAware(ctx context.Contex
 		// If we've hit an error, and we haven't had a successful heartbeat in just under its TTL then we need to quit
 		// out. If we fail to write heartbeat for this time we can no longer ensure that this would be the only process
 		// running and another could end up starting.
-		if time.Now().Sub(time.Unix(b.clusterAwareOptions.lastSuccessfulHeartbeatUnix.Value(), 0)) > (BackgroundManagerHeartbeatExpirySecs - BackgroundManagerHeartbeatIntervalSecs) {
+		if time.Since(time.Unix(b.clusterAwareOptions.lastSuccessfulHeartbeatUnix.Value(), 0)) > (BackgroundManagerHeartbeatExpirySecs-BackgroundManagerHeartbeatIntervalSecs)*time.Second {
 			return err
 		}
 		return nil

--- a/db/background_mgr_test.go
+++ b/db/background_mgr_test.go
@@ -1530,3 +1530,57 @@ func TestUpdateStatusClusterAware(t *testing.T) {
 		})
 	}
 }
+
+// TestUpdateHeartbeatDocClusterAwareTransientError reproduces a bug in UpdateHeartbeatDocClusterAware: the
+// grace-period check compares an elapsed time.Duration (nanoseconds) against
+// (BackgroundManagerHeartbeatExpirySecs - BackgroundManagerHeartbeatIntervalSecs), which is an untyped
+// constant representing *seconds* (29) that is never multiplied by time.Second. Since any measurable elapsed
+// time comfortably exceeds 29 nanoseconds, a single transient heartbeat write error is treated as if the
+// ~29 second grace period had already elapsed, and the error is propagated (causing the caller to call
+// SetError and terminate the background process) instead of being tolerated.
+func TestUpdateHeartbeatDocClusterAwareTransientError(t *testing.T) {
+	testBucket := base.GetTestBucket(t)
+	ctx := base.TestCtx(t)
+
+	metaKeys := base.NewMetadataKeys("test-heartbeat-transient-error")
+	processSuffix := "heartbeat-transient-error"
+	heartbeatDocID := metaKeys.BackgroundProcessHeartbeatPrefix(processSuffix)
+
+	var injectError atomic.Bool
+	injectError.Store(true)
+	leakyBucket := testBucket.LeakyBucketClone(base.LeakyBucketConfig{
+		GetAndTouchRawCallback: func(key string) error {
+			if key == heartbeatDocID && injectError.Load() {
+				return fmt.Errorf("injected transient heartbeat write error")
+			}
+			return nil
+		},
+	})
+	defer leakyBucket.Close(ctx)
+	metadataStore := leakyBucket.DefaultDataStore(ctx)
+
+	// Write the heartbeat doc up front, as markStart would, so a heartbeat update that isn't intercepted by
+	// the injected error above can succeed for real against the underlying bucket.
+	require.NoError(t, metadataStore.SetRaw(ctx, heartbeatDocID, BackgroundManagerHeartbeatExpirySecs, nil, []byte("{}")))
+
+	mgr := &BackgroundManager[map[string]any]{
+		name:    "test-heartbeat-transient-error-mgr",
+		Process: &MockProcess{},
+		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
+			metadataStore: metadataStore,
+			metaKeys:      metaKeys,
+			processSuffix: processSuffix,
+		},
+		terminator: base.NewSafeTerminator(),
+	}
+
+	// Simulate a heartbeat that succeeded moments ago, well within the ~29 second grace period.
+	mgr.clusterAwareOptions.lastSuccessfulHeartbeatUnix.Set(time.Now().Unix())
+
+	err := mgr.UpdateHeartbeatDocClusterAware(ctx)
+	require.NoError(t, err, "a transient heartbeat write error should be tolerated within the grace period")
+
+	// Once the injected error clears, the next heartbeat should succeed for real and record a new success time.
+	injectError.Store(false)
+	require.NoError(t, mgr.UpdateHeartbeatDocClusterAware(ctx))
+}


### PR DESCRIPTION
CBG-5653 switch backgroundmanager options to strong types

I am about to make a slight change to some attachment compaction code to fix a race condition in a place that called `AttachmentCompactionManager.Init` and wrote a bug where the values of the map were not checked and it caused a runtime panic.

Background Manager only started support generic types in Sync Gateway 4.1 

I would have liked to remove `Database` as an option which is odd and pass `Database` as part of constructing the BackgroundManager but that's more work. The only reason I could imagine this existed was because the Database is scoped to the requesting user's database - but given that these are admin api only endpoints it might make sense to have a different  function that is `AdminDatabase(*DatabaseContext) *Database` which could be used on these background managers. This is well out of scope though.

## Pre-review checklist
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/

<!--
Automated review runs on every non-draft PR raised from this repo (forks are not reviewed automatically).
  - Re-run it, or ask a follow-up, by commenting `@droid <question>`
  - Suppress it with the `droid-skip` label, or `WIP`/`DO NOT MERGE` in the title
-->
