### PR TITLE
[4.1.2 Backport] CBG-5543: Don't re-run metadata migration once complete

### DIFF
--- a/db/background_mgr_metadata_migration_test.go
+++ b/db/background_mgr_metadata_migration_test.go
@@ -60,7 +60,7 @@ func TestShouldRunMetadataMigration(t *testing.T) {
 				},
 				ClusterCompatVersionFunc: test.compatVersion,
 			}
-			assert.Equal(t, test.expectedResult, dbCtx.shouldRunMetadataMigration())
+			assert.Equal(t, test.expectedResult, dbCtx.shouldRunMetadataMigration(base.TestCtx(t)))
 		})
 	}
 }

--- a/db/database.go
+++ b/db/database.go
@@ -164,27 +164,31 @@ type DatabaseContext struct {
 	// SiblingMetadataIDFunc returns metadataIDs of all sibling databases sharing the same bucket (excluding this database).
 	// Used by metadata migration to recognise co-located sibling databases' metadata documents, avoid migrating them, and
 	// classify them as out-of-scope.
-	SiblingMetadataIDFunc       func(ctx context.Context) ([]string, error)
-	ClusterCompatVersionFunc    func() *base.ClusterCompatVersion // Resolves the current cluster-wide minimum SG version, or nil if not yet known. Re-resolved at call time since CCV changes during rolling upgrades.
-	UserFunctionTimeout         time.Duration                     // Default timeout for N1QL & JavaScript queries. (Applies to REST and BLIP requests.)
-	Scopes                      map[string]Scope                  // A map keyed by scope name containing a set of scopes/collections. Nil if running with only _default._default
-	CollectionByID              map[uint32]*DatabaseCollection    // A map keyed by collection ID to Collection
-	CollectionNames             map[string]map[string]struct{}    // Map of scope, collection names
-	MetadataKeys                *base.MetadataKeys                // Factory to generate metadata document keys
-	RequireResync               base.ScopeAndCollectionNames      // Collections requiring resync before database can go online
-	RequireAttachmentMigration  base.ScopeAndCollectionNames      // Collections that require the attachment migration background task to run against
-	CORS                        *auth.CORSConfig                  // CORS configuration
-	EnableMou                   bool                              // Write _mou xattr when performing metadata-only update.  Set based on bucket capability on connect
-	WasInitializedSynchronously bool                              // true if the database was initialized synchronously
-	BroadcastSlowMode           atomic.Bool                       // bool to indicate if a slower ticker value should be used to notify changes feeds of changes
-	DatabaseStartupError        *DatabaseError                    // Error that occurred during database online processes startup
-	CachedPurgeInterval         atomic.Pointer[time.Duration]     // If set, the cached value of the purge interval to avoid repeated lookups
-	CachedVersionPruningWindow  atomic.Pointer[time.Duration]     // If set, the cached value of the version pruning window to avoid repeated lookups
-	CachedCCVStartingCas        *base.VBucketCAS                  // If set, the cached value of the CCV starting CAS value to avoid repeated lookups
-	CachedCCVEnabled            atomic.Bool                       // If set, the cached value of the CCV Enabled flag (this is not expected to transition from true->false, but could go false->true)
-	numVBuckets                 uint16                            // Number of vbuckets in the bucket
-	SameSiteCookieMode          http.SameSite
-	DBStateManager              *DatabaseStateMgr // Manager used to manage the state of processes across nodes
+	SiblingMetadataIDFunc func(ctx context.Context) ([]string, error)
+	// PerDBMetadataMigrationCompleteFunc reads the durable bucket-level status doc and reports whether
+	// this database's per-DB migration is complete cluster-wide (so a peer node's completion is seen even
+	// though this node's local MetadataStore flag is still unset). Wired when the DB has opted in.
+	PerDBMetadataMigrationCompleteFunc func(ctx context.Context) bool
+	ClusterCompatVersionFunc           func() *base.ClusterCompatVersion // Resolves the current cluster-wide minimum SG version, or nil if not yet known. Re-resolved at call time since CCV changes during rolling upgrades.
+	UserFunctionTimeout                time.Duration                     // Default timeout for N1QL & JavaScript queries. (Applies to REST and BLIP requests.)
+	Scopes                             map[string]Scope                  // A map keyed by scope name containing a set of scopes/collections. Nil if running with only _default._default
+	CollectionByID                     map[uint32]*DatabaseCollection    // A map keyed by collection ID to Collection
+	CollectionNames                    map[string]map[string]struct{}    // Map of scope, collection names
+	MetadataKeys                       *base.MetadataKeys                // Factory to generate metadata document keys
+	RequireResync                      base.ScopeAndCollectionNames      // Collections requiring resync before database can go online
+	RequireAttachmentMigration         base.ScopeAndCollectionNames      // Collections that require the attachment migration background task to run against
+	CORS                               *auth.CORSConfig                  // CORS configuration
+	EnableMou                          bool                              // Write _mou xattr when performing metadata-only update.  Set based on bucket capability on connect
+	WasInitializedSynchronously        bool                              // true if the database was initialized synchronously
+	BroadcastSlowMode                  atomic.Bool                       // bool to indicate if a slower ticker value should be used to notify changes feeds of changes
+	DatabaseStartupError               *DatabaseError                    // Error that occurred during database online processes startup
+	CachedPurgeInterval                atomic.Pointer[time.Duration]     // If set, the cached value of the purge interval to avoid repeated lookups
+	CachedVersionPruningWindow         atomic.Pointer[time.Duration]     // If set, the cached value of the version pruning window to avoid repeated lookups
+	CachedCCVStartingCas               *base.VBucketCAS                  // If set, the cached value of the CCV starting CAS value to avoid repeated lookups
+	CachedCCVEnabled                   atomic.Bool                       // If set, the cached value of the CCV Enabled flag (this is not expected to transition from true->false, but could go false->true)
+	numVBuckets                        uint16                            // Number of vbuckets in the bucket
+	SameSiteCookieMode                 http.SameSite
+	DBStateManager                     *DatabaseStateMgr // Manager used to manage the state of processes across nodes
 
 	scopeName string // name of the single scope for the database
 }
@@ -652,16 +656,41 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 // migration unless all of the following is true:
 //   - The option to use a system metadata collection is enabled on db context
 //   - The cluster compatibility version is at least 4.1
-//   - The per-DB MetadataStore wrapper hasn't already been flagged migration-complete (new-DB fast
-//     path applied at construction time when _default._default has no legacy metadata for this DB)
-func (context *DatabaseContext) shouldRunMetadataMigration() bool {
+//   - The migration is not already complete (see MetadataMigrationComplete — the process-local
+//     wrapper flag, or the authoritative status doc for a migration a peer node completed)
+func (context *DatabaseContext) shouldRunMetadataMigration(ctx context.Context) bool {
 	if !context.Options.UseSystemMetadataCollection {
 		return false
 	}
-	if ms, ok := context.MetadataStore.(*base.MetadataStore); ok && ms.MigrationComplete() {
+	if context.MetadataMigrationComplete(ctx) {
 		return false
 	}
 	return context.ClusterCompatVersion().AtLeast(4, 1)
+}
+
+// MetadataMigrationComplete reports whether this database's metadata migration has already finished.
+// Fast path: the process-local dual-store flag, set when this node completed the run or detected an
+// already-migrated database at construction. When that flag is not set it consults the authoritative,
+// cluster-wide status doc via PerDBMetadataMigrationCompleteFunc — catching the case where a *peer*
+// node completed the migration and this node's local flag is a stale false. When the durable status
+// shows complete, the local flag is converged (SetMigrationComplete) so subsequent callers use the
+// fast path and this node's fallback reads stop too. It only converges on a complete status — an
+// in-progress migration returns false, so fallback reads are never disabled mid-migration.
+func (context *DatabaseContext) MetadataMigrationComplete(ctx context.Context) bool {
+	ms, isDual := context.MetadataStore.(*base.MetadataStore)
+	if isDual && ms.MigrationComplete() {
+		return true
+	}
+	if context.PerDBMetadataMigrationCompleteFunc == nil {
+		return false
+	}
+	if context.PerDBMetadataMigrationCompleteFunc(ctx) {
+		if isDual {
+			ms.SetMigrationComplete()
+		}
+		return true
+	}
+	return false
 }
 
 // ClusterCompatVersion returns the current cluster-wide minimum SG version, or nil if it is not
@@ -711,6 +740,14 @@ func (dbCtx *DatabaseContext) armMetadataMigrationTask(ctx context.Context) {
 // migration, or because another node already owns the run. It returns false (keep polling) when the
 // cluster has not yet converged on the config or a transient error occurred.
 func (dbCtx *DatabaseContext) tryStartMetadataMigration(ctx context.Context) bool {
+	// A migration kicked off via the manual REST endpoint (or by a peer node) may already have
+	// completed while this poller was waiting on config convergence. Re-check completion each attempt
+	// so we don't win the now-free heartbeat lease and re-run a finished migration. Returning true
+	// stops the arm loop — there is nothing left to migrate.
+	if dbCtx.MetadataMigrationComplete(ctx) {
+		base.DebugfCtx(ctx, base.KeyAll, "Metadata migration already complete for database %s, not starting", base.MD(dbCtx.Name))
+		return true
+	}
 	applied, missing, err := dbCtx.ConfigFullyAppliedFunc(ctx)
 	if err != nil {
 		base.WarnfCtx(ctx, "No eligible nodes for database %s: %v", base.MD(dbCtx.Name), err)
@@ -2553,7 +2590,7 @@ func (db *DatabaseContext) StartOnlineProcesses(ctx context.Context) (returnedEr
 	}
 
 	db.MetadataMigrationManager = NewMetadataMigrationManager(db)
-	if db.shouldRunMetadataMigration() {
+	if db.shouldRunMetadataMigration(ctx) {
 		// Run the first attempt synchronously: an already-converged cluster starts migration
 		// without spawning a polling goroutine, and tests that observe state immediately after
 		// StartOnlineProcesses returns see a deterministic outcome (either the migration started,

--- a/rest/api.go
+++ b/rest/api.go
@@ -227,7 +227,13 @@ func (h *handler) handleMetadataMigration() error {
 				return base.HTTPErrorf(http.StatusServiceUnavailable, "cannot start metadata migration until the opted-in database config has been applied on all nodes (waiting on: %v)", missing)
 			}
 		}
-		if err := h.db.MetadataMigrationManager.Start(h.ctx(), map[string]any{
+		// Don't re-run a migration that has already completed. Falling through to the status write
+		// below makes a repeat start idempotent (returns the completed status), which stops the
+		// auto-arming poller and a manual retry from flapping the status doc back through in_progress.
+		// An explicit reset=true is still honored as an operator override to force a fresh run.
+		if h.db.MetadataMigrationComplete(h.ctx()) && !reset {
+			base.InfofCtx(h.ctx(), base.KeyAll, "Metadata migration already complete for database %s, returning current status without restarting", base.MD(h.db.Name))
+		} else if err := h.db.MetadataMigrationManager.Start(h.ctx(), map[string]any{
 			"reset": reset,
 		}); err != nil {
 			return err

--- a/rest/metadatamigrationtest/metadata_migration_test.go
+++ b/rest/metadatamigrationtest/metadata_migration_test.go
@@ -207,6 +207,96 @@ func TestMetadataMigrationRESTGetReportsStatus(t *testing.T) {
 	assert.Contains(t, body, "passes")
 }
 
+// TestMetadataMigrationNotRestartedAfterCompletion is the CBG-5475 regression: once a database's
+// metadata migration has completed, a repeat manual start must be an idempotent no-op. It must NOT
+// reset the durable status doc back through in_progress — that flap (triggered when the ~10s
+// auto-arm poller re-fired after a fast REST-triggered completion) is what made status assertions
+// in longer-running tests flaky. reset=true remains an operator override and is exercised separately
+// in unit tests of Init; here we pin the default (reset=false) no-op path, which is fully deterministic
+// because the guard skips Start entirely and leaves the status doc untouched.
+func TestMetadataMigrationNotRestartedAfterCompletion(t *testing.T) {
+	rt := rest.NewRestTesterPersistentConfigNoDB(t)
+	defer rt.Close()
+	ctx := rt.Context()
+
+	// Create in legacy mode and write a user so real per-DB metadata (a user doc + the _sync:seq
+	// counter) lands in _default._default. Without legacy data the new-DB fast path would flip the
+	// wrapper straight to MigrationComplete at construction and no migration would actually run.
+	dbConfig := rt.NewDbConfig()
+	dbConfig.UseSystemMobileMetadataCollection = base.Ptr(false)
+	rest.RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
+	rest.RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_user/alice",
+		`{"name":"alice","password":"letmein","admin_channels":["public"]}`), http.StatusCreated)
+
+	// Opt in and drive the migration to completion via the REST endpoint.
+	dbConfig.UseSystemMobileMetadataCollection = base.Ptr(true)
+	rest.RequireStatus(t, rt.UpsertDbConfig("db", dbConfig), http.StatusCreated)
+	rt.ServerContext().ForceClusterCompatRefresh(t, ctx)
+	rest.RequireStatus(t, rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_metadata_migration?action=start", ""), http.StatusOK)
+	completed := rt.WaitForMetadataMigrationStatus(db.BackgroundProcessStateCompleted)
+	require.NotEmpty(t, completed.MigrationID)
+
+	// The completion signal both start paths consult is now true.
+	require.True(t, rt.GetDatabase().MetadataMigrationComplete(ctx), "migration should report complete after finishing")
+
+	// Repeat the manual start (reset defaults to false): the guard skips Start, so the durable status
+	// doc is untouched — same state, same migration ID, same start time. No in_progress flap.
+	resp := rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_metadata_migration?action=start", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	var after db.MigrationManagerResponse
+	require.NoError(t, base.JSONUnmarshal(resp.BodyBytes(), &after))
+	assert.Equal(t, db.BackgroundProcessStateCompleted, after.State, "repeat start must leave the migration completed")
+	assert.Equal(t, completed.MigrationID, after.MigrationID, "repeat start must not begin a fresh migration run")
+	assert.True(t, completed.StartTime.Equal(after.StartTime), "repeat start must not reset the migration start time")
+}
+
+// TestMetadataMigrationGuardHonoursPeerCompletion covers the multi-node arm of CBG-5475: a node
+// that never ran the migration itself (its process-local MetadataStore flag is a stale false) must
+// still recognise completion from the authoritative bucket-level status doc — and, on observing it,
+// converge its local flag so fallback reads stop. Mirrors the peer-completion simulation in
+// TestRecheckConvergesLocalCacheOnPeerCompletedMigration.
+func TestMetadataMigrationGuardHonoursPeerCompletion(t *testing.T) {
+	rt := rest.NewRestTesterPersistentConfigNoDB(t)
+	defer rt.Close()
+	ctx := rt.Context()
+
+	// Create in legacy mode, then seed the _sync:seq counter in _default._default so the new-DB fast
+	// path can't flip the wrapper to MigrationComplete at construction — the local flag must stay
+	// false to model a peer that ran the migration while this node did not.
+	dbConfig := rt.NewDbConfig()
+	dbConfig.UseSystemMobileMetadataCollection = base.Ptr(false)
+	rest.RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
+	legacyDB := rt.GetDatabase()
+	_, err := legacyDB.Bucket.DefaultDataStore(ctx).Incr(ctx, legacyDB.MetadataKeys.SyncSeqKey(), 1, 0, 0)
+	require.NoError(t, err)
+
+	// Opt in but deliberately DON'T flush this node's applied-config version, so ConfigFullyAppliedFunc
+	// reports not-applied and the auto-arm never actually starts a local migration.
+	dbConfig.UseSystemMobileMetadataCollection = base.Ptr(true)
+	rest.RequireStatus(t, rt.UpsertDbConfig("db", dbConfig), http.StatusCreated)
+
+	dbCtx := rt.GetDatabase()
+	ms, ok := dbCtx.MetadataStore.(*base.MetadataStore)
+	require.True(t, ok, "opted-in DB with legacy metadata should have a dual MetadataStore")
+	require.False(t, ms.MigrationComplete(), "precondition: local node must not have marked migration complete")
+
+	// Simulate a peer node completing this DB's migration by stamping the per-DB status entry to
+	// complete directly — this writes only the durable doc, not this node's local flag.
+	conn := rt.ServerContext().BootstrapContext.Connection
+	_, err = conn.UpdateMetadataMigrationStatus(ctx, dbCtx.Bucket.GetName(), func(s *base.MetadataMigrationStatus) error {
+		if s.Databases == nil {
+			s.Databases = map[string]*base.DatabaseMigrationStatus{}
+		}
+		s.Databases[dbCtx.Options.MetadataID] = &base.DatabaseMigrationStatus{State: base.MigrationStateComplete}
+		return nil
+	})
+	require.NoError(t, err)
+
+	// The guard reads the authoritative status doc, reports complete, and converges the local flag.
+	require.True(t, dbCtx.MetadataMigrationComplete(ctx), "guard must recognise a peer-completed migration from the status doc")
+	require.True(t, ms.MigrationComplete(), "observing a peer-completed status doc must converge the local migration-complete flag")
+}
+
 // TestMetadataMigrationPreservesJSONDatatypeForUserDocs is a regression test for the
 // AddRaw → SGRawTranscoder datatype regression: prior to the moveFallbackDoc datatype
 // fix, every user/role/session doc migrated to _system._mobile landed with the Binary

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1104,9 +1104,13 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	// per-DB UseSystemMobileMetadataCollection config field.
 	if resolveUseSystemMetadataCollection(sc.Config, &config.DbConfig) {
 		bucketName := spec.BucketName
+		metadataID := config.MetadataID
 		dbcontext.MetadataMigrationStatusUpdater = func(ctx context.Context, mutator func(*base.MetadataMigrationStatus) error) error {
 			_, err := sc.BootstrapContext.Connection.UpdateMetadataMigrationStatus(ctx, bucketName, mutator)
 			return err
+		}
+		dbcontext.PerDBMetadataMigrationCompleteFunc = func(ctx context.Context) bool {
+			return sc.isPerDBMigrationComplete(ctx, bucketName, metadataID)
 		}
 		dbcontext.PostMetadataMigrationCompleteFunc = func(ctx context.Context) error {
 			return sc.maybeCompleteBucketMetadataMigration(ctx, bucketName)
@@ -2494,6 +2498,34 @@ func (sc *ServerContext) isPerDBMigrationInProgress(ctx context.Context, bucketN
 		return false
 	}
 	return entry.State == base.MigrationStateInProgress
+}
+
+// isPerDBMigrationComplete reports whether the bucket-level metadata-migration status doc records
+// this database's per-DB migration as complete. This is the authoritative, cluster-wide signal —
+// unlike the process-local MetadataStore flag it is also true on a node that never ran the migration
+// itself (e.g. a peer completed it). Used to avoid re-running a finished migration.
+//
+// Returns false when the status doc or per-DB entry is absent or unreadable: a false "complete"
+// would only cause a redundant (idempotent, resumable) migration start, whereas a false-positive
+// "complete" would wrongly skip a needed migration. This is the deliberate opposite bias to
+// isPerDBMigrationInProgress, which errs toward "in progress" to avoid prematurely disabling
+// fallback reads.
+func (sc *ServerContext) isPerDBMigrationComplete(ctx context.Context, bucketName, metadataID string) bool {
+	if sc.BootstrapContext == nil || sc.BootstrapContext.Connection == nil {
+		return false
+	}
+	status, _, err := sc.BootstrapContext.Connection.GetMetadataMigrationStatus(ctx, bucketName)
+	if err != nil {
+		if !base.IsDocNotFoundError(err) {
+			base.WarnfCtx(ctx, "Unable to read %s on bucket %q while checking per-DB migration completion: %v — treating as not complete", base.MD(base.MetadataMigrationStatusDocID), base.MD(bucketName), err)
+		}
+		return false
+	}
+	entry, ok := status.Databases[metadataID]
+	if !ok || entry == nil {
+		return false
+	}
+	return entry.State == base.MigrationStateComplete
 }
 
 // maybeCompleteBucketMetadataMigration is invoked after each per-DB migration reports complete.


### PR DESCRIPTION
Unclean cherry pick of #8410 for 4.1.2

- `db/database.go` — struct field alignment conflict in `DatabaseContextOptions`: kept 4.1.2's `EnableMou` field (not present on `main` at the time) and re-ran gofmt after inserting `PerDBMetadataMigrationCompleteFunc`
