### PR TITLE
CBG-5653 switch backgroundmanager options to strong types

### DIFF
--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -433,8 +433,7 @@ func TestAttachmentCompactionRunTwice(t *testing.T) {
 	// Kick off another run with an attempted start from the other node, checks for error on other node
 	cb3 := runFunctionStartedCallbackFunc(func(_ context.Context, _ AttachmentCompactionOptions, _ updateStatusCallbackFunc, _ *base.SafeTerminator) {
 		err := testDB2.AttachmentCompactionManager.Start(ctx2, AttachmentCompactionOptions{Database: testDB2})
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "Process already running")
+		assert.ErrorContains(t, err, "Process already running")
 	})
 	testDB1.AttachmentCompactionManager.Process.(*AttachmentCompactionManager).runFunctionStartedCallback.Store(&cb3)
 	err = testDB1.AttachmentCompactionManager.Start(ctx1, AttachmentCompactionOptions{Database: testDB1})
@@ -519,7 +518,7 @@ func TestAttachmentCompactionStopImmediateStart(t *testing.T) {
 	// get a 'process already running' error
 	if err != nil {
 		err = testDB2.AttachmentCompactionManager.Start(ctx2, AttachmentCompactionOptions{Database: testDB2})
-		assert.NotContains(t, err.Error(), "Process already running")
+		assert.ErrorContains(t, err, "Process already running")
 	}
 }
 

--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -518,7 +518,8 @@ func TestAttachmentCompactionStopImmediateStart(t *testing.T) {
 	// get a 'process already running' error
 	if err != nil {
 		err = testDB2.AttachmentCompactionManager.Start(ctx2, AttachmentCompactionOptions{Database: testDB2})
-		assert.ErrorContains(t, err, "Process already running")
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), "Process already running")
 	}
 }
 

--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -292,7 +292,7 @@ func TestAttachmentCleanupRollback(t *testing.T) {
 	})
 
 	terminator := base.NewSafeTerminator()
-	err = testDb.AttachmentCompactionManager.Process.Run(ctx, map[string]any{"database": testDb}, testDb.AttachmentCompactionManager.UpdateStatusClusterAware, terminator)
+	err = testDb.AttachmentCompactionManager.Process.Run(ctx, AttachmentCompactionOptions{Database: testDb}, testDb.AttachmentCompactionManager.UpdateStatusClusterAware, terminator)
 	require.NoError(t, err)
 
 	RequireBackgroundManagerState(t, testDb.AttachmentCompactionManager, BackgroundProcessStateCompleted)
@@ -389,11 +389,11 @@ func TestAttachmentCompactionRunTwice(t *testing.T) {
 	var err error
 
 	// Trigger start with immediate abort. Then resume, ensure that dry run is resumed
-	cb1 := runFunctionStartedCallbackFunc(func(_ context.Context, _ map[string]any, _ updateStatusCallbackFunc, terminator *base.SafeTerminator) {
+	cb1 := runFunctionStartedCallbackFunc(func(_ context.Context, _ AttachmentCompactionOptions, _ updateStatusCallbackFunc, terminator *base.SafeTerminator) {
 		<-terminator.Done()
 	})
 	testDB2.AttachmentCompactionManager.Process.(*AttachmentCompactionManager).runFunctionStartedCallback.Store(&cb1)
-	err = testDB2.AttachmentCompactionManager.Start(ctx2, map[string]any{"database": testDB2, "dryRun": true})
+	err = testDB2.AttachmentCompactionManager.Start(ctx2, AttachmentCompactionOptions{Database: testDB2, DryRun: true})
 	assert.NoError(t, err)
 	err = testDB2.AttachmentCompactionManager.Stop(ctx2)
 	assert.NoError(t, err)
@@ -407,7 +407,7 @@ func TestAttachmentCompactionRunTwice(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, testStatus.DryRun)
 
-	err = testDB2.AttachmentCompactionManager.Start(ctx2, map[string]any{"database": testDB2, "dryRun": false})
+	err = testDB2.AttachmentCompactionManager.Start(ctx2, AttachmentCompactionOptions{Database: testDB2, DryRun: false})
 	assert.NoError(t, err)
 
 	RequireBackgroundManagerState(t, testDB2.AttachmentCompactionManager, BackgroundProcessStateCompleted)
@@ -419,11 +419,11 @@ func TestAttachmentCompactionRunTwice(t *testing.T) {
 	assert.True(t, testStatus.DryRun)
 
 	// Trigger start with immediate stop (stopped from db2)
-	cb2 := runFunctionStartedCallbackFunc(func(_ context.Context, _ map[string]any, _ updateStatusCallbackFunc, terminator *base.SafeTerminator) {
+	cb2 := runFunctionStartedCallbackFunc(func(_ context.Context, _ AttachmentCompactionOptions, _ updateStatusCallbackFunc, terminator *base.SafeTerminator) {
 		<-terminator.Done()
 	})
 	testDB1.AttachmentCompactionManager.Process.(*AttachmentCompactionManager).runFunctionStartedCallback.Store(&cb2)
-	err = testDB1.AttachmentCompactionManager.Start(ctx1, map[string]any{"database": testDB1})
+	err = testDB1.AttachmentCompactionManager.Start(ctx1, AttachmentCompactionOptions{Database: testDB1})
 	assert.NoError(t, err)
 	err = testDB2.AttachmentCompactionManager.Stop(ctx2)
 	assert.NoError(t, err)
@@ -431,13 +431,13 @@ func TestAttachmentCompactionRunTwice(t *testing.T) {
 	RequireBackgroundManagerState(t, testDB1.AttachmentCompactionManager, BackgroundProcessStateStopped)
 
 	// Kick off another run with an attempted start from the other node, checks for error on other node
-	cb3 := runFunctionStartedCallbackFunc(func(_ context.Context, _ map[string]any, _ updateStatusCallbackFunc, _ *base.SafeTerminator) {
-		err := testDB2.AttachmentCompactionManager.Start(ctx2, map[string]any{"database": testDB2})
+	cb3 := runFunctionStartedCallbackFunc(func(_ context.Context, _ AttachmentCompactionOptions, _ updateStatusCallbackFunc, _ *base.SafeTerminator) {
+		err := testDB2.AttachmentCompactionManager.Start(ctx2, AttachmentCompactionOptions{Database: testDB2})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "Process already running")
 	})
 	testDB1.AttachmentCompactionManager.Process.(*AttachmentCompactionManager).runFunctionStartedCallback.Store(&cb3)
-	err = testDB1.AttachmentCompactionManager.Start(ctx1, map[string]any{"database": testDB1})
+	err = testDB1.AttachmentCompactionManager.Start(ctx1, AttachmentCompactionOptions{Database: testDB1})
 	assert.NoError(t, err)
 
 	RequireBackgroundManagerState(t, testDB1.AttachmentCompactionManager, BackgroundProcessStateCompleted)
@@ -474,11 +474,11 @@ func TestAttachmentCompactionStopImmediateStart(t *testing.T) {
 	var err error
 
 	// Trigger start with immediate abort. Then resume, ensure that dry run is resumed
-	stopCb1 := runFunctionStartedCallbackFunc(func(_ context.Context, _ map[string]any, _ updateStatusCallbackFunc, terminator *base.SafeTerminator) {
+	stopCb1 := runFunctionStartedCallbackFunc(func(_ context.Context, _ AttachmentCompactionOptions, _ updateStatusCallbackFunc, terminator *base.SafeTerminator) {
 		<-terminator.Done()
 	})
 	testDB2.AttachmentCompactionManager.Process.(*AttachmentCompactionManager).runFunctionStartedCallback.Store(&stopCb1)
-	err = testDB2.AttachmentCompactionManager.Start(ctx2, map[string]any{"database": testDB2, "dryRun": true})
+	err = testDB2.AttachmentCompactionManager.Start(ctx2, AttachmentCompactionOptions{Database: testDB2, DryRun: true})
 	assert.NoError(t, err)
 	err = testDB2.AttachmentCompactionManager.Stop(ctx2)
 	assert.NoError(t, err)
@@ -492,7 +492,7 @@ func TestAttachmentCompactionStopImmediateStart(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, testStatus.DryRun)
 
-	err = testDB2.AttachmentCompactionManager.Start(ctx2, map[string]any{"database": testDB2, "dryRun": false})
+	err = testDB2.AttachmentCompactionManager.Start(ctx2, AttachmentCompactionOptions{Database: testDB2, DryRun: false})
 	assert.NoError(t, err)
 
 	RequireBackgroundManagerState(t, testDB2.AttachmentCompactionManager, BackgroundProcessStateCompleted)
@@ -504,21 +504,21 @@ func TestAttachmentCompactionStopImmediateStart(t *testing.T) {
 	assert.True(t, testStatus.DryRun)
 
 	// Trigger start with immediate stop (stopped from db2)
-	stopCb2 := runFunctionStartedCallbackFunc(func(_ context.Context, _ map[string]any, _ updateStatusCallbackFunc, terminator *base.SafeTerminator) {
+	stopCb2 := runFunctionStartedCallbackFunc(func(_ context.Context, _ AttachmentCompactionOptions, _ updateStatusCallbackFunc, terminator *base.SafeTerminator) {
 		<-terminator.Done()
 	})
 	testDB1.AttachmentCompactionManager.Process.(*AttachmentCompactionManager).runFunctionStartedCallback.Store(&stopCb2)
-	err = testDB1.AttachmentCompactionManager.Start(ctx1, map[string]any{"database": testDB1})
+	err = testDB1.AttachmentCompactionManager.Start(ctx1, AttachmentCompactionOptions{Database: testDB1})
 	assert.NoError(t, err)
 	err = testDB2.AttachmentCompactionManager.Stop(ctx2)
 	assert.NoError(t, err)
 
 	// Kick off another run with an attempted start, verify we don't get 'process already running' error
-	err = testDB1.AttachmentCompactionManager.Start(ctx1, map[string]any{"database": testDB1})
+	err = testDB1.AttachmentCompactionManager.Start(ctx1, AttachmentCompactionOptions{Database: testDB1})
 	// Hitting this error may be racy (depending on when heartbeat is polled from previous stop), but we should never
 	// get a 'process already running' error
 	if err != nil {
-		err = testDB2.AttachmentCompactionManager.Start(ctx2, map[string]any{"database": testDB2})
+		err = testDB2.AttachmentCompactionManager.Start(ctx2, AttachmentCompactionOptions{Database: testDB2})
 		assert.NotContains(t, err.Error(), "Process already running")
 	}
 }
@@ -537,7 +537,7 @@ func TestAttachmentProcessError(t *testing.T) {
 	collection, ctx1 := GetSingleDatabaseCollectionWithUser(ctx1, t, testDB1)
 	CreateLegacyAttachmentDoc(t, ctx1, collection, "docID", []byte("{}"), "attKey", []byte("{}"))
 
-	err := testDB1.AttachmentCompactionManager.Start(ctx1, map[string]any{"database": testDB1})
+	err := testDB1.AttachmentCompactionManager.Start(ctx1, AttachmentCompactionOptions{Database: testDB1})
 	assert.NoError(t, err)
 
 	RequireBackgroundManagerState(t, testDB1.AttachmentCompactionManager, BackgroundProcessStateError)

--- a/db/background_mgr_async_index_init.go
+++ b/db/background_mgr_async_index_init.go
@@ -10,6 +10,7 @@ package db
 
 import (
 	"context"
+	"errors"
 	"sync"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -32,8 +33,23 @@ type AsyncIndexInitOptions struct {
 	DoneChan chan error
 }
 
+// Validate returns an error if the options are not usable by Init/Run.
+func (o AsyncIndexInitOptions) Validate() error {
+	if o.StatusMap == nil {
+		return errors.New("async index init requires a StatusMap")
+	}
+	if o.DoneChan == nil {
+		return errors.New("async index init requires a DoneChan")
+	}
+	return nil
+}
+
 // Init is called synchronously to set up a run for the background manager process. See Run() for the async part.
 func (a *AsyncIndexInitManager) Init(ctx context.Context, options AsyncIndexInitOptions, clusterStatus []byte) (backgroundManagerInitMode, error) {
+	if err := options.Validate(); err != nil {
+		return backgroundManagerInitReset, err
+	}
+
 	a.lock.Lock()
 	defer a.lock.Unlock()
 	a._statusMap = options.StatusMap
@@ -43,6 +59,10 @@ func (a *AsyncIndexInitManager) Init(ctx context.Context, options AsyncIndexInit
 
 // Run is called inside a goroutine to perform the job of the job. This function should block until the job is complete.
 func (a *AsyncIndexInitManager) Run(ctx context.Context, options AsyncIndexInitOptions, persistClusterStatusCallback updateStatusCallbackFunc, terminator *base.SafeTerminator) error {
+	if err := options.Validate(); err != nil {
+		return err
+	}
+
 	a.lock.Lock()
 	doneChan := a._doneChan
 	a.lock.Unlock()

--- a/db/background_mgr_async_index_init.go
+++ b/db/background_mgr_async_index_init.go
@@ -24,17 +24,25 @@ type AsyncIndexInitManager struct {
 	_doneChan  chan error               // _doneChan is a DatabaseInitManager worker's done channel. Here to allow Run to block until complete.
 }
 
+// AsyncIndexInitOptions defines the options passed when starting an asynchronous index initialization process.
+type AsyncIndexInitOptions struct {
+	// StatusMap provides a reference to the structure tracking index status per collection.
+	StatusMap *IndexStatusByCollection
+	// DoneChan receives the completion status/error from the index initialization task.
+	DoneChan chan error
+}
+
 // Init is called synchronously to set up a run for the background manager process. See Run() for the async part.
-func (a *AsyncIndexInitManager) Init(ctx context.Context, options map[string]any, clusterStatus []byte) (backgroundManagerInitMode, error) {
+func (a *AsyncIndexInitManager) Init(ctx context.Context, options AsyncIndexInitOptions, clusterStatus []byte) (backgroundManagerInitMode, error) {
 	a.lock.Lock()
 	defer a.lock.Unlock()
-	a._statusMap = options["statusMap"].(*IndexStatusByCollection)
-	a._doneChan = options["doneChan"].(chan error)
+	a._statusMap = options.StatusMap
+	a._doneChan = options.DoneChan
 	return backgroundManagerInitReset, nil
 }
 
 // Run is called inside a goroutine to perform the job of the job. This function should block until the job is complete.
-func (a *AsyncIndexInitManager) Run(ctx context.Context, options map[string]any, persistClusterStatusCallback updateStatusCallbackFunc, terminator *base.SafeTerminator) error {
+func (a *AsyncIndexInitManager) Run(ctx context.Context, options AsyncIndexInitOptions, persistClusterStatusCallback updateStatusCallbackFunc, terminator *base.SafeTerminator) error {
 	a.lock.Lock()
 	doneChan := a._doneChan
 	a.lock.Unlock()
@@ -89,10 +97,10 @@ func (a *AsyncIndexInitManager) ResetStatus() {
 	return
 }
 
-var _ BackgroundManagerProcessI[map[string]any] = &AsyncIndexInitManager{}
+var _ BackgroundManagerProcessI[AsyncIndexInitOptions] = &AsyncIndexInitManager{}
 
-func NewAsyncIndexInitManager(metadataStore base.DataStore, metaKeys *base.MetadataKeys) *BackgroundManager[map[string]any] {
-	return &BackgroundManager[map[string]any]{
+func NewAsyncIndexInitManager(metadataStore base.DataStore, metaKeys *base.MetadataKeys) *BackgroundManager[AsyncIndexInitOptions] {
+	return &BackgroundManager[AsyncIndexInitOptions]{
 		name:    "index_init",
 		Process: &AsyncIndexInitManager{},
 		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{

--- a/db/background_mgr_async_index_init.go
+++ b/db/background_mgr_async_index_init.go
@@ -33,8 +33,8 @@ type AsyncIndexInitOptions struct {
 	DoneChan chan error
 }
 
-// Validate returns an error if the options are not usable by Init/Run.
-func (o AsyncIndexInitOptions) Validate() error {
+// validate returns an error if the options are not usable by Init/Run.
+func (o AsyncIndexInitOptions) validate() error {
 	if o.StatusMap == nil {
 		return errors.New("async index init requires a StatusMap")
 	}
@@ -46,7 +46,7 @@ func (o AsyncIndexInitOptions) Validate() error {
 
 // Init is called synchronously to set up a run for the background manager process. See Run() for the async part.
 func (a *AsyncIndexInitManager) Init(ctx context.Context, options AsyncIndexInitOptions, clusterStatus []byte) (backgroundManagerInitMode, error) {
-	if err := options.Validate(); err != nil {
+	if err := options.validate(); err != nil {
 		return backgroundManagerInitReset, err
 	}
 
@@ -59,7 +59,7 @@ func (a *AsyncIndexInitManager) Init(ctx context.Context, options AsyncIndexInit
 
 // Run is called inside a goroutine to perform the job of the job. This function should block until the job is complete.
 func (a *AsyncIndexInitManager) Run(ctx context.Context, options AsyncIndexInitOptions, persistClusterStatusCallback updateStatusCallbackFunc, terminator *base.SafeTerminator) error {
-	if err := options.Validate(); err != nil {
+	if err := options.validate(); err != nil {
 		return err
 	}
 

--- a/db/background_mgr_attachment_compaction.go
+++ b/db/background_mgr_attachment_compaction.go
@@ -25,7 +25,7 @@ import (
 // =====================================================================
 
 // runFunctionStartedCallbackFunc is a test seam called at the top of Run before any compaction phases execute.
-type runFunctionStartedCallbackFunc func(context.Context, map[string]any, updateStatusCallbackFunc, *base.SafeTerminator)
+type runFunctionStartedCallbackFunc func(context.Context, AttachmentCompactionOptions, updateStatusCallbackFunc, *base.SafeTerminator)
 
 // AttachmentCompactionManager implements the attachment compaction background process. Compaction
 // runs in three sequential phases — mark, sweep, cleanup.
@@ -47,10 +47,20 @@ type AttachmentCompactionManager struct {
 	runFunctionStartedCallback atomic.Pointer[runFunctionStartedCallbackFunc]
 }
 
-var _ BackgroundManagerProcessI[map[string]any] = &AttachmentCompactionManager{}
+// AttachmentCompactionOptions defines options for running the attachment compaction process.
+type AttachmentCompactionOptions struct {
+	// Database is the reference to the Database context compaction is running on.
+	Database *Database
+	// DryRun indicates that compaction should report progress without purging any attachments.
+	DryRun bool
+	// Reset indicates whether to restart the compaction process from scratch rather than resuming.
+	Reset bool
+}
 
-func NewAttachmentCompactionManager(metadataStore base.DataStore, metaKeys *base.MetadataKeys) *BackgroundManager[map[string]any] {
-	return &BackgroundManager[map[string]any]{
+var _ BackgroundManagerProcessI[AttachmentCompactionOptions] = &AttachmentCompactionManager{}
+
+func NewAttachmentCompactionManager(metadataStore base.DataStore, metaKeys *base.MetadataKeys) *BackgroundManager[AttachmentCompactionOptions] {
+	return &BackgroundManager[AttachmentCompactionOptions]{
 		name:    "attachment_compaction",
 		Process: &AttachmentCompactionManager{},
 		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
@@ -62,9 +72,8 @@ func NewAttachmentCompactionManager(metadataStore base.DataStore, metaKeys *base
 	}
 }
 
-func (a *AttachmentCompactionManager) Init(ctx context.Context, options map[string]any, clusterStatus []byte) (backgroundManagerInitMode, error) {
-	database := options["database"].(*Database)
-	database.DbStats.Database().CompactionAttachmentStartTime.Set(uint64(time.Now().UTC().Unix()))
+func (a *AttachmentCompactionManager) Init(ctx context.Context, options AttachmentCompactionOptions, clusterStatus []byte) (backgroundManagerInitMode, error) {
+	options.Database.DbStats.Database().CompactionAttachmentStartTime.Set(uint64(time.Now().UTC().Unix()))
 
 	newRunInit := func() error {
 		uniqueUUID, err := uuid.NewRandom()
@@ -72,13 +81,12 @@ func (a *AttachmentCompactionManager) Init(ctx context.Context, options map[stri
 			return err
 		}
 
-		dryRun, _ := options["dryRun"].(bool)
-		if dryRun {
+		if options.DryRun {
 			base.InfofCtx(ctx, base.KeyAll, "Attachment Compaction: Running as dry run. No attachments will be purged")
 		}
 
 		compactID := uniqueUUID.String()
-		a.initializeNewRun(compactID, dryRun)
+		a.initializeNewRun(compactID, options.DryRun)
 		base.InfofCtx(ctx, base.KeyAll, "Attachment Compaction: Starting new compaction run with compact ID: %q", compactID)
 		return nil
 	}
@@ -87,8 +95,7 @@ func (a *AttachmentCompactionManager) Init(ctx context.Context, options map[stri
 		var statusDoc AttachmentManagerStatusDoc
 		err := base.JSONUnmarshal(clusterStatus, &statusDoc)
 
-		reset, ok := options["reset"].(bool)
-		if reset && ok {
+		if options.Reset {
 			base.InfofCtx(ctx, base.KeyAll, "Attachment Compaction: Resetting compaction process. Will not  resume any "+
 				"partially completed process")
 		}
@@ -96,7 +103,7 @@ func (a *AttachmentCompactionManager) Init(ctx context.Context, options map[stri
 		// If the previous run completed, or there was an error during unmarshalling the status we will start the
 		// process from scratch with a new compaction ID. Otherwise, we should resume with the compact ID, phase and
 		// stats specified in the doc.
-		if statusDoc.State == BackgroundProcessStateCompleted || err != nil || (reset && ok) {
+		if statusDoc.State == BackgroundProcessStateCompleted || err != nil || options.Reset {
 			return backgroundManagerInitReset, newRunInit()
 		} else {
 			compactID, phase := a.initializeFromPreviousStatus(statusDoc)
@@ -110,19 +117,18 @@ func (a *AttachmentCompactionManager) Init(ctx context.Context, options map[stri
 	return backgroundManagerInitReset, newRunInit()
 }
 
-func (a *AttachmentCompactionManager) Run(ctx context.Context, options map[string]any, persistClusterStatusCallback updateStatusCallbackFunc, terminator *base.SafeTerminator) error {
+func (a *AttachmentCompactionManager) Run(ctx context.Context, options AttachmentCompactionOptions, persistClusterStatusCallback updateStatusCallbackFunc, terminator *base.SafeTerminator) error {
 	if cb := a.runFunctionStartedCallback.Load(); cb != nil {
 		(*cb)(ctx, options, persistClusterStatusCallback, terminator)
 		a.runFunctionStartedCallback.Store(nil)
 	}
-	database := options["database"].(*Database)
 
 	// Attachment compaction only needs to operate the default scope/collection,
 	// because all collection-based attachments will be written by 3.1+ and will be stored in the new format that doesn't need compaction.
 	//
 	// This may not be true if a user migrated/XDCR'd an existing _default collection into a named collection,
 	// but we'll consider that a follow-up enhancement to point this compaction operation at arbitrary collections.
-	dataStore := database.Bucket.DefaultDataStore(ctx)
+	dataStore := options.Database.Bucket.DefaultDataStore(ctx)
 	collectionID := base.DefaultCollectionID
 
 	persistClusterStatus := func() {
@@ -144,7 +150,7 @@ func (a *AttachmentCompactionManager) Run(ctx context.Context, options map[strin
 		a.SetPhase("mark")
 		worker := func() (shouldRetry bool, err error, value any) {
 			persistClusterStatus()
-			_, dcpClient, err := attachmentCompactMarkPhase(ctx, dataStore, collectionID, database, a.getCompactID(), terminator, &a.MarkedAttachments)
+			_, dcpClient, err := attachmentCompactMarkPhase(ctx, dataStore, collectionID, options.Database, a.getCompactID(), terminator, &a.MarkedAttachments)
 			if dcpClient != nil {
 				a.setVBUUIDs(base.GetVBUUIDs(dcpClient.GetMetadata()))
 			}
@@ -155,7 +161,7 @@ func (a *AttachmentCompactionManager) Run(ctx context.Context, options map[strin
 					return false, err, nil
 				}
 
-				shouldRetry, err = a.handleAttachmentCompactionRollbackError(ctx, options, dataStore, database, err, MarkPhase, dcpClient.GetMetadataKeyPrefix())
+				shouldRetry, err = a.handleAttachmentCompactionRollbackError(ctx, options, options.Database, err, MarkPhase, dcpClient.GetMetadataKeyPrefix())
 			}
 			return shouldRetry, err, nil
 		}
@@ -172,7 +178,7 @@ func (a *AttachmentCompactionManager) Run(ctx context.Context, options map[strin
 	case "sweep":
 		a.SetPhase("sweep")
 		persistClusterStatus()
-		_, _, err := attachmentCompactSweepPhase(ctx, dataStore, collectionID, database, a.getCompactID(), a.getVBUUIDs(), a.getDryRun(), terminator, &a.PurgedAttachments)
+		_, _, err := attachmentCompactSweepPhase(ctx, dataStore, collectionID, options.Database, a.getCompactID(), a.getVBUUIDs(), a.getDryRun(), terminator, &a.PurgedAttachments)
 		if err != nil || terminator.IsClosed() {
 			return err
 		}
@@ -181,9 +187,9 @@ func (a *AttachmentCompactionManager) Run(ctx context.Context, options map[strin
 		a.SetPhase("cleanup")
 		worker := func() (shouldRetry bool, err error, value any) {
 			persistClusterStatus()
-			metadataKeyPrefix, err := attachmentCompactCleanupPhase(ctx, dataStore, collectionID, database, a.getCompactID(), a.getVBUUIDs(), terminator)
+			metadataKeyPrefix, err := attachmentCompactCleanupPhase(ctx, dataStore, collectionID, options.Database, a.getCompactID(), a.getVBUUIDs(), terminator)
 			if err != nil {
-				shouldRetry, err = a.handleAttachmentCompactionRollbackError(ctx, options, dataStore, database, err, CleanupPhase, metadataKeyPrefix)
+				shouldRetry, err = a.handleAttachmentCompactionRollbackError(ctx, options, options.Database, err, CleanupPhase, metadataKeyPrefix)
 			}
 			return shouldRetry, err, nil
 		}
@@ -212,7 +218,7 @@ func (*AttachmentCompactionManager) purgeCheckpoints(ctx context.Context, databa
 	)
 }
 
-func (a *AttachmentCompactionManager) handleAttachmentCompactionRollbackError(ctx context.Context, options map[string]any, dataStore base.DataStore, database *Database, err error, phase attachmentCompactionPhase, keyPrefix string) (bool, error) {
+func (a *AttachmentCompactionManager) handleAttachmentCompactionRollbackError(ctx context.Context, options AttachmentCompactionOptions, database *Database, err error, phase attachmentCompactionPhase, keyPrefix string) (bool, error) {
 	var rollbackErr gocbcore.DCPRollbackError
 	if errors.As(err, &rollbackErr) || errors.Is(err, base.ErrVbUUIDMismatch) {
 		base.InfofCtx(ctx, base.KeyDCP, "rollback indicated on %s phase of attachment compaction, resetting the task", phase)

--- a/db/background_mgr_attachment_migration.go
+++ b/db/background_mgr_attachment_migration.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/uuid"
 )
 
+// AttachmentMigrationManager manages the process of migrating attachment metadata to Sync Gateway 4.0+.
 type AttachmentMigrationManager struct {
 	docsProcessed atomic.Int64
 	docsChanged   atomic.Int64
@@ -31,14 +32,20 @@ type AttachmentMigrationManager struct {
 	lock          sync.RWMutex
 }
 
-var _ BackgroundManagerProcessI[map[string]any] = &AttachmentMigrationManager{}
+// AttachmentMigrationOptions defines options for configuring an attachment migration run.
+type AttachmentMigrationOptions struct {
+	// Reset indicates whether to start the migration process from scratch rather than resuming.
+	Reset bool
+}
+
+var _ BackgroundManagerProcessI[AttachmentMigrationOptions] = &AttachmentMigrationManager{}
 
 const MetaVersionValue = "4.0.0" // Meta version to set in syncInfo document upon completion of attachment migration for collection
 
-func NewAttachmentMigrationManager(database *DatabaseContext) *BackgroundManager[map[string]any] {
+func NewAttachmentMigrationManager(database *DatabaseContext) *BackgroundManager[AttachmentMigrationOptions] {
 	metadataStore := database.MetadataStore
 	metaKeys := database.MetadataKeys
-	return &BackgroundManager[map[string]any]{
+	return &BackgroundManager[AttachmentMigrationOptions]{
 		name: "attachment_migration",
 		Process: &AttachmentMigrationManager{
 			databaseCtx: database,
@@ -52,7 +59,7 @@ func NewAttachmentMigrationManager(database *DatabaseContext) *BackgroundManager
 	}
 }
 
-func (a *AttachmentMigrationManager) Init(ctx context.Context, options map[string]any, clusterStatus []byte) (backgroundManagerInitMode, error) {
+func (a *AttachmentMigrationManager) Init(ctx context.Context, options AttachmentMigrationOptions, clusterStatus []byte) (backgroundManagerInitMode, error) {
 	newRunInit := func() error {
 		uniqueUUID, err := uuid.NewRandom()
 		if err != nil {
@@ -68,14 +75,13 @@ func (a *AttachmentMigrationManager) Init(ctx context.Context, options map[strin
 		var statusDoc AttachmentMigrationManagerStatusDoc
 		err := base.JSONUnmarshal(clusterStatus, &statusDoc)
 
-		reset, _ := options["reset"].(bool)
-		if reset {
+		if options.Reset {
 			base.InfofCtx(ctx, base.KeyAll, "Attachment Migration: Resetting migration process. Will not resume any partially completed process")
 		}
 
 		// If the previous run completed, or there was an error during unmarshalling the status we will start the
 		// process from scratch with a new migration ID. Otherwise, we should resume with the migration ID, stats specified in the doc.
-		if statusDoc.State == BackgroundProcessStateCompleted || err != nil || reset {
+		if statusDoc.State == BackgroundProcessStateCompleted || err != nil || options.Reset {
 			return backgroundManagerInitReset, newRunInit()
 		}
 		a.MigrationID = statusDoc.MigrationID
@@ -92,7 +98,7 @@ func (a *AttachmentMigrationManager) Init(ctx context.Context, options map[strin
 	return backgroundManagerInitReset, newRunInit()
 }
 
-func (a *AttachmentMigrationManager) Run(ctx context.Context, options map[string]any, persistClusterStatusCallback updateStatusCallbackFunc, terminator *base.SafeTerminator) error {
+func (a *AttachmentMigrationManager) Run(ctx context.Context, options AttachmentMigrationOptions, persistClusterStatusCallback updateStatusCallbackFunc, terminator *base.SafeTerminator) error {
 	db := a.databaseCtx
 	migrationLoggingID := "Migration: " + a.MigrationID
 

--- a/db/background_mgr_attachment_migration_test.go
+++ b/db/background_mgr_attachment_migration_test.go
@@ -47,7 +47,7 @@ func TestAttachmentMigrationTaskMixMigratedAndNonMigratedDocs(t *testing.T) {
 		MoveAttachmentXattrFromGlobalToSync(t, collection.dataStore, key, value, true)
 	}
 
-	err := db.AttachmentMigrationManager.Start(ctx, nil)
+	err := db.AttachmentMigrationManager.Start(ctx, AttachmentMigrationOptions{})
 	require.NoError(t, err)
 
 	// wait for task to complete
@@ -103,7 +103,7 @@ func TestAttachmentMigrationManagerResumeStoppedMigration(t *testing.T) {
 		require.NotNil(t, doc.Attachments())
 	}
 
-	err := db.AttachmentMigrationManager.Start(ctx, nil)
+	err := db.AttachmentMigrationManager.Start(ctx, AttachmentMigrationOptions{})
 	require.NoError(t, err)
 
 	// Attempt to Stop Process
@@ -127,7 +127,7 @@ func TestAttachmentMigrationManagerResumeStoppedMigration(t *testing.T) {
 	require.Error(t, err)
 
 	// Resume process
-	err = db.AttachmentMigrationManager.Start(ctx, nil)
+	err = db.AttachmentMigrationManager.Start(ctx, AttachmentMigrationOptions{})
 	require.NoError(t, err)
 
 	RequireBackgroundManagerState(t, db.AttachmentMigrationManager, BackgroundProcessStateCompleted)
@@ -157,7 +157,7 @@ func TestAttachmentMigrationManagerNoDocsToMigrate(t *testing.T) {
 	_, err = collection.dataStore.Add(ctx, key, 0, []byte(`{"test":"doc"}`))
 	require.NoError(t, err)
 
-	err = db.AttachmentMigrationManager.Start(ctx, nil)
+	err = db.AttachmentMigrationManager.Start(ctx, AttachmentMigrationOptions{})
 	require.NoError(t, err)
 
 	// wait for task to complete
@@ -209,7 +209,7 @@ func TestMigrationManagerDocWithSyncAndGlobalAttachmentMetadata(t *testing.T) {
 	_, err = collection.dataStore.UpdateXattrs(ctx, key, 0, cas, updateXattrs, DefaultMutateInOpts())
 	require.NoError(t, err)
 
-	err = db.AttachmentMigrationManager.Start(ctx, nil)
+	err = db.AttachmentMigrationManager.Start(ctx, AttachmentMigrationOptions{})
 	require.NoError(t, err)
 
 	// wait for task to complete
@@ -343,7 +343,7 @@ func TestAttachmentMigrationWritesV1SyncInfoAtCcv41(t *testing.T) {
 
 	mgr := NewAttachmentMigrationManager(db.DatabaseContext)
 	require.NotNil(t, mgr)
-	require.NoError(t, mgr.Start(ctx, nil))
+	require.NoError(t, mgr.Start(ctx, AttachmentMigrationOptions{}))
 	RequireBackgroundManagerState(t, mgr, BackgroundProcessStateCompleted)
 
 	raw, _, err := collection.dataStore.GetRaw(ctx, base.SGSyncInfo)

--- a/db/background_mgr_metadata_migration.go
+++ b/db/background_mgr_metadata_migration.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/uuid"
 )
 
+// MetadataMigrationManager manages the process of migrating system metadata.
 type MetadataMigrationManager struct {
 	docsProcessed  atomic.Int64 // cumulative successful moves/deletes across all passes
 	docsFailed     atomic.Int64 // cumulative per-doc errors across all passes
@@ -34,15 +35,21 @@ type MetadataMigrationManager struct {
 
 const MetadataMigrationManagerName = "metadata_migration"
 
-var _ BackgroundManagerProcessI[map[string]any] = &MetadataMigrationManager{}
+// MetadataMigrationOptions defines options for configuring a metadata migration run.
+type MetadataMigrationOptions struct {
+	// Reset indicates whether to start the metadata migration process from scratch rather than resuming.
+	Reset bool
+}
+
+var _ BackgroundManagerProcessI[MetadataMigrationOptions] = &MetadataMigrationManager{}
 
 // errMetadataMigrationTerminated is the cancellation cause propagated to the run context when
 // the BackgroundManager terminator fires, so ops blocked on ctx (seq-counter retry loop, range
 // scan iteration) can distinguish an operator stop from a parent-context cancellation.
 var errMetadataMigrationTerminated = errors.New("metadata migration terminated by stop request")
 
-func NewMetadataMigrationManager(dbContext *DatabaseContext) *BackgroundManager[map[string]any] {
-	return &BackgroundManager[map[string]any]{
+func NewMetadataMigrationManager(dbContext *DatabaseContext) *BackgroundManager[MetadataMigrationOptions] {
+	return &BackgroundManager[MetadataMigrationOptions]{
 		name:    MetadataMigrationManagerName,
 		Process: &MetadataMigrationManager{dbContext: dbContext},
 		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
@@ -68,7 +75,7 @@ type MigrationManagerStatusDoc struct {
 	MigrationManagerResponse `json:"status"`
 }
 
-func (m *MetadataMigrationManager) Init(ctx context.Context, options map[string]any, clusterStatus []byte) (backgroundManagerInitMode, error) {
+func (m *MetadataMigrationManager) Init(ctx context.Context, options MetadataMigrationOptions, clusterStatus []byte) (backgroundManagerInitMode, error) {
 	newRunInit := func() error {
 		uniqueUUID, err := uuid.NewRandom()
 		if err != nil {
@@ -84,14 +91,13 @@ func (m *MetadataMigrationManager) Init(ctx context.Context, options map[string]
 		var status MigrationManagerStatusDoc
 		err := base.JSONUnmarshal(clusterStatus, &status)
 
-		reset, _ := options["reset"].(bool)
-		if reset {
+		if options.Reset {
 			base.InfofCtx(ctx, base.KeyAll, "Metadata Migration: Resetting migration process. Will not resume any partially completed process")
 		}
 
 		// If the previous run completed, there was an error during unmarshalling the status, or
 		// the caller requested a reset, start again with a fresh migration ID and zeroed counters.
-		if status.State == BackgroundProcessStateCompleted || err != nil || reset {
+		if status.State == BackgroundProcessStateCompleted || err != nil || options.Reset {
 			return backgroundManagerInitReset, newRunInit()
 		}
 		m.docsProcessed.Store(status.DocsProcessed)
@@ -105,7 +111,7 @@ func (m *MetadataMigrationManager) Init(ctx context.Context, options map[string]
 	return backgroundManagerInitReset, newRunInit()
 }
 
-func (m *MetadataMigrationManager) Run(ctx context.Context, options map[string]any, persistClusterStatusCallback updateStatusCallbackFunc, terminator *base.SafeTerminator) error {
+func (m *MetadataMigrationManager) Run(ctx context.Context, options MetadataMigrationOptions, persistClusterStatusCallback updateStatusCallbackFunc, terminator *base.SafeTerminator) error {
 	metadataMigrationLoggingID := "Metadata Migration: " + m.MigrationID
 
 	persistClusterStatus := func() {

--- a/db/background_mgr_metadata_migration_test.go
+++ b/db/background_mgr_metadata_migration_test.go
@@ -190,7 +190,7 @@ func TestMetadataMigrationManagerMovesUsersAndRoles(t *testing.T) {
 	}
 	dbCtx.MetadataMigrationManager = NewMetadataMigrationManager(dbCtx)
 
-	require.NoError(t, dbCtx.MetadataMigrationManager.Start(ctx, nil))
+	require.NoError(t, dbCtx.MetadataMigrationManager.Start(ctx, MetadataMigrationOptions{}))
 	RequireBackgroundManagerState(t, dbCtx.MetadataMigrationManager, BackgroundProcessStateCompleted)
 
 	rawStatus, err := dbCtx.MetadataMigrationManager.GetStatus(ctx)
@@ -276,7 +276,7 @@ func TestMetadataMigrationCompletesWithCollectionScopedDataInFallback(t *testing
 	}
 	dbCtx.MetadataMigrationManager = NewMetadataMigrationManager(dbCtx)
 
-	require.NoError(t, dbCtx.MetadataMigrationManager.Start(ctx, nil))
+	require.NoError(t, dbCtx.MetadataMigrationManager.Start(ctx, MetadataMigrationOptions{}))
 	// Must complete — the collection-scoped data docs are out-of-scope, not blockers. If any wedges
 	// the job it exhausts maxPasses and lands in Error instead.
 	RequireBackgroundManagerState(t, dbCtx.MetadataMigrationManager, BackgroundProcessStateCompleted)
@@ -346,7 +346,7 @@ func TestMetadataMigrationManagerCompletesWithUnknownPrefixLeftInPlace(t *testin
 	}
 	dbCtx.MetadataMigrationManager = NewMetadataMigrationManager(dbCtx)
 
-	require.NoError(t, dbCtx.MetadataMigrationManager.Start(ctx, nil))
+	require.NoError(t, dbCtx.MetadataMigrationManager.Start(ctx, MetadataMigrationOptions{}))
 	// Unknown-prefix docs no longer block completion — the manager reaches the Completed state.
 	RequireBackgroundManagerState(t, dbCtx.MetadataMigrationManager, BackgroundProcessStateCompleted)
 
@@ -407,7 +407,7 @@ func TestMetadataMigrationManagerDCPCheckpointGroupIDCollisionCompletesEndToEnd(
 	}
 	dbCtx.MetadataMigrationManager = NewMetadataMigrationManager(dbCtx)
 
-	require.NoError(t, dbCtx.MetadataMigrationManager.Start(ctx, nil))
+	require.NoError(t, dbCtx.MetadataMigrationManager.Start(ctx, MetadataMigrationOptions{}))
 	// The collision yields an out-of-scope (not unknown-prefix) classification, so the run
 	// still reaches Completed rather than the bounded-pass Errored give-up branch.
 	RequireBackgroundManagerState(t, dbCtx.MetadataMigrationManager, BackgroundProcessStateCompleted)

--- a/db/background_mgr_test.go
+++ b/db/background_mgr_test.go
@@ -24,6 +24,16 @@ import (
 	"github.com/couchbaselabs/rosmar"
 )
 
+// MockProcessOptions defines configurations used for testing various background managers.
+type MockProcessOptions struct {
+	// Key is an arbitrary string value used to test options passing/resuming.
+	Key string
+	// Num is an arbitrary float value used to test options passing/resuming.
+	Num float64
+	// Reset indicates whether the mock process should start clean or resume.
+	Reset bool
+}
+
 type MockProcess struct {
 	InitCalled           bool
 	RunCalled            bool
@@ -33,14 +43,14 @@ type MockProcess struct {
 	lock                 sync.Mutex
 }
 
-func (m *MockProcess) Init(ctx context.Context, options map[string]any, clusterStatus []byte) (backgroundManagerInitMode, error) {
+func (m *MockProcess) Init(ctx context.Context, options MockProcessOptions, clusterStatus []byte) (backgroundManagerInitMode, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	m.InitCalled = true
 	return backgroundManagerInitReset, nil
 }
 
-func (m *MockProcess) Run(ctx context.Context, options map[string]any, persistClusterStatusCallback updateStatusCallbackFunc, terminator *base.SafeTerminator) error {
+func (m *MockProcess) Run(ctx context.Context, options MockProcessOptions, persistClusterStatusCallback updateStatusCallbackFunc, terminator *base.SafeTerminator) error {
 	m.lock.Lock()
 	m.RunCalled = true
 	m.updateStatusCallback = persistClusterStatusCallback
@@ -125,13 +135,13 @@ func TestBackgroundManagerModes(t *testing.T) {
 	for _, mode := range modes {
 		t.Run(mode.name, func(t *testing.T) {
 			process := &MockProcess{}
-			mgr := &BackgroundManager[map[string]any]{
+			mgr := &BackgroundManager[MockProcessOptions]{
 				name:                "test-mgr-" + mode.name,
 				clusterAwareOptions: mode.clusterAwareOptions,
 				Process:             process,
 			}
 
-			err := mgr.Start(ctx, nil)
+			err := mgr.Start(ctx, MockProcessOptions{})
 			require.NoError(t, err)
 
 			require.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -168,29 +178,29 @@ func TestBackgroundManagerMultiNodeTransitions(t *testing.T) {
 	}
 
 	process1 := &MockProcess{}
-	mgr1 := &BackgroundManager[map[string]any]{
+	mgr1 := &BackgroundManager[MockProcessOptions]{
 		name:                "mgr1",
 		clusterAwareOptions: options,
 		Process:             process1,
 	}
 
 	// 1. Start mgr1
-	err := mgr1.Start(ctx, nil)
+	err := mgr1.Start(ctx, MockProcessOptions{})
 	require.NoError(t, err)
 	defer func() { assert.NoError(t, mgr1.Stop(ctx)) }()
 
 	// 2. Try to start mgr1 again
-	err = mgr1.Start(ctx, nil)
+	err = mgr1.Start(ctx, MockProcessOptions{})
 	require.NoError(t, err)
 
 	// 3. Start mgr2 (should succeed because it's MultiNode)
 	process2 := &MockProcess{}
-	mgr2 := &BackgroundManager[map[string]any]{
+	mgr2 := &BackgroundManager[MockProcessOptions]{
 		name:                "mgr2",
 		clusterAwareOptions: options,
 		Process:             process2,
 	}
-	err = mgr2.Start(ctx, nil)
+	err = mgr2.Start(ctx, MockProcessOptions{})
 	require.NoError(t, err)
 	defer func() { assert.NoError(t, mgr2.Stop(ctx)) }()
 
@@ -214,7 +224,7 @@ func TestBackgroundManagerMultiNodeTransitions(t *testing.T) {
 	require.True(t, process2.StopRequested, "mgr2 should have received stop request")
 
 	// 5. Restart (from Stopped state)
-	err = mgr1.Start(ctx, nil)
+	err = mgr1.Start(ctx, MockProcessOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, BackgroundProcessStateRunning, mgr1.GetRunState())
 }
@@ -234,12 +244,12 @@ func TestBackgroundManagerMultiNodeSimultaneousTransitions(t *testing.T) {
 	}
 
 	numNodes := 5
-	managers := make([]*BackgroundManager[map[string]any], numNodes)
+	managers := make([]*BackgroundManager[MockProcessOptions], numNodes)
 	processes := make([]*MockProcess, numNodes)
 
 	for i := 0; i < numNodes; i++ {
 		processes[i] = &MockProcess{}
-		managers[i] = &BackgroundManager[map[string]any]{
+		managers[i] = &BackgroundManager[MockProcessOptions]{
 			name:                fmt.Sprintf("mgr%d", i),
 			clusterAwareOptions: options,
 			Process:             processes[i],
@@ -252,7 +262,7 @@ func TestBackgroundManagerMultiNodeSimultaneousTransitions(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			assert.NoError(t, managers[i].Start(ctx, nil))
+			assert.NoError(t, managers[i].Start(ctx, MockProcessOptions{}))
 		}(i)
 		defer func(i int) { assert.NoError(t, managers[i].Stop(ctx)) }(i)
 	}
@@ -298,13 +308,13 @@ func TestBackgroundManagerStartTimePreservedOnJoin(t *testing.T) {
 	}
 
 	process1 := &MockProcess{}
-	mgr1 := &BackgroundManager[map[string]any]{
+	mgr1 := &BackgroundManager[MockProcessOptions]{
 		name:                "mgr1",
 		clusterAwareOptions: options,
 		Process:             process1,
 	}
 
-	err := mgr1.Start(ctx, nil)
+	err := mgr1.Start(ctx, MockProcessOptions{})
 	require.NoError(t, err)
 
 	origStartTime := mgr1.getStartTime()
@@ -323,12 +333,12 @@ func TestBackgroundManagerStartTimePreservedOnJoin(t *testing.T) {
 	WaitForBackgroundManagerHeartbeatDocRemoval(t, mgr1)
 
 	process2 := &MockProcess{}
-	mgr2 := &BackgroundManager[map[string]any]{
+	mgr2 := &BackgroundManager[MockProcessOptions]{
 		name:                "mgr2",
 		clusterAwareOptions: options,
 		Process:             process2,
 	}
-	err = mgr2.Start(ctx, nil)
+	err = mgr2.Start(ctx, MockProcessOptions{})
 	require.NoError(t, err)
 	defer func() { assert.NoError(t, mgr2.Stop(ctx)) }()
 
@@ -350,14 +360,14 @@ func TestBackgroundManagerMultiNodeStartTimePreserved(t *testing.T) {
 	}
 
 	process1 := &MockProcess{}
-	mgr1 := &BackgroundManager[map[string]any]{
+	mgr1 := &BackgroundManager[MockProcessOptions]{
 		name:                "mgr1",
 		clusterAwareOptions: options,
 		Process:             process1,
 	}
 
 	// 1. Start mgr1
-	err := mgr1.Start(ctx, nil)
+	err := mgr1.Start(ctx, MockProcessOptions{})
 	require.NoError(t, err)
 	defer func() { assert.NoError(t, mgr1.Stop(ctx)) }()
 
@@ -375,13 +385,13 @@ func TestBackgroundManagerMultiNodeStartTimePreserved(t *testing.T) {
 
 	// 2. Start mgr2 (MultiNode)
 	process2 := &MockProcess{}
-	mgr2 := &BackgroundManager[map[string]any]{
+	mgr2 := &BackgroundManager[MockProcessOptions]{
 		name:                "mgr2",
 		clusterAwareOptions: options,
 		Process:             process2,
 	}
 
-	err = mgr2.Start(ctx, nil)
+	err = mgr2.Start(ctx, MockProcessOptions{})
 	require.NoError(t, err)
 	defer func() { assert.NoError(t, mgr2.Stop(ctx)) }()
 
@@ -470,11 +480,11 @@ func TestResyncMultiNodeStatsAggregation(t *testing.T) {
 // It stores the options passed to Init and serialises them into the "meta" returned by GetProcessStatus.
 type ResumableMockProcess struct {
 	MockProcess
-	receivedOptions map[string]any
+	receivedOptions MockProcessOptions
 	optionsLock     sync.RWMutex
 }
 
-func (r *ResumableMockProcess) Init(ctx context.Context, options map[string]any, clusterStatus []byte) (backgroundManagerInitMode, error) {
+func (r *ResumableMockProcess) Init(ctx context.Context, options MockProcessOptions, clusterStatus []byte) (backgroundManagerInitMode, error) {
 	r.optionsLock.Lock()
 	r.receivedOptions = options
 	r.optionsLock.Unlock()
@@ -491,7 +501,7 @@ func (r *ResumableMockProcess) GetProcessStatus(status BackgroundManagerStatus, 
 	r.optionsLock.RUnlock()
 
 	type mockMeta struct {
-		Options map[string]any `json:"options,omitempty"`
+		Options MockProcessOptions `json:"options,omitempty"`
 	}
 	metaBytes, err := base.JSONMarshal(mockMeta{Options: opts})
 	if err != nil {
@@ -501,7 +511,7 @@ func (r *ResumableMockProcess) GetProcessStatus(status BackgroundManagerStatus, 
 }
 
 // ReceivedOptions returns the options most recently passed to Init (safe for concurrent use).
-func (r *ResumableMockProcess) ReceivedOptions() map[string]any {
+func (r *ResumableMockProcess) ReceivedOptions() MockProcessOptions {
 	r.optionsLock.RLock()
 	defer r.optionsLock.RUnlock()
 	return r.receivedOptions
@@ -524,14 +534,14 @@ func TestBackgroundManagerJoin(t *testing.T) {
 	}
 
 	process := &ResumableMockProcess{}
-	mgr := &BackgroundManager[map[string]any]{
+	mgr := &BackgroundManager[MockProcessOptions]{
 		name:                "test-join-mgr",
 		Process:             process,
 		clusterAwareOptions: clusterOpts,
 		terminator:          base.NewSafeTerminator(),
 	}
 
-	startOptions := map[string]any{"key": "value", "num": float64(42)}
+	startOptions := MockProcessOptions{Key: "value", Num: 42}
 
 	// Start mgr — this writes the options into the status document and sets cluster state to running.
 	require.NoError(t, mgr.Start(ctx, startOptions))
@@ -541,7 +551,7 @@ func TestBackgroundManagerJoin(t *testing.T) {
 
 	// While cluster state is running, a second manager sharing the same status document should join via Join.
 	process2 := &ResumableMockProcess{}
-	mgr2 := &BackgroundManager[map[string]any]{
+	mgr2 := &BackgroundManager[MockProcessOptions]{
 		name:                "test-join-mgr2",
 		Process:             process2,
 		clusterAwareOptions: clusterOpts,
@@ -567,7 +577,7 @@ func TestBackgroundManagerJoinNoDoc(t *testing.T) {
 	metadataStore := testBucket.DefaultDataStore(ctx)
 	metaKeys := base.NewMetadataKeys("test-join-no-doc")
 
-	mgr := &BackgroundManager[map[string]any]{
+	mgr := &BackgroundManager[MockProcessOptions]{
 		name:    "test-join-no-doc-mgr",
 		Process: &ResumableMockProcess{},
 		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
@@ -592,7 +602,7 @@ func TestBackgroundManagerJoinSingleNodeError(t *testing.T) {
 	metaKeys := base.NewMetadataKeys("test-join-single-node")
 
 	process := &ResumableMockProcess{}
-	mgr := &BackgroundManager[map[string]any]{
+	mgr := &BackgroundManager[MockProcessOptions]{
 		name:    "test-join-single-node-mgr",
 		Process: process,
 		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
@@ -618,7 +628,7 @@ func TestBackgroundManagerJoinWhileRunning(t *testing.T) {
 	metaKeys := base.NewMetadataKeys("test-join-running")
 
 	process := &ResumableMockProcess{}
-	mgr := &BackgroundManager[map[string]any]{
+	mgr := &BackgroundManager[MockProcessOptions]{
 		name:    "test-join-running-mgr",
 		Process: process,
 		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
@@ -630,7 +640,7 @@ func TestBackgroundManagerJoinWhileRunning(t *testing.T) {
 		terminator: base.NewSafeTerminator(),
 	}
 
-	startOptions := map[string]any{"key": "value"}
+	startOptions := MockProcessOptions{Key: "value"}
 	require.NoError(t, mgr.Start(ctx, startOptions))
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		assert.Equal(c, BackgroundProcessStateRunning, mgr.GetRunState())
@@ -660,14 +670,14 @@ func TestBackgroundManagerJoinWhenNotRunning(t *testing.T) {
 		multiNode:     true,
 	}
 
-	mgr := &BackgroundManager[map[string]any]{
+	mgr := &BackgroundManager[MockProcessOptions]{
 		name:                "test-join-not-running-mgr",
 		Process:             &ResumableMockProcess{},
 		clusterAwareOptions: clusterOpts,
 		terminator:          base.NewSafeTerminator(),
 	}
 
-	require.NoError(t, mgr.Start(ctx, map[string]any{"key": "value"}))
+	require.NoError(t, mgr.Start(ctx, MockProcessOptions{Key: "value"}))
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		assert.Equal(c, BackgroundProcessStateRunning, mgr.GetRunState())
 	}, 5*time.Second, 100*time.Millisecond)
@@ -681,7 +691,7 @@ func TestBackgroundManagerJoinWhenNotRunning(t *testing.T) {
 	}, 5*time.Second, 100*time.Millisecond)
 
 	// Cluster state is now stopped; a second manager must not be able to Join.
-	mgr2 := &BackgroundManager[map[string]any]{
+	mgr2 := &BackgroundManager[MockProcessOptions]{
 		name:                "test-join-not-running-mgr2",
 		Process:             &ResumableMockProcess{},
 		clusterAwareOptions: clusterOpts,
@@ -698,7 +708,7 @@ func TestBackgroundManagerJoinWhenNotRunning(t *testing.T) {
 func TestBackgroundManagerJoinLocalModeError(t *testing.T) {
 	ctx := base.TestCtx(t)
 	process := &ResumableMockProcess{}
-	mgr := &BackgroundManager[map[string]any]{
+	mgr := &BackgroundManager[MockProcessOptions]{
 		name:       "test-join-local-mgr",
 		Process:    process,
 		terminator: base.NewSafeTerminator(),
@@ -721,7 +731,7 @@ func TestBackgroundManagerUpdateDatabaseStateRunning(t *testing.T) {
 	var dbStateCalls []bool
 	var mu sync.Mutex
 
-	mgr := &BackgroundManager[map[string]any]{
+	mgr := &BackgroundManager[MockProcessOptions]{
 		name:    "test-update-db-state-running",
 		Process: &MockProcess{},
 		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
@@ -739,7 +749,7 @@ func TestBackgroundManagerUpdateDatabaseStateRunning(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, mgr.Start(ctx, nil))
+	require.NoError(t, mgr.Start(ctx, MockProcessOptions{}))
 	defer func() { assert.NoError(t, mgr.Stop(ctx)) }()
 
 	// UpdateStatusClusterAware is called synchronously at the end of Start, so by the time
@@ -763,7 +773,7 @@ func TestBackgroundManagerUpdateDatabaseStateOnCompletion(t *testing.T) {
 
 	calledWithFalse := make(chan struct{}, 1)
 
-	mgr := &BackgroundManager[map[string]any]{
+	mgr := &BackgroundManager[MockProcessOptions]{
 		name:    "test-update-db-state-done",
 		Process: &MockProcess{},
 		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
@@ -784,7 +794,7 @@ func TestBackgroundManagerUpdateDatabaseStateOnCompletion(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, mgr.Start(ctx, nil))
+	require.NoError(t, mgr.Start(ctx, MockProcessOptions{}))
 
 	// Stopping the manager causes the run goroutine to exit, which transitions the state to
 	// Stopped and then calls UpdateStatusClusterAware — which must call updateDatabaseState(false).
@@ -811,7 +821,7 @@ func TestBackgroundManagerJoinCallsUpdateDatabaseStateWhenNotRunning(t *testing.
 	var dbStateCalls []bool
 	var mu sync.Mutex
 
-	mgr := &BackgroundManager[map[string]any]{
+	mgr := &BackgroundManager[MockProcessOptions]{
 		name:    "test-join-db-state-not-running",
 		Process: &ResumableMockProcess{},
 		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
@@ -859,13 +869,13 @@ func TestBackgroundManagerJoinCallsUpdateDatabaseStateWhenStopped(t *testing.T) 
 	}
 
 	// Start and then stop a manager so the cluster status doc shows Stopped.
-	starter := &BackgroundManager[map[string]any]{
+	starter := &BackgroundManager[MockProcessOptions]{
 		name:                "test-join-db-state-stopped-starter",
 		Process:             &ResumableMockProcess{},
 		clusterAwareOptions: clusterOpts,
 		terminator:          base.NewSafeTerminator(),
 	}
-	require.NoError(t, starter.Start(ctx, map[string]any{"key": "value"}))
+	require.NoError(t, starter.Start(ctx, MockProcessOptions{Key: "value"}))
 	require.NoError(t, starter.Stop(ctx))
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		rawStatus, err := starter.GetStatus(ctx)
@@ -881,7 +891,7 @@ func TestBackgroundManagerJoinCallsUpdateDatabaseStateWhenStopped(t *testing.T) 
 	// A fresh manager observing the same (stopped) cluster state should call updateDatabaseState(false).
 	var dbStateCalls []bool
 	var mu sync.Mutex
-	observer := &BackgroundManager[map[string]any]{
+	observer := &BackgroundManager[MockProcessOptions]{
 		name:                "test-join-db-state-stopped-observer",
 		Process:             &ResumableMockProcess{},
 		clusterAwareOptions: clusterOpts,
@@ -913,7 +923,7 @@ type immediateCallbackProcess struct {
 	MockProcess
 }
 
-func (m *immediateCallbackProcess) Run(ctx context.Context, _ map[string]any, cb updateStatusCallbackFunc, _ *base.SafeTerminator) error {
+func (m *immediateCallbackProcess) Run(ctx context.Context, _ MockProcessOptions, cb updateStatusCallbackFunc, _ *base.SafeTerminator) error {
 	m.lock.Lock()
 	m.RunCalled = true
 	m.lock.Unlock()
@@ -925,9 +935,9 @@ func (m *immediateCallbackProcess) Run(ctx context.Context, _ map[string]any, cb
 
 // newTestManagerWithStateDoc returns a multi-node BackgroundManager whose updateDatabaseState is wired
 // to a DatabaseStateMgr backed by the given metadata store.
-func newTestManagerWithStateDoc(metadataStore base.DataStore, metaKeys *base.MetadataKeys, suffix string, proc BackgroundManagerProcessI[map[string]any]) (*BackgroundManager[map[string]any], *DatabaseStateMgr) {
+func newTestManagerWithStateDoc(metadataStore base.DataStore, metaKeys *base.MetadataKeys, suffix string, proc BackgroundManagerProcessI[MockProcessOptions]) (*BackgroundManager[MockProcessOptions], *DatabaseStateMgr) {
 	dbStateMgr := NewDatabaseStateMgr(metadataStore, metaKeys.DatabaseStateKey(), nil)
-	mgr := &BackgroundManager[map[string]any]{
+	mgr := &BackgroundManager[MockProcessOptions]{
 		name:    "test-" + suffix,
 		Process: proc,
 		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
@@ -972,7 +982,7 @@ func TestUpdateDatabaseStateRapidCycles(t *testing.T) {
 		metaKeys := base.NewMetadataKeys(fmt.Sprintf("rapid-cycle-%d", i))
 		mgr, dbStateMgr := newTestManagerWithStateDoc(metadataStore, metaKeys, "rapid", &ResumableMockProcess{})
 
-		require.NoError(t, mgr.Start(ctx, nil))
+		require.NoError(t, mgr.Start(ctx, MockProcessOptions{}))
 		assertResyncRunningEventually(t, dbStateMgr, true, ctx)
 
 		require.NoError(t, mgr.Stop(ctx))
@@ -995,7 +1005,7 @@ func TestUpdateDatabaseStateProcessCompletesBeforeStartReturns(t *testing.T) {
 
 	// immediateCallbackProcess returns from Run immediately, making the goroutine cleanup race
 	// with the synchronous UpdateStatusClusterAware call at the end of Start.
-	require.NoError(t, mgr.Start(ctx, nil))
+	require.NoError(t, mgr.Start(ctx, MockProcessOptions{}))
 
 	// Regardless of ordering, the final state must settle to false because the process completed.
 	assertResyncRunningEventually(t, dbStateMgr, false, ctx)
@@ -1015,9 +1025,9 @@ func TestUpdateDatabaseStateConcurrentManagersSharedStateDoc(t *testing.T) {
 	dbStateMgr := NewDatabaseStateMgr(metadataStore, metaKeys.DatabaseStateKey(), nil)
 
 	const numNodes = 5
-	managers := make([]*BackgroundManager[map[string]any], numNodes)
+	managers := make([]*BackgroundManager[MockProcessOptions], numNodes)
 	for i := range numNodes {
-		managers[i] = &BackgroundManager[map[string]any]{
+		managers[i] = &BackgroundManager[MockProcessOptions]{
 			name:    fmt.Sprintf("test-concurrent-shared-%d", i),
 			Process: &ResumableMockProcess{},
 			clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
@@ -1039,7 +1049,7 @@ func TestUpdateDatabaseStateConcurrentManagersSharedStateDoc(t *testing.T) {
 		startWG.Add(1)
 		go func(i int) {
 			defer startWG.Done()
-			assert.NoError(t, managers[i].Start(ctx, nil))
+			assert.NoError(t, managers[i].Start(ctx, MockProcessOptions{}))
 		}(i)
 	}
 	startWG.Wait()
@@ -1087,7 +1097,7 @@ func TestUpdateDatabaseStateJoinOverwritesRunningState(t *testing.T) {
 
 	// Manager A is the running node.
 	mgrA, dbStateMgr := newTestManagerWithStateDoc(metadataStore, metaKeys, "join-overwrite", &ResumableMockProcess{})
-	require.NoError(t, mgrA.Start(ctx, nil))
+	require.NoError(t, mgrA.Start(ctx, MockProcessOptions{}))
 	defer func() { assert.NoError(t, mgrA.Stop(ctx)) }()
 
 	assertResyncRunningEventually(t, dbStateMgr, true, ctx)
@@ -1096,7 +1106,7 @@ func TestUpdateDatabaseStateJoinOverwritesRunningState(t *testing.T) {
 	// "not running" by stopping the cluster state doc before B calls Join.
 	// In practice this can happen when B reads the status doc during a brief window between
 	// an old run completing and a new one starting.
-	mgrB := &BackgroundManager[map[string]any]{
+	mgrB := &BackgroundManager[MockProcessOptions]{
 		name:    "test-join-overwrite-observer",
 		Process: &ResumableMockProcess{},
 		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
@@ -1194,10 +1204,10 @@ func TestBackgroundManagerJoinConcurrentWhileStopping(t *testing.T) {
 		multiNode:     true,
 	}
 
-	startOptions := map[string]any{"key": "value"}
+	startOptions := MockProcessOptions{Key: "value"}
 
 	// mgr1 is the "originating" node that starts the process and then stops it.
-	mgr1 := &BackgroundManager[map[string]any]{
+	mgr1 := &BackgroundManager[MockProcessOptions]{
 		name:                "test-join-race-mgr1",
 		Process:             &ResumableMockProcess{},
 		clusterAwareOptions: clusterOpts,
@@ -1214,9 +1224,9 @@ func TestBackgroundManagerJoinConcurrentWhileStopping(t *testing.T) {
 	const numJoinCallers = 10
 
 	// Build a fleet of managers that will all call Join concurrently.
-	joinManagers := make([]*BackgroundManager[map[string]any], numJoinCallers)
+	joinManagers := make([]*BackgroundManager[MockProcessOptions], numJoinCallers)
 	for i := range numJoinCallers {
-		joinManagers[i] = &BackgroundManager[map[string]any]{
+		joinManagers[i] = &BackgroundManager[MockProcessOptions]{
 			name:                fmt.Sprintf("test-join-race-caller%d", i),
 			Process:             &ResumableMockProcess{},
 			clusterAwareOptions: clusterOpts,
@@ -1300,7 +1310,7 @@ func TestBackgroundManagerStartAfterCompletedSucceeds(t *testing.T) {
 	metadataStore := testBucket.DefaultDataStore(ctx)
 	metaKeys := base.NewMetadataKeys("test-start-after-complete")
 
-	mgr := &BackgroundManager[map[string]any]{
+	mgr := &BackgroundManager[MockProcessOptions]{
 		name:    "test-start-after-complete-mgr",
 		Process: &immediateCallbackProcess{},
 		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
@@ -1313,10 +1323,10 @@ func TestBackgroundManagerStartAfterCompletedSucceeds(t *testing.T) {
 	}
 
 	// Start and wait for the process to run to completion.
-	require.NoError(t, mgr.Start(ctx, nil))
+	require.NoError(t, mgr.Start(ctx, MockProcessOptions{}))
 	RequireBackgroundManagerState(t, mgr, BackgroundProcessStateCompleted)
 
-	err := mgr.Start(ctx, nil)
+	err := mgr.Start(ctx, MockProcessOptions{})
 	require.NoError(t, err)
 }
 
@@ -1357,21 +1367,21 @@ func TestBackgroundManagerJoinPreservesPreviousStatus(t *testing.T) {
 	}
 
 	process1 := &statsMockProcess{}
-	mgr1 := &BackgroundManager[map[string]any]{
+	mgr1 := &BackgroundManager[MockProcessOptions]{
 		name:                "test-join-mgr1",
 		Process:             process1,
 		clusterAwareOptions: clusterOpts,
 		terminator:          base.NewSafeTerminator(),
 	}
 
-	require.NoError(t, mgr1.Start(ctx, nil))
+	require.NoError(t, mgr1.Start(ctx, MockProcessOptions{}))
 	RequireBackgroundManagerState(t, mgr1, BackgroundProcessStateRunning)
 
 	// Ensure the running status is written to the cluster.
 	require.NoError(t, mgr1.UpdateStatusClusterAware(ctx))
 
 	process2 := &statsMockProcess{}
-	mgr2 := &BackgroundManager[map[string]any]{
+	mgr2 := &BackgroundManager[MockProcessOptions]{
 		name:                "test-join-mgr2",
 		Process:             process2,
 		clusterAwareOptions: clusterOpts,
@@ -1412,7 +1422,7 @@ func TestBackgroundManagerMultiNodePollingAvoidsOverwrite(t *testing.T) {
 	}
 
 	process1 := &MockProcess{}
-	mgr1 := &BackgroundManager[map[string]any]{
+	mgr1 := &BackgroundManager[MockProcessOptions]{
 		name:                "mgr1",
 		Process:             process1,
 		clusterAwareOptions: clusterOpts,
@@ -1420,7 +1430,7 @@ func TestBackgroundManagerMultiNodePollingAvoidsOverwrite(t *testing.T) {
 	}
 
 	process2 := &MockProcess{}
-	mgr2 := &BackgroundManager[map[string]any]{
+	mgr2 := &BackgroundManager[MockProcessOptions]{
 		name:                "mgr2",
 		Process:             process2,
 		clusterAwareOptions: clusterOpts,
@@ -1428,10 +1438,10 @@ func TestBackgroundManagerMultiNodePollingAvoidsOverwrite(t *testing.T) {
 	}
 
 	// Start both managers. Both should run.
-	require.NoError(t, mgr1.Start(ctx, nil))
+	require.NoError(t, mgr1.Start(ctx, MockProcessOptions{}))
 	defer func() { _ = mgr1.Stop(ctx) }()
 
-	require.NoError(t, mgr2.Start(ctx, nil))
+	require.NoError(t, mgr2.Start(ctx, MockProcessOptions{}))
 	defer func() { _ = mgr2.Stop(ctx) }()
 
 	RequireBackgroundManagerState(t, mgr1, BackgroundProcessStateRunning)
@@ -1514,7 +1524,7 @@ func TestUpdateStatusClusterAware(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			mgr := &BackgroundManager[map[string]any]{
+			mgr := &BackgroundManager[MockProcessOptions]{
 				name:                testCase.name + "-mgr",
 				Process:             &MockProcess{},
 				clusterAwareOptions: testCase.clusterAwareOptions,

--- a/db/background_mgr_tombstone_compaction.go
+++ b/db/background_mgr_tombstone_compaction.go
@@ -20,36 +20,41 @@ import (
 // Tombstone Compaction Implementation of Background Manager Process
 // =====================================================================
 
+// TombstoneCompactionManager implements the tombstone compaction background process.
 type TombstoneCompactionManager struct {
 	PurgedDocCount int64
 }
 
-var _ BackgroundManagerProcessI[map[string]any] = &TombstoneCompactionManager{}
+// TombstoneCompactionOptions defines options for running the tombstone compaction process.
+type TombstoneCompactionOptions struct {
+	// Database is the reference to the Database context compaction is running on.
+	Database *Database
+}
 
-func NewTombstoneCompactionManager() *BackgroundManager[map[string]any] {
-	return &BackgroundManager[map[string]any]{
+var _ BackgroundManagerProcessI[TombstoneCompactionOptions] = &TombstoneCompactionManager{}
+
+func NewTombstoneCompactionManager() *BackgroundManager[TombstoneCompactionOptions] {
+	return &BackgroundManager[TombstoneCompactionOptions]{
 		name:       "tombstone_compaction",
 		Process:    &TombstoneCompactionManager{},
 		terminator: base.NewSafeTerminator(),
 	}
 }
 
-func (t *TombstoneCompactionManager) Init(ctx context.Context, options map[string]any, clusterStatus []byte) (backgroundManagerInitMode, error) {
-	database := options["database"].(*Database)
-	database.DbStats.Database().CompactionTombstoneStartTime.Set(uint64(time.Now().UTC().Unix()))
+func (t *TombstoneCompactionManager) Init(ctx context.Context, options TombstoneCompactionOptions, clusterStatus []byte) (backgroundManagerInitMode, error) {
+	options.Database.DbStats.Database().CompactionTombstoneStartTime.Set(uint64(time.Now().UTC().Unix()))
 
 	return backgroundManagerInitReset, nil
 }
 
-func (t *TombstoneCompactionManager) Run(ctx context.Context, options map[string]any, persistClusterStatusCallback updateStatusCallbackFunc, terminator *base.SafeTerminator) error {
-	database := options["database"].(*Database)
+func (t *TombstoneCompactionManager) Run(ctx context.Context, options TombstoneCompactionOptions, persistClusterStatusCallback updateStatusCallbackFunc, terminator *base.SafeTerminator) error {
 
-	defer atomic.CompareAndSwapUint32(&database.CompactState, DBCompactRunning, DBCompactNotRunning)
+	defer atomic.CompareAndSwapUint32(&options.Database.CompactState, DBCompactRunning, DBCompactNotRunning)
 	updateStatusCallback := func(docsPurged *int) {
 		atomic.StoreInt64(&t.PurgedDocCount, int64(*docsPurged))
 	}
 
-	_, err := database.Compact(ctx, true, updateStatusCallback, terminator, false)
+	_, err := options.Database.Compact(ctx, true, updateStatusCallback, terminator, false)
 	if err != nil {
 		return err
 	}

--- a/db/background_mgr_tombstone_compaction.go
+++ b/db/background_mgr_tombstone_compaction.go
@@ -10,6 +10,7 @@ package db
 
 import (
 	"context"
+	"errors"
 	"sync/atomic"
 	"time"
 
@@ -31,6 +32,14 @@ type TombstoneCompactionOptions struct {
 	Database *Database
 }
 
+// Validate returns an error if the options are not usable by Init/Run.
+func (o TombstoneCompactionOptions) Validate() error {
+	if o.Database == nil {
+		return errors.New("tombstone compaction requires a Database")
+	}
+	return nil
+}
+
 var _ BackgroundManagerProcessI[TombstoneCompactionOptions] = &TombstoneCompactionManager{}
 
 func NewTombstoneCompactionManager() *BackgroundManager[TombstoneCompactionOptions] {
@@ -42,12 +51,19 @@ func NewTombstoneCompactionManager() *BackgroundManager[TombstoneCompactionOptio
 }
 
 func (t *TombstoneCompactionManager) Init(ctx context.Context, options TombstoneCompactionOptions, clusterStatus []byte) (backgroundManagerInitMode, error) {
+	if err := options.Validate(); err != nil {
+		return backgroundManagerInitReset, err
+	}
+
 	options.Database.DbStats.Database().CompactionTombstoneStartTime.Set(uint64(time.Now().UTC().Unix()))
 
 	return backgroundManagerInitReset, nil
 }
 
 func (t *TombstoneCompactionManager) Run(ctx context.Context, options TombstoneCompactionOptions, persistClusterStatusCallback updateStatusCallbackFunc, terminator *base.SafeTerminator) error {
+	if err := options.Validate(); err != nil {
+		return err
+	}
 
 	defer atomic.CompareAndSwapUint32(&options.Database.CompactState, DBCompactRunning, DBCompactNotRunning)
 	updateStatusCallback := func(docsPurged *int) {

--- a/db/background_mgr_tombstone_compaction.go
+++ b/db/background_mgr_tombstone_compaction.go
@@ -32,8 +32,8 @@ type TombstoneCompactionOptions struct {
 	Database *Database
 }
 
-// Validate returns an error if the options are not usable by Init/Run.
-func (o TombstoneCompactionOptions) Validate() error {
+// validate returns an error if the options are not usable by Init/Run.
+func (o TombstoneCompactionOptions) validate() error {
 	if o.Database == nil {
 		return errors.New("tombstone compaction requires a Database")
 	}
@@ -51,7 +51,7 @@ func NewTombstoneCompactionManager() *BackgroundManager[TombstoneCompactionOptio
 }
 
 func (t *TombstoneCompactionManager) Init(ctx context.Context, options TombstoneCompactionOptions, clusterStatus []byte) (backgroundManagerInitMode, error) {
-	if err := options.Validate(); err != nil {
+	if err := options.validate(); err != nil {
 		return backgroundManagerInitReset, err
 	}
 
@@ -61,7 +61,7 @@ func (t *TombstoneCompactionManager) Init(ctx context.Context, options Tombstone
 }
 
 func (t *TombstoneCompactionManager) Run(ctx context.Context, options TombstoneCompactionOptions, persistClusterStatusCallback updateStatusCallbackFunc, terminator *base.SafeTerminator) error {
-	if err := options.Validate(); err != nil {
+	if err := options.validate(); err != nil {
 		return err
 	}
 

--- a/db/database.go
+++ b/db/database.go
@@ -130,11 +130,11 @@ type DatabaseContext struct {
 	AccessLock                  sync.RWMutex           // Allows DB offline to block until synchronous calls have completed
 	State                       uint32                 // The runtime state of the DB from a service perspective
 	ResyncManager               *BackgroundManager[ResyncOptions]
-	TombstoneCompactionManager  *BackgroundManager[map[string]any]
-	AttachmentCompactionManager *BackgroundManager[map[string]any]
-	AttachmentMigrationManager  *BackgroundManager[map[string]any]
-	AsyncIndexInitManager       *BackgroundManager[map[string]any]
-	MetadataMigrationManager    *BackgroundManager[map[string]any]
+	TombstoneCompactionManager  *BackgroundManager[TombstoneCompactionOptions]
+	AttachmentCompactionManager *BackgroundManager[AttachmentCompactionOptions]
+	AttachmentMigrationManager  *BackgroundManager[AttachmentMigrationOptions]
+	AsyncIndexInitManager       *BackgroundManager[AsyncIndexInitOptions]
+	MetadataMigrationManager    *BackgroundManager[MetadataMigrationOptions]
 	OIDCProviders               auth.OIDCProviderMap // OIDC clients
 	LocalJWTProviders           auth.LocalJWTProviderMap
 	ServerUUID                  string // UUID of the server, if available
@@ -753,7 +753,7 @@ func (dbCtx *DatabaseContext) tryStartMetadataMigration(ctx context.Context) boo
 		return false
 	}
 	base.InfofCtx(ctx, base.KeyAll, "Config fully applied across cluster for database %s, starting metadata migration", base.MD(dbCtx.Name))
-	if err := dbCtx.MetadataMigrationManager.Start(ctx, nil); err != nil {
+	if err := dbCtx.MetadataMigrationManager.Start(ctx, MetadataMigrationOptions{}); err != nil {
 		// Another node already holds the migration heartbeat lock, so it owns this run. Stop arming
 		// to avoid re-acquiring the lock and re-running the migration once that node completes and
 		// releases it.
@@ -2551,7 +2551,7 @@ func (db *DatabaseContext) StartOnlineProcesses(ctx context.Context) (returnedEr
 	// if we have collections requiring migration, run the job
 	if len(db.RequireAttachmentMigration) > 0 {
 		cols := slices.Clone(db.RequireAttachmentMigration) // duplicate slice before logging, in case AttachmentMigrationManager runs very fast
-		err := db.AttachmentMigrationManager.Start(ctx, nil)
+		err := db.AttachmentMigrationManager.Start(ctx, AttachmentMigrationOptions{})
 		if err != nil {
 			base.WarnfCtx(ctx, "Error trying to migrate attachments for %s with error: %v", db.Name, err)
 		}

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -3821,7 +3821,7 @@ func TestTombstoneCompactionStopWithManager(t *testing.T) {
 		})
 	}
 
-	assert.NoError(t, db.TombstoneCompactionManager.Start(ctx, map[string]any{"database": db}))
+	assert.NoError(t, db.TombstoneCompactionManager.Start(ctx, TombstoneCompactionOptions{Database: db}))
 
 	waitAndAssertConditionWithOptions(t, func() bool {
 		return db.TombstoneCompactionManager.GetRunState() == BackgroundProcessStateStopped
@@ -4334,8 +4334,8 @@ func Test_stopBackgroundManagers(t *testing.T) {
 
 	testCases := []struct {
 		resyncManager               *BackgroundManager[ResyncOptions]
-		tombstoneCompactionManager  *BackgroundManager[map[string]any]
-		attachmentCompactionManager *BackgroundManager[map[string]any]
+		tombstoneCompactionManager  *BackgroundManager[TombstoneCompactionOptions]
+		attachmentCompactionManager *BackgroundManager[AttachmentCompactionOptions]
 		expected                    int
 	}{
 		{
@@ -4353,13 +4353,13 @@ func Test_stopBackgroundManagers(t *testing.T) {
 				name:    "test_resync",
 				Process: &testBackgroundProcess[ResyncOptions]{isStoppable: true},
 			},
-			tombstoneCompactionManager: &BackgroundManager[map[string]any]{
+			tombstoneCompactionManager: &BackgroundManager[TombstoneCompactionOptions]{
 				name:    "test_tombstone",
-				Process: &testBackgroundProcess[map[string]any]{isStoppable: true},
+				Process: &testBackgroundProcess[TombstoneCompactionOptions]{isStoppable: true},
 			},
-			attachmentCompactionManager: &BackgroundManager[map[string]any]{
+			attachmentCompactionManager: &BackgroundManager[AttachmentCompactionOptions]{
 				name:    "test_attachment",
-				Process: &testBackgroundProcess[map[string]any]{isStoppable: true},
+				Process: &testBackgroundProcess[AttachmentCompactionOptions]{isStoppable: true},
 			},
 			expected: 3,
 		},
@@ -4375,11 +4375,11 @@ func Test_stopBackgroundManagers(t *testing.T) {
 				assert.NoError(t, err)
 			}
 			if db.AttachmentCompactionManager != nil {
-				err := db.AttachmentCompactionManager.Start(ctx, map[string]any{})
+				err := db.AttachmentCompactionManager.Start(ctx, AttachmentCompactionOptions{})
 				assert.NoError(t, err)
 			}
 			if db.TombstoneCompactionManager != nil {
-				err := db.TombstoneCompactionManager.Start(ctx, map[string]any{})
+				err := db.TombstoneCompactionManager.Start(ctx, TombstoneCompactionOptions{})
 				assert.NoError(t, err)
 			}
 

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -526,9 +526,9 @@ func (h *handler) handlePostIndexInit() error {
 		return err
 	}
 
-	opts := map[string]any{
-		"statusMap": &statusMap,
-		"doneChan":  done,
+	opts := db.AsyncIndexInitOptions{
+		StatusMap: &statusMap,
+		DoneChan:  done,
 	}
 	err = h.db.AsyncIndexInitManager.Start(h.ctx(), opts)
 	if err != nil {

--- a/rest/api.go
+++ b/rest/api.go
@@ -148,8 +148,8 @@ func (h *handler) handleAttachmentMigration() error {
 	}
 
 	if action == string(db.BackgroundProcessActionStart) {
-		err := h.db.AttachmentMigrationManager.Start(h.ctx(), map[string]any{
-			"reset": reset,
+		err := h.db.AttachmentMigrationManager.Start(h.ctx(), db.AttachmentMigrationOptions{
+			Reset: reset,
 		})
 		if err != nil {
 			return err
@@ -233,8 +233,8 @@ func (h *handler) handleMetadataMigration() error {
 		// An explicit reset=true is still honored as an operator override to force a fresh run.
 		if h.db.MetadataMigrationComplete(h.ctx()) && !reset {
 			base.InfofCtx(h.ctx(), base.KeyAll, "Metadata migration already complete for database %s, returning current status without restarting", base.MD(h.db.Name))
-		} else if err := h.db.MetadataMigrationManager.Start(h.ctx(), map[string]any{
-			"reset": reset,
+		} else if err := h.db.MetadataMigrationManager.Start(h.ctx(), db.MetadataMigrationOptions{
+			Reset: reset,
 		}); err != nil {
 			return err
 		}
@@ -287,8 +287,8 @@ func (h *handler) handleCompact() error {
 	if compactionType == compactionTypeTombstone {
 		if action == string(db.BackgroundProcessActionStart) {
 			if atomic.CompareAndSwapUint32(&h.db.CompactState, db.DBCompactNotRunning, db.DBCompactRunning) {
-				err := h.db.TombstoneCompactionManager.Start(h.ctx(), map[string]any{
-					"database": h.db,
+				err := h.db.TombstoneCompactionManager.Start(h.ctx(), db.TombstoneCompactionOptions{
+					Database: h.db,
 				})
 				if err != nil {
 					return err
@@ -325,10 +325,10 @@ func (h *handler) handleCompact() error {
 
 	if compactionType == compactionTypeAttachment {
 		if action == string(db.BackgroundProcessActionStart) {
-			err := h.db.AttachmentCompactionManager.Start(h.ctx(), map[string]any{
-				"database": h.db,
-				"reset":    h.getBoolQuery("reset"),
-				"dryRun":   h.getBoolQuery("dry_run"),
+			err := h.db.AttachmentCompactionManager.Start(h.ctx(), db.AttachmentCompactionOptions{
+				Database: h.db,
+				Reset:    h.getBoolQuery("reset"),
+				DryRun:   h.getBoolQuery("dry_run"),
 			})
 			if err != nil {
 				return err

--- a/rest/attachmentmigrationtest/attachment_migration_test.go
+++ b/rest/attachmentmigrationtest/attachment_migration_test.go
@@ -359,7 +359,7 @@ func TestStartMigrationAlreadyRunningProcess(t *testing.T) {
 	// Wait until migration is blocked mid-UpdateXattrs, guaranteeing Running state.
 	base.RequireChanClosed(t, blocked)
 
-	err = rt.GetDatabase().AttachmentMigrationManager.Start(ctx, nil)
+	err = rt.GetDatabase().AttachmentMigrationManager.Start(ctx, db.AttachmentMigrationOptions{})
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "Process already running")
 


### PR DESCRIPTION
CBG-5653 switch backgroundmanager options to strong types

I am about to make a slight change to some attachment compaction code to fix a race condition in a place that called `AttachmentCompactionManager.Init` and wrote a bug where the values of the map were not checked and it caused a runtime panic.

Background Manager only started support generic types in Sync Gateway 4.1

I would have liked to remove `Database` as an option which is odd and pass `Database` as part of constructing the BackgroundManager but that's more work. The only reason I could imagine this existed was because the Database is scoped to the requesting user's database - but given that these are admin api only endpoints it might make sense to have a different  function that is `AdminDatabase(*DatabaseContext) *Database` which could be used on these background managers. This is well out of scope though.

## Pre-review checklist
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/1004/
