### PR TITLE
[4.1.2 Backport] CBG-5495: add RestTestCluster

### DIFF
--- a/rest/adminapitest/resync_test.go
+++ b/rest/adminapitest/resync_test.go
@@ -534,22 +534,20 @@ func TestDistributedResync(t *testing.T) {
 
 	t.Skip("Long-running dev-time test used to test multi-node cbgt rebalance during resync")
 
-	// Create first rest tester with persistent config
-	rt1 := rest.NewRestTesterPersistentConfig(t)
-	defer rt1.Close()
-
-	// Create second RT targeting the same bucket, with matching groupID and config polling enabled
-	rt2Config := &rest.RestTesterConfig{
-		GroupID: &rt1.ServerContext().Config.Bootstrap.ConfigGroupID,
+	ctx := base.TestCtx(t)
+	rtc := rest.NewRestTesterCluster(t, &rest.RestTesterClusterConfig{
+		NumNodes: 2,
 		MutateStartupConfig: func(config *rest.StartupConfig) {
 			// enable config polling
 			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(50 * time.Millisecond)
 		},
-		CustomTestBucket: rt1.TestBucket.NoCloseClone(),
-		PersistentConfig: true,
-	}
-	rt2 := rest.NewRestTester(t, rt2Config)
-	defer rt2.Close()
+	})
+	defer rtc.Close(ctx)
+
+	rt1 := rtc.Node(0)
+	rt2 := rtc.Node(1)
+
+	rest.RequireStatus(t, rt1.CreateDatabase("db", rt1.NewDbConfig()), http.StatusCreated)
 
 	// wait for db to be online on rt1
 	rt1.WaitForDBState(db.RunStateString[db.DBOnline])

--- a/rest/cluster_compat_test.go
+++ b/rest/cluster_compat_test.go
@@ -751,22 +751,14 @@ func refreshAndGetRegistry(t *testing.T, rt *RestTester, bucketName string) *Gat
 // IsConfigFullyApplied returns true once both nodes have applied the config.
 func TestIsConfigFullyAppliedTwoNodeConvergence(t *testing.T) {
 	ctx := base.TestCtx(t)
-	tb := base.GetTestBucket(t)
-	defer tb.Close(ctx)
+	rtc := NewRestTesterCluster(t, &RestTesterClusterConfig{
+		NumNodes: 2,
+	})
+	defer rtc.Close(ctx)
 
-	groupID := t.Name()
-	rtConfig := &RestTesterConfig{
-		CustomTestBucket: tb.NoCloseClone(),
-		PersistentConfig: true,
-		GroupID:          &groupID,
-	}
-
-	rtA := NewRestTester(t, rtConfig)
-	defer rtA.Close()
-	rtB := NewRestTester(t, rtConfig)
-	defer rtB.Close()
-
-	bucketName := tb.GetName()
+	rtA := rtc.Node(0)
+	rtB := rtc.Node(1)
+	bucketName := rtc.testBucket.GetName()
 
 	dbConfig := rtA.NewDbConfig()
 	resp := rtA.CreateDatabase("db", dbConfig)
@@ -781,7 +773,7 @@ func TestIsConfigFullyAppliedTwoNodeConvergence(t *testing.T) {
 	require.NotEmpty(t, dbVersion)
 
 	registry := refreshAndGetRegistry(t, rtA, bucketName)
-	acked, missing, err := registry.IsConfigFullyApplied(ctx, groupID, "db", dbVersion)
+	acked, missing, err := registry.IsConfigFullyApplied(ctx, rtc.groupID, "db", dbVersion)
 	require.NoError(t, err)
 	assert.True(t, acked, "both nodes should have acked; missing: %v (registry nodes: %v)", missing, registry.Nodes)
 	assert.Empty(t, missing)
@@ -792,22 +784,14 @@ func TestIsConfigFullyAppliedTwoNodeConvergence(t *testing.T) {
 // node A's view even though B never acked the latest version.
 func TestIsConfigFullyAppliedStaleNodePruned(t *testing.T) {
 	ctx := base.TestCtx(t)
-	tb := base.GetTestBucket(t)
-	defer tb.Close(ctx)
+	rtc := NewRestTesterCluster(t, &RestTesterClusterConfig{
+		NumNodes: 2,
+	})
+	defer rtc.Close(ctx)
 
-	groupID := t.Name()
-	rtConfig := &RestTesterConfig{
-		CustomTestBucket: tb.NoCloseClone(),
-		PersistentConfig: true,
-		GroupID:          &groupID,
-	}
-
-	rtA := NewRestTester(t, rtConfig)
-	defer rtA.Close()
-	rtB := NewRestTester(t, rtConfig)
-	defer rtB.Close()
-
-	bucketName := tb.GetName()
+	rtA := rtc.Node(0)
+	rtB := rtc.Node(1)
+	bucketName := rtc.testBucket.GetName()
 
 	dbConfig := rtA.NewDbConfig()
 	resp := rtA.CreateDatabase("db", dbConfig)
@@ -824,7 +808,7 @@ func TestIsConfigFullyAppliedStaleNodePruned(t *testing.T) {
 	assert.NotContains(t, registry.Nodes, rtB.ServerContext().NodeUID, "stale node B should be pruned")
 
 	dbVersion := rtA.ServerContext().ClusterCompat.getAppliedDBVersionsForBucket(bucketName)["db"]
-	acked, missing, err := registry.IsConfigFullyApplied(ctx, groupID, "db", dbVersion)
+	acked, missing, err := registry.IsConfigFullyApplied(ctx, rtc.groupID, "db", dbVersion)
 	require.NoError(t, err)
 	assert.True(t, acked, "gate should pass after stale node is pruned; missing: %v", missing)
 	assert.Empty(t, missing)
@@ -834,20 +818,14 @@ func TestIsConfigFullyAppliedStaleNodePruned(t *testing.T) {
 // picks up the config via polling, it re-acks and IsConfigFullyApplied remains true.
 func TestIsConfigFullyAppliedNodeRestart(t *testing.T) {
 	ctx := base.TestCtx(t)
-	tb := base.GetTestBucket(t)
-	defer tb.Close(ctx)
+	rtc := NewRestTesterCluster(t, &RestTesterClusterConfig{
+		NumNodes: 2,
+	})
+	defer rtc.Close(ctx)
 
-	groupID := t.Name()
-	rtConfig := &RestTesterConfig{
-		CustomTestBucket: tb.NoCloseClone(),
-		PersistentConfig: true,
-		GroupID:          &groupID,
-	}
-
-	rtA := NewRestTester(t, rtConfig)
-	defer rtA.Close()
-
-	bucketName := tb.GetName()
+	rtA := rtc.Node(0)
+	rtB := rtc.Node(1)
+	bucketName := rtc.testBucket.GetName()
 
 	dbConfig := rtA.NewDbConfig()
 	resp := rtA.CreateDatabase("db", dbConfig)
@@ -856,15 +834,12 @@ func TestIsConfigFullyAppliedNodeRestart(t *testing.T) {
 	dbVersion := rtA.ServerContext().ClusterCompat.getAppliedDBVersionsForBucket(bucketName)["db"]
 	require.NotEmpty(t, dbVersion)
 
-	rtB := NewRestTester(t, rtConfig)
-	defer rtB.Close()
-
 	rtB.ServerContext().ForceDbConfigsReload(t, ctx)
 
 	refreshAndGetRegistry(t, rtB, bucketName)
 
 	registry := refreshAndGetRegistry(t, rtA, bucketName)
-	acked, missing, err := registry.IsConfigFullyApplied(ctx, groupID, "db", dbVersion)
+	acked, missing, err := registry.IsConfigFullyApplied(ctx, rtc.groupID, "db", dbVersion)
 	require.NoError(t, err)
 	assert.True(t, acked, "restarted node B should have re-acked; missing: %v", missing)
 	assert.Empty(t, missing)
@@ -879,8 +854,6 @@ func TestIsConfigFullyAppliedCrossGroupIgnored(t *testing.T) {
 	tb := base.GetTestBucket(t)
 	defer tb.Close(ctx)
 
-	groupA := t.Name() + "-A"
-	groupB := t.Name() + "-B"
 	bucketName := tb.GetName()
 
 	twoCollectionScopesConfig := GetCollectionsConfig(t, tb, 2)
@@ -894,9 +867,9 @@ func TestIsConfigFullyAppliedCrossGroupIgnored(t *testing.T) {
 	rtA := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb.NoCloseClone(),
 		PersistentConfig: true,
-		GroupID:          &groupA,
 	})
 	defer rtA.Close()
+	groupA := rtA.ServerContext().Config.Bootstrap.ConfigGroupID
 
 	dbConfigA := rtA.NewDbConfig()
 	dbConfigA.Scopes = collection1ScopesConfig
@@ -910,7 +883,6 @@ func TestIsConfigFullyAppliedCrossGroupIgnored(t *testing.T) {
 	rtB := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb.NoCloseClone(),
 		PersistentConfig: true,
-		GroupID:          &groupB,
 	})
 	defer rtB.Close()
 
@@ -946,22 +918,14 @@ func TestIsConfigFullyAppliedCrossGroupIgnored(t *testing.T) {
 // and IsConfigFullyApplied for V1 becomes true.
 func TestIsConfigFullyAppliedRollback(t *testing.T) {
 	ctx := base.TestCtx(t)
-	tb := base.GetTestBucket(t)
-	defer tb.Close(ctx)
+	rtc := NewRestTesterCluster(t, &RestTesterClusterConfig{
+		NumNodes: 2,
+	})
+	defer rtc.Close(ctx)
 
-	groupID := t.Name()
-	rtConfig := &RestTesterConfig{
-		CustomTestBucket: tb.NoCloseClone(),
-		PersistentConfig: true,
-		GroupID:          &groupID,
-	}
-
-	rtA := NewRestTester(t, rtConfig)
-	defer rtA.Close()
-	rtB := NewRestTester(t, rtConfig)
-	defer rtB.Close()
-
-	bucketName := tb.GetName()
+	rtA := rtc.Node(0)
+	rtB := rtc.Node(1)
+	bucketName := rtc.testBucket.GetName()
 
 	dbConfig := rtA.NewDbConfig()
 	resp := rtA.CreateDatabase("db", dbConfig)
@@ -988,11 +952,11 @@ func TestIsConfigFullyAppliedRollback(t *testing.T) {
 
 	registry := refreshAndGetRegistry(t, rtA, bucketName)
 
-	acked, _, err := registry.IsConfigFullyApplied(ctx, groupID, "db", versionV)
+	acked, _, err := registry.IsConfigFullyApplied(ctx, rtc.groupID, "db", versionV)
 	require.NoError(t, err)
 	assert.False(t, acked, "old version V should no longer be acked after rollback to V1")
 
-	acked, missing, err := registry.IsConfigFullyApplied(ctx, groupID, "db", versionV1)
+	acked, missing, err := registry.IsConfigFullyApplied(ctx, rtc.groupID, "db", versionV1)
 	require.NoError(t, err)
 	assert.True(t, acked, "new version V1 should be acked by both nodes; missing: %v", missing)
 	assert.Empty(t, missing)
@@ -1004,22 +968,14 @@ func TestIsConfigFullyAppliedRollback(t *testing.T) {
 // tracking should be removed from the second node's clusterCompatManager.
 func TestIsConfigFullyAppliedDeleteDBRemovesTracking(t *testing.T) {
 	ctx := base.TestCtx(t)
-	tb := base.GetTestBucket(t)
-	defer tb.Close(ctx)
+	rtc := NewRestTesterCluster(t, &RestTesterClusterConfig{
+		NumNodes: 2,
+	})
+	defer rtc.Close(ctx)
 
-	groupID := t.Name()
-	rtConfig := &RestTesterConfig{
-		CustomTestBucket: tb.NoCloseClone(),
-		PersistentConfig: true,
-		GroupID:          &groupID,
-	}
-
-	rtA := NewRestTester(t, rtConfig)
-	defer rtA.Close()
-	rtB := NewRestTester(t, rtConfig)
-	defer rtB.Close()
-
-	bucketName := tb.GetName()
+	rtA := rtc.Node(0)
+	rtB := rtc.Node(1)
+	bucketName := rtc.testBucket.GetName()
 
 	dbConfig := rtA.NewDbConfig()
 	resp := rtA.CreateDatabase("db", dbConfig)
@@ -1109,7 +1065,6 @@ func TestClusterCompatMultipleDBsSameBucket(t *testing.T) {
 	tb := base.GetTestBucket(t)
 	defer tb.Close(ctx)
 
-	groupID := t.Name()
 	bucketName := tb.GetName()
 
 	twoCollectionScopesConfig := GetCollectionsConfig(t, tb, 2)
@@ -1123,7 +1078,6 @@ func TestClusterCompatMultipleDBsSameBucket(t *testing.T) {
 	rt := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb.NoCloseClone(),
 		PersistentConfig: true,
-		GroupID:          &groupID,
 	})
 	defer rt.Close()
 
@@ -1161,26 +1115,22 @@ func TestClusterCompatMultipleDBsSameBucket(t *testing.T) {
 func TestClusterCompatApplyConfigsBatchVersions(t *testing.T) {
 	base.TestRequiresCollections(t)
 	ctx := base.TestCtx(t)
-	tb := base.GetTestBucket(t)
-	defer tb.Close(ctx)
+	rtc := NewRestTesterCluster(t, &RestTesterClusterConfig{
+		NumNodes: 2,
+	})
+	defer rtc.Close(ctx)
 
-	groupID := t.Name()
-	bucketName := tb.GetName()
+	rtA := rtc.Node(0)
+	rtB := rtc.Node(1)
+	bucketName := rtc.testBucket.GetName()
 
-	twoCollectionScopesConfig := GetCollectionsConfig(t, tb, 2)
+	twoCollectionScopesConfig := GetCollectionsConfig(t, rtc.testBucket, 2)
 	dataStoreNames := GetDataStoreNamesFromScopesConfig(twoCollectionScopesConfig)
 	scopeName := dataStoreNames[0].ScopeName()
 	collection1Name := dataStoreNames[0].CollectionName()
 	collection2Name := dataStoreNames[1].CollectionName()
 	collection1ScopesConfig := ScopesConfig{scopeName: ScopeConfig{Collections: map[string]*CollectionConfig{collection1Name: {}}}}
 	collection2ScopesConfig := ScopesConfig{scopeName: ScopeConfig{Collections: map[string]*CollectionConfig{collection2Name: {}}}}
-
-	rtA := NewRestTester(t, &RestTesterConfig{
-		CustomTestBucket: tb.NoCloseClone(),
-		PersistentConfig: true,
-		GroupID:          &groupID,
-	})
-	defer rtA.Close()
 
 	dbConfig1 := rtA.NewDbConfig()
 	dbConfig1.Scopes = collection1ScopesConfig
@@ -1191,13 +1141,6 @@ func TestClusterCompatApplyConfigsBatchVersions(t *testing.T) {
 	dbConfig2.Scopes = collection2ScopesConfig
 	resp = rtA.CreateDatabase("db2", dbConfig2)
 	RequireStatus(t, resp, http.StatusCreated)
-
-	rtB := NewRestTester(t, &RestTesterConfig{
-		CustomTestBucket: tb.NoCloseClone(),
-		PersistentConfig: true,
-		GroupID:          &groupID,
-	})
-	defer rtB.Close()
 
 	rtB.ServerContext().ForceDbConfigsReload(t, ctx)
 
@@ -1227,16 +1170,14 @@ func TestIsConfigFullyAppliedNoEligibleAckersIntegration(t *testing.T) {
 	tb := base.GetTestBucket(t)
 	defer tb.Close(ctx)
 
-	groupA := t.Name() + "-A"
-	groupB := t.Name() + "-B"
 	bucketName := tb.GetName()
 
 	rt := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb.NoCloseClone(),
 		PersistentConfig: true,
-		GroupID:          &groupA,
 	})
 	defer rt.Close()
+	groupA := rt.ServerContext().Config.Bootstrap.ConfigGroupID
 
 	dbConfig := rt.NewDbConfig()
 	resp := rt.CreateDatabase("db", dbConfig)
@@ -1251,8 +1192,9 @@ func TestIsConfigFullyAppliedNoEligibleAckersIntegration(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, acked, "group A node should have acked; missing: %v", missing)
 
-	acked, missing, err = registry.IsConfigFullyApplied(ctx, groupB, "db", dbVersion)
-	require.ErrorIs(t, err, ErrNoEligibleAckers, "group B has no nodes, should return ErrNoEligibleAckers")
+	// Any group with no registered nodes returns ErrNoEligibleAckers.
+	acked, missing, err = registry.IsConfigFullyApplied(ctx, t.Name(), "db", dbVersion)
+	require.ErrorIs(t, err, ErrNoEligibleAckers, "a group with no nodes should return ErrNoEligibleAckers")
 	assert.False(t, acked)
 	assert.Empty(t, missing)
 }

--- a/rest/metadatamigrationtest/metadata_migration_test.go
+++ b/rest/metadatamigrationtest/metadata_migration_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbase/sync_gateway/rest"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -67,23 +66,10 @@ func TestMetadataMigrationNotStartedWithExplicitFalse(t *testing.T) {
 //  2. Once node B applies the config and the registry reflects this, the migration starts.
 func TestMetadataMigrationStartsAfterAllNodesApplyConfig(t *testing.T) {
 	ctx := base.TestCtx(t)
-	tb := base.GetTestBucket(t)
-	defer tb.Close(ctx)
-
-	rtConfig := &rest.RestTesterConfig{
-		CustomTestBucket: tb.NoCloseClone(),
-		PersistentConfig: true,
-		// rtA and rtB share a group to simulate one two-node cluster, but it must be unique per
-		// run: a fixed group lets a stale "db" registry entry (from a recycled-but-still-flushing
-		// pool bucket, or a prior test's lingering config-poll/heartbeat) collide with this test's
-		// create ("Duplicate database name").
-		GroupID: base.Ptr(uuid.NewString()),
-	}
-
-	rtA := rest.NewRestTester(t, rtConfig)
-	defer rtA.Close()
-	rtB := rest.NewRestTester(t, rtConfig)
-	defer rtB.Close()
+	rtc := rest.NewRestTesterCluster(t, &rest.RestTesterClusterConfig{NumNodes: 2})
+	defer rtc.Close(ctx)
+	rtA := rtc.Node(0)
+	rtB := rtc.Node(1)
 
 	// Create db on node A with migration disabled.
 	dbConfig := rtA.NewDbConfig()
@@ -109,7 +95,7 @@ func TestMetadataMigrationStartsAfterAllNodesApplyConfig(t *testing.T) {
 	// flag, which the SGJSONTranscoder used by GetCounter can't decode into a *uint64 —
 	// fine on Rosmar (relaxed datatype handling) but a hard failure on Couchbase Server.
 	dbCtxBefore := rtA.GetDatabase()
-	_, err := tb.Bucket.DefaultDataStore(ctx).Incr(ctx, dbCtxBefore.MetadataKeys.SyncSeqKey(), 1, 0, 0)
+	_, err := rtA.TestBucket.Bucket.DefaultDataStore(ctx).Incr(ctx, dbCtxBefore.MetadataKeys.SyncSeqKey(), 1, 0, 0)
 	require.NoError(t, err)
 
 	// Update db config on node A to enable the system metadata collection.
@@ -1261,22 +1247,10 @@ func TestMetadataMigrationRESTStartRejectedWithoutOptIn(t *testing.T) {
 // writes. The POST must be rejected until every node has applied the config.
 func TestMetadataMigrationRESTStartRejectedBeforeConfigApplied(t *testing.T) {
 	ctx := base.TestCtx(t)
-	tb := base.GetTestBucket(t)
-	defer tb.Close(ctx)
-
-	rtConfig := &rest.RestTesterConfig{
-		CustomTestBucket: tb.NoCloseClone(),
-		PersistentConfig: true,
-		// rtA and rtB share a group to simulate one two-node cluster, but it must be unique per
-		// run: a fixed group lets a stale "db" registry entry (from a recycled-but-still-flushing
-		// pool bucket, or a prior test's lingering config-poll/heartbeat) collide with this test's
-		// create ("Duplicate database name").
-		GroupID: base.Ptr(uuid.NewString()),
-	}
-	rtA := rest.NewRestTester(t, rtConfig)
-	defer rtA.Close()
-	rtB := rest.NewRestTester(t, rtConfig)
-	defer rtB.Close()
+	rtc := rest.NewRestTesterCluster(t, &rest.RestTesterClusterConfig{NumNodes: 2})
+	defer rtc.Close(ctx)
+	rtA := rtc.Node(0)
+	rtB := rtc.Node(1)
 
 	// Create db on node A with migration disabled, let node B pick it up, register both nodes.
 	dbConfig := rtA.NewDbConfig()
@@ -1288,7 +1262,7 @@ func TestMetadataMigrationRESTStartRejectedBeforeConfigApplied(t *testing.T) {
 
 	// Seed a legacy seq counter so the new-DB fast path doesn't auto-complete the migration (see
 	// TestMetadataMigrationStartsAfterAllNodesApplyConfig for the rationale on using Incr).
-	_, err := tb.Bucket.DefaultDataStore(ctx).Incr(ctx, rtA.GetDatabase().MetadataKeys.SyncSeqKey(), 1, 0, 0)
+	_, err := rtA.TestBucket.Bucket.DefaultDataStore(ctx).Incr(ctx, rtA.GetDatabase().MetadataKeys.SyncSeqKey(), 1, 0, 0)
 	require.NoError(t, err)
 
 	// Opt in on node A and flush its registry entry. Node B has NOT applied the new config version.

--- a/rest/rest_tester_cluster_test.go
+++ b/rest/rest_tester_cluster_test.go
@@ -9,9 +9,7 @@
 package rest
 
 import (
-	"context"
 	"net/http"
-	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -21,137 +19,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// RestTesterCluster can be used to simulate a multi-node Sync Gateway cluster.
-type RestTesterCluster struct {
-	testBucket      *base.TestBucket
-	restTesters     []*RestTester
-	roundRobinCount int64
-	config          *RestTesterClusterConfig
-}
-
-// RefreshClusterDbConfigs will synchronously fetch the latest db configs from each bucket for each RestTester.
-func (rtc *RestTesterCluster) RefreshClusterDbConfigs() (count int, err error) {
-	for _, rt := range rtc.restTesters {
-		c, err := rt.ServerContext().fetchAndLoadConfigs(rt.Context(), false)
-		if err != nil {
-			return 0, err
-		}
-		count += c
-	}
-	return count, nil
-}
-
-func (rtc *RestTesterCluster) NumNodes() int {
-	return len(rtc.restTesters)
-}
-
-// ForEachNode runs the given function on each RestTester node.
-func (rtc *RestTesterCluster) ForEachNode(fn func(rt *RestTester)) {
-	for _, rt := range rtc.restTesters {
-		fn(rt)
-	}
-}
-
-// RoundRobin returns the next RestTester instance, cycling through all of them sequentially.
-func (rtc *RestTesterCluster) RoundRobin() *RestTester {
-	requestNum := atomic.AddInt64(&rtc.roundRobinCount, 1) % int64(len(rtc.restTesters))
-	node := requestNum % int64(len(rtc.restTesters))
-	return rtc.restTesters[node]
-}
-
-// Node returns a specific RestTester instance.
-func (rtc *RestTesterCluster) Node(i int) *RestTester {
-	return rtc.restTesters[i]
-}
-
-// Close closes all of RestTester nodes and the shared TestBucket.
-func (rtc *RestTesterCluster) Close(ctx context.Context) {
-	for _, rt := range rtc.restTesters {
-		rt.Close()
-	}
-	rtc.testBucket.Close(ctx)
-}
-
-// var _ base.BootstrapConnection = &testBootstrapConnection{}
-
-type RestTesterClusterConfig struct {
-	numNodes   uint8
-	groupID    *string
-	rtConfig   *RestTesterConfig
-	testBucket *base.TestBucket
-}
-
-func defaultRestTesterClusterConfig(t *testing.T) *RestTesterClusterConfig {
-	return &RestTesterClusterConfig{
-		numNodes:   3,
-		groupID:    base.Ptr(t.Name()),
-		rtConfig:   nil,
-		testBucket: nil,
-	}
-}
-
-func NewRestTesterCluster(t *testing.T, config *RestTesterClusterConfig) *RestTesterCluster {
-	if base.UnitTestUrlIsWalrus() {
-		// TODO: implementing a single bucket/mock base.BootstrapConnection might work here
-		t.Skip("Walrus not supported for RestTesterCluster")
-	}
-
-	if config == nil {
-		config = defaultRestTesterClusterConfig(t)
-	}
-
-	// Set group ID for each RestTester from cluster
-	if config.rtConfig == nil {
-		config.rtConfig = &RestTesterConfig{GroupID: config.groupID}
-	} else {
-		config.rtConfig.GroupID = config.groupID
-	}
-	// only persistent mode is supported for a RestTesterCluster
-	config.rtConfig.PersistentConfig = true
-
-	// Make all RestTesters share the same unclosable TestBucket
-	tb := config.testBucket
-	if tb == nil {
-		tb = base.GetTestBucket(t)
-	}
-	config.rtConfig.CustomTestBucket = tb.NoCloseClone()
-
-	// Start up all rest testers in parallel
-	wg := sync.WaitGroup{}
-	restTesters := make([]*RestTester, 0, config.numNodes)
-	for i := 0; i < int(config.numNodes); i++ {
-		wg.Add(1)
-		go func() {
-			rt := NewRestTester(t, config.rtConfig)
-			// initialize the RestTester before we attempt to use it
-			_ = rt.ServerContext()
-			restTesters = append(restTesters, rt)
-			wg.Done()
-		}()
-	}
-	wg.Wait()
-
-	return &RestTesterCluster{
-		testBucket:  tb,
-		restTesters: restTesters,
-		config:      config,
-	}
-}
-
-// dbConfigForTestBucket returns a barebones DbConfig for the given TestBucket.
-func dbConfigForTestBucket(tb *base.TestBucket) DbConfig {
-	return DbConfig{
-		BucketConfig: BucketConfig{
-			Bucket: base.Ptr(tb.GetName()),
-		},
-		Index: &IndexConfig{
-			NumReplicas: base.Ptr(uint(0)),
-		},
-		UseViews:     base.Ptr(base.TestsDisableGSI()),
-		EnableXattrs: base.Ptr(base.TestUseXattrs()),
-	}
-}
 
 func TestPersistentDbConfigWithInvalidUpsert(t *testing.T) {
 
@@ -205,10 +72,8 @@ func TestPersistentDbConfigWithInvalidUpsert(t *testing.T) {
 	assert.NotContains(t, string(resp.BodyBytes()), `"revs_limit":`)
 
 	// remove the db config directly from the bucket
-	docID := PersistentConfigKey(base.TestCtx(t), *rtc.config.groupID, db)
-	// metadata store
-	_, err = rtc.testBucket.DefaultDataStore(ctx).Remove(ctx, docID, 0)
-	require.NoError(t, err)
+	docID := PersistentConfigKey(base.TestCtx(t), rtc.groupID, db)
+	require.NoError(t, rtNode.GetDatabase().MetadataStore.Delete(ctx, docID))
 
 	// ensure all nodes remove the database
 	count, err = rtc.RefreshClusterDbConfigs()

--- a/rest/upgradetest/remove_collection_test.go
+++ b/rest/upgradetest/remove_collection_test.go
@@ -43,10 +43,10 @@ func TestRemoveCollection(t *testing.T) {
 	rtConfig := &rest.RestTesterConfig{
 		CustomTestBucket:             bucket.NoCloseClone(),
 		PersistentConfig:             true,
-		GroupID:                      base.Ptr(t.Name()),
 		AdminInterfaceAuthentication: true,
 	}
 	rt := rest.NewRestTesterMultipleCollections(t, rtConfig, 2)
+	groupID := rt.ServerContext().Config.Bootstrap.ConfigGroupID
 
 	dbConfig := rt.NewDbConfig()
 	dbConfig.Scopes = rest.GetCollectionsConfig(t, rt.TestBucket, numCollections)
@@ -66,7 +66,7 @@ func TestRemoveCollection(t *testing.T) {
 	rtConfig = &rest.RestTesterConfig{
 		CustomTestBucket:             bucket.NoCloseClone(),
 		PersistentConfig:             true,
-		GroupID:                      base.Ptr(t.Name()),
+		GroupID:                      &groupID,
 		AdminInterfaceAuthentication: true,
 	}
 

--- a/rest/upgradetest/upgrade_registry_test.go
+++ b/rest/upgradetest/upgrade_registry_test.go
@@ -272,14 +272,12 @@ func TestMetadataIDWithConfigGroups(t *testing.T) {
 	group1RT := rest.NewRestTester(t, &rest.RestTesterConfig{
 		CustomTestBucket: tb1,
 		PersistentConfig: true,
-		GroupID:          base.Ptr("group1"),
 	})
 	defer group1RT.Close()
 
 	group2RT := rest.NewRestTester(t, &rest.RestTesterConfig{
 		CustomTestBucket: tb1,
 		PersistentConfig: true,
-		GroupID:          base.Ptr("group2"),
 	})
 	defer group2RT.Close()
 

--- a/rest/utilities_testing_rest_tester_cluster.go
+++ b/rest/utilities_testing_rest_tester_cluster.go
@@ -1,0 +1,137 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package rest
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// RestTesterCluster can be used to simulate a multi-node Sync Gateway cluster.
+type RestTesterCluster struct {
+	testBucket      *base.TestBucket
+	restTesters     []*RestTester
+	roundRobinCount int64
+	config          *RestTesterClusterConfig
+	groupID         string
+}
+
+// RefreshClusterDbConfigs will synchronously fetch the latest db configs from each bucket for each RestTester.
+func (rtc *RestTesterCluster) RefreshClusterDbConfigs() (count int, err error) {
+	for _, rt := range rtc.restTesters {
+		c, err := rt.ServerContext().fetchAndLoadConfigs(rt.Context(), false)
+		if err != nil {
+			return 0, err
+		}
+		count += c
+	}
+	return count, nil
+}
+
+func (rtc *RestTesterCluster) NumNodes() int {
+	return len(rtc.restTesters)
+}
+
+// ForEachNode runs the given function on each RestTester node.
+func (rtc *RestTesterCluster) ForEachNode(fn func(rt *RestTester)) {
+	for _, rt := range rtc.restTesters {
+		fn(rt)
+	}
+}
+
+// RoundRobin returns the next RestTester instance, cycling through all of them sequentially.
+func (rtc *RestTesterCluster) RoundRobin() *RestTester {
+	requestNum := atomic.AddInt64(&rtc.roundRobinCount, 1) % int64(len(rtc.restTesters))
+	node := requestNum % int64(len(rtc.restTesters))
+	return rtc.restTesters[node]
+}
+
+// Node returns a specific RestTester instance.
+func (rtc *RestTesterCluster) Node(i int) *RestTester {
+	return rtc.restTesters[i]
+}
+
+// Close closes all of RestTester nodes and the shared TestBucket.
+func (rtc *RestTesterCluster) Close(ctx context.Context) {
+	for _, rt := range rtc.restTesters {
+		rt.Close()
+	}
+	rtc.testBucket.Close(ctx)
+}
+
+// RestTesterClusterConfig are options to create multiple RestTester objects backed by the same bucket.
+type RestTesterClusterConfig struct {
+	NumNodes            uint8                // Number of RestTester objects to create
+	MutateStartupConfig func(*StartupConfig) // Passes this option to the RestTesterConfig for each RestTester
+}
+
+func defaultRestTesterClusterConfig() *RestTesterClusterConfig {
+	return &RestTesterClusterConfig{
+		NumNodes: 3,
+	}
+}
+
+func NewRestTesterCluster(t *testing.T, config *RestTesterClusterConfig) *RestTesterCluster {
+	if config == nil {
+		config = defaultRestTesterClusterConfig()
+	}
+
+	require.NotZero(t, config.NumNodes)
+
+	groupID := uuid.NewString()
+
+	tb := base.GetTestBucket(t)
+
+	// Start up all rest testers in parallel
+	wg := sync.WaitGroup{}
+	restTesters := make([]*RestTester, config.NumNodes)
+	for i := range config.NumNodes {
+		wg.Go(func() {
+			// RestTesterConfig is mutated by NewRestTester, make a new instance in each loop
+			rtConfig := &RestTesterConfig{
+				GroupID:             &groupID,
+				PersistentConfig:    true,
+				CustomTestBucket:    tb.NoCloseClone(),
+				MutateStartupConfig: config.MutateStartupConfig,
+			}
+			rt := NewRestTester(t, rtConfig)
+			// initialize the RestTester before we attempt to use it
+			_ = rt.ServerContext()
+			restTesters[i] = rt
+		})
+	}
+	wg.Wait()
+
+	return &RestTesterCluster{
+		testBucket:  tb,
+		restTesters: restTesters,
+		config:      config,
+		groupID:     groupID,
+	}
+}
+
+// dbConfigForTestBucket returns a barebones DbConfig for the given TestBucket.
+func dbConfigForTestBucket(tb *base.TestBucket) DbConfig {
+	return DbConfig{
+		BucketConfig: BucketConfig{
+			Bucket: base.Ptr(tb.GetName()),
+		},
+		Index: &IndexConfig{
+			NumReplicas: base.Ptr(uint(0)),
+		},
+		UseViews:     base.Ptr(base.TestsDisableGSI()),
+		EnableXattrs: base.Ptr(base.TestUseXattrs()),
+	}
+}


### PR DESCRIPTION
Unclean cherry pick of #8407 for 4.1.2

- `rest/metadatamigrationtest/metadata_migration_test.go` — import conflict: kept `stretchr/testify`, dropped the now-unused `github.com/google/uuid` import
- `rest/utilities_testing_rest_tester_cluster.go` — swapped `sync_gateway/testing/require` for `stretchr/testify/require`; the `testing/` wrapper packages (#8386) are not on 4.1.2
