### PR TITLE
CBG-4622 test-only: fix race in TestBlipDeltaSyncPullResend

### DIFF
--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -15,6 +15,7 @@ import (
 	"maps"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/couchbase/go-blip"
 	"github.com/couchbase/sync_gateway/base"
@@ -490,19 +491,27 @@ func TestBlipDeltaSyncPullResend(t *testing.T) {
 			expectedDocVersion2RevID = docVersion2.CV.String()
 		}
 		var revMsgs []*blip.Message
-		for _, msg := range client.pullReplication.GetMessages() {
-			if msg.Profile() != db.RevMessageRev {
-				continue
+		// We must use require.EventuallyWithT to poll the messages list here. While WaitForVersion
+		// guarantees that the client's document store has been updated (via addRev), the raw BLIP message
+		// itself is appended to pullReplication.GetMessages() via a defer hook after handleRev exits.
+		// Polling prevents a race condition where WaitForVersion returns but the final accepted full-body
+		// message is not yet appended to the replication messages log.
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			revMsgs = nil
+			for _, msg := range client.pullReplication.GetMessages() {
+				if msg.Profile() != db.RevMessageRev {
+					continue
+				}
+				if msg.Properties[db.RevMessageID] != docID {
+					continue
+				}
+				if msg.Properties[db.RevMessageRev] != expectedDocVersion2RevID {
+					continue
+				}
+				revMsgs = append(revMsgs, msg)
 			}
-			if msg.Properties[db.RevMessageID] != docID {
-				continue
-			}
-			if msg.Properties[db.RevMessageRev] != expectedDocVersion2RevID {
-				continue
-			}
-			revMsgs = append(revMsgs, msg)
-		}
-		require.Len(t, revMsgs, 2, client.pullReplication.GetAllMessagesSummary())
+			assert.Len(c, revMsgs, 2)
+		}, 5*time.Second, 5*time.Millisecond, client.pullReplication.GetAllMessagesSummary())
 		var serialNumber []blip.MessageNumber
 		for _, msg := range revMsgs {
 			serialNumber = append(serialNumber, msg.SerialNumber())


### PR DESCRIPTION
CBG-4622 test-only: fix race in TestBlipDeltaSyncPullResend

The test WaitForVersion blocks on the local document state being updated, but the raw BLIP message is asynchronously stored via a defer hook after handleRev exits. This creates a race condition where WaitForVersion can return and the message log queried before the final accepted message is actually stored.

This fixes the intermittent failure by replacing the rigid require.Len assertion with require.EventuallyWithT to poll the messages list.

Example failure:
Error: "[MSG#5~]" should have 2 item(s), but has 1 Test: TestBlipDeltaSyncPullResend/versionVector
Messages: {
  MSG#1~:{Properties:map[Content-Type:application/json Profile:changes collection:0] Body: [[1,"doc1","18c6b9e0f2810000@rosmar1"]]}
  MSG#2~:{Properties:map[Content-Type:application/json Profile:changes collection:0] Body: null}
  MSG#3~:{Properties:map[Content-Type:application/json Profile:rev collection:0 id:doc1 rev:18c6b9e0f2810000@rosmar1 sequence:1] Body: {"greetings":[{"hello":"world!"},{"hi":"alice"}]}}
  MSG#4~:{Properties:map[Content-Type:application/json Profile:changes collection:0] Body: [[2,"doc1","18c6b9e0f53a0000@rosmar1"]]}
  MSG#5~:{Properties:map[Content-Type:application/json Profile:rev collection:0 deltaSrc:18c6b9e0f2810000@rosmar1 id:doc1 rev:18c6b9e0f53a0000@rosmar1 sequence:2] Body: {"greetings":{"2-":[{"howdy":1234567890123}]}}}
}
