### PR TITLE
CBG-5969 enable nilness checker

### DIFF
--- a/.golangci-strict.yml
+++ b/.golangci-strict.yml
@@ -62,6 +62,9 @@ linters:
         ruleguard:
           failOn: all
           rules: ${base-path}/ruleguard/rules-*.go
+    govet:
+      enable:
+        - nilness
     staticcheck:
       checks:
         - all # enable all

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,6 +48,7 @@ linters:
     govet:
       enable:
         - fieldalignment
+        - nilness
   exclusions:
     generated: strict
     rules:

--- a/auth/session.go
+++ b/auth/session.go
@@ -134,8 +134,6 @@ func (auth *Authenticator) CreateSession(ctx context.Context, user User, ttl tim
 
 	if user != nil && user.Disabled() {
 		return nil, base.HTTPErrorf(400, "User is disabled")
-	} else if err != nil {
-		return nil, err
 	}
 
 	session := &LoginSession{

--- a/base/gocb_dcp_client.go
+++ b/base/gocb_dcp_client.go
@@ -421,9 +421,7 @@ func (dc *GoCBDCPClient) initAgent(spec BucketSpec) error {
 			waitError = fmt.Errorf("WaitUntilReady error channel for dcp agent returned error (%d): %w", i, err)
 			continue
 		}
-		if waitError == nil {
-			break
-		}
+		break
 
 	}
 	if waitError != nil {

--- a/db/attachment_compaction.go
+++ b/db/attachment_compaction.go
@@ -491,7 +491,7 @@ func attachmentCompactCleanupPhase(ctx context.Context, dataStore base.DataStore
 				if err == nil {
 					return true
 				}
-				if err != nil && !base.IsCasMismatch(err) {
+				if !base.IsCasMismatch(err) {
 					base.WarnfCtx(ctx, "[%s] Failed to remove compaction ID xattr for doc %s: %v", compactionLoggingID, base.UD(docID), err)
 					return true
 				}

--- a/db/crud.go
+++ b/db/crud.go
@@ -1684,9 +1684,7 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 	})
 
 	if doc != nil && doc.HLV != nil {
-		if cv == nil {
-			cv = &Version{}
-		}
+		cv = &Version{}
 		source, version := doc.HLV.GetCurrentVersion()
 		cv.SourceID = source
 		cv.Value = version

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -236,7 +236,7 @@ func (il *importListener) ImportFeedEvent(ctx context.Context, collection *Datab
 				base.DebugfCtx(ctx, base.KeyImport, "Did not import doc %q - external update will not be accessible via Sync Gateway.  Reason: %v", base.UD(docID), err)
 			}
 		}
-	} else if syncData != nil && syncData.AttachmentsPre4dot0 != nil {
+	} else if syncData.AttachmentsPre4dot0 != nil {
 		base.DebugfCtx(ctx, base.KeyImport, "Attachment metadata found in sync data for doc with id %s, migrating attachment metadata", base.UD(docID))
 		// we have attachments to migrate
 		err := collection.MigrateAttachmentMetadata(ctx, docID, event.Cas, syncData)

--- a/rest/diagnostic_api.go
+++ b/rest/diagnostic_api.go
@@ -250,10 +250,6 @@ func (h *handler) handleGetUserDocAccessSpan() error {
 		return fmt.Errorf("unable to get scope and collection from keyspace")
 	}
 
-	if err != nil {
-		return err
-	}
-
 	keyspace := scope + "." + coll
 
 	for _, docID := range docidsList {

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -445,7 +445,7 @@ func (h *handler) handlePutAttachment() error {
 			}
 			// couchdb creates empty body on attachment PUT for non-existent doc id
 			body = db.Body{bodyKey: occValue}
-		} else if err != nil {
+		} else {
 			return err
 		}
 	} else if body != nil {
@@ -503,7 +503,7 @@ func (h *handler) handleDeleteAttachment() error {
 			}
 			// Need to return an error if a document is not found
 			return base.HTTPErrorf(http.StatusNotFound, "Document specified is not found")
-		} else if err != nil {
+		} else {
 			return err
 		}
 	} else if body != nil {


### PR DESCRIPTION
CBG-5969 enable nilness checker

Enable go vet nilness checker, used by gopls.

Remove tautological conditions for nil == nil or nil != nil 