### PR TITLE
CBG-5659: fix S1023 remove redunant return

### DIFF
--- a/.golangci-strict.yml
+++ b/.golangci-strict.yml
@@ -83,7 +83,6 @@ linters:
         - -S1011 # Use a single 'append' to concatenate two slices.
         - -S1012 # Replace 'time.Now().Sub(x)' with 'time.Since(x)'.
         - -S1021 # Merge variable declaration and assignment.
-        - -S1023 # redundant return statement
         - -S1024 # Replace 'x.Sub(time.Now())' with 'time.Until(x)'.
         - -S1025 # Don't use 'fmt.Sprintf("%s", x)' unnecessarily.
         - -S1028 # Simplify error construction with 'fmt.Errorf'.

--- a/base/dcp_client_metadata.go
+++ b/base/dcp_client_metadata.go
@@ -147,12 +147,10 @@ func (m *dcpMetadataBase) SetEndSeqNos(endSeqNos map[uint16]uint64) {
 
 // Persist is no-op for in-memory metadata store
 func (md *DCPMetadataMem) Persist(_ context.Context, workerID int, vbIDs []uint16) {
-	return
 }
 
 // Purge is no-op for in-memory metadata store
 func (md *DCPMetadataMem) Purge(_ context.Context, numWorkers int) {
-	return
 }
 
 func (md *DCPMetadataMem) GetKeyPrefix() string {
@@ -235,7 +233,6 @@ func (m *DCPMetadataCS) Persist(ctx context.Context, workerID int, vbIDs []uint1
 	} else {
 		TracefCtx(ctx, KeyDCP, "Persisted metadata for worker %d: %v", workerID, meta)
 	}
-	return
 }
 
 func (m *DCPMetadataCS) load(ctx context.Context, workerID int) {

--- a/base/heartbeat.go
+++ b/base/heartbeat.go
@@ -389,7 +389,6 @@ func (dh *documentBackedListener) GetNodes(ctx context.Context) ([]string, error
 }
 
 func (dh *documentBackedListener) Stop() {
-	return
 }
 
 func (dh *documentBackedListener) StaleHeartbeatDetected(ctx context.Context, nodeUUID string) {

--- a/base/heartbeat_test.go
+++ b/base/heartbeat_test.go
@@ -87,7 +87,6 @@ func (th *TestHeartbeatListener) GetNodes(_ context.Context) (nodeUUIDs []string
 }
 
 func (th *TestHeartbeatListener) Stop() {
-	return
 }
 
 // TestNewCouchbaseHeartbeater starts three heartbeaters (simulating three nodes), then stops a node

--- a/db/background_mgr_async_index_init.go
+++ b/db/background_mgr_async_index_init.go
@@ -114,7 +114,6 @@ func (a *AsyncIndexInitManager) ResetStatus() {
 	defer a.lock.Unlock()
 	a._statusMap = nil
 	a._doneChan = nil
-	return
 }
 
 var _ BackgroundManagerProcessI[AsyncIndexInitOptions] = &AsyncIndexInitManager{}

--- a/db/background_mgr_attachment_migration.go
+++ b/db/background_mgr_attachment_migration.go
@@ -265,7 +265,6 @@ func (a *AttachmentMigrationManager) ResetStatus() {
 }
 
 func (a *AttachmentMigrationManager) SetProcessStatus(context.Context, []byte, []byte) {
-	return
 }
 
 func (a *AttachmentMigrationManager) GetProcessStatus(status BackgroundManagerStatus, _ []byte) ([]byte, []byte, error) {

--- a/db/background_mgr_tombstone_compaction.go
+++ b/db/background_mgr_tombstone_compaction.go
@@ -84,7 +84,6 @@ type TombstoneManagerResponse struct {
 }
 
 func (t *TombstoneCompactionManager) SetProcessStatus(context.Context, []byte, []byte) {
-	return
 }
 
 func (t *TombstoneCompactionManager) GetProcessStatus(backgroundManagerStatus BackgroundManagerStatus, _ []byte) ([]byte, []byte, error) {

--- a/db/channel_cache_single.go
+++ b/db/channel_cache_single.go
@@ -562,7 +562,6 @@ func (c *singleChannelCacheImpl) insertChange(log *LogEntries, change *LogEntry)
 	*log = append(*log, nil)
 	copy((*log)[insertAtIndex+1:], (*log)[insertAtIndex:])
 	(*log)[insertAtIndex] = change
-	return
 }
 
 // Prepends an array of entries to this one, skipping ones that I already have.


### PR DESCRIPTION
CBG-5659: fix S1023 remove redunant return

This is part of a larger set of fixes to make `gopls check` pass so that claude doesn't have to reprocess files when modifying them to discover preexisting issues.

There will be a series of very small PRs to make it easier to review and evaluate risk, though I do not think any of them are risky.