### PR TITLE
CBG-5969 gopls: use fmt.Errorf vs errors.New

### DIFF
--- a/.golangci-strict.yml
+++ b/.golangci-strict.yml
@@ -85,7 +85,6 @@ linters:
         - -S1021 # Merge variable declaration and assignment.
         - -S1024 # Replace 'x.Sub(time.Now())' with 'time.Until(x)'.
         - -S1025 # Don't use 'fmt.Sprintf("%s", x)' unnecessarily.
-        - -S1028 # Simplify error construction with 'fmt.Errorf'.
         - -S1030 # Use 'bytes.Buffer.String' or 'bytes.Buffer.Bytes'.
         - -S1031 # unnecessary nil check around range
         - -S1039 # Unnecessary use of 'fmt.Sprint'.

--- a/base/bucket.go
+++ b/base/bucket.go
@@ -438,7 +438,7 @@ func retrievePurgeInterval(ctx context.Context, bucket CouchbaseBucketStore, uri
 	if statusCode == http.StatusForbidden {
 		WarnfCtx(ctx, "403 Forbidden attempting to access %s.  Bucket user must have Bucket Full Access and Bucket Admin roles to retrieve metadata purge interval.", UD(uri))
 	} else if statusCode != http.StatusOK {
-		return 0, fmt.Errorf("failed with status code, %d, statusCode", statusCode)
+		return 0, fmt.Errorf("failed to retrieve purge interval from %s: status code %d", UD(uri), statusCode)
 	}
 
 	if err := JSONUnmarshal(respBytes, &purgeResponse); err != nil {

--- a/base/bucket.go
+++ b/base/bucket.go
@@ -438,7 +438,7 @@ func retrievePurgeInterval(ctx context.Context, bucket CouchbaseBucketStore, uri
 	if statusCode == http.StatusForbidden {
 		WarnfCtx(ctx, "403 Forbidden attempting to access %s.  Bucket user must have Bucket Full Access and Bucket Admin roles to retrieve metadata purge interval.", UD(uri))
 	} else if statusCode != http.StatusOK {
-		return 0, fmt.Errorf("failed to retrieve purge interval from %s: status code %d", UD(uri), statusCode)
+		return 0, RedactErrorf("failed to retrieve purge interval from %s: status code %d", UD(uri), statusCode)
 	}
 
 	if err := JSONUnmarshal(respBytes, &purgeResponse); err != nil {

--- a/base/bucket.go
+++ b/base/bucket.go
@@ -14,7 +14,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -439,7 +438,7 @@ func retrievePurgeInterval(ctx context.Context, bucket CouchbaseBucketStore, uri
 	if statusCode == http.StatusForbidden {
 		WarnfCtx(ctx, "403 Forbidden attempting to access %s.  Bucket user must have Bucket Full Access and Bucket Admin roles to retrieve metadata purge interval.", UD(uri))
 	} else if statusCode != http.StatusOK {
-		return 0, errors.New(fmt.Sprintf("failed with status code, %d, statusCode", statusCode))
+		return 0, fmt.Errorf("failed with status code, %d, statusCode", statusCode)
 	}
 
 	if err := JSONUnmarshal(respBytes, &purgeResponse); err != nil {

--- a/base/leaky_datastore.go
+++ b/base/leaky_datastore.go
@@ -229,7 +229,7 @@ func (lds *LeakyDataStore) GetDDoc(ctx context.Context, docname string) (ddoc sg
 		return sgbucket.DesignDoc{}, errors.New("bucket does not support views")
 	}
 	if remaining, shouldFail := lds.bucket.decrementDDocGetErrorCount(); shouldFail {
-		return ddoc, errors.New(fmt.Sprintf("Artificial leaky bucket error %d fails remaining", remaining))
+		return ddoc, fmt.Errorf("Artificial leaky bucket error %d fails remaining", remaining)
 	}
 	return vs.GetDDoc(ctx, docname)
 }
@@ -248,7 +248,7 @@ func (lds *LeakyDataStore) DeleteDDoc(ctx context.Context, docname string) error
 		return errors.New("bucket does not support views")
 	}
 	if remaining, shouldFail := lds.bucket.decrementDDocDeleteErrorCount(); shouldFail {
-		return errors.New(fmt.Sprintf("Artificial leaky bucket error %d fails remaining", remaining))
+		return fmt.Errorf("Artificial leaky bucket error %d fails remaining", remaining)
 	}
 	return vs.DeleteDDoc(ctx, docname)
 }

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -1732,7 +1732,7 @@ func (h *handler) writeStatus(status int, message string) {
 	_, _ = h.response.Write([]byte(`{"error":"` + errorStr + `","reason":` + base.ConvertToJSONString(message) + `}`))
 }
 
-var kRangeRegex = regexp.MustCompile("^bytes=(\\d+)?-(\\d+)?$")
+var kRangeRegex = regexp.MustCompile(`^bytes=(\d+)?-(\d+)?$`)
 
 // Detects and partially HTTP content range requests.
 // If the request _can_ accept ranges, sets the "Accept-Ranges" response header to "bytes".

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1790,7 +1790,7 @@ func (sc *ServerContext) processEventHandlersForEvent(ctx context.Context, event
 			}
 			dbcontext.EventMgr.RegisterEventHandler(ctx, wh, eventType)
 		default:
-			return errors.New(fmt.Sprintf("Unknown event handler type %s", event.HandlerType))
+			return fmt.Errorf("Unknown event handler type %s", event.HandlerType)
 		}
 
 	}


### PR DESCRIPTION
CBG-5969 gopls: use fmt.Errorf vs errors.New and use string literal for regex.
