### PR TITLE
[4.1.2 Backport] CBG-5476: do not fail migration with unknown prefixes in bucket

### DIFF
--- a/base/stats_descriptions.go
+++ b/base/stats_descriptions.go
@@ -421,7 +421,7 @@ const (
 
 	MetadataMigrationDocsOutOfScopeDesc = "The number of fallback keys classified as out-of-scope on the most recent pass (sibling-DB or bucket-level docs not owned by this database)."
 
-	MetadataMigrationDocsUnknownPrefixDesc = "The number of fallback keys with an unrecognised prefix observed on the most recent pass — these are left in place and cause an additional pass."
+	MetadataMigrationDocsUnknownPrefixDesc = "The number of fallback keys with an unrecognised prefix observed on the most recent pass — these are left in place on the source collection and do not block completion."
 
 	MetadataMigrationErrorsDesc = "The total number of per-doc errors observed during metadata migration moves or deletes across all passes."
 

--- a/db/background_mgr_metadata_migration.go
+++ b/db/background_mgr_metadata_migration.go
@@ -245,25 +245,33 @@ func (m *MetadataMigrationManager) Run(ctx context.Context, options map[string]a
 				return err
 			}
 
-			// Completion gates on a pass that is clean of BOTH unknown-prefix docs (remaining)
-			// AND per-doc move/delete errors. A failed in-scope move increments stats.Errors and
-			// leaves the doc on the fallback, but does not count toward remaining — so breaking on
-			// remaining == 0 alone could call SetMigrationComplete() with an un-migrated doc still
-			// on the fallback, which the wrapper would then permanently ignore (data loss). Errors
-			// are typically transient (CAS races), so a non-clean pass simply forces a retry; only
-			// a persistent failure reaches the maxPasses give-up below, which never completes.
+			// Completion gates ONLY on per-doc move/delete errors. A failed in-scope move
+			// increments stats.Errors and leaves the doc on the fallback, which the wrapper
+			// would then permanently ignore — so those must clear before we
+			// SetMigrationComplete(). Errors are typically transient (CAS races), so a non-clean
+			// pass simply forces a retry; only a persistent failure reaches the maxPasses give-up
+			// below, which never completes.
+			//
+			// Unknown-prefix docs (remaining) do NOT block completion: they are left in place on
+			// the fallback (non-destructive — nothing deletes them), so a foreign `_sync:`-rooted
+			// doc written directly to the bucket can't wedge the migration. They are still logged
+			// per-key by handleMigrationKey; we additionally warn with the count here so the
+			// completion event itself records the leftovers.
 			passErrors := stats.Errors.Load()
-			if remaining == 0 && passErrors == 0 {
+			if passErrors == 0 {
+				if remaining > 0 {
+					base.WarnfCtx(ctx, "[%s] migration completing with %d unrecognised-prefix doc(s) left on %s; see per-key warnings above", metadataMigrationLoggingID, remaining, ms.Fallback().GetName())
+				}
 				// finished successfully — fallback verified clear of in-scope metadata
 				break
 			}
 
 			if pass+1 >= maxPasses {
-				base.WarnfCtx(ctx, "[%s] gave up after %d passes with %d unknown-prefix doc(s) and %d per-doc error(s) on the last pass", metadataMigrationLoggingID, maxPasses, remaining, passErrors)
+				base.WarnfCtx(ctx, "[%s] gave up after %d passes with %d per-doc error(s) on the last pass", metadataMigrationLoggingID, maxPasses, passErrors)
 				if promStats != nil {
 					promStats.AbandonedRuns.Add(1)
 				}
-				return fmt.Errorf("%s still not clear of metadata after %d passes: %d unknown-prefix doc(s), %d per-doc error(s) remain", ms.Fallback().GetName(), maxPasses, remaining, passErrors)
+				return fmt.Errorf("%s still not clear of metadata after %d passes: %d per-doc error(s) remain", ms.Fallback().GetName(), maxPasses, passErrors)
 			}
 		}
 

--- a/db/background_mgr_metadata_migration_test.go
+++ b/db/background_mgr_metadata_migration_test.go
@@ -302,13 +302,14 @@ func TestMetadataMigrationCompletesWithCollectionScopedDataInFallback(t *testing
 	}
 }
 
-// TestMetadataMigrationManagerErrorsOnUnclearableUnknownPrefix forces the bounded-pass
-// give-up branch: an in-scope unknown-prefix doc is reported as "remaining" every pass
-// (the dispatcher classifies it as DocsUnknownPrefix and leaves it on the fallback), so
-// the orchestrator must hit maxPasses and surface a non-nil error rather than silently
-// completing. SetMigrationComplete must NOT be flipped, otherwise the dual-store wrapper
-// would start ignoring the fallback while there is still real data on it.
-func TestMetadataMigrationManagerErrorsOnUnclearableUnknownPrefix(t *testing.T) {
+// TestMetadataMigrationManagerCompletesWithUnknownPrefixLeftInPlace pins the policy that an
+// unrecognised `_sync:`-prefixed doc does NOT wedge the migration. The dispatcher classifies it
+// as DocsUnknownPrefix and leaves it on the fallback every pass, but unknown-prefix docs no longer
+// count toward the completion gate (only per-doc move/delete errors do). So the migration must
+// complete, flip MigrationComplete, and leave the unrecognised doc untouched on the fallback —
+// rather than retrying to maxPasses and erroring. This protects against a foreign doc (written
+// directly to the bucket, bypassing SG's public API) being able to abort an operator's upgrade.
+func TestMetadataMigrationManagerCompletesWithUnknownPrefixLeftInPlace(t *testing.T) {
 	ctx := base.TestCtx(t)
 	bucket := base.GetTestBucket(t)
 	defer bucket.Close(ctx)
@@ -324,17 +325,16 @@ func TestMetadataMigrationManagerErrorsOnUnclearableUnknownPrefix(t *testing.T) 
 	const metadataID = "test-mgr-unknown-prefix"
 	// `_sync:m_<id>:wat` is in-scope (starts with our standard-form prefix) but matches
 	// no known family, so handleMigrationKey hits the default branch and counts it as
-	// DocsUnknownPrefix every pass without removing it.
-	stuckKey := base.SyncDocPrefix + base.MetadataIdPrefix + metadataID + ":wat"
-	_, err = ms.Fallback().AddRaw(ctx, stuckKey, 0, []byte(`{"body":"stuck"}`))
+	// DocsUnknownPrefix without removing it.
+	unknownKey := base.SyncDocPrefix + base.MetadataIdPrefix + metadataID + ":wat"
+	_, err = ms.Fallback().AddRaw(ctx, unknownKey, 0, []byte(`{"body":"left-in-place"}`))
 	require.NoError(t, err, "seed in-scope unknown-prefix fallback doc")
 
 	// KV range scan reads from a per-vBucket snapshot view, so a scan issued immediately
-	// after the write can miss the seeded doc until the vBucket's scan view catches up. If this
-	// occurs and the migration's first pass doesn't see the doc, it reports remaining=0 and completes
-	// immediately instead of hitting the bounded-pass error path, flaking this test. Wait for the
-	// seed to be visible to scan before starting.
-	base.RequireDocsVisibleToRangeScan(t, ms.Fallback(), []string{stuckKey})
+	// after the write can miss the seeded doc until the vBucket's scan view catches up. Wait
+	// for the seed to be visible to scan so we exercise the unknown-prefix path rather than a
+	// trivially-empty first pass.
+	base.RequireDocsVisibleToRangeScan(t, ms.Fallback(), []string{unknownKey})
 
 	dbCtx := &DatabaseContext{
 		Name:                           "test",
@@ -347,13 +347,13 @@ func TestMetadataMigrationManagerErrorsOnUnclearableUnknownPrefix(t *testing.T) 
 	dbCtx.MetadataMigrationManager = NewMetadataMigrationManager(dbCtx)
 
 	require.NoError(t, dbCtx.MetadataMigrationManager.Start(ctx, nil))
-	// The manager surfaces the bounded-pass failure via the Errored terminal state.
-	RequireBackgroundManagerState(t, dbCtx.MetadataMigrationManager, BackgroundProcessStateError)
+	// Unknown-prefix docs no longer block completion — the manager reaches the Completed state.
+	RequireBackgroundManagerState(t, dbCtx.MetadataMigrationManager, BackgroundProcessStateCompleted)
 
-	assert.False(t, ms.MigrationComplete(), "MigrationComplete must not be flipped when the migration gave up with work outstanding")
+	assert.True(t, ms.MigrationComplete(), "MigrationComplete should be flipped — unknown-prefix docs do not block completion")
 
-	_, _, err = ms.Fallback().GetRaw(ctx, stuckKey)
-	assert.NoError(t, err, "stuck unknown-prefix doc should still be on the fallback")
+	_, _, err = ms.Fallback().GetRaw(ctx, unknownKey)
+	assert.NoError(t, err, "unrecognised doc should be left in place on the fallback (non-destructive)")
 }
 
 // TestMetadataMigrationManagerDCPCheckpointGroupIDCollisionCompletesEndToEnd is the

--- a/db/metadata_migration.go
+++ b/db/metadata_migration.go
@@ -37,10 +37,11 @@ type MigrationStats struct {
 // migrateSeqCounter, which the orchestrator calls once before entering the pass loop —
 // MigrateMetadata is per-pass and does not re-pill the seq doc on each iteration.
 //
-// Returns the number of in-scope fallback keys still classified as remaining after the run
-// (DocsUnknownPrefix from this pass). The orchestrator drives this in a loop until remaining
-// reaches zero — a doc written underneath an in-flight scan can be missed on this pass but
-// will surface on the next one.
+// Returns the number of unrecognised-prefix fallback keys seen this pass (DocsUnknownPrefix),
+// reported for observability only. The orchestrator does NOT retry on this count — unknown-prefix
+// docs are left in place on the fallback and do not block completion. Retries are driven solely by
+// per-doc move/delete errors (stats.Errors); a doc written underneath an in-flight scan that is
+// in-scope is either moved on a later error-forced pass or written directly to primary by the wrapper.
 func MigrateMetadata(ctx context.Context, ms *base.MetadataStore, metadataID string, siblingMetadataIDs []string, dbSyncFunctionKeys map[string]struct{}, stats *MigrationStats) (remaining int, err error) {
 	if ms == nil {
 		return 0, errors.New("MigrateMetadata: nil MetadataStore")


### PR DESCRIPTION
Clean cherry pick of #8359 for 4.1.2
