### PR TITLE
CBG-5969: fix staticcheck time.Since/time.Until

### DIFF
--- a/.golangci-strict.yml
+++ b/.golangci-strict.yml
@@ -81,9 +81,7 @@ linters:
         - -S1008 # Simplify returning boolean expression.
         - -S1009 # Omit redundant nil check on slices, maps, and channels.
         - -S1011 # Use a single 'append' to concatenate two slices.
-        - -S1012 # Replace 'time.Now().Sub(x)' with 'time.Since(x)'.
         - -S1021 # Merge variable declaration and assignment.
-        - -S1024 # Replace 'x.Sub(time.Now())' with 'time.Until(x)'.
         - -S1025 # Don't use 'fmt.Sprintf("%s", x)' unnecessarily.
         - -S1028 # Simplify error construction with 'fmt.Errorf'.
         - -S1030 # Use 'bytes.Buffer.String' or 'bytes.Buffer.Bytes'.

--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -490,7 +490,7 @@ func isTransientIndexerError(err error) bool {
 }
 
 func SlowQueryLog(ctx context.Context, startTime time.Time, threshold time.Duration, messageFormat string, args ...any) {
-	if elapsed := time.Now().Sub(startTime); elapsed > threshold {
+	if elapsed := time.Since(startTime); elapsed > threshold {
 		InfofCtx(ctx, KeyQuery, messageFormat+" took "+elapsed.String(), args...)
 	}
 }

--- a/db/database.go
+++ b/db/database.go
@@ -914,7 +914,7 @@ func waitForBGTCompletion(ctx context.Context, waitTimeMax time.Duration, tasks 
 		start := time.Now()
 		select {
 		case <-t.doneChan:
-			waitTime -= time.Now().Sub(start)
+			waitTime -= time.Since(start)
 			continue
 		case <-time.After(waitTime):
 			// Timeout after waiting for background task to terminate.

--- a/rest/oidc_api.go
+++ b/rest/oidc_api.go
@@ -204,7 +204,7 @@ func (h *handler) handleOIDCCallback() error {
 
 	if provider.IncludeAccessToken {
 		callbackResponse.AccessToken = token.AccessToken
-		callbackResponse.Expires = int(token.Expiry.Sub(time.Now()).Seconds())
+		callbackResponse.Expires = int(time.Until(token.Expiry).Seconds())
 		callbackResponse.TokenType = token.TokenType
 	}
 
@@ -255,7 +255,7 @@ func (h *handler) handleOIDCRefresh() error {
 
 	if provider.IncludeAccessToken {
 		refreshResponse.AccessToken = token.AccessToken
-		refreshResponse.Expires = int(token.Expiry.Sub(time.Now()).Seconds())
+		refreshResponse.Expires = int(time.Until(token.Expiry).Seconds())
 		refreshResponse.TokenType = token.TokenType
 	}
 
@@ -278,7 +278,7 @@ func (h *handler) createSessionForTrustedIdToken(rawIDToken string, provider *au
 	}
 
 	if !provider.DisableSession {
-		sessionTTL := tokenExpiryTime.Sub(time.Now())
+		sessionTTL := time.Until(tokenExpiryTime)
 		oneTime := false
 		sessionID, err := h.makeSessionWithTTL(user, sessionTTL, oneTime)
 		return user.Name(), sessionID, err

--- a/rest/session_test.go
+++ b/rest/session_test.go
@@ -742,7 +742,7 @@ func TestSessionExpirationDateTimeFormat(t *testing.T) {
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	expires, err := time.Parse(time.RFC3339, body["expires"].(string))
 	assert.NoError(t, err, "Couldn't parse session expiration datetime")
-	assert.True(t, expires.Sub(time.Now()).Hours() <= 24, "Couldn't validate session expiration")
+	assert.True(t, time.Until(expires).Hours() <= 24, "Couldn't validate session expiration")
 
 	sessionId := body["session_id"].(string)
 	require.NotEmpty(t, sessionId, "Couldn't parse sessionID from response body")
@@ -752,7 +752,7 @@ func TestSessionExpirationDateTimeFormat(t *testing.T) {
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	expires, err = time.Parse(time.RFC3339, body["expires"].(string))
 	assert.NoError(t, err, "Couldn't parse session expiration datetime")
-	assert.True(t, expires.Sub(time.Now()).Hours() <= 24, "Couldn't validate session expiration")
+	assert.True(t, time.Until(expires).Hours() <= 24, "Couldn't validate session expiration")
 }
 
 // TestSessionCreationCookieBehavior verifies that POST /_session sets a cookie for regular sessions


### PR DESCRIPTION
CBG-5969: Enable and fix staticcheck S1012 and S1024 linter issues

Use time.Since and time.Until simplifications

Suitable for hiding gopls warnings.