### PR TITLE
CBG-5586: stop indexes being built on default when not required

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -521,7 +521,11 @@ func (h *handler) handlePostIndexInit() error {
 	} else {
 		defaultCollectionPresent = exists
 	}
-	done, err := h.server.DatabaseInitManager.InitializeDatabaseWithStatusCallback(h.ctx(), h.server.initialStartupConfig, &newDbConfig, statusCallback, useLegacySyncDocsIndex, defaultCollectionPresent)
+	migrationComplete := false
+	if dual, isDual := h.db.MetadataStore.(*base.MetadataStore); isDual {
+		migrationComplete = dual.MigrationComplete()
+	}
+	done, err := h.server.DatabaseInitManager.InitializeDatabaseWithStatusCallback(h.ctx(), h.server.initialStartupConfig, &newDbConfig, statusCallback, useLegacySyncDocsIndex, defaultCollectionPresent, migrationComplete)
 	if err != nil {
 		return err
 	}

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -521,11 +521,8 @@ func (h *handler) handlePostIndexInit() error {
 	} else {
 		defaultCollectionPresent = exists
 	}
-	migrationComplete := false
-	if dual, isDual := h.db.MetadataStore.(*base.MetadataStore); isDual {
-		migrationComplete = dual.MigrationComplete()
-	}
-	done, err := h.server.DatabaseInitManager.InitializeDatabaseWithStatusCallback(h.ctx(), h.server.initialStartupConfig, &newDbConfig, statusCallback, useLegacySyncDocsIndex, defaultCollectionPresent, migrationComplete)
+
+	done, err := h.server.DatabaseInitManager.InitializeDatabaseWithStatusCallback(h.ctx(), h.server.initialStartupConfig, &newDbConfig, statusCallback, useLegacySyncDocsIndex, defaultCollectionPresent, h.db.MetadataMigrationComplete(h.ctx()))
 	if err != nil {
 		return err
 	}

--- a/rest/database_init_manager.go
+++ b/rest/database_init_manager.go
@@ -230,7 +230,11 @@ func buildCollectionIndexData(startup *StartupConfig, config *DatabaseConfig, de
 	useSystemMetadataCollection := resolveUseSystemMetadataCollection(startup, &config.DbConfig)
 	if len(config.Scopes) == 0 {
 		if useSystemMetadataCollection {
-			return CollectionInitData{base.DefaultScopeAndCollectionName(): db.IndexesAll, base.MobileSystemScopeAndCollectionName(): db.IndexesMetadataOnly}
+			defaultIndexes := db.IndexesAll
+			if migrationComplete {
+				defaultIndexes = db.IndexesWithoutMetadata
+			}
+			return CollectionInitData{base.DefaultScopeAndCollectionName(): defaultIndexes, base.MobileSystemScopeAndCollectionName(): db.IndexesMetadataOnly}
 		} else {
 			return CollectionInitData{base.DefaultScopeAndCollectionName(): db.IndexesAll}
 		}

--- a/rest/database_init_manager.go
+++ b/rest/database_init_manager.go
@@ -56,7 +56,7 @@ type InitializeIndexesFunc func(context.Context, base.N1QLStore, db.InitializeIn
 // indexes required for each collection.
 type CollectionInitData map[base.ScopeAndCollectionName]db.CollectionIndexesType
 
-func (m *DatabaseInitManager) InitializeDatabaseWithStatusCallback(ctx context.Context, startupConfig *StartupConfig, dbConfig *DatabaseConfig, statusCallback CollectionCallbackFunc, useLegacySyncDocsIndex bool, defaultCollectionExists bool) (doneChan chan error, err error) {
+func (m *DatabaseInitManager) InitializeDatabaseWithStatusCallback(ctx context.Context, startupConfig *StartupConfig, dbConfig *DatabaseConfig, statusCallback CollectionCallbackFunc, useLegacySyncDocsIndex bool, defaultCollectionExists bool, migrationComplete bool) (doneChan chan error, err error) {
 	m.workersLock.Lock()
 	defer m.workersLock.Unlock()
 	if m.workers == nil {
@@ -66,7 +66,7 @@ func (m *DatabaseInitManager) InitializeDatabaseWithStatusCallback(ctx context.C
 		base.MD(dbConfig.Name))
 	dbInitWorker, ok := m.workers[dbConfig.Name]
 
-	collectionSet := buildCollectionIndexData(startupConfig, dbConfig, defaultCollectionExists)
+	collectionSet := buildCollectionIndexData(startupConfig, dbConfig, defaultCollectionExists, migrationComplete)
 	if ok {
 		// If worker exists for the database and the collection sets match, add watcher to the existing worker
 		if dbInitWorker.collectionsEqual(collectionSet) {
@@ -152,8 +152,8 @@ func (m *DatabaseInitManager) InitializeDatabaseWithStatusCallback(ctx context.C
 
 // InitializeDatabase will establish a new cluster connection using the provided server config.  Establishes a new
 // cluster-only N1QLStore based on the startup config to perform initialization.
-func (m *DatabaseInitManager) InitializeDatabase(ctx context.Context, startupConfig *StartupConfig, dbConfig *DatabaseConfig, useLegacySyncDocsIndex bool, defaultCollectionExists bool) (doneChan chan error, err error) {
-	return m.InitializeDatabaseWithStatusCallback(ctx, startupConfig, dbConfig, nil, useLegacySyncDocsIndex, defaultCollectionExists)
+func (m *DatabaseInitManager) InitializeDatabase(ctx context.Context, startupConfig *StartupConfig, dbConfig *DatabaseConfig, useLegacySyncDocsIndex bool, defaultCollectionExists bool, migrationComplete bool) (doneChan chan error, err error) {
+	return m.InitializeDatabaseWithStatusCallback(ctx, startupConfig, dbConfig, nil, useLegacySyncDocsIndex, defaultCollectionExists, migrationComplete)
 }
 
 func (m *DatabaseInitManager) HasActiveInitialization(dbName string) bool {
@@ -220,12 +220,13 @@ func (m *DatabaseInitManager) cancelWorkers() {
 }
 
 // buildCollectionIndexData determines the set of indexes required for each collection in the config, including
-// the metadata collection. defaultCollectionExists reports whether _default._default physically exists in the
-// bucket: _default carries metadata indexes that support dual-read principal queries during migration, but a
-// customer may drop it once migration completes, at which point those indexes are vestigial and attempting to
-// build them on the missing collection would retry until the op times out and fail initialization. When
-// _default is gone (and not itself a configured data collection) it is omitted from the index set.
-func buildCollectionIndexData(startup *StartupConfig, config *DatabaseConfig, defaultCollectionExists bool) CollectionInitData {
+// the metadata collection. _default._default's index set is the union of two independent roles: its data
+// indexes when it's a configured data collection, and its metadata indexes while it's still the metadata store
+// (legacy) or a dual-read fallback (system-metadata, mid-migration). migrationComplete reports whether a
+// system-metadata database has finished migrating off _default (afterwards its metadata indexes are vestigial),
+// and defaultCollectionExists reports whether _default physically exists (a customer may drop it post-migration;
+// building indexes on a missing collection would retry until the op times out and fail initialization).
+func buildCollectionIndexData(startup *StartupConfig, config *DatabaseConfig, defaultCollectionExists bool, migrationComplete bool) CollectionInitData {
 	useSystemMetadataCollection := resolveUseSystemMetadataCollection(startup, &config.DbConfig)
 	if len(config.Scopes) == 0 {
 		if useSystemMetadataCollection {
@@ -235,7 +236,6 @@ func buildCollectionIndexData(startup *StartupConfig, config *DatabaseConfig, de
 		}
 	}
 
-	defaultScopeAndCollectionMetadataIndexes := db.IndexesMetadataOnly
 	defaultIsConfiguredCollection := false
 
 	collectionInitData := make(CollectionInitData)
@@ -243,7 +243,6 @@ func buildCollectionIndexData(startup *StartupConfig, config *DatabaseConfig, de
 		for collectionName := range scopeConfig.Collections {
 			scName := base.ScopeAndCollectionName{Scope: scopeName, Collection: collectionName}
 			if scName.IsDefault() {
-				defaultScopeAndCollectionMetadataIndexes = db.IndexesAll
 				defaultIsConfiguredCollection = true
 				continue
 			}
@@ -251,10 +250,24 @@ func buildCollectionIndexData(startup *StartupConfig, config *DatabaseConfig, de
 		}
 	}
 
-	// Include _default for metadata indexes only when it actually exists. If _default is itself a
-	// configured data collection it necessarily exists, so it is always included in that case.
-	if defaultCollectionExists || defaultIsConfiguredCollection {
-		collectionInitData[base.DefaultScopeAndCollectionName()] = defaultScopeAndCollectionMetadataIndexes
+	// _default's index set is the union of two independent roles: it holds data when it's a configured
+	// collection, and it holds metadata while it's still the metadata store (legacy) or a dual-read
+	// fallback (system-metadata, mid-migration). These used to always coincide, but a system-metadata
+	// database that has finished migrating uses _default for neither — its metadata indexes there are
+	// vestigial. migrationComplete is only ever set once system metadata is in use, so migratedOffDefault
+	// captures "fully migrated off _default"; defaultCollectionExists guards against building metadata
+	// indexes on a _default the customer dropped post-migration (the op would otherwise retry until it
+	// times out). Callers always report defaultCollectionExists=true for a configured _default, since the
+	// database load fails earlier (GetAndWaitUntilDataStoreReady) if a configured collection is missing.
+	migratedOffDefault := useSystemMetadataCollection && migrationComplete
+	defaultHoldsMetadata := !migratedOffDefault && defaultCollectionExists
+	switch {
+	case defaultIsConfiguredCollection && defaultHoldsMetadata:
+		collectionInitData[base.DefaultScopeAndCollectionName()] = db.IndexesAll
+	case defaultIsConfiguredCollection:
+		collectionInitData[base.DefaultScopeAndCollectionName()] = db.IndexesWithoutMetadata
+	case defaultHoldsMetadata:
+		collectionInitData[base.DefaultScopeAndCollectionName()] = db.IndexesMetadataOnly
 	}
 	if useSystemMetadataCollection {
 		collectionInitData[base.MobileSystemScopeAndCollectionName()] = db.IndexesMetadataOnly

--- a/rest/database_init_manager_test.go
+++ b/rest/database_init_manager_test.go
@@ -143,7 +143,6 @@ func TestDatabaseInitCollectionsForMetadataStoreMode(t *testing.T) {
 	base.TestRequiresCollections(t)
 	base.LongRunningTest(t)
 
-	// lowercase only - db.ValidateDatabaseName rejects anything else
 	const dbName = "testdb"
 
 	testCases := []struct {
@@ -261,6 +260,140 @@ func TestDatabaseInitCollectionsForMetadataStoreMode(t *testing.T) {
 			RequireSystemCollectionHasMetadataIndexes(t, tb, testCase.expectMobileCollectionInit)
 		})
 	}
+}
+
+// TestDatabaseInitDefaultCollectionForMetadataStoreMode:
+//  1. system metadata collection opted in, no legacy metadata in _default._default (fresh deployment,
+//     so the database is migration-complete from the outset) - _default is a data collection only. So it gets
+//     the data indexes and _system._mobile gets the metadata indexes
+//  2. system metadata collection opted in, legacy metadata still in _default._default - migration is
+//     still required, so _default is both the data collection and a metadata dual-read fallback, and
+//     needs the full index set alongside _system._mobile's metadata indexes
+//  3. not opted in - _default._default is both the data collection and the metadata store, so it needs
+//     the full index set, and _system._mobile is unused
+func TestDatabaseInitDefaultCollectionForMetadataStoreMode(t *testing.T) {
+	RequireN1QLIndexes(t)
+	base.TestRequiresCollections(t)
+	base.LongRunningTest(t)
+
+	const dbName = "testdb"
+
+	testCases := []struct {
+		name                        string
+		useSystemMetadataCollection bool
+		legacyMetadataInDefault     bool // seed legacy per-DB metadata in _default._default, so migration is still required
+		expectMobileCollectionInit  bool
+		expectedDefaultIndexes      db.CollectionIndexesType
+	}{
+		{
+			name:                        "system metadata collection, migration complete",
+			useSystemMetadataCollection: true,
+			legacyMetadataInDefault:     false,
+			expectMobileCollectionInit:  true,
+			expectedDefaultIndexes:      db.IndexesWithoutMetadata,
+		},
+		{
+			name:                        "system metadata collection, migration required",
+			useSystemMetadataCollection: true,
+			legacyMetadataInDefault:     true,
+			expectMobileCollectionInit:  true,
+			expectedDefaultIndexes:      db.IndexesAll,
+		},
+		{
+			name:                        "legacy metadata collection",
+			useSystemMetadataCollection: false,
+			legacyMetadataInDefault:     false,
+			expectMobileCollectionInit:  false,
+			expectedDefaultIndexes:      db.IndexesAll,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx := base.TestCtx(t)
+			tb := base.GetTestBucket(t)
+			defer tb.Close(ctx)
+
+			sc, closeFn := StartBootstrapServer(t)
+			defer closeFn()
+
+			// Drop the indexes created by the bucket pool, so the indexes found in the bucket afterwards
+			// are only the ones this database's initialization built. It also leaves no principal indexes
+			// online anywhere, so the database resolves to the separate users/roles indexes rather than
+			// the legacy syncDocs index - which is what the expected index sets below are computed with.
+			base.DropAllBucketIndexes(t, tb)
+			dropSystemCollectionMetadataIndexes(t, tb)
+
+			if testCase.legacyMetadataInDefault {
+				// Model a database that predates the system metadata collection. The per-DB sequence
+				// counter in _default._default is what the database load probes to decide whether the
+				// metadata store still needs _default as a read fallback. A database that includes
+				// _default._default gets the default (unprefixed) metadata ID, asserted after creation.
+				_, err := tb.DefaultDataStore(ctx).Incr(ctx, base.NewMetadataKeys(base.DefaultMetadataID).SyncSeqKey(), 1, 1, 0)
+				require.NoError(t, err)
+			}
+
+			// Record every collection index initialization completes for.
+			var seenLock sync.Mutex
+			seen := make(map[base.ScopeAndCollectionName]struct{})
+			sc.DatabaseInitManager.testCollectionStatusUpdateCallback = func(_ string, scName base.ScopeAndCollectionName, status db.CollectionIndexStatus) {
+				if status != db.CollectionIndexStatusReady {
+					return
+				}
+				seenLock.Lock()
+				defer seenLock.Unlock()
+				seen[scName] = struct{}{}
+			}
+
+			// No scopes in the config - _default._default is the database's only data collection.
+			dbConfig := makeDbConfig(tb.GetName(), dbName, nil)
+			dbConfig.UseSystemMobileMetadataCollection = base.Ptr(testCase.useSystemMetadataCollection)
+
+			// Index initialization runs synchronously for this create (the database isn't started
+			// offline and no initialization is already in flight), so it has completed for every
+			// collection by the time the request returns.
+			resp := BootstrapAdminRequest(t, sc, http.MethodPut, "/"+dbName+"/", string(base.MustJSONMarshal(t, dbConfig)))
+			resp.RequireStatus(http.StatusCreated)
+
+			require.Equal(t, base.DefaultMetadataID, sc.GetDatabaseConfig(dbName).MetadataID,
+				"a database including _default._default must be assigned the default metadata ID, which the legacy metadata seeded by this test is keyed by")
+
+			expected := []base.ScopeAndCollectionName{base.DefaultScopeAndCollectionName()}
+			if testCase.expectMobileCollectionInit {
+				expected = append(expected, base.MobileSystemScopeAndCollectionName())
+			}
+
+			seenLock.Lock()
+			defer seenLock.Unlock()
+			require.ElementsMatch(t, expected, slices.Collect(maps.Keys(seen)), "unexpected set of initialized collections")
+
+			// The collection set is the same for cases 2 and 3, so the index sets in the bucket are what
+			// actually separate the permutations - whether _default carries the metadata (principal)
+			// indexes on top of the data indexes it needs as a configured collection.
+			requireDefaultCollectionIndexes(t, tb, testCase.expectedDefaultIndexes)
+			RequireSystemCollectionHasMetadataIndexes(t, tb, testCase.expectMobileCollectionInit)
+		})
+	}
+}
+
+// requireDefaultCollectionIndexes asserts that the indexes present on _default._default are exactly
+// those implied by indexesType, derived from the index definitions so the expectation tracks changes to
+// the index set. IndexesAll is the data indexes plus the metadata (principal) indexes;
+// IndexesWithoutMetadata is the data indexes alone.
+func requireDefaultCollectionIndexes(t *testing.T, tb *base.TestBucket, indexesType db.CollectionIndexesType) {
+	t.Helper()
+	dataStore, err := tb.NamedDataStore(base.TestCtx(t), base.DefaultScopeAndCollectionName())
+	require.NoError(t, err)
+	n1qlStore, ok := base.AsN1QLStore(dataStore)
+	require.True(t, ok, "expected %s to be a N1QLStore, got %T", base.DefaultScopeAndCollectionName(), dataStore)
+	indexes, err := n1qlStore.GetIndexes()
+	require.NoError(t, err)
+	expected := db.GetIndexNames(db.InitializeIndexOptions{
+		MetadataIndexes:     indexesType,
+		NumPartitions:       db.DefaultNumIndexPartitions,
+		LegacySyncDocsIndex: testUseLegacySyncDocsIndex,
+	}, db.GetSGIndexes())
+	require.ElementsMatch(t, expected, indexes, "unexpected indexes on %s", base.DefaultScopeAndCollectionName())
 }
 
 // RequireSystemCollectionHasMetadataIndexes asserts whether the metadata indexes are present on
@@ -902,6 +1035,34 @@ func TestBuildCollectionIndexData(t *testing.T) {
 			want: CollectionInitData{
 				base.MobileSystemScopeAndCollectionName():               db.IndexesMetadataOnly,
 				base.NewScopeAndCollectionName("scope1", "collection1"): db.IndexesWithoutMetadata,
+			},
+		},
+		{
+			// Implicit default collection (no scopes configured): _default is a configured data collection
+			// by default, so post-migration it needs only its data indexes — same reasoning as the explicit
+			// case below, reached through the no-scopes branch.
+			name: "system metadata: migration complete, implicit default collection",
+			config: &DatabaseConfig{DbConfig: DbConfig{
+				UseSystemMobileMetadataCollection: base.Ptr(true),
+			}},
+			defaultCollectionExists: true,
+			migrationComplete:       true,
+			want: CollectionInitData{
+				base.DefaultScopeAndCollectionName():      db.IndexesWithoutMetadata,
+				base.MobileSystemScopeAndCollectionName(): db.IndexesMetadataOnly,
+			},
+		},
+		{
+			// migrationComplete is meaningless in legacy mode — _default is still the metadata store as
+			// well as the data collection, so it keeps the full index set. Callers never report
+			// migrationComplete=true here (the metadata store isn't dual), so this locks the branch
+			// against a future caller that does.
+			name:                    "legacy metadata: migrationComplete ignored, implicit default collection",
+			config:                  &DatabaseConfig{},
+			defaultCollectionExists: true,
+			migrationComplete:       true,
+			want: CollectionInitData{
+				base.DefaultScopeAndCollectionName(): db.IndexesAll,
 			},
 		},
 		{

--- a/rest/database_init_manager_test.go
+++ b/rest/database_init_manager_test.go
@@ -48,7 +48,7 @@ func TestDatabaseInitManager(t *testing.T) {
 	base.DropAllBucketIndexes(t, tb)
 
 	// Async index creation
-	doneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true)
+	doneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true, false)
 	require.NoError(t, err)
 
 	select {
@@ -58,6 +58,73 @@ func TestDatabaseInitManager(t *testing.T) {
 		require.Fail(t, "InitializeDatabase didn't complete in 10s")
 	}
 
+}
+
+// TestDatabaseInitPostMigrationExcludesDefault verifies that once a system-metadata database has completed its
+// metadata migration (migrationComplete=true), DatabaseInitManager does not initialize indexes on
+// _default._default — its metadata indexes there are vestigial, and building them would be wasteful (or fail if
+// the customer has since dropped the collection). This is the DatabaseInitManager-level counterpart to the
+// TestBuildCollectionIndexData "migration complete" cases.
+func TestDatabaseInitPostMigrationExcludesDefault(t *testing.T) {
+	RequireN1QLIndexes(t)
+	base.TestRequiresCollections(t)
+
+	sc, closeFn := StartBootstrapServer(t)
+	defer closeFn()
+
+	ctx := base.TestCtx(t)
+	tb := base.GetTestBucket(t)
+	defer tb.Close(ctx)
+
+	// Drop all test indexes so we can test InitializeDatabase
+	base.DropAllBucketIndexes(t, tb)
+
+	// Two named data collections with system metadata opted in; _default is NOT a configured collection.
+	scopesConfig := GetCollectionsConfig(t, tb, 2)
+	dataStoreNames := GetDataStoreNamesFromScopesConfig(scopesConfig)
+
+	initMgr := sc.DatabaseInitManager
+
+	// Record every collection the manager initializes.
+	var seenLock sync.Mutex
+	seen := make(map[base.ScopeAndCollectionName]struct{})
+	initMgr.testCollectionStatusUpdateCallback = func(dbName string, scName base.ScopeAndCollectionName, status db.CollectionIndexStatus) {
+		if status != db.CollectionIndexStatusReady {
+			return
+		}
+		seenLock.Lock()
+		defer seenLock.Unlock()
+		seen[scName] = struct{}{}
+	}
+
+	dbName := "dbName"
+	dbConfig := makeDbConfig(tb.GetName(), dbName, scopesConfig)
+	dbConfig.UseSystemMobileMetadataCollection = base.Ptr(true)
+	require.NoError(t, dbConfig.setup(ctx, dbName, sc.Config.Bootstrap, nil, nil))
+
+	// migrationComplete=true models a system-metadata database that has finished migrating off _default.
+	doneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true, true)
+	require.NoError(t, err)
+	WaitForChannel(t, doneChan, "post-migration init done chan")
+
+	seenLock.Lock()
+	defer seenLock.Unlock()
+
+	// _default must be excluded: its metadata indexes are vestigial post-migration.
+	_, defaultSeen := seen[base.DefaultScopeAndCollectionName()]
+	require.False(t, defaultSeen, "expected _default._default to be excluded from index init post-migration, got collections: %v", seen)
+
+	// The metadata collection and both configured data collections must still be initialized.
+	expected := []base.ScopeAndCollectionName{
+		base.MobileSystemScopeAndCollectionName(),
+		{Scope: dataStoreNames[0].ScopeName(), Collection: dataStoreNames[0].CollectionName()},
+		{Scope: dataStoreNames[1].ScopeName(), Collection: dataStoreNames[1].CollectionName()},
+	}
+	for _, scName := range expected {
+		_, ok := seen[scName]
+		require.True(t, ok, "expected collection %s to be initialized, got collections: %v", scName, seen)
+	}
+	require.Len(t, seen, len(expected), "unexpected collection set: %v", seen)
 }
 
 // TestDatabaseInitConfigChangeSameCollections tests modifications made to the database config while init is running.
@@ -113,14 +180,14 @@ func TestDatabaseInitConfigChangeSameCollections(t *testing.T) {
 	require.NoError(t, dbConfig.setup(ctx, dbName, sc.Config.Bootstrap, nil, nil))
 
 	// Start first async index creation, blocks after first collection
-	doneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true)
+	doneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true, false)
 	require.NoError(t, err)
 
 	// Wait for first collection to be initialized
 	WaitForChannel(t, singleCollectionInitChannel, "first collection init")
 
 	// Make a duplicate call to initialize database, should reuse the existing agent
-	duplicateDoneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true)
+	duplicateDoneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true, false)
 	require.NoError(t, err)
 
 	// Unblock collection callback to process all remaining collections
@@ -137,7 +204,7 @@ func TestDatabaseInitConfigChangeSameCollections(t *testing.T) {
 	waitForWorkerDone(t, initMgr, "dbName")
 
 	// Rerun init, should start a new worker for the database and re-verify init for each collection
-	rerunDoneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true)
+	rerunDoneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true, false)
 	require.NoError(t, err)
 	WaitForChannel(t, rerunDoneChan, "repeated init done chan")
 	totalCount = atomic.LoadInt64(&collectionCount)
@@ -203,7 +270,7 @@ func TestDatabaseInitConfigChangeDifferentCollections(t *testing.T) {
 	dbConfig.UseSystemMobileMetadataCollection = base.Ptr(true)
 
 	// Start first async index creation, should block after first collection
-	doneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true)
+	doneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true, false)
 	require.NoError(t, err)
 
 	// Wait for first collection to be initialized
@@ -213,7 +280,7 @@ func TestDatabaseInitConfigChangeDifferentCollections(t *testing.T) {
 	modifiedDbConfig := makeDbConfig(tb.GetName(), dbName, collection1and3ScopesConfig)
 	require.NoError(t, modifiedDbConfig.setup(ctx, dbName, sc.Config.Bootstrap, nil, nil))
 	modifiedDbConfig.UseSystemMobileMetadataCollection = base.Ptr(true)
-	modifiedDoneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, modifiedDbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true)
+	modifiedDoneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, modifiedDbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true, false)
 	require.NoError(t, err)
 
 	// Unblock the first InitializeDatabase, should cancel
@@ -307,14 +374,14 @@ func TestDatabaseInitConcurrentDatabasesDifferentBuckets(t *testing.T) {
 	db2Config.UseSystemMobileMetadataCollection = base.Ptr(true)
 
 	// Start first async index creation, should block after first collection
-	doneChan1, err := initMgr.InitializeDatabase(ctx, sc.Config, db1Config.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true)
+	doneChan1, err := initMgr.InitializeDatabase(ctx, sc.Config, db1Config.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true, false)
 	require.NoError(t, err)
 
 	// Wait for first collection to be initialized
 	WaitForChannel(t, firstCollectionInitChannel, "first collection init")
 
 	// Start second async index creation for db2 while first is still running
-	doneChan2, err := initMgr.InitializeDatabase(ctx, sc.Config, db2Config.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true)
+	doneChan2, err := initMgr.InitializeDatabase(ctx, sc.Config, db2Config.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true, false)
 	require.NoError(t, err)
 
 	// Unblock the first InitializeDatabase, should cancel
@@ -386,14 +453,14 @@ func TestDatabaseInitTeardownTiming(t *testing.T) {
 		if databaseCompleteCount.Add(1) == 1 {
 			defer wg.Done()
 			log.Printf("invoking InitializeDatabase again during teardown")
-			doneChan2, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true)
+			doneChan2, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true, false)
 			require.NoError(t, err)
 			WaitForChannel(t, doneChan2, "done chan 2")
 		}
 	}
 
 	// Start first async index creation, should block after first collection
-	doneChan1, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true)
+	doneChan1, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true, false)
 	require.NoError(t, err)
 
 	WaitForChannel(t, doneChan1, "done chan 1")
@@ -439,6 +506,7 @@ func TestBuildCollectionIndexData(t *testing.T) {
 		name                    string
 		config                  *DatabaseConfig
 		defaultCollectionExists bool
+		migrationComplete       bool
 		want                    CollectionInitData
 		startupConfig           *StartupConfig
 	}{
@@ -487,6 +555,8 @@ func TestBuildCollectionIndexData(t *testing.T) {
 					Scopes: makeScopesConfig(base.DefaultScope, []string{base.DefaultCollection}),
 				},
 			},
+			// a configured _default necessarily exists; callers never report it as absent
+			defaultCollectionExists: true,
 			want: CollectionInitData{
 				base.DefaultScopeAndCollectionName(): db.IndexesAll,
 			},
@@ -512,6 +582,8 @@ func TestBuildCollectionIndexData(t *testing.T) {
 				Scopes:                            makeScopesConfig(base.DefaultScope, []string{base.DefaultCollection, "collection1"}),
 				UseSystemMobileMetadataCollection: base.Ptr(true),
 			}},
+			// a configured _default necessarily exists; callers never report it as absent
+			defaultCollectionExists: true,
 			want: CollectionInitData{
 				base.DefaultScopeAndCollectionName():                             db.IndexesAll,
 				base.MobileSystemScopeAndCollectionName():                        db.IndexesMetadataOnly,
@@ -585,11 +657,99 @@ func TestBuildCollectionIndexData(t *testing.T) {
 				base.NewScopeAndCollectionName("scope1", "collection1"): db.IndexesWithoutMetadata,
 			},
 		},
+		// migrationComplete gating — verifies _default is included only while it's still serving
+		// metadata (legacy store, or dual-read fallback during migration) and excluded once a
+		// system-metadata database has migrated off it.
+		{
+			// Legacy metadata (system metadata disabled): _default._default IS the metadata store, so
+			// it must be indexed even though it's not a configured collection. Regression guard: a
+			// system-metadata-only gate would wrongly drop it here.
+			name: "legacy metadata: named collection, _default is metadata store",
+			config: &DatabaseConfig{
+				DbConfig: DbConfig{
+					Scopes: makeScopesConfig("scope1", []string{"collection1"}),
+				},
+			},
+			defaultCollectionExists: true,
+			migrationComplete:       false,
+			want: CollectionInitData{
+				base.DefaultScopeAndCollectionName():                    db.IndexesMetadataOnly,
+				base.NewScopeAndCollectionName("scope1", "collection1"): db.IndexesWithoutMetadata,
+			},
+		},
+		{
+			// migrationComplete has no effect in legacy mode — _default is still the metadata store and
+			// stays indexed regardless. Locks the invariant-independence of the migratedOffDefault gate.
+			name: "legacy metadata: migrationComplete ignored, _default still indexed",
+			config: &DatabaseConfig{
+				DbConfig: DbConfig{
+					Scopes: makeScopesConfig("scope1", []string{"collection1"}),
+				},
+			},
+			defaultCollectionExists: true,
+			migrationComplete:       true,
+			want: CollectionInitData{
+				base.DefaultScopeAndCollectionName():                    db.IndexesMetadataOnly,
+				base.NewScopeAndCollectionName("scope1", "collection1"): db.IndexesWithoutMetadata,
+			},
+		},
+		{
+			// System metadata in use and migration complete: _default's metadata indexes are vestigial
+			// and must be dropped even though _default still physically exists.
+			name: "system metadata: migration complete, _default still exists",
+			config: &DatabaseConfig{
+				DbConfig: DbConfig{
+					Scopes:                            makeScopesConfig("scope1", []string{"collection1"}),
+					UseSystemMobileMetadataCollection: base.Ptr(true),
+				},
+			},
+			defaultCollectionExists: true,
+			migrationComplete:       true,
+			want: CollectionInitData{
+				base.MobileSystemScopeAndCollectionName():               db.IndexesMetadataOnly,
+				base.NewScopeAndCollectionName("scope1", "collection1"): db.IndexesWithoutMetadata,
+			},
+		},
+		{
+			// Both gates agree _default should be excluded: migration complete AND the collection dropped.
+			name: "system metadata: migration complete, _default dropped",
+			config: &DatabaseConfig{
+				DbConfig: DbConfig{
+					Scopes:                            makeScopesConfig("scope1", []string{"collection1"}),
+					UseSystemMobileMetadataCollection: base.Ptr(true),
+				},
+			},
+			defaultCollectionExists: false,
+			migrationComplete:       true,
+			want: CollectionInitData{
+				base.MobileSystemScopeAndCollectionName():               db.IndexesMetadataOnly,
+				base.NewScopeAndCollectionName("scope1", "collection1"): db.IndexesWithoutMetadata,
+			},
+		},
+		{
+			// _default is a configured data collection but metadata has migrated to _system._mobile, so it
+			// needs only its data indexes — its metadata indexes would be vestigial. The data role
+			// (configured) and metadata role (migrated off) are independent, hence IndexesWithoutMetadata.
+			name: "system metadata: migration complete, _default is a configured data collection",
+			config: &DatabaseConfig{
+				DbConfig: DbConfig{
+					Scopes:                            makeScopesConfig(base.DefaultScope, []string{base.DefaultCollection, "collection1"}),
+					UseSystemMobileMetadataCollection: base.Ptr(true),
+				},
+			},
+			defaultCollectionExists: true,
+			migrationComplete:       true,
+			want: CollectionInitData{
+				base.DefaultScopeAndCollectionName():                             db.IndexesWithoutMetadata,
+				base.MobileSystemScopeAndCollectionName():                        db.IndexesMetadataOnly,
+				base.NewScopeAndCollectionName(base.DefaultScope, "collection1"): db.IndexesWithoutMetadata,
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actual := buildCollectionIndexData(test.startupConfig, test.config, test.defaultCollectionExists)
-			assert.Equalf(t, test.want, actual, "buildCollectionIndexData(startup=%v, config=%v, defaultCollectionExists=%v)", test.startupConfig, test.config, test.defaultCollectionExists)
+			actual := buildCollectionIndexData(test.startupConfig, test.config, test.defaultCollectionExists, test.migrationComplete)
+			assert.Equalf(t, test.want, actual, "buildCollectionIndexData(startup=%v, config=%v, defaultCollectionExists=%v, migrationComplete=%v)", test.startupConfig, test.config, test.defaultCollectionExists, test.migrationComplete)
 		})
 	}
 }

--- a/rest/database_init_manager_test.go
+++ b/rest/database_init_manager_test.go
@@ -11,6 +11,9 @@ package rest
 import (
 	"fmt"
 	"log"
+	"maps"
+	"net/http"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -125,6 +128,181 @@ func TestDatabaseInitPostMigrationExcludesDefault(t *testing.T) {
 		require.True(t, ok, "expected collection %s to be initialized, got collections: %v", scName, seen)
 	}
 	require.Len(t, seen, len(expected), "unexpected collection set: %v", seen)
+}
+
+// TestDatabaseInitCollectionsForMetadataStoreMode:
+// _default._default is deliberately never a configured data collection here, so it is only ever a
+// candidate for index initialization in its metadata role:
+//  1. system metadata collection opted in, no legacy metadata in _default._default (fresh deployment, so
+//     the database is migration-complete from the outset) - metadata indexes belong on _system._mobile only
+//  2. system metadata collection opted in, legacy metadata still in _default._default - migration is still
+//     required, so _default remains a dual-read fallback and needs its metadata indexes too
+//  3. not opted in - _default._default *is* the metadata store, and _system._mobile is unused
+func TestDatabaseInitCollectionsForMetadataStoreMode(t *testing.T) {
+	RequireN1QLIndexes(t)
+	base.TestRequiresCollections(t)
+	base.LongRunningTest(t)
+
+	// lowercase only - db.ValidateDatabaseName rejects anything else
+	const dbName = "testdb"
+
+	testCases := []struct {
+		name                        string
+		useSystemMetadataCollection bool
+		legacyMetadataInDefault     bool // seed legacy per-DB metadata in _default._default, so migration is still required
+		expectMobileCollectionInit  bool
+		expectDefaultCollectionInit bool
+	}{
+		{
+			name:                        "system metadata collection, migration complete",
+			useSystemMetadataCollection: true,
+			legacyMetadataInDefault:     false,
+			expectMobileCollectionInit:  true,
+			expectDefaultCollectionInit: false,
+		},
+		{
+			name:                        "system metadata collection, migration required",
+			useSystemMetadataCollection: true,
+			legacyMetadataInDefault:     true,
+			expectMobileCollectionInit:  true,
+			expectDefaultCollectionInit: true,
+		},
+		{
+			name:                        "legacy metadata collection",
+			useSystemMetadataCollection: false,
+			legacyMetadataInDefault:     false,
+			expectMobileCollectionInit:  false,
+			expectDefaultCollectionInit: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx := base.TestCtx(t)
+			tb := base.GetTestBucket(t)
+			defer tb.Close(ctx)
+
+			sc, closeFn := StartBootstrapServer(t)
+			defer closeFn()
+
+			// Drop the indexes created by the bucket pool, so the indexes found in the bucket afterwards
+			// are only the ones this database's initialization built.
+			base.DropAllBucketIndexes(t, tb)
+			dropSystemCollectionMetadataIndexes(t, tb)
+
+			// Two named data collections - _default._default is not a configured collection.
+			scopesConfig := GetCollectionsConfig(t, tb, 2)
+			dataStoreNames := GetDataStoreNamesFromScopesConfig(scopesConfig)
+
+			// The metadata ID the database will be created with, since its config doesn't include
+			// _default._default. Asserted after creation, because the legacy metadata seeded below is
+			// keyed by it.
+			metadataID := sc.BootstrapContext.standardMetadataID(dbName)
+			if testCase.legacyMetadataInDefault {
+				// Model a database that predates the system metadata collection. The per-DB sequence
+				// counter in _default._default is what the database load probes to decide whether the
+				// metadata store still needs _default as a read fallback.
+				_, err := tb.DefaultDataStore(ctx).Incr(ctx, base.NewMetadataKeys(metadataID).SyncSeqKey(), 1, 1, 0)
+				require.NoError(t, err)
+			}
+
+			// Record every collection index initialization completes for.
+			var seenLock sync.Mutex
+			seen := make(map[base.ScopeAndCollectionName]struct{})
+			sc.DatabaseInitManager.testCollectionStatusUpdateCallback = func(_ string, scName base.ScopeAndCollectionName, status db.CollectionIndexStatus) {
+				if status != db.CollectionIndexStatusReady {
+					return
+				}
+				seenLock.Lock()
+				defer seenLock.Unlock()
+				seen[scName] = struct{}{}
+			}
+
+			dbConfig := makeDbConfig(tb.GetName(), dbName, scopesConfig)
+			dbConfig.UseSystemMobileMetadataCollection = base.Ptr(testCase.useSystemMetadataCollection)
+
+			// Index initialization runs synchronously for this create (the database isn't started
+			// offline and no initialization is already in flight), so it has completed for every
+			// collection by the time the request returns.
+			resp := BootstrapAdminRequest(t, sc, http.MethodPut, "/"+dbName+"/", string(base.MustJSONMarshal(t, dbConfig)))
+			resp.RequireStatus(http.StatusCreated)
+
+			require.Equal(t, metadataID, sc.GetDatabaseConfig(dbName).MetadataID,
+				"metadata ID assigned at database creation must match the one the test derives legacy metadata keys from")
+
+			expected := []base.ScopeAndCollectionName{
+				{Scope: dataStoreNames[0].ScopeName(), Collection: dataStoreNames[0].CollectionName()},
+				{Scope: dataStoreNames[1].ScopeName(), Collection: dataStoreNames[1].CollectionName()},
+			}
+			if testCase.expectMobileCollectionInit {
+				expected = append(expected, base.MobileSystemScopeAndCollectionName())
+			}
+			if testCase.expectDefaultCollectionInit {
+				expected = append(expected, base.DefaultScopeAndCollectionName())
+			}
+
+			seenLock.Lock()
+			defer seenLock.Unlock()
+			require.ElementsMatch(t, expected, slices.Collect(maps.Keys(seen)), "unexpected set of initialized collections")
+
+			// Corroborate the collection set against the indexes actually in the bucket. _default isn't a
+			// configured data collection in any of these cases, so any index in it is a metadata index.
+			dataStore, err := tb.NamedDataStore(base.TestCtx(t), base.DefaultScopeAndCollectionName())
+			require.NoError(t, err)
+			n1qlStore, ok := base.AsN1QLStore(dataStore)
+			require.True(t, ok, "expected %s to be a N1QLStore, got %T", base.DefaultScopeAndCollectionName(), dataStore)
+			indexes, err := n1qlStore.GetIndexes()
+			require.NoError(t, err)
+			if testCase.expectDefaultCollectionInit {
+				require.NotEmpty(t, indexes, "expected indexes to have been built on %s", base.DefaultScopeAndCollectionName())
+			} else {
+				require.Empty(t, indexes, "expected no indexes to have been built on %s", base.DefaultScopeAndCollectionName())
+			}
+			RequireSystemCollectionHasMetadataIndexes(t, tb, testCase.expectMobileCollectionInit)
+		})
+	}
+}
+
+// RequireSystemCollectionHasMetadataIndexes asserts whether the metadata indexes are present on
+// _system._mobile. CBS omits system-scope collections from system:indexes, so this goes via
+// system:all_indexes rather than N1QLStore.GetIndexes, which reports nothing for those collections.
+func RequireSystemCollectionHasMetadataIndexes(t *testing.T, tb *base.TestBucket, expectIndexes bool) {
+	t.Helper()
+	gocbBucket, err := base.AsGocbV2Bucket(tb.Bucket)
+	require.NoError(t, err)
+	n1qlStore, err := base.NewClusterOnlyN1QLStore(gocbBucket.GetCluster(), gocbBucket.BucketName(), base.SystemScope, base.SystemCollectionMobile)
+	require.NoError(t, err)
+	indexesMeta, err := base.GetSystemCollectionIndexesMeta(base.TestCtx(t), n1qlStore, base.SystemScope, base.SystemCollectionMobile, []string{"sg_users_x1", "sg_roles_x1"})
+	require.NoError(t, err)
+	if expectIndexes {
+		base.RequireKeysEqual(t, []string{"sg_users_x1", "sg_roles_x1"}, indexesMeta, "unexpected metadata indexes on %s", base.MobileSystemScopeAndCollectionName())
+	} else {
+		require.Empty(t, indexesMeta, "expected no metadata indexes on %s", base.MobileSystemScopeAndCollectionName())
+	}
+}
+
+// dropSystemCollectionMetadataIndexes drops the metadata indexes the bucket pool builds on
+// _system._mobile. base.DropAllBucketIndexes leaves them in place because it enumerates via
+// N1QLStore.GetIndexes, which doesn't see system-scope collections - to be fixed by CBG-5585, after
+// which this can go away.
+func dropSystemCollectionMetadataIndexes(t *testing.T, tb *base.TestBucket) {
+	t.Helper()
+	ctx := base.TestCtx(t)
+	gocbBucket, err := base.AsGocbV2Bucket(tb.Bucket)
+	require.NoError(t, err)
+	n1qlStore, err := base.NewClusterOnlyN1QLStore(gocbBucket.GetCluster(), gocbBucket.BucketName(), base.SystemScope, base.SystemCollectionMobile)
+	require.NoError(t, err)
+	for _, indexName := range []string{"sg_users_x1", "sg_roles_x1"} {
+		if err := base.DropIndex(ctx, n1qlStore, indexName); err != nil && !base.IsIndexNotFoundError(err) {
+			require.NoError(t, err, "error dropping index %s on %s", indexName, base.MobileSystemScopeAndCollectionName())
+		}
+	}
+	// DROP INDEX is asynchronous - wait for the drops to land, so the index initialization under test
+	// doesn't skip creating an index that's about to disappear.
+	require.Eventually(t, func() bool {
+		indexesMeta, err := base.GetSystemCollectionIndexesMeta(ctx, n1qlStore, base.SystemScope, base.SystemCollectionMobile, []string{"sg_users_x1", "sg_roles_x1"})
+		return err == nil && len(indexesMeta) == 0
+	}, 30*time.Second, 100*time.Millisecond, "metadata indexes on %s were not dropped", base.MobileSystemScopeAndCollectionName())
 }
 
 // TestDatabaseInitConfigChangeSameCollections tests modifications made to the database config while init is running.

--- a/rest/indextest/index_test.go
+++ b/rest/indextest/index_test.go
@@ -359,13 +359,12 @@ func TestAsyncOnlineOffline(t *testing.T) {
 
 	dbConfig := makeDbConfig(t, tb, syncFunc, importFilter)
 	dbConfig.StartOffline = base.Ptr(true)
-	dbConfig.UseSystemMobileMetadataCollection = base.Ptr(true)
 	dbConfigPayload, err := json.Marshal(dbConfig)
 	require.NoError(t, err)
 	dbName := "db"
 
 	keyspace := dbName
-	expectedCollectionCount := 2 // _default metadata store + _mobile metadata stores
+	expectedCollectionCount := 1 // metadata store
 	if len(dbConfig.Scopes) > 0 {
 		keyspaces := getRESTKeyspaces(dbName, dbConfig.Scopes)
 		keyspace = keyspaces[0]
@@ -490,11 +489,10 @@ func TestAsyncCreateThenDelete(t *testing.T) {
 
 	dbConfig := makeDbConfig(t, tb, syncFunc, importFilter)
 	dbConfig.StartOffline = base.Ptr(true)
-	dbConfig.UseSystemMobileMetadataCollection = base.Ptr(true)
 	dbConfigPayload, err := json.Marshal(dbConfig)
 	require.NoError(t, err)
 	dbName := "db"
-	expectedCollectionCount := 2 // _default metadata store + _mobile metadata stores
+	expectedCollectionCount := 1 // metadata store
 	if len(dbConfig.Scopes) > 0 {
 		keyspaces := getRESTKeyspaces(dbName, dbConfig.Scopes)
 		expectedCollectionCount += len(keyspaces)

--- a/rest/manualbucketpooltest/database_init_manager_test.go
+++ b/rest/manualbucketpooltest/database_init_manager_test.go
@@ -101,14 +101,14 @@ func TestDatabaseInitConcurrentDatabasesSameBucket(t *testing.T) {
 	require.NoError(t, rest.SetupDbConfigForTest(ctx, &db2Config, db2Name, sc.Config.Bootstrap))
 
 	// Start first async index creation, should block after first collection
-	doneChan1, err := initMgr.InitializeDatabase(ctx, sc.Config, db1Config.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true)
+	doneChan1, err := initMgr.InitializeDatabase(ctx, sc.Config, db1Config.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true, false)
 	require.NoError(t, err)
 
 	// Wait for first collection to be initialized
 	rest.WaitForChannel(t, firstCollectionInitChannel, "first collection init")
 
 	// Start second async index creation for db2 while first is still running
-	doneChan2, err := initMgr.InitializeDatabase(ctx, sc.Config, db2Config.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true)
+	doneChan2, err := initMgr.InitializeDatabase(ctx, sc.Config, db2Config.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true, false)
 	require.NoError(t, err)
 
 	// Unblock the first InitializeDatabase, should cancel

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -944,6 +944,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 			return nil, errors.New("Sync Gateway was unable to connect to a query node on the provided Couchbase Server cluster.  Ensure a query node is accessible, or set 'use_views':true in Sync Gateway's database config.")
 		}
 
+		migrationComplete := false
 		// MetadataStore intentionally doesn't implement N1QLStore — principal queries fan out
 		// to both stores via dualMetadataN1QLQuery — so unwrap to the underlying store(s) for
 		// index inventory inspection. Primary is the write target and the policy default;
@@ -959,6 +960,8 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 			// and noisy (ShouldUseLegacySyncDocsIndex tolerates the error but still fires the query).
 			if !dual.MigrationComplete() {
 				fallbackIndexStore = dual.Fallback()
+			} else {
+				migrationComplete = true
 			}
 		}
 		metadataStore, ok := base.AsN1QLStore(primaryIndexStore)
@@ -985,7 +988,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		// Initialize indexes using DatabaseInitManager. defaultCollectionPresent prevents building
 		// metadata indexes on _default._default when it has been dropped post-migration — otherwise
 		// the index create retries until it times out and fails db initialization.
-		dbInitDoneChan, err = sc.DatabaseInitManager.InitializeDatabase(ctx, sc.Config, &config, contextOptions.UseLegacySyncDocsIndex, defaultCollectionPresent)
+		dbInitDoneChan, err = sc.DatabaseInitManager.InitializeDatabase(ctx, sc.Config, &config, contextOptions.UseLegacySyncDocsIndex, defaultCollectionPresent, migrationComplete)
 		if err != nil {
 			if options.loadFromBucket {
 				sc._handleInvalidDatabaseConfig(ctx, spec.BucketName, config, db.NewDatabaseError(db.DatabaseInitializationIndexError))

--- a/rest/utilities_testing_isgr.go
+++ b/rest/utilities_testing_isgr.go
@@ -214,12 +214,18 @@ func SetupISGRPeersWithOpts(t *testing.T, opts TestISGRPeerOpts) TestISGRPeers {
 		passiveRTConfig = opts.PassiveRestTesterConfig
 	} else {
 		passiveRTConfig = &RestTesterConfig{
-			CustomTestBucket: passiveTestBucket.NoCloseClone(),
 			DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
 				Name: "passivedb",
 			}},
 			SyncFn: channels.DocChannelsSyncFunction,
 		}
+	}
+	// Back the RestTester with the bucket obtained above. A caller-supplied config that doesn't bring
+	// its own bucket would otherwise take a second one from the pool, leaving the bucket above unused
+	// and doubling the test's real bucket requirement past its RequireNumTestBuckets(t, 2) - which
+	// stalls for waitForReadyBucketTimeout and then fails whenever the pool is smaller than that.
+	if passiveRTConfig.CustomTestBucket == nil {
+		passiveRTConfig.CustomTestBucket = passiveTestBucket.NoCloseClone()
 	}
 	passiveRT := NewRestTester(t, passiveRTConfig)
 	t.Cleanup(passiveRT.Close)
@@ -252,10 +258,12 @@ func SetupISGRPeersWithOpts(t *testing.T, opts TestISGRPeerOpts) TestISGRPeers {
 			DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
 				Name: "activedb",
 			}},
-			CustomTestBucket:   activeTestBucket.NoCloseClone(),
 			SgReplicateEnabled: true,
 			SyncFn:             channels.DocChannelsSyncFunction,
 		}
+	}
+	if activeRTConfig.CustomTestBucket == nil {
+		activeRTConfig.CustomTestBucket = activeTestBucket.NoCloseClone()
 	}
 	activeRT := NewRestTester(t, activeRTConfig)
 	t.Cleanup(activeRT.Close)

--- a/rest/utilities_testing_isgr.go
+++ b/rest/utilities_testing_isgr.go
@@ -206,9 +206,6 @@ func (runner *SGRTestRunner) SetupSGRPeersWithOptions(t *testing.T, opts TestISG
 func SetupISGRPeersWithOpts(t *testing.T, opts TestISGRPeerOpts) TestISGRPeers {
 	ctx := base.TestCtx(t)
 	// Set up passive RestTester (rt2)
-	passiveTestBucket := base.GetTestBucket(t)
-	t.Cleanup(func() { passiveTestBucket.Close(ctx) })
-
 	var passiveRTConfig *RestTesterConfig
 	if opts.PassiveRestTesterConfig != nil {
 		passiveRTConfig = opts.PassiveRestTesterConfig
@@ -220,11 +217,14 @@ func SetupISGRPeersWithOpts(t *testing.T, opts TestISGRPeerOpts) TestISGRPeers {
 			SyncFn: channels.DocChannelsSyncFunction,
 		}
 	}
-	// Back the RestTester with the bucket obtained above. A caller-supplied config that doesn't bring
-	// its own bucket would otherwise take a second one from the pool, leaving the bucket above unused
-	// and doubling the test's real bucket requirement past its RequireNumTestBuckets(t, 2) - which
+	// Take a bucket from the pool only once we know the config doesn't already bring one, and hand it
+	// to the RestTester rather than letting NewRestTester fetch its own. Either half of that - a bucket
+	// obtained and left unused, or a config left without one - reserves two pool buckets for this peer
+	// instead of one, doubling the test's real requirement past its RequireNumTestBuckets(t, 2), which
 	// stalls for waitForReadyBucketTimeout and then fails whenever the pool is smaller than that.
 	if passiveRTConfig.CustomTestBucket == nil {
+		passiveTestBucket := base.GetTestBucket(t)
+		t.Cleanup(func() { passiveTestBucket.Close(ctx) })
 		passiveRTConfig.CustomTestBucket = passiveTestBucket.NoCloseClone()
 	}
 	passiveRT := NewRestTester(t, passiveRTConfig)
@@ -247,9 +247,6 @@ func SetupISGRPeersWithOpts(t *testing.T, opts TestISGRPeerOpts) TestISGRPeers {
 	passiveDBURL, _ := url.Parse(srv.URL + "/" + passiveRT.GetDatabase().Name)
 	passiveDBURL.User = url.UserPassword("alice", RestTesterDefaultUserPassword)
 
-	activeTestBucket := base.GetTestBucket(t)
-	t.Cleanup(func() { activeTestBucket.Close(ctx) })
-
 	var activeRTConfig *RestTesterConfig
 	if opts.ActiveRestTesterConfig != nil {
 		activeRTConfig = opts.ActiveRestTesterConfig
@@ -262,7 +259,10 @@ func SetupISGRPeersWithOpts(t *testing.T, opts TestISGRPeerOpts) TestISGRPeers {
 			SyncFn:             channels.DocChannelsSyncFunction,
 		}
 	}
+	// As above - only take a pool bucket if the caller's config didn't supply one.
 	if activeRTConfig.CustomTestBucket == nil {
+		activeTestBucket := base.GetTestBucket(t)
+		t.Cleanup(func() { activeTestBucket.Close(ctx) })
 		activeRTConfig.CustomTestBucket = activeTestBucket.NoCloseClone()
 	}
 	activeRT := NewRestTester(t, activeRTConfig)


### PR DESCRIPTION
CBG-5586

Change to stop building indexes on _default when not configured to do so. There was also a pre existing issue where all indexes were being built on _default if it was configured in the db config but will not consider if mobile collection is in use or not. So if you have opted into use mobile collection and is migration complete you will end up with metadata indexes on mobile, and user data + metadata indexes on _default (although _default is not being used for metadata). There is a similar pattern that makes this assumption in `GetInUseIndexes` but consider out of scope for a different ticket. 

## Pre-review checklist
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/1009/ (flake)

<!--
Automated review runs on every non-draft PR raised from this repo (forks are not reviewed automatically).
  - Re-run it, or ask a follow-up, by commenting `@droid <question>`
  - Suppress it with the `droid-skip` label, or `WIP`/`DO NOT MERGE` in the title
-->
