### PR TITLE
CBG-5001 test-only: fix flaky BLIP revocation pull tests

### DIFF
--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -2191,16 +2191,15 @@ func TestRevocationMessage(t *testing.T) {
 		revocationTester, rt := InitScenario(t, nil)
 		defer rt.Close()
 
+		revocationTester.addRoleChannel("foo", "A")
+		revocationTester.addRole("user", "foo")
+
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
 			Username:        "user",
 			ClientDeltas:    false,
 			SendRevocations: true,
 		})
 		defer btc.Close()
-
-		// Add channel to role and role to user
-		revocationTester.addRoleChannel("foo", "A")
-		revocationTester.addRole("user", "foo")
 
 		// Skip to seq 4 and then create doc in channel A
 		revocationTester.fillToSeq(4)
@@ -2301,16 +2300,15 @@ func TestRevocationNoRev(t *testing.T) {
 		revocationTester, rt := InitScenario(t, nil)
 		defer rt.Close()
 
+		revocationTester.addRoleChannel("foo", "A")
+		revocationTester.addRole("user", "foo")
+
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
 			Username:        "user",
 			ClientDeltas:    false,
 			SendRevocations: true,
 		})
 		defer btc.Close()
-
-		// Add channel to role and role to user
-		revocationTester.addRoleChannel("foo", "A")
-		revocationTester.addRole("user", "foo")
 
 		// Skip to seq 4 and then create doc in channel A
 		revocationTester.fillToSeq(4)
@@ -2394,16 +2392,15 @@ func TestRevocationGetSyncDataError(t *testing.T) {
 
 		defer rt.Close()
 
+		revocationTester.addRoleChannel("foo", "A")
+		revocationTester.addRole("user", "foo")
+
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
 			Username:        "user",
 			ClientDeltas:    false,
 			SendRevocations: true,
 		})
 		defer btc.Close()
-
-		// Add channel to role and role to user
-		revocationTester.addRoleChannel("foo", "A")
-		revocationTester.addRole("user", "foo")
 
 		// Skip to seq 4 and then create doc in channel A
 		revocationTester.fillToSeq(4)


### PR DESCRIPTION
CBG-5001 test-only: fix flaky BLIP revocation pull tests

TestRevocationMessage, TestRevocationNoRev, and TestRevocationGetSyncDataError opened a BLIP connection for "user" before granting it access to channel "A" (via addRoleChannel/addRole, which apply the grant through a sync function's access()/role() calls on the roleChannels/userRoles documents). That grant write triggers MarkPrincipalsChanged -> auth.InvalidateChannels, which makes a separate KV write to the real principal doc (_sync:role:foo / _sync:user:user)
- a distinct DCP mutation event from the roleChannels/userRoles document write itself.

For an already-open BLIP connection to notice the grant, its cached auth.User must be refreshed via userBlipHandler/refreshUser(), gated on bc.userChangeWaiter.RefreshUserCount(). That counter is only bumped once the principal doc's DCP mutation reaches changeListener.ProcessFeedEvent, which defers a call to listener.notifyKey(...) for DocTypeUser/DocTypeRole events.

rt.WaitForPendingChanges() only waits for changeCache.nextSequence to reach the roleChannels/userRoles document's own sequence - a different signal from "the principal-doc invalidation mutation has round-tripped through the DCP feed and notifyKey has fired." There's no synchronization between the two, so there's a real window where WaitForPendingChanges() returns, the oneshot pull starts, refreshUser() runs before the invalidation is observed, and the one-shot subChanges is served from the stale (pre-grant) channel set - missing the doc permanently, since a one-shot pull is a snapshot with no later retry.

This is scheduling dependent, so it only reproduced on a loaded CI runner (arm64); 130 local iterations, including under -race, didn't hit it.

To reproduce deterministically: add a sleep in
db/change_listener.go:ProcessFeedEvent, in the `docType == DocTypeUser || docType == DocTypeRole` branch, right before the `defer listener.notifyKey(...)` call. This delays only the principal-doc notify path (what flips userChangeWaiter.RefreshUserCount()) without touching the regular-document path WaitForPendingChanges() polls on, reproducing the exact asymmetry that caused the flake. Combine with temporarily reverting this commit's reordering (open the BLIP connection before the addRoleChannel/ addRole calls) to see the repro, since with the fix applied the first pull no longer depends on refreshUser() picking up the grant.

Fix: move the addRoleChannel/addRole grants before the BLIP connection is opened in all three tests, so the connection's initial GetUser call (which always computes channels fresh) already has the correct channel set, and the race never enters into the initial pull. The later removeRole step - the actual "does a live connection see a revocation" behavior under test - is unaffected.