### PR TITLE
CBG-5636 use cbdinocluster in CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ planPIndexes/
 
 couchbase-lite-tests
 integration-test/e2e/.gitconfig.e2e
+.cbdinocluster-sg-cluster-id

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ planPIndexes/
 couchbase-lite-tests
 integration-test/e2e/.gitconfig.e2e
 .cbdinocluster-sg-cluster-id
+cbs.env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,23 +10,9 @@ go test ./...                    # unit tests, in-memory Rosmar backing store
 ```
 
 - **Enterprise Edition** builds and tests need the `cb_sg_enterprise,cb_sg_devmode` build tags on every Go command, plus SSH access to a private repo — see [docs/BUILD.md](docs/BUILD.md). Don't add these tags unless you specifically intend to test EE.
-- **Integration tests** against a real Couchbase Server, the `SG_TEST_*` environment variables, and the bucket pool are covered in [docs/TESTING.md](docs/TESTING.md).
+- **Integration tests** against a real Couchbase Server are covered in [docs/TESTING.md](docs/TESTING.md): starting a local cluster with `integration-test/start_cbs.py`, the `SG_TEST_*` environment variables, and the bucket pool.
 - **Python tooling** (`tools/`): See [tools/AGENTS.md](tools/AGENTS.md).
 - **Lint**: CI enforces `.golangci-strict.yml`; reproduce it locally with `pre-commit run golangci-lint --all-files`. Some conventions are enforced here rather than written down — the linter message explains the fix.
-
-### Starting a Couchbase Server for integration tests
-
-`integration-test/start_cbs.py` allocates a single-node cluster via [cbdinocluster](https://github.com/couchbaselabs/cbdinocluster) (Docker + Go are the only prerequisites; it runs `cbdinocluster init` for you on first use). This is what CI uses.
-
-```sh
-./integration-test/start_cbs.py   # allocate/reuse a cluster, write ./cbs.env
-source cbs.env                    # SG_TEST_COUCHBASE_SERVER_URL, CBS_CLUSTER_ID
-SG_TEST_BACKING_STORE=Couchbase go test -count=1 -p 1 -timeout 45m ./...
-```
-
-Useful flags: `--env-file` (default `./cbs.env`), `--version` (default 8.0.1), `--nodes`, `--services` (default `kv,n1ql,index`), `--kv-memory-mb`/`--index-memory-mb`, `--tls`, `--purpose`.
-
-The allocated cluster ID is recorded in `.cbdinocluster-sg-cluster-id` in the working directory (gitignored), so re-running the script reuses the running cluster when the version/node count/services still match. Tear down with `go run github.com/couchbaselabs/cbdinocluster@latest remove "$CBS_CLUSTER_ID"` (or `list` / `remove-all`); clusters expire on their own but hold Docker memory until then.
 
 Git: `main` is the current in-development version. Released versions and backports live in `release/x.y.z` branches. Feature branches are named `CBG-xxxx` after the Jira ticket.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,12 +19,12 @@ go test ./...                    # unit tests, in-memory Rosmar backing store
 `integration-test/start_cbs.py` allocates a single-node cluster via [cbdinocluster](https://github.com/couchbaselabs/cbdinocluster) (Docker + Go are the only prerequisites; it runs `cbdinocluster init` for you on first use). This is what CI uses.
 
 ```sh
-./integration-test/start_cbs.py --env-file cbs.env    # allocate/reuse a cluster
-source cbs.env                                        # SG_TEST_COUCHBASE_SERVER_URL, CBS_CLUSTER_ID
+./integration-test/start_cbs.py   # allocate/reuse a cluster, write ./cbs.env
+source cbs.env                    # SG_TEST_COUCHBASE_SERVER_URL, CBS_CLUSTER_ID
 SG_TEST_BACKING_STORE=Couchbase go test -count=1 -p 1 -timeout 45m ./...
 ```
 
-Useful flags: `--version` (default 8.0.1), `--nodes`, `--services` (default `kv,n1ql,index`), `--kv-memory-mb`/`--index-memory-mb`, `--tls`, `--purpose`.
+Useful flags: `--env-file` (default `./cbs.env`), `--version` (default 8.0.1), `--nodes`, `--services` (default `kv,n1ql,index`), `--kv-memory-mb`/`--index-memory-mb`, `--tls`, `--purpose`.
 
 The allocated cluster ID is recorded in `.cbdinocluster-sg-cluster-id` in the working directory (gitignored), so re-running the script reuses the running cluster when the version/node count/services still match. Tear down with `go run github.com/couchbaselabs/cbdinocluster@latest remove "$CBS_CLUSTER_ID"` (or `list` / `remove-all`); clusters expire on their own but hold Docker memory until then.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,20 @@ go test ./...                    # unit tests, in-memory Rosmar backing store
 - **Python tooling** (`tools/`): See [tools/AGENTS.md](tools/AGENTS.md).
 - **Lint**: CI enforces `.golangci-strict.yml`; reproduce it locally with `pre-commit run golangci-lint --all-files`. Some conventions are enforced here rather than written down — the linter message explains the fix.
 
+### Starting a Couchbase Server for integration tests
+
+`integration-test/start_cbs.py` allocates a single-node cluster via [cbdinocluster](https://github.com/couchbaselabs/cbdinocluster) (Docker + Go are the only prerequisites; it runs `cbdinocluster init` for you on first use). This is what CI uses.
+
+```sh
+./integration-test/start_cbs.py --env-file cbs.env    # allocate/reuse a cluster
+source cbs.env                                        # SG_TEST_COUCHBASE_SERVER_URL, CBS_CLUSTER_ID
+SG_TEST_BACKING_STORE=Couchbase go test -count=1 -p 1 -timeout 45m ./...
+```
+
+Useful flags: `--version` (default 8.0.1), `--nodes`, `--services` (default `kv,n1ql,index`), `--kv-memory-mb`/`--index-memory-mb`, `--tls`, `--purpose`.
+
+The allocated cluster ID is recorded in `.cbdinocluster-sg-cluster-id` in the working directory (gitignored), so re-running the script reuses the running cluster when the version/node count/services still match. Tear down with `go run github.com/couchbaselabs/cbdinocluster@latest remove "$CBS_CLUSTER_ID"` (or `list` / `remove-all`); clusters expire on their own but hold Docker memory until then.
+
 Git: `main` is the current in-development version. Released versions and backports live in `release/x.y.z` branches. Feature branches are named `CBG-xxxx` after the Jira ticket.
 
 ## Architecture Overview

--- a/base/constants.go
+++ b/base/constants.go
@@ -65,7 +65,7 @@ const (
 	TestEnvX509LocalUser = "SG_TEST_X509_LOCAL_USER"
 
 	// If set, corresponds to name of the docker image of couchbase server
-	TestEnvCouchbaseServerDockerName = "SG_TEST_COUCHBASE_SERVER_DOCKER_NAME"
+	TestEnvCouchbaseServerDockerName = sgtest.EnvCouchbaseServerDockerName
 
 	// TestEnvGoroutineDump if set to true will capture a goroutine pprof profile and log the location at the end of each package
 	TestEnvGoroutineDump = "SG_TEST_GOROUTINE_DUMP"

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -26,6 +26,7 @@ import (
 	"github.com/couchbase/gocb/v2"
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/testing/require"
+	"github.com/couchbase/sync_gateway/testing/sgtest"
 	"github.com/couchbaselabs/rosmar"
 	"github.com/pkg/errors"
 )
@@ -124,6 +125,22 @@ type TestBucketPool struct {
 
 	// needsBucketTeardown indicates whether the test bucket pool needs to be torn down after tests are run.
 	needsBucketTeardown bool
+
+	// dockerContainerNameForServer caches the docker container name lookup, computed lazily since most packages never need it.
+	dockerContainerNameOnce           sync.Once
+	dockerContainerNameForServer      string
+	dockerContainerNameForServerFound bool
+}
+
+// DockerContainerNameForServer returns the docker container name the pool's cluster is running in, if any.
+func (tbp *TestBucketPool) DockerContainerNameForServer() (string, bool) {
+	if UnitTestUrlIsWalrus() {
+		return "", false
+	}
+	tbp.dockerContainerNameOnce.Do(func() {
+		tbp.dockerContainerNameForServer, tbp.dockerContainerNameForServerFound = sgtest.GetServerDockerContainer(UnitTestUrl())
+	})
+	return tbp.dockerContainerNameForServer, tbp.dockerContainerNameForServerFound
 }
 
 type TestBucketPoolOptions struct {
@@ -193,8 +210,10 @@ func NewTestBucketPoolWithOptions(ctx context.Context, bucketReadierFunc TBPBuck
 		FatalfCtx(ctx, "Invalid value for %s: %s. Valid values are: %s, %s", tbpEnvXDCRConflictResolutionStrategy, os.Getenv(tbpEnvXDCRConflictResolutionStrategy), XDCRConflictResolutionStrategyLWW, XDCRConflictResolutionStrategyMWW)
 	}
 
+	integrationMode := !UnitTestUrlIsWalrus() && !TestUseExistingBucket()
+
 	tbp := TestBucketPool{
-		integrationMode:                !UnitTestUrlIsWalrus() && !TestUseExistingBucket(),
+		integrationMode:                integrationMode,
 		numBuckets:                     numBuckets,
 		readyBucketPool:                make(chan Bucket, numBuckets),
 		bucketReadierQueue:             make(chan tbpBucketName, numBuckets),

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -225,12 +225,19 @@ func TestUseSystemMetadataCollection() bool {
 	return val
 }
 
+// TestUseCouchbaseServerDockerName returns whether the Couchbase Server under test is running in a local Docker
+// container, and if so, the container's name. SG_TEST_COUCHBASE_SERVER_DOCKER_NAME overrides the lookup when set.
+// Otherwise, the container is found by matching the host in SG_TEST_COUCHBASE_SERVER_URL against the docker network
+// IP addresses of currently running containers, since tools like cbdinocluster assign a random container name per node.
+// If GTestBucketPool has already computed this (the common case), the cached value is reused instead of
+// re-running docker commands on every call.
 func TestUseCouchbaseServerDockerName() (bool, string) {
-	testX509CouchbaseServerDockerName, isSet := os.LookupEnv(TestEnvCouchbaseServerDockerName)
-	if !isSet {
-		return false, ""
+	if GTestBucketPool != nil {
+		name, found := GTestBucketPool.DockerContainerNameForServer()
+		return found, name
 	}
-	return true, testX509CouchbaseServerDockerName
+	name, found := sgtest.GetServerDockerContainer(UnitTestUrl())
+	return found, name
 }
 
 func TestX509LocalServer() (bool, string) {

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -34,6 +34,28 @@ Three flags matter here and are easy to get wrong:
 Tests run with `-shuffle=on` by default (see `.github/workflows/ci.yml`), so ordering dependencies
 between tests will surface as intermittent failures.
 
+Starting a Couchbase Server
+---------------------------
+
+`integration-test/start_cbs.py` allocates a single-node cluster via
+[cbdinocluster](https://github.com/couchbaselabs/cbdinocluster) (Docker + Go are the only
+prerequisites; it runs `cbdinocluster init` for you on first use). This is what CI uses.
+
+```sh
+./integration-test/start_cbs.py   # allocate/reuse a cluster, write ./cbs.env
+source cbs.env                    # SG_TEST_COUCHBASE_SERVER_URL, CBS_CLUSTER_ID
+SG_TEST_BACKING_STORE=Couchbase go test -count=1 -p 1 -timeout 45m ./...
+```
+
+Useful flags: `--env-file` (default `./cbs.env`), `--version` (default 8.0.1), `--nodes`,
+`--services` (default `kv,n1ql,index`), `--kv-memory-mb`/`--index-memory-mb`, `--tls`, `--purpose`.
+
+The allocated cluster ID is recorded in `.cbdinocluster-sg-cluster-id` in the working directory
+(gitignored), so re-running the script reuses the running cluster when the version/node
+count/services still match. Tear down with
+`go run github.com/couchbaselabs/cbdinocluster@latest remove "$CBS_CLUSTER_ID"` (or `list` /
+`remove-all`); clusters expire on their own but hold Docker memory until then.
+
 Capturing output
 ----------------
 

--- a/integration-test/e2e/Jenkinsfile
+++ b/integration-test/e2e/Jenkinsfile
@@ -135,7 +135,7 @@ pipeline {
                     sh '''
                         set -eu
                         mkdir -p integration-test/e2e .github
-                        curl -sSf https://raw.githubusercontent.com/couchbase/sync_gateway/main/integration-test/e2e/run_e2e_tests.sh -o integration-test/e2e/run_e2e_tests.sh
+                        curl -sSf https://raw.githubusercontent.com/couchbase/sync_gateway/CBG-5636/integration-test/e2e/run_e2e_tests.sh -o integration-test/e2e/run_e2e_tests.sh
                         curl -sSf https://raw.githubusercontent.com/couchbase/sync_gateway/main/integration-test/slackUtils.groovy -o integration-test/slackUtils.groovy
                         curl -sSf https://raw.githubusercontent.com/couchbase/sync_gateway/main/.github/slack_usernames.yaml -o .github/slack_usernames.yaml
                         /bin/bash integration-test/e2e/run_e2e_tests.sh

--- a/integration-test/e2e/Jenkinsfile
+++ b/integration-test/e2e/Jenkinsfile
@@ -135,7 +135,7 @@ pipeline {
                     sh '''
                         set -eu
                         mkdir -p integration-test/e2e .github
-                        curl -sSf https://raw.githubusercontent.com/couchbase/sync_gateway/CBG-5636/integration-test/e2e/run_e2e_tests.sh -o integration-test/e2e/run_e2e_tests.sh
+                        curl -sSf https://raw.githubusercontent.com/couchbase/sync_gateway/main/integration-test/e2e/run_e2e_tests.sh -o integration-test/e2e/run_e2e_tests.sh
                         curl -sSf https://raw.githubusercontent.com/couchbase/sync_gateway/main/integration-test/slackUtils.groovy -o integration-test/slackUtils.groovy
                         curl -sSf https://raw.githubusercontent.com/couchbase/sync_gateway/main/.github/slack_usernames.yaml -o .github/slack_usernames.yaml
                         /bin/bash integration-test/e2e/run_e2e_tests.sh

--- a/integration-test/e2e/run_e2e_tests.sh
+++ b/integration-test/e2e/run_e2e_tests.sh
@@ -28,7 +28,11 @@ fi
 
 if [[ "$BACKING_STORE" == "cbs" ]]; then
     : "${COUCHBASE_SERVER_VERSION:?COUCHBASE_SERVER_VERSION must be set when BACKING_STORE=cbs}"
-    "${REPO_DIR}/integration-test/start_server.sh" "${COUCHBASE_SERVER_VERSION}"
+    CBS_ENV_FILE="$(mktemp)"
+    "${REPO_DIR}/integration-test/start_cbs.py" --version "${COUCHBASE_SERVER_VERSION}" --purpose sync_gateway_e2e --env-file "${CBS_ENV_FILE}"
+    # shellcheck disable=SC1090
+    source "${CBS_ENV_FILE}"
+    rm -f "${CBS_ENV_FILE}"
 fi
 
 export GIT_CONFIG_GLOBAL="${SCRIPT_DIR}/.gitconfig.e2e"
@@ -45,8 +49,17 @@ git checkout --detach FETCH_HEAD
 git submodule sync --recursive
 git submodule update --init --recursive --force
 
-uv run -- ./environment/local/start_local.py --build-testserver "${COUCHBASE_LITE_VERSION}"
-uv run -- ./environment/local/build_sync_gateway.py --repo-path "${REPO_DIR}"
-uv run -- ./environment/local/run_sync_gateway.py --start --server "${BACKING_STORE}"
+# start_local.py builds/starts the test server and Sync Gateway in one go, and (for
+# --server cbs) patches the cbltest topology config's Couchbase Server hostname with
+# --connstr, since cbdinocluster clusters are reachable at their docker-network
+# address, not localhost. cbltest's CouchbaseServer accepts either a bare host or a
+# full connection string in the "hostname" field.
+START_LOCAL_ARGS=(--server "${BACKING_STORE}" --build-testserver "${COUCHBASE_LITE_VERSION}" --repo-path "${REPO_DIR}")
+if [[ "$BACKING_STORE" == "cbs" ]]; then
+    START_LOCAL_ARGS+=(--connstr "${SG_TEST_COUCHBASE_SERVER_URL}")
+fi
+uv run -- ./environment/local/start_local.py "${START_LOCAL_ARGS[@]}"
+
+TOPOLOGY_CONFIG="$(cat environment/local/topology_config)"
 # shellcheck disable=SC2086
-uv run pytest --config "./environment/local/${BACKING_STORE}_config.json" --junitxml="${TEST_DIRECTORY}/junit_report.xml" -o junit_logging=all -o junit_log_passing_tests=false "./${TEST_DIRECTORY}" ${PYTEST_EXTRA_ARGS:-}
+uv run pytest --config "${TOPOLOGY_CONFIG}" --junitxml="${TEST_DIRECTORY}/junit_report.xml" -o junit_logging=all -o junit_log_passing_tests=false "./${TEST_DIRECTORY}" ${PYTEST_EXTRA_ARGS:-}

--- a/integration-test/start_cbs.py
+++ b/integration-test/start_cbs.py
@@ -31,6 +31,9 @@ DEFAULT_NODES = 1
 # local invocations (e.g. re-running tests) reuse the running cluster instead of allocating a
 # new one every time.
 STATE_FILE_NAME = ".cbdinocluster-sg-cluster-id"
+# Written next to the state file unless --env-file says otherwise, so that a plain invocation
+# leaves something sourceable behind rather than only printing the exports to stdout.
+DEFAULT_ENV_FILE_NAME = "cbs.env"
 # cbdinocluster keeps its configuration in a single file in the user's home directory, written by
 # 'cbdinocluster init'. Every other subcommand fails to load its config until that file exists.
 CBDINOCLUSTER_CONFIG_PATH = os.path.join(os.path.expanduser("~"), ".cbdinocluster")
@@ -181,8 +184,9 @@ def main() -> None:
     )
     parser.add_argument(
         "--env-file",
-        help="If set, write shell-sourceable 'export SG_TEST_COUCHBASE_SERVER_URL=...' and "
-        "'export CBS_CLUSTER_ID=...' lines to this path.",
+        default=os.path.join(os.getcwd(), DEFAULT_ENV_FILE_NAME),
+        help="Path to write shell-sourceable 'export SG_TEST_COUCHBASE_SERVER_URL=...' and "
+        f"'export CBS_CLUSTER_ID=...' lines to (default: ./{DEFAULT_ENV_FILE_NAME})",
     )
     opts = parser.parse_args()
 
@@ -249,10 +253,9 @@ def main() -> None:
     for line in env_lines:
         print(f"  {line}", flush=True)
 
-    if opts.env_file:
-        with open(opts.env_file, "w") as f:
-            f.write("\n".join(env_lines) + "\n")
-        print(f"\nWrote connection details to {opts.env_file}", flush=True)
+    with open(opts.env_file, "w") as f:
+        f.write("\n".join(env_lines) + "\n")
+    print(f"\nWrote connection details to {opts.env_file}", flush=True)
 
 
 if __name__ == "__main__":

--- a/integration-test/start_cbs.py
+++ b/integration-test/start_cbs.py
@@ -16,6 +16,7 @@
 import argparse
 import os
 import re
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -204,9 +205,11 @@ def main() -> None:
     connstr = connstr_result.stdout.strip()
     print(f"Connection string: {connstr}", flush=True)
 
+    # Connection strings can contain characters the shell would interpret (e.g. ?/& in query
+    # params), so quote the values to keep the output safe to source.
     env_lines = [
-        f"export SG_TEST_COUCHBASE_SERVER_URL={connstr}",
-        f"export CBS_CLUSTER_ID={cluster_id}",
+        f"export SG_TEST_COUCHBASE_SERVER_URL={shlex.quote(connstr)}",
+        f"export CBS_CLUSTER_ID={shlex.quote(cluster_id)}",
     ]
 
     print("\nExport for tests:")

--- a/integration-test/start_cbs.py
+++ b/integration-test/start_cbs.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+# Copyright 2024-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
+# /// script
+# requires-python = ">=3.10"
+# ///
+
+"""Start a Couchbase Server cluster using cbdinocluster."""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import textwrap
+
+CBDINOCLUSTER = "github.com/couchbaselabs/cbdinocluster@latest"
+DEFAULT_CBS_VERSION = "8.0.1"
+DEFAULT_SERVICES = "kv,n1ql,index"
+DEFAULT_MEMORY_MB = 3072
+DEFAULT_NODES = 1
+# Tracks the cluster this script last allocated from a given working directory, so repeated
+# local invocations (e.g. re-running tests) reuse the running cluster instead of allocating a
+# new one every time.
+STATE_FILE_NAME = ".cbdinocluster-sg-cluster-id"
+
+
+def run(args: list[str], **kwargs) -> subprocess.CompletedProcess:
+    print(f"+ {' '.join(args)}", flush=True)
+    return subprocess.run(args, check=True, **kwargs)
+
+
+def find_reusable_cluster(version: str, nodes: int, services: str) -> str | None:
+    """Return the cluster ID recorded in the cwd's state file, if it's still running and
+    matches the requested version/node count/services. Otherwise return None."""
+    state_path = os.path.join(os.getcwd(), STATE_FILE_NAME)
+    if not os.path.exists(state_path):
+        return None
+
+    with open(state_path) as f:
+        cluster_id = f.read().strip()
+    if not cluster_id:
+        return None
+
+    result = subprocess.run(
+        ["go", "run", CBDINOCLUSTER, "get-definition", cluster_id],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
+        if "not found" in stderr.lower():
+            print(
+                f"Cluster {cluster_id} recorded in {state_path} is no longer running; "
+                "allocating a new one",
+                flush=True,
+            )
+            return None
+        # Unknown failure - don't assume the cluster is gone and silently allocate a duplicate.
+        raise RuntimeError(
+            f"Failed to check status of cluster {cluster_id} recorded in {state_path}: "
+            f"{stderr or 'get-definition failed with no stderr output'}"
+        )
+
+    definition = result.stdout
+    version_match = re.search(r"version:\s*(\S+)", definition)
+    nodes_match = re.search(r"count:\s*(\S+)", definition)
+    services_match = re.search(r"services:\s*\[([^\]]*)\]", definition)
+    requested_services = {s.strip() for s in services.split(",") if s.strip()}
+    existing_services = (
+        {s.strip() for s in services_match.group(1).split(",") if s.strip()}
+        if services_match
+        else None
+    )
+    if (
+        version_match is None
+        or nodes_match is None
+        or existing_services is None
+        or version_match.group(1) != version
+        or nodes_match.group(1) != str(nodes)
+        or existing_services != requested_services
+    ):
+        print(
+            f"Cluster {cluster_id} recorded in {state_path} doesn't match the requested "
+            f"version={version}/nodes={nodes}/services={sorted(requested_services)}; "
+            "allocating a new one",
+            flush=True,
+        )
+        return None
+
+    print(f"Reusing existing cluster {cluster_id} recorded in {state_path}", flush=True)
+    return cluster_id
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Start a Couchbase Server cluster via cbdinocluster."
+    )
+    parser.add_argument(
+        "--version",
+        default=os.environ.get("COUCHBASE_SERVER_VERSION", DEFAULT_CBS_VERSION),
+        help="Couchbase Server version to deploy "
+        f"(default: ${{COUCHBASE_SERVER_VERSION}} or {DEFAULT_CBS_VERSION})",
+    )
+    parser.add_argument(
+        "--nodes",
+        type=int,
+        default=int(os.environ.get("COUCHBASE_NUM_NODES", DEFAULT_NODES)),
+        help="Number of nodes in the cluster, all running the same services "
+        f"(default: $COUCHBASE_NUM_NODES or {DEFAULT_NODES})",
+    )
+    parser.add_argument(
+        "--purpose",
+        default=os.environ.get("CBDINOCLUSTER_PURPOSE", ""),
+        help="Optional purpose label for the cluster (default: $CBDINOCLUSTER_PURPOSE)",
+    )
+    parser.add_argument(
+        "--services",
+        default=os.environ.get("COUCHBASE_SERVICES", DEFAULT_SERVICES),
+        help="Comma-separated list of services to run on each node "
+        f"(default: $COUCHBASE_SERVICES or {DEFAULT_SERVICES})",
+    )
+    parser.add_argument(
+        "--kv-memory-mb",
+        type=int,
+        default=int(os.environ.get("COUCHBASE_KV_MEMORY_MB", DEFAULT_MEMORY_MB)),
+        help="KV service memory quota in MB "
+        f"(default: $COUCHBASE_KV_MEMORY_MB or {DEFAULT_MEMORY_MB})",
+    )
+    parser.add_argument(
+        "--index-memory-mb",
+        type=int,
+        default=int(os.environ.get("COUCHBASE_INDEX_MEMORY_MB", DEFAULT_MEMORY_MB)),
+        help="Index service memory quota in MB "
+        f"(default: $COUCHBASE_INDEX_MEMORY_MB or {DEFAULT_MEMORY_MB})",
+    )
+    parser.add_argument(
+        "--tls",
+        action="store_true",
+        help="Request a TLS (couchbases://) connection string instead of the default couchbase://",
+    )
+    parser.add_argument(
+        "--env-file",
+        help="If set, write shell-sourceable 'export SG_TEST_COUCHBASE_SERVER_URL=...' and "
+        "'export CBS_CLUSTER_ID=...' lines to this path.",
+    )
+    opts = parser.parse_args()
+
+    state_path = os.path.join(os.getcwd(), STATE_FILE_NAME)
+    cluster_id = find_reusable_cluster(opts.version, opts.nodes, opts.services)
+
+    if cluster_id is None:
+        services = ", ".join(s.strip() for s in opts.services.split(",") if s.strip())
+
+        yaml_content = textwrap.dedent(f"""\
+            nodes:
+              - count: {opts.nodes}
+                version: {opts.version}
+                services: [{services}]
+            docker:
+                kv-memory: {opts.kv_memory_mb}
+                index-memory: {opts.index_memory_mb}
+        """)
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False, prefix="cbdino-sg-"
+        ) as f:
+            f.write(yaml_content)
+            def_file = f.name
+
+        print(f"Cluster definition written to {def_file}:", flush=True)
+        print(yaml_content, flush=True)
+
+        allocate_cmd = ["go", "run", CBDINOCLUSTER, "allocate", "--def-file", def_file]
+        if opts.purpose:
+            allocate_cmd += ["--purpose", opts.purpose]
+
+        try:
+            result = run(allocate_cmd, stdout=subprocess.PIPE, text=True)
+        finally:
+            os.remove(def_file)
+        cluster_id = result.stdout.strip()
+        print(f"Cluster ID: {cluster_id}", flush=True)
+
+        with open(state_path, "w") as f:
+            f.write(cluster_id + "\n")
+        print(f"Wrote cluster ID to {state_path}", flush=True)
+
+    connstr_cmd = ["go", "run", CBDINOCLUSTER, "connstr", cluster_id]
+    connstr_cmd += ["--tls"] if opts.tls else ["--no-tls"]
+    connstr_result = run(
+        connstr_cmd,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    connstr = connstr_result.stdout.strip()
+    print(f"Connection string: {connstr}", flush=True)
+
+    env_lines = [
+        f"export SG_TEST_COUCHBASE_SERVER_URL={connstr}",
+        f"export CBS_CLUSTER_ID={cluster_id}",
+    ]
+
+    print("\nExport for tests:")
+    for line in env_lines:
+        print(f"  {line}", flush=True)
+
+    if opts.env_file:
+        with open(opts.env_file, "w") as f:
+            f.write("\n".join(env_lines) + "\n")
+        print(f"\nWrote connection details to {opts.env_file}", flush=True)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except subprocess.CalledProcessError as e:
+        print(f"Error: command failed with exit code {e.returncode}", file=sys.stderr)
+        sys.exit(e.returncode)
+    except RuntimeError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)

--- a/integration-test/start_cbs.py
+++ b/integration-test/start_cbs.py
@@ -31,11 +31,42 @@ DEFAULT_NODES = 1
 # local invocations (e.g. re-running tests) reuse the running cluster instead of allocating a
 # new one every time.
 STATE_FILE_NAME = ".cbdinocluster-sg-cluster-id"
+# cbdinocluster keeps its configuration in a single file in the user's home directory, written by
+# 'cbdinocluster init'. Every other subcommand fails to load its config until that file exists.
+CBDINOCLUSTER_CONFIG_PATH = os.path.join(os.path.expanduser("~"), ".cbdinocluster")
 
 
 def run(args: list[str], **kwargs) -> subprocess.CompletedProcess:
     print(f"+ {' '.join(args)}", flush=True)
     return subprocess.run(args, check=True, **kwargs)
+
+
+def ensure_initialized() -> None:
+    """Run 'cbdinocluster init' if it hasn't been run before, since no other subcommand works
+    without the config file it writes. Existing configuration is left alone."""
+    if os.path.exists(CBDINOCLUSTER_CONFIG_PATH):
+        return
+    print(
+        f"{CBDINOCLUSTER_CONFIG_PATH} not found, initializing cbdinocluster for docker",
+        flush=True,
+    )
+    # Sync Gateway only ever uses the docker deployer, so skip the cloud/k8s providers - they
+    # default to enabled under --auto and would otherwise probe for credentials we don't have.
+    run(
+        [
+            "go",
+            "run",
+            CBDINOCLUSTER,
+            "init",
+            "--auto",
+            "--disable-k8s",
+            "--disable-capella",
+            "--disable-aws",
+            "--disable-azure",
+            "--disable-gcp",
+            "--disable-dns",
+        ]
+    )
 
 
 def find_reusable_cluster(version: str, nodes: int, services: str) -> str | None:
@@ -154,6 +185,8 @@ def main() -> None:
         "'export CBS_CLUSTER_ID=...' lines to this path.",
     )
     opts = parser.parse_args()
+
+    ensure_initialized()
 
     state_path = os.path.join(os.getcwd(), STATE_FILE_NAME)
     cluster_id = find_reusable_cluster(opts.version, opts.nodes, opts.services)

--- a/integration-test/start_server.sh
+++ b/integration-test/start_server.sh
@@ -9,6 +9,9 @@
 
 set -eu -o pipefail
 
+# Prefer start_cbs.py (cbdinocluster) - it's what CI uses now. This script is kept for local dev,
+# since it starts CBS directly in a docker-compose container reachable on localhost.
+
 function usage() {
     echo "Usage: $0 [-m] [-h] containername"
     exit 1

--- a/jenkins-integration-build.sh
+++ b/jenkins-integration-build.sh
@@ -120,19 +120,23 @@ if [ "${RUN_WALRUS}" == "true" ]; then
 fi
 
 # Run CBS
+CBS_NODES=1
 if [ "${MULTI_NODE:-}" == "true" ]; then
-    # multi node
-    ./integration-test/start_server.sh -m "${COUCHBASE_SERVER_VERSION}"
+    CBS_NODES=3
     export SG_TEST_BUCKET_NUM_REPLICAS=1
-else
-    # single node
-    ./integration-test/start_server.sh "${COUCHBASE_SERVER_VERSION}"
-    export SG_TEST_COUCHBASE_SERVER_DOCKER_NAME="couchbase"
 fi
+START_CBS_ARGS=(--version "${COUCHBASE_SERVER_VERSION}" --nodes "${CBS_NODES}" --purpose sync_gateway_integration)
+if [ "${COUCHBASE_SERVER_PROTOCOL}" == "couchbases" ]; then
+    START_CBS_ARGS+=(--tls)
+fi
+CBS_ENV_FILE="$(mktemp)"
+./integration-test/start_cbs.py "${START_CBS_ARGS[@]}" --env-file "${CBS_ENV_FILE}"
+# shellcheck disable=SC1090
+source "${CBS_ENV_FILE}"
+rm -f "${CBS_ENV_FILE}"
 
 # Set up test environment variables for CBS runs
 export SG_TEST_USE_GSI=${GSI}
-export SG_TEST_COUCHBASE_SERVER_URL="${COUCHBASE_SERVER_PROTOCOL}://127.0.0.1"
 export SG_TEST_BACKING_STORE="Couchbase"
 export SG_TEST_TLS_SKIP_VERIFY=${TLS_SKIP_VERIFY}
 
@@ -153,7 +157,7 @@ set +x # Stop outputting all executed shell commands
 
 # Collect CBS logs if server error occurred
 if [ "${SG_CBCOLLECT_ALWAYS:-}" == "true" ] || grep -a -q "server logs for details\|Timed out after 1m0s waiting for a bucket to become available" "${INT_LOG_FILE_NAME}.out"; then
-    docker exec -t couchbase /opt/couchbase/bin/cbcollect_info /workspace/cbcollect.zip
+    go run github.com/couchbaselabs/cbdinocluster@latest collect-logs "${CBS_CLUSTER_ID}" cbcollect.zip
 fi
 
 # If rosmar tests were run, then prepend classname with integration to tell them apart

--- a/testing/sgtest/docker.go
+++ b/testing/sgtest/docker.go
@@ -22,12 +22,12 @@ import (
 const EnvCouchbaseServerDockerName = "SG_TEST_COUCHBASE_SERVER_DOCKER_NAME"
 
 // GetServerDockerContainer returns whether the Couchbase Server under test is running in a local Docker
-// container, and if so, the container's name. EnvCouchbaseServerDockerName overrides the lookup when set.
-// Otherwise, the container is found by matching the host of serverURL against the docker network
-// IP addresses of currently running containers. If more than one running container matches, the result
-// is ambiguous and (\"\", false) is returned rather than guessing.
+// container, and if so, the container's name. EnvCouchbaseServerDockerName overrides the lookup when set
+// to a non-empty value; if it is unset or blank, the container is found by matching the host of serverURL
+// against the docker network IP addresses of currently running containers. If more than one running
+// container matches, the result is ambiguous and (\"\", false) is returned rather than guessing.
 func GetServerDockerContainer(serverURL string) (string, bool) {
-	if name, isSet := os.LookupEnv(EnvCouchbaseServerDockerName); isSet {
+	if name := strings.TrimSpace(os.Getenv(EnvCouchbaseServerDockerName)); name != "" {
 		return name, true
 	}
 

--- a/testing/sgtest/docker.go
+++ b/testing/sgtest/docker.go
@@ -1,0 +1,71 @@
+// Copyright 2026-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package sgtest
+
+import (
+	"os"
+	"os/exec"
+	"slices"
+	"strings"
+
+	"github.com/couchbase/gocbcore/v10/connstr"
+)
+
+// EnvCouchbaseServerDockerName is the environment variable that overrides the docker container name lookup
+// performed by GetServerDockerContainer.
+const EnvCouchbaseServerDockerName = "SG_TEST_COUCHBASE_SERVER_DOCKER_NAME"
+
+// GetServerDockerContainer returns whether the Couchbase Server under test is running in a local Docker
+// container, and if so, the container's name. EnvCouchbaseServerDockerName overrides the lookup when set.
+// Otherwise, the container is found by matching the host of serverURL against the docker network
+// IP addresses of currently running containers. If more than one running container matches, the result
+// is ambiguous and (\"\", false) is returned rather than guessing.
+func GetServerDockerContainer(serverURL string) (string, bool) {
+	if name, isSet := os.LookupEnv(EnvCouchbaseServerDockerName); isSet {
+		return name, true
+	}
+
+	connSpec, err := connstr.Parse(serverURL)
+	if err != nil || len(connSpec.Addresses) == 0 {
+		return "", false
+	}
+	host := connSpec.Addresses[0].Host
+	if host == "" || host == "localhost" || host == "127.0.0.1" {
+		return "", false
+	}
+
+	psOutput, err := exec.Command("docker", "ps", "-q").Output()
+	if err != nil {
+		return "", false
+	}
+	containerIDs := strings.Fields(string(psOutput))
+	if len(containerIDs) == 0 {
+		return "", false
+	}
+
+	inspectArgs := append([]string{"inspect", "--format", "{{.Name}}||{{range .NetworkSettings.Networks}}{{.IPAddress}} {{end}}"}, containerIDs...)
+	inspectOutput, err := exec.Command("docker", inspectArgs...).Output()
+	if err != nil {
+		return "", false
+	}
+	var matches []string
+	for line := range strings.SplitSeq(strings.TrimSpace(string(inspectOutput)), "\n") {
+		name, ips, ok := strings.Cut(line, "||")
+		if !ok {
+			continue
+		}
+		if slices.Contains(strings.Fields(ips), host) {
+			matches = append(matches, strings.TrimPrefix(name, "/"))
+		}
+	}
+	if len(matches) != 1 {
+		return "", false
+	}
+	return matches[0], true
+}

--- a/testing/sgtest/docker.go
+++ b/testing/sgtest/docker.go
@@ -25,7 +25,7 @@ const EnvCouchbaseServerDockerName = "SG_TEST_COUCHBASE_SERVER_DOCKER_NAME"
 // container, and if so, the container's name. EnvCouchbaseServerDockerName overrides the lookup when set
 // to a non-empty value; if it is unset or blank, the container is found by matching the host of serverURL
 // against the docker network IP addresses of currently running containers. If more than one running
-// container matches, the result is ambiguous and (\"\", false) is returned rather than guessing.
+// container matches, the result is ambiguous and ("", false) is returned rather than guessing.
 func GetServerDockerContainer(serverURL string) (string, bool) {
 	if name := strings.TrimSpace(os.Getenv(EnvCouchbaseServerDockerName)); name != "" {
 		return name, true


### PR DESCRIPTION
CBG-5636 use cbdinocluster in CI

switch start_server.sh script to use cbdinocluster. This allows starting a multi node Couchbase Server and be able to run multiple Couchbase Server instances at the same time.

Replacing start_server.sh has more benefit than just the use in Couchbase Lite E2E tests, such as directing an agent to create/use/manage its own copy of Couchbase Server.

Allow optional autodetection of SG_TEST_COUCHBASE_SERVER_DOCKER_NAME via docker inspect, since I have been likely to get this wrong easily and have perplexing failures in xdcr package.

The original motivation was to be able to run a multi node cluster using sgwjenkins Couchbase Lite E2E tests.

## Pre-review checklist
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/1007/ (only xdcr package, multiple packages don't add to tests)

Couchbase Lite E2E tests:

https://jenkins.sgwdev.com/job/Couchbase%20Lite%20E2E%20jenkins%20testing/27/ (failures are unrelated but fixed by https://github.com/couchbaselabs/couchbase-lite-tests/pull/458)

Note that I need to unpin change in Jenkinsfile to swap back to pull branch from main.