### PR TITLE
CBG-5658 fix flaky TestBlipSendConcurrentRevs

### DIFF
--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1136,11 +1136,29 @@ func TestBlipSendConcurrentRevs(t *testing.T) {
 	const (
 		maxConcurrentRevs    = 10
 		concurrentSendRevNum = 50
+		// Once all maxConcurrentRevs slots are held, every remaining rev has to wait for one.
+		expectedThrottledRevs = concurrentSendRevNum - maxConcurrentRevs
 	)
-	rt := NewRestTester(t, &RestTesterConfig{
+	docIDPrefix := t.Name() + "-"
+
+	var rt *RestTester
+	throttledRevs := func() int64 {
+		return rt.GetDatabase().DbStats.CBLReplicationPush().WriteThrottledCount.Value()
+	}
+	rt = NewRestTester(t, &RestTesterConfig{
 		LeakyBucketConfig: &base.LeakyBucketConfig{
-			UpdateCallback: func(_ string) {
-				time.Sleep(time.Millisecond * 5) // slow down rosmar - it's too quick to be throttled
+			// Hold each rev inside its throttle slot until all of the remaining revs have been
+			// throttled waiting for a slot. Without this the test relies on the client being able
+			// to push more than maxConcurrentRevs revs to the server in the time it takes the
+			// server to write one, which isn't true on a slow or busy machine (CBG-3741).
+			UpdateCallback: func(docID string) {
+				if !strings.HasPrefix(docID, docIDPrefix) {
+					return
+				}
+				deadline := time.Now().Add(time.Second * 20)
+				for throttledRevs() < expectedThrottledRevs && time.Now().Before(deadline) {
+					time.Sleep(time.Millisecond)
+				}
 			},
 		},
 		maxConcurrentRevs: base.Ptr(maxConcurrentRevs),
@@ -1157,7 +1175,7 @@ func TestBlipSendConcurrentRevs(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(concurrentSendRevNum)
 	for i := range concurrentSendRevNum {
-		docID := fmt.Sprintf("%s-%d", t.Name(), i)
+		docID := fmt.Sprintf("%s%d", docIDPrefix, i)
 		go func() {
 			defer wg.Done()
 			bt.SendRev(docID, "1-abc", []byte(`{"key": "val", "channels": ["user1"]}`), blip.Properties{})
@@ -1170,7 +1188,7 @@ func TestBlipSendConcurrentRevs(t *testing.T) {
 	throttleTime := rt.GetDatabase().DbStats.CBLReplicationPush().WriteThrottledTime.Value()
 	throttleDuration := time.Duration(throttleTime) * time.Nanosecond
 
-	assert.Greater(t, throttleCount, int64(0), "Expected throttled revs")
+	assert.Equal(t, int64(expectedThrottledRevs), throttleCount, "Expected throttled revs")
 	assert.Greater(t, throttleTime, int64(0), "Expected non-zero throttled revs time")
 
 	t.Logf("Throttled revs: %d, Throttled duration: %s", throttleCount, throttleDuration)

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1173,13 +1173,11 @@ func TestBlipSendConcurrentRevs(t *testing.T) {
 	defer bt.Close()
 
 	wg := sync.WaitGroup{}
-	wg.Add(concurrentSendRevNum)
 	for i := range concurrentSendRevNum {
 		docID := fmt.Sprintf("%s%d", docIDPrefix, i)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			bt.SendRev(docID, "1-abc", []byte(`{"key": "val", "channels": ["user1"]}`), blip.Properties{})
-		}()
+		})
 	}
 
 	base.WaitWithTimeout(t, &wg, time.Second*30)


### PR DESCRIPTION
CBG-5658 fix flaky TestBlipSendConcurrentRevs

Make this code determinstic.

The test pushed 50 concurrent revs with max_concurrent_revs=10 and asserted some were throttled, but nothing guaranteed any would be:

- A rev only counts as throttled if it finds all 10 slots taken, so an 11th rev must reach processRev while the first 10 are still writing.
- In-flight revs settle at arrival_rate * write_time, so with the 5ms UpdateCallback sleep the client had to deliver revs <500us apart (5ms / 10 slots) for an 11th to ever exist. Locally they arrive ~60us apart: 8x headroom.
- That headroom is per-message work the client and server share a CPU for (deflate, frame decode, dbUserLock, testify reflection), which stretches under load, while the 5ms sleep is wall-clock and does not - so a busy CI machine makes the failure more likely, not less.
- 500us of client-side pacing reproduces the CI failure exactly: 6 revs in flight, 0 throttled, both assertions failing "0 is not greater than 0".
- The sleep never produced the throttling anyway - without it 40 revs are still throttled locally. It only widened the race window.

Instead of racing the client against the server, hold each rev inside its throttle slot until the remaining revs have been throttled waiting for one - the leaky bucket callback already runs inside the slot, so it waits on the throttled-revs stat. The count is now exactly concurrentSendRevNum - maxConcurrentRevs, so the assertion tightens from > 0 to that value, and the fixed sleeps are gone.

Verified: exactly 40 throttled with 0/500us/2ms/10ms client pacing, under 25x CPU oversubscription pinned to one core, and 15/15 with -race.

## Pre-review checklist
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/1010/

