### PR TITLE
[4.1.2 Backport] CBG-5477: complete migration when a pending db drops out of cluster

### DIFF
--- a/base/bootstrap.go
+++ b/base/bootstrap.go
@@ -52,6 +52,8 @@ type BootstrapConnection interface {
 	// for the given bucket; subsequent bootstrap reads for that bucket stop falling back to
 	// _default._default. Per-bucket so completing one bucket never disables another's fallback.
 	SetMigrationComplete(bucketName string)
+	// IsMigrationComplete reports whether this process has marked bootstrap-metadata migration complete for the given bucket (local cache).
+	IsMigrationComplete(bucketName string) bool
 	// GetMetadataMigrationStatus reads the bucket-level metadata-migration status doc directly from
 	// _system._mobile (never via the dual-collection wrapper). Returns ErrNotFound when the doc has
 	// not yet been stamped on this bucket.
@@ -509,6 +511,10 @@ func (cc *CouchbaseCluster) shouldFallback(err error, fallback *gocb.Collection)
 // operations.
 func (cc *CouchbaseCluster) SetMigrationComplete(bucketName string) {
 	cc.bucketsBootstrapMigrationComplete.Store(bucketName, true)
+}
+
+func (cc *CouchbaseCluster) IsMigrationComplete(bucketName string) bool {
+	return cc.bucketBootstrapMigrationComplete(bucketName)
 }
 
 // bucketBootstrapMigrationComplete reports whether bootstrap-metadata migration has been marked

--- a/base/metadata_migration_status.go
+++ b/base/metadata_migration_status.go
@@ -83,7 +83,7 @@ func NewMetadataMigrationStatus() *MetadataMigrationStatus {
 // Callers must pass the live registry-derived set so a DB added mid-migration isn't missed.
 func (s *MetadataMigrationStatus) AllDatabasesComplete(expected []string) bool {
 	if len(expected) == 0 {
-		return false
+		return true // no databases to wait for, complete migration
 	}
 	for _, id := range expected {
 		entry, ok := s.Databases[id]

--- a/base/rosmar_cluster.go
+++ b/base/rosmar_cluster.go
@@ -272,6 +272,10 @@ func (c *RosmarCluster) SetMigrationComplete(bucketName string) {
 	c.bucketsBootstrapMigrationComplete.Store(bucketName, true)
 }
 
+func (c *RosmarCluster) IsMigrationComplete(bucketName string) bool {
+	return c.bucketBootstrapMigrationComplete(bucketName)
+}
+
 // bucketBootstrapMigrationComplete reports whether bootstrap-metadata migration has been marked
 // complete for the given bucket. Absence of an entry means not-complete, so reads keep the
 // _default._default fallback.

--- a/rest/metadatamigrationtest/metadata_migration_test.go
+++ b/rest/metadatamigrationtest/metadata_migration_test.go
@@ -1536,3 +1536,213 @@ func TestMetadataMigrationNamedDBFirstThenDefaultSiblingExclusion(t *testing.T) 
 	rest.RequireStatus(t, resp, http.StatusOK)
 	assert.Contains(t, resp.Body.String(), `"name":"bob"`, "dbnamed must remain readable after dbdefault's later migration")
 }
+
+func TestDeleteNonMigratedDbUnblocksBootstrapMigration(t *testing.T) {
+	base.TestRequiresCollections(t)
+
+	ctx := base.TestCtx(t)
+	tb := base.GetTestBucket(t)
+	defer tb.Close(ctx)
+
+	dataStore1, err := tb.GetNamedDataStore(0)
+	require.NoError(t, err)
+	dataStore2, err := tb.GetNamedDataStore(1)
+	require.NoError(t, err)
+
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		CustomTestBucket: tb.NoCloseClone(),
+		PersistentConfig: true,
+	})
+	defer rt.Close()
+
+	db1Cfg := rt.NewDbConfig()
+	db1Cfg.UseSystemMobileMetadataCollection = base.Ptr(false)
+	db1Cfg.Scopes = rest.ScopesConfig{
+		dataStore1.ScopeName(): rest.ScopeConfig{
+			Collections: rest.CollectionsConfig{dataStore1.CollectionName(): {}},
+		},
+	}
+	rest.RequireStatus(t, rt.CreateDatabase("db1", db1Cfg), http.StatusCreated)
+
+	db2Cfg := rt.NewDbConfig()
+	db2Cfg.UseSystemMobileMetadataCollection = base.Ptr(false)
+	db2Cfg.Scopes = rest.ScopesConfig{
+		dataStore2.ScopeName(): rest.ScopeConfig{
+			Collections: rest.CollectionsConfig{dataStore2.CollectionName(): {}},
+		},
+	}
+	rest.RequireStatus(t, rt.CreateDatabase("db2", db2Cfg), http.StatusCreated)
+
+	// Opt in for db1 and start migration
+	db1Cfg.UseSystemMobileMetadataCollection = base.Ptr(true)
+	rest.RequireStatus(t, rt.UpsertDbConfig("db1", db1Cfg), http.StatusCreated)
+	rt.ServerContext().ForceClusterCompatRefresh(t, rt.Context())
+	resp := rt.SendAdminRequest(http.MethodPost, "/db1/_metadata_migration?action=start", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+
+	rt.WaitForMetadataMigrationStatusForDB(db.BackgroundProcessStateCompleted, "db1")
+
+	// Delete db2
+	resp = rt.SendAdminRequest(http.MethodDelete, "/db2/", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+
+	// force a recheck of pending bucket bootstrap migration, which takes place in config polling
+	rt.ServerContext().RecheckPendingBucketMetadataMigrations(ctx)
+
+	conn := rt.ServerContext().BootstrapContext.Connection
+	require.EventuallyWithT(rt.TB(), func(c *assert.CollectT) {
+		status, _, err := conn.GetMetadataMigrationStatus(ctx, tb.GetName())
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, status) {
+			return
+		}
+		assert.Equal(c, base.MigrationStateComplete, status.Bootstrap.State, "bucket bootstrap migration should be complete")
+	}, 10*time.Second, 100*time.Millisecond)
+}
+
+// TestRecheckConvergesLocalCacheOnPeerCompletedMigration ensures when a node completes the bucket bootstrap migration,
+// this node's status doc reads complete but its local "migration complete" cache (IsMigrationComplete) is updated too.
+// RecheckPendingBucketMetadataMigrations should converge that cache so the node stops falling back
+// to _default._default and stops re-doing the recheck work for that bucket every poll.
+func TestRecheckConvergesLocalCacheOnPeerCompletedMigration(t *testing.T) {
+	base.TestRequiresCollections(t)
+
+	ctx := base.TestCtx(t)
+	tb := base.GetTestBucket(t)
+	defer tb.Close(ctx)
+
+	dataStore1, err := tb.GetNamedDataStore(0)
+	require.NoError(t, err)
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		CustomTestBucket: tb.NoCloseClone(),
+		PersistentConfig: true,
+	})
+	defer rt.Close()
+
+	db1Cfg := rt.NewDbConfig()
+	db1Cfg.UseSystemMobileMetadataCollection = base.Ptr(false)
+	db1Cfg.Scopes = rest.ScopesConfig{
+		dataStore1.ScopeName(): rest.ScopeConfig{
+			Collections: rest.CollectionsConfig{dataStore1.CollectionName(): {}},
+		},
+	}
+	rest.RequireStatus(t, rt.CreateDatabase("db1", db1Cfg), http.StatusCreated)
+
+	dataStore2, err := tb.GetNamedDataStore(1)
+	require.NoError(t, err)
+	db2Cfg := rt.NewDbConfig()
+	db2Cfg.UseSystemMobileMetadataCollection = base.Ptr(false)
+	db2Cfg.Scopes = rest.ScopesConfig{
+		dataStore2.ScopeName(): rest.ScopeConfig{
+			Collections: rest.CollectionsConfig{dataStore2.CollectionName(): {}},
+		},
+	}
+	rest.RequireStatus(t, rt.CreateDatabase("db2", db2Cfg), http.StatusCreated)
+
+	// Opt in for db1 and run its migration. db2 stays un-migrated, so this node never completes the
+	// bucket migration on its own — its local IsMigrationComplete cache stays false. (db2 also
+	// guarantees the recheck can't complete the bucket itself, isolating the test to the cache
+	// convergence path.)
+	db1Cfg.UseSystemMobileMetadataCollection = base.Ptr(true)
+	rest.RequireStatus(t, rt.UpsertDbConfig("db1", db1Cfg), http.StatusCreated)
+	rt.ServerContext().ForceClusterCompatRefresh(t, rt.Context())
+	resp := rt.SendAdminRequest(http.MethodPost, "/db1/_metadata_migration?action=start", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	rt.WaitForMetadataMigrationStatusForDB(db.BackgroundProcessStateCompleted, "db1")
+
+	conn := rt.ServerContext().BootstrapContext.Connection
+
+	// Simulate a peer node winning the completion: stamp the bucket status doc to complete directly.
+	// UpdateMetadataMigrationStatus only writes the doc — it does not touch this node's local cache,
+	// so IsMigrationComplete is still false afterwards, exactly as it would be on a peer that didn't
+	// run the completion itself.
+	_, err = conn.UpdateMetadataMigrationStatus(ctx, tb.GetName(), func(s *base.MetadataMigrationStatus) error {
+		s.Bootstrap.State = base.MigrationStateComplete
+		return nil
+	})
+	require.NoError(t, err)
+	require.False(t, conn.IsMigrationComplete(tb.GetName()), "precondition: local node should not have marked migration complete yet")
+
+	// The recheck observes the completed status doc; it should converge the local cache.
+	rt.ServerContext().RecheckPendingBucketMetadataMigrations(ctx)
+
+	require.True(t, conn.IsMigrationComplete(tb.GetName()), "finding 2: recheck observing a peer-completed status doc should converge the local migration-complete cache")
+}
+
+// TestDeleteAllDbsCompletesPendingBootstrapMigration is similar to TestDeleteNonMigratedDbUnblocksBootstrapMigration
+// except that it deletes *every* db (both the migrated db1 and the un-migrated db2) and asserts the same thing
+func TestDeleteAllDbsCompletesPendingBootstrapMigration(t *testing.T) {
+	base.TestRequiresCollections(t)
+
+	ctx := base.TestCtx(t)
+	tb := base.GetTestBucket(t)
+	defer tb.Close(ctx)
+
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		CustomTestBucket: tb.NoCloseClone(),
+		PersistentConfig: true,
+	})
+	defer rt.Close()
+
+	dataStore1, err := tb.GetNamedDataStore(0)
+	require.NoError(t, err)
+	db1Cfg := rt.NewDbConfig()
+	db1Cfg.UseSystemMobileMetadataCollection = base.Ptr(false)
+	db1Cfg.Scopes = rest.ScopesConfig{
+		dataStore1.ScopeName(): rest.ScopeConfig{
+			Collections: rest.CollectionsConfig{dataStore1.CollectionName(): {}},
+		},
+	}
+	rest.RequireStatus(t, rt.CreateDatabase("db1", db1Cfg), http.StatusCreated)
+
+	dataStore2, err := tb.GetNamedDataStore(1)
+	require.NoError(t, err)
+	db2Cfg := rt.NewDbConfig()
+	db2Cfg.UseSystemMobileMetadataCollection = base.Ptr(false)
+	db2Cfg.Scopes = rest.ScopesConfig{
+		dataStore2.ScopeName(): rest.ScopeConfig{
+			Collections: rest.CollectionsConfig{dataStore2.CollectionName(): {}},
+		},
+	}
+	rest.RequireStatus(t, rt.CreateDatabase("db2", db2Cfg), http.StatusCreated)
+
+	// Opt in for db1 and start its migration. This stamps the bucket-level status doc with
+	// Bootstrap.State == pending. The bucket cannot complete yet because db2 has not opted in.
+	db1Cfg.UseSystemMobileMetadataCollection = base.Ptr(true)
+	rest.RequireStatus(t, rt.UpsertDbConfig("db1", db1Cfg), http.StatusCreated)
+	rt.ServerContext().ForceClusterCompatRefresh(t, rt.Context())
+	resp := rt.SendAdminRequest(http.MethodPost, "/db1/_metadata_migration?action=start", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+
+	rt.WaitForMetadataMigrationStatusForDB(db.BackgroundProcessStateCompleted, "db1")
+
+	conn := rt.ServerContext().BootstrapContext.Connection
+
+	// Sanity check: with db2 still present and un-migrated, the bucket bootstrap migration is pending.
+	status, _, err := conn.GetMetadataMigrationStatus(ctx, tb.GetName())
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	require.Equal(t, base.MigrationStatePending, status.Bootstrap.State, "precondition: bucket migration should be pending while db2 is un-migrated")
+
+	// Delete every database in the bucket — both the migrated db1 and the un-migrated db2 — so the
+	// registry has no live entries left.
+	rest.RequireStatus(t, rt.SendAdminRequest(http.MethodDelete, "/db2/", ""), http.StatusOK)
+	rest.RequireStatus(t, rt.SendAdminRequest(http.MethodDelete, "/db1/", ""), http.StatusOK)
+
+	// Re-run the recheck on every tick (mirroring the config-polling cadence) and expect the bucket
+	// migration to converge to complete now that nothing blocks it. It never does — this assertion
+	// fails on the current code because maybeComplete bails at its len(expected) == 0 guard.
+	require.EventuallyWithT(rt.TB(), func(c *assert.CollectT) {
+		rt.ServerContext().RecheckPendingBucketMetadataMigrations(ctx)
+		status, _, err := conn.GetMetadataMigrationStatus(ctx, tb.GetName())
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, status) {
+			return
+		}
+		assert.Equal(c, base.MigrationStateComplete, status.Bootstrap.State, "deleting all dbs should let the pending bucket migration complete")
+	}, 5*time.Second, 100*time.Millisecond)
+}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -2396,6 +2396,7 @@ func (sc *ServerContext) initializeBootstrapConnection(ctx context.Context) erro
 					}
 					sc.ClusterCompat.Refresh(ctx)
 					sc.refreshBucketBootstrapTargets(ctx)
+					sc.RecheckPendingBucketMetadataMigrations(ctx)
 				}
 			}
 		}()
@@ -2405,6 +2406,24 @@ func (sc *ServerContext) initializeBootstrapConnection(ctx context.Context) erro
 	base.InfofCtx(ctx, base.KeyAll, "Finished initializing bootstrap connection")
 
 	return nil
+}
+
+// RecheckPendingBucketMetadataMigrations iterates through all config buckets and re-evaluates
+// whether bucket-level metadata migration can now be completed.
+func (sc *ServerContext) RecheckPendingBucketMetadataMigrations(ctx context.Context) {
+	if sc.BootstrapContext == nil || sc.BootstrapContext.Connection == nil {
+		return
+	}
+	buckets := sc.ClusterCompat.trackedBucketList()
+	for _, bucket := range buckets {
+		if sc.BootstrapContext.Connection.IsMigrationComplete(bucket) {
+			// migration done for this bucket, fast path skip to next bucket
+			continue
+		}
+		if err := sc.maybeCompleteBucketMetadataMigration(ctx, bucket); err != nil {
+			base.WarnfCtx(ctx, "Re-check of bucket %q metadata migration failed: %v", base.MD(bucket), err)
+		}
+	}
 }
 
 // resolveUseSystemMetadataCollection returns the effective use_system_metadata_collection
@@ -2511,16 +2530,13 @@ func (sc *ServerContext) maybeCompleteBucketMetadataMigration(ctx context.Contex
 		return fmt.Errorf("read registry for bucket %q: %w", bucketName, err)
 	}
 	expected := registryMetadataIDs(registry)
-	if len(expected) == 0 {
-		// No DBs in registry → nothing to migrate
-		return nil
-	}
 
 	status, _, err := sc.BootstrapContext.Connection.GetMetadataMigrationStatus(ctx, bucketName)
 	if err != nil {
 		return fmt.Errorf("read status doc for bucket %q: %w", bucketName, err)
 	}
 	if status.Bootstrap.State == base.MigrationStateComplete {
+		sc.BootstrapContext.Connection.SetMigrationComplete(bucketName)
 		return nil
 	}
 	if !status.AllDatabasesComplete(expected) {


### PR DESCRIPTION
Clean cherry pick of #8373 for 4.1.2
