### PR TITLE
[4.1.2 Backport] CBG-5593: Persist last processed sequence in cbgt DCP checkpoints

### DIFF
--- a/base/cbgt_checkpoint.go
+++ b/base/cbgt_checkpoint.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2026-Present Couchbase, Inc.
+
+Use of this software is governed by the Business Source License included in
+the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+file, in accordance with the Business Source License, use of this software will
+be governed by the Apache License, Version 2.0, included in the file
+licenses/APL2.txt.
+*/
+
+package base
+
+// cbgtOpaqueCheckpoint mirrors cbgt's own private metaData struct (feed_dcp_gocbcore.go) - the opaque checkpoint
+// value cbgt itself round-trips through OpaqueSet/OpaqueGet. Its fields (name, type, and json tag) must stay
+// identical to cbgt's - TestCbgtOpaqueMetadataMatchesCbgtMetaData (cbgt_checkpoint_test.go) parses cbgt's actual
+// source at test time to verify this, rather than relying on a hand-maintained mirror staying in sync.
+type cbgtOpaqueCheckpoint struct {
+	FailOverLog [][]uint64 `json:"failOverLog"`
+	SeqStart    uint64     `json:"seqStart"`
+	SeqEnd      uint64     `json:"seqEnd"`
+	SnapStart   uint64     `json:"snapStart"`
+	SnapEnd     uint64     `json:"snapEnd"`
+}
+
+// isEmpty reports whether none of cbgt's own checkpoint fields are populated, i.e. there's no cbgt checkpoint to
+// speak of - in practice cbgt doesn't ever persist a legitimately all-zero checkpoint (a real one always carries
+// at least a non-empty failOverLog).
+func (c cbgtOpaqueCheckpoint) isEmpty() bool {
+	return len(c.FailOverLog) == 0 && c.SeqStart == 0 && c.SeqEnd == 0 && c.SnapStart == 0 && c.SnapEnd == 0
+}
+
+// CbgtCheckpoint is the full shape of a persisted DCP checkpoint: cbgt's own opaque checkpoint fields, embedded so
+// they marshal/unmarshal at the top level (matching cbgt's own flat JSON shape), plus SG's own LastSeq tracking
+// field - the last sequence SG actually processed for the vbucket, which isn't part of cbgt's own checkpoint shape.
+type CbgtCheckpoint struct {
+	cbgtOpaqueCheckpoint
+	LastSeq uint64 `json:"lastSeq,omitempty"`
+}
+
+// readCbgtCheckpoint parses a persisted DCP checkpoint value, returning the last sequence SG actually processed
+// for the vbucket alongside cbgt's own opaque checkpoint fields (i.e. without SG's lastSeq), for use by DCPCommon.
+// Checkpoints persisted before lastSeq was tracked have no lastSeq field at all, which unmarshals the same as a
+// legitimately-persisted value of zero, so this falls back to the checkpoint's snapStart in either case.
+func readCbgtCheckpoint(rawValue []byte) (lastSeq uint64, metadata []byte, err error) {
+	var checkpoint CbgtCheckpoint
+	if err := JSONUnmarshal(rawValue, &checkpoint); err != nil {
+		return 0, nil, err
+	}
+
+	lastSeq = checkpoint.LastSeq
+	if lastSeq == 0 {
+		lastSeq = checkpoint.SnapStart
+	}
+
+	// Guardrail: Ensure lastSeq is within the snapshot boundaries [SnapStart, SnapEnd] of the cbgt checkpoint.
+	if lastSeq < checkpoint.SnapStart {
+		lastSeq = checkpoint.SnapStart
+	}
+	if checkpoint.SnapEnd > 0 && lastSeq > checkpoint.SnapEnd {
+		lastSeq = checkpoint.SnapEnd
+	}
+
+	// A checkpoint with no cbgt-owned fields at all must round-trip back to nil, not "{}", so OpaqueGet's
+	// len(metadata) == 0 check still treats it as "no cbgt checkpoint".
+	if checkpoint.isEmpty() {
+		return lastSeq, nil, nil
+	}
+	metadata, err = JSONMarshal(checkpoint.cbgtOpaqueCheckpoint)
+	return lastSeq, metadata, err
+}
+
+// createCbgtCheckpoint builds the raw JSON to persist for a DCP checkpoint from cbgt's own opaque checkpoint value
+// and the last sequence SG actually processed for the vbucket, for use by DCPCommon. A nil/empty opaqueValue (e.g.
+// a vbucket with no prior cbgt checkpoint) is treated as an empty cbgt checkpoint, rather than a JSON parse error.
+func createCbgtCheckpoint(opaqueValue []byte, lastSeq uint64) ([]byte, error) {
+	checkpoint := CbgtCheckpoint{LastSeq: lastSeq}
+	if len(opaqueValue) > 0 {
+		if err := JSONUnmarshal(opaqueValue, &checkpoint.cbgtOpaqueCheckpoint); err != nil {
+			return nil, err
+		}
+	}
+	return JSONMarshal(checkpoint)
+}

--- a/base/cbgt_checkpoint_test.go
+++ b/base/cbgt_checkpoint_test.go
@@ -1,0 +1,425 @@
+/*
+Copyright 2026-Present Couchbase, Inc.
+
+Use of this software is governed by the Business Source License included in
+the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+file, in accordance with the Business Source License, use of this software will
+be governed by the Apache License, Version 2.0, included in the file
+licenses/APL2.txt.
+*/
+
+package base
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const cbgtModulePath = "github.com/couchbase/cbgt"
+
+// fieldSummary is the subset of a struct field's shape that matters for JSON (de)serialization.
+type fieldSummary struct {
+	Type    string
+	JSONTag string
+}
+
+// TestCbgtOpaqueMetadataMatchesCbgtMetaData verifies that cbgtOpaqueCheckpoint has the same fields (name, type,
+// and json tag) as cbgt's own unexported metaData struct (feed_dcp_gocbcore.go), which cbgt's gocbcore DCP
+// feed uses to marshal/unmarshal checkpoint metadata. cbgt.metaData is unexported, so it can't be referenced
+// directly from this package - instead this locates and parses the actual cbgt source file, at the version
+// resolved into this build, out of the local module cache, so the check stays correct across cbgt upgrades
+// without a hand-maintained mirror struct.
+func TestCbgtOpaqueMetadataMatchesCbgtMetaData(t *testing.T) {
+	cbgtFields := parseCbgtMetaDataFields(t)
+	sgFields := reflectedFields(reflect.TypeFor[cbgtOpaqueCheckpoint]())
+	assert.Equal(t, cbgtFields, sgFields)
+}
+
+// parseCbgtMetaDataFields locates cbgt's feed_dcp_gocbcore.go in the module cache (at the version this build
+// resolved) and parses out the fields of its private metaData struct.
+func parseCbgtMetaDataFields(t *testing.T) map[string]fieldSummary {
+	out, err := exec.Command("go", "list", "-m", "-f", "{{.Dir}}", cbgtModulePath).Output()
+	require.NoError(t, err, "failed to locate %s module directory", cbgtModulePath)
+	sourceFile := filepath.Join(strings.TrimSpace(string(out)), "feed_dcp_gocbcore.go")
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, sourceFile, nil, 0)
+	require.NoError(t, err)
+
+	var structType *ast.StructType
+	ast.Inspect(file, func(n ast.Node) bool {
+		typeSpec, ok := n.(*ast.TypeSpec)
+		if !ok || typeSpec.Name.Name != "metaData" {
+			return true
+		}
+		structType, ok = typeSpec.Type.(*ast.StructType)
+		require.True(t, ok, "expected cbgt.metaData to be declared as a struct type")
+		return false
+	})
+	require.NotNil(t, structType, "could not find cbgt.metaData struct in %s", sourceFile)
+
+	fields := make(map[string]fieldSummary, len(structType.Fields.List))
+	for _, field := range structType.Fields.List {
+		require.Len(t, field.Names, 1, "expected each cbgt.metaData field to have exactly one name")
+		name := field.Names[0].Name
+
+		var jsonTag string
+		if field.Tag != nil {
+			unquoted, err := strconv.Unquote(field.Tag.Value)
+			require.NoError(t, err)
+			jsonTag = reflect.StructTag(unquoted).Get("json")
+		}
+		fields[name] = fieldSummary{Type: types.ExprString(field.Type), JSONTag: jsonTag}
+	}
+	return fields
+}
+
+// reflectedFields returns a struct type's fields keyed by name, capturing only the parts of each field
+// relevant to JSON (de)serialization, so it can be compared against parseCbgtMetaDataFields regardless of
+// field ordering.
+func reflectedFields(t reflect.Type) map[string]fieldSummary {
+	fields := make(map[string]fieldSummary, t.NumField())
+	for field := range t.Fields() {
+		fields[field.Name] = fieldSummary{Type: field.Type.String(), JSONTag: field.Tag.Get("json")}
+	}
+	return fields
+}
+
+// checkpointShapeTestCases enumerates the shapes of cbgt checkpoint data used to exercise round-tripping: cbgt
+// always marshals its metaData struct in full (no omitempty), so the only shapes a real cbgt checkpoint takes are
+// all cbgtOpaqueCheckpoint fields present, or no cbgt checkpoint at all yet (nil/empty).
+var checkpointShapeTestCases = []struct {
+	name string
+	raw  string
+}{
+	{name: "full known fields", raw: `{"failOverLog":[[123,0]],"seqStart":10,"seqEnd":20,"snapStart":15,"snapEnd":20}`},
+	{name: "empty object", raw: `{}`},
+}
+
+// TestCbgtCheckpointRoundTrip chains createCbgtCheckpoint -> readCbgtCheckpoint directly (i.e. without going
+// through persistCheckpoint/loadCheckpoint or a metadata bucket), across checkpoint shapes, verifying every field
+// survives exactly.
+func TestCbgtCheckpointRoundTrip(t *testing.T) {
+	const lastSeq = uint64(18)
+	for _, testCase := range checkpointShapeTestCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			persisted, err := createCbgtCheckpoint([]byte(testCase.raw), lastSeq)
+			require.NoError(t, err)
+
+			extractedLastSeq, rawMetadata, err := readCbgtCheckpoint(persisted)
+			require.NoError(t, err)
+			assert.Equal(t, lastSeq, extractedLastSeq)
+
+			var original map[string]any
+			require.NoError(t, JSONUnmarshal([]byte(testCase.raw), &original))
+			if len(original) == 0 {
+				assert.Len(t, rawMetadata, 0)
+				return
+			}
+
+			var remains map[string]any
+			require.NoError(t, JSONUnmarshal(rawMetadata, &remains))
+			assert.Equal(t, original, remains)
+		})
+	}
+}
+
+// TestCbgtCheckpointPreservesLargeSequenceNumberPrecision verifies that sequence numbers beyond float64's safe
+// integer range (2^53) survive both createCbgtCheckpoint and readCbgtCheckpoint intact - CbgtCheckpoint's fields
+// are typed uint64, decoded directly rather than via interface{} (which would go through float64 and lose
+// precision).
+func TestCbgtCheckpointPreservesLargeSequenceNumberPrecision(t *testing.T) {
+	const largeSeq uint64 = 1<<53 + 1 // smallest uint64 not exactly representable as a float64
+
+	raw := fmt.Sprintf(`{"snapStart":%d,"snapEnd":%d}`, largeSeq, largeSeq)
+
+	persisted, err := createCbgtCheckpoint([]byte(raw), largeSeq)
+	require.NoError(t, err)
+
+	lastSeq, rawMetadata, err := readCbgtCheckpoint(persisted)
+	require.NoError(t, err)
+	assert.Equal(t, largeSeq, lastSeq)
+
+	var remains cbgtOpaqueCheckpoint
+	require.NoError(t, JSONUnmarshal(rawMetadata, &remains))
+	assert.Equal(t, largeSeq, remains.SnapEnd)
+}
+
+// TestCbgtCheckpointGuardrails verifies that readCbgtCheckpoint clamps lastSeq to the checkpoint's snapStart and snapEnd boundaries.
+func TestCbgtCheckpointGuardrails(t *testing.T) {
+	testCases := []struct {
+		name             string
+		raw              string
+		persistedLastSeq uint64
+		expectedLastSeq  uint64
+	}{
+		{
+			name:             "lastSeq below snapStart is clamped to snapStart",
+			raw:              `{"failOverLog":[[123,0]],"seqStart":10,"seqEnd":20,"snapStart":15,"snapEnd":20}`,
+			persistedLastSeq: 5,
+			expectedLastSeq:  15,
+		},
+		{
+			name:             "lastSeq above snapEnd is clamped to snapEnd",
+			raw:              `{"failOverLog":[[123,0]],"seqStart":10,"seqEnd":20,"snapStart":15,"snapEnd":20}`,
+			persistedLastSeq: 25,
+			expectedLastSeq:  20,
+		},
+		{
+			name:             "lastSeq within boundaries is not clamped",
+			raw:              `{"failOverLog":[[123,0]],"seqStart":10,"seqEnd":20,"snapStart":15,"snapEnd":20}`,
+			persistedLastSeq: 18,
+			expectedLastSeq:  18,
+		},
+		{
+			name:             "lastSeq is not clamped if boundaries are 0 (e.g. empty/new checkpoints)",
+			raw:              `{}`,
+			persistedLastSeq: 42,
+			expectedLastSeq:  42,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			persisted, err := createCbgtCheckpoint([]byte(testCase.raw), testCase.persistedLastSeq)
+			require.NoError(t, err)
+
+			extractedLastSeq, _, err := readCbgtCheckpoint(persisted)
+			require.NoError(t, err)
+			assert.Equal(t, testCase.expectedLastSeq, extractedLastSeq)
+		})
+	}
+}
+
+// TestDCPCommonCheckpointRoundTrip verifies that persistCheckpoint followed by loadCheckpoint on a *DCPCommon
+// correctly extracts lastSeq (falling back to snapStart for pre-existing checkpoints without it) and preserves
+// cbgt's own checkpoint fields across different shapes of underlying cbgt checkpoint data.
+func TestDCPCommonCheckpointRoundTrip(t *testing.T) {
+	testCases := []struct {
+		name             string
+		value            string
+		persistedLastSeq uint64
+		endSeqNos        map[uint16]uint64
+		expectedLastSeq  uint64
+	}{
+		{
+			name:             "lastSeq persisted directly",
+			value:            `{"failOverLog":[[123,0]],"seqStart":10,"seqEnd":20,"snapStart":15,"snapEnd":20}`,
+			persistedLastSeq: 18,
+			expectedLastSeq:  18,
+		},
+		{
+			name:             "endSeqNos caps lastSeq when snapStart is beyond the expected end",
+			value:            `{"failOverLog":[[123,0]],"seqStart":10,"seqEnd":20,"snapStart":9000,"snapEnd":9000}`,
+			persistedLastSeq: 9000,
+			endSeqNos:        map[uint16]uint64{0: 100},
+			expectedLastSeq:  100,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx := TestCtx(t)
+			bucket := GetTestBucket(t)
+			defer bucket.Close(ctx)
+
+			dcpCommon, err := NewDCPCommon(ctx, DCPDestOptions{
+				MetadataStore:      bucket.GetSingleDataStore(),
+				MaxVbNo:            1,
+				PersistCheckpoints: true,
+				CheckpointPrefix:   "test_dcp_checkpoint_round_trip_" + testCase.name + "_",
+				EndSeqNos:          testCase.endSeqNos,
+			})
+			require.NoError(t, err)
+
+			require.NoError(t, dcpCommon.persistCheckpoint(0, []byte(testCase.value), testCase.persistedLastSeq))
+
+			rawMetadata, lastSeq, err := dcpCommon.loadCheckpoint(0)
+			require.NoError(t, err)
+			assert.Equal(t, testCase.expectedLastSeq, lastSeq)
+
+			var remains map[string]any
+			require.NoError(t, JSONUnmarshal(rawMetadata, &remains))
+			_, hasLastSeq := remains["lastSeq"]
+			assert.False(t, hasLastSeq)
+
+			var originalFields map[string]any
+			require.NoError(t, JSONUnmarshal([]byte(testCase.value), &originalFields))
+			assert.Equal(t, originalFields, remains)
+		})
+	}
+}
+
+// TestDCPCommonLoadLegacyCheckpointFallsBackToSnapStart verifies that a checkpoint persisted by an older version of
+// Sync Gateway (i.e. before lastSeq was tracked, so the raw value has no lastSeq field) still loads correctly,
+// falling back to the checkpoint's snapStart.
+func TestDCPCommonLoadLegacyCheckpointFallsBackToSnapStart(t *testing.T) {
+	ctx := TestCtx(t)
+	bucket := GetTestBucket(t)
+	defer bucket.Close(ctx)
+
+	const checkpointPrefix = "test_dcp_legacy_checkpoint_"
+	dcpCommon, err := NewDCPCommon(ctx, DCPDestOptions{
+		MetadataStore:      bucket.GetSingleDataStore(),
+		MaxVbNo:            1,
+		PersistCheckpoints: true,
+		CheckpointPrefix:   checkpointPrefix,
+	})
+	require.NoError(t, err)
+
+	// Simulate a checkpoint written before lastSeq was tracked, by writing directly rather than via
+	// persistCheckpoint (which always injects lastSeq).
+	legacyValue := []byte(`{"failOverLog":[[123,0]],"seqStart":10,"seqEnd":20,"snapStart":15,"snapEnd":20}`)
+	require.NoError(t, bucket.GetSingleDataStore().SetRaw(ctx, fmt.Sprintf("%s%d", checkpointPrefix, 0), 0, nil, legacyValue))
+
+	rawMetadata, lastSeq, err := dcpCommon.loadCheckpoint(0)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(15), lastSeq)
+
+	var remains map[string]any
+	require.NoError(t, JSONUnmarshal(rawMetadata, &remains))
+	var originalFields map[string]any
+	require.NoError(t, JSONUnmarshal(legacyValue, &originalFields))
+	assert.Equal(t, originalFields, remains)
+}
+
+// TestDCPCommonPersistCheckpointNilValue verifies that persistCheckpoint succeeds when passed a nil value, as
+// happens when ForceCheckpointWrite runs for a vbucket that completed InitVbMeta but has no prior cbgt checkpoint
+// metadata yet (meta[vbNo] is still nil).
+func TestDCPCommonPersistCheckpointNilValue(t *testing.T) {
+	ctx := TestCtx(t)
+	bucket := GetTestBucket(t)
+	defer bucket.Close(ctx)
+
+	const checkpointPrefix = "test_dcp_persist_checkpoint_nil_value_"
+	dcpCommon, err := NewDCPCommon(ctx, DCPDestOptions{
+		MetadataStore:      bucket.GetSingleDataStore(),
+		MaxVbNo:            1,
+		PersistCheckpoints: true,
+		CheckpointPrefix:   checkpointPrefix,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, dcpCommon.persistCheckpoint(0, nil, 42))
+
+	rawMetadata, lastSeq, err := dcpCommon.loadCheckpoint(0)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(42), lastSeq)
+	assert.Len(t, rawMetadata, 0)
+}
+
+// TestMakeVbucketMetadataIncludesLastSeq verifies that makeVbucketMetadataForSequence builds a full CbgtCheckpoint
+// (cbgt's own opaque fields plus SG's lastSeq), so a vbucket's in-memory metadata immediately after a rollback
+// (before the next persist/load cycle through createCbgtCheckpoint/readCbgtCheckpoint) already carries a correct,
+// consistent lastSeq value. It also covers seqEnd: unbounded (max uint64) by default, but capped to the vbucket's
+// endSeqNos entry for one-shot feeds.
+func TestMakeVbucketMetadataIncludesLastSeq(t *testing.T) {
+	const (
+		vbucketUUID = uint64(1234)
+		sequence    = uint64(5678)
+	)
+
+	testCases := []struct {
+		name           string
+		endSeqNos      map[uint16]uint64
+		expectedSeqEnd uint64
+	}{
+		{name: "no endSeqNos leaves seqEnd unbounded", endSeqNos: nil, expectedSeqEnd: 0xFFFFFFFFFFFFFFFF},
+		{name: "endSeqNos caps seqEnd for this vbucket", endSeqNos: map[uint16]uint64{0: 9000}, expectedSeqEnd: 9000},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx := TestCtx(t)
+			bucket := GetTestBucket(t)
+			defer bucket.Close(ctx)
+
+			dcpCommon, err := NewDCPCommon(ctx, DCPDestOptions{
+				MetadataStore: bucket.GetSingleDataStore(),
+				MaxVbNo:       1,
+				EndSeqNos:     testCase.endSeqNos,
+			})
+			require.NoError(t, err)
+
+			raw, err := dcpCommon.makeVbucketMetadataForSequence(0, vbucketUUID, sequence)
+			require.NoError(t, err)
+
+			var checkpoint CbgtCheckpoint
+			require.NoError(t, JSONUnmarshal(raw, &checkpoint))
+			assert.Equal(t, sequence, checkpoint.LastSeq)
+			assert.Equal(t, sequence, checkpoint.SeqStart)
+			assert.Equal(t, sequence, checkpoint.SnapStart)
+			assert.Equal(t, sequence, checkpoint.SnapEnd)
+			assert.Equal(t, testCase.expectedSeqEnd, checkpoint.SeqEnd)
+			assert.Equal(t, [][]uint64{{vbucketUUID, 0}}, checkpoint.FailOverLog)
+
+			var fields map[string]any
+			require.NoError(t, JSONUnmarshal(raw, &fields))
+			_, hasLastSeq := fields["lastSeq"]
+			assert.True(t, hasLastSeq, "expected makeVbucketMetadataForSequence's output to include a lastSeq field")
+		})
+	}
+}
+
+// TestDCPCommonRollbackExPersistsLastSeq exercises rollbackEx end-to-end through a real metadata bucket - the same
+// path DCPDest.RollbackEx uses - verifying that the persisted checkpoint's lastSeq (read back via loadCheckpoint)
+// reflects the rollback sequence, and that cbgt's own fields still round-trip correctly: makeVbucketMetadataForSequence's
+// extra lastSeq field doesn't confuse createCbgtCheckpoint, which always derives lastSeq from its own parameter,
+// not from opaqueValue.
+func TestDCPCommonRollbackExPersistsLastSeq(t *testing.T) {
+	const (
+		vbucketUUID      = uint64(1234)
+		rollbackSeq      = uint64(100)
+		checkpointPrefix = "test_dcp_rollback_ex_persists_lastseq_"
+	)
+
+	ctx := TestCtx(t)
+	bucket := GetTestBucket(t)
+	defer bucket.Close(ctx)
+
+	dcpCommon, err := NewDCPCommon(ctx, DCPDestOptions{
+		MetadataStore:      bucket.GetSingleDataStore(),
+		MaxVbNo:            1,
+		PersistCheckpoints: true,
+		CheckpointPrefix:   checkpointPrefix,
+	})
+	require.NoError(t, err)
+	dcpCommon.InitVbMeta(0)
+
+	rollbackMetadata, err := dcpCommon.makeVbucketMetadataForSequence(0, vbucketUUID, rollbackSeq)
+	require.NoError(t, err)
+	require.NoError(t, dcpCommon.rollbackEx(0, vbucketUUID, rollbackSeq, rollbackMetadata))
+
+	rawMetadata, lastSeq, err := dcpCommon.loadCheckpoint(0)
+	require.NoError(t, err)
+	assert.Equal(t, rollbackSeq, lastSeq)
+
+	var remains cbgtOpaqueCheckpoint
+	require.NoError(t, JSONUnmarshal(rawMetadata, &remains))
+	assert.Equal(t, rollbackSeq, remains.SeqStart)
+	assert.Equal(t, rollbackSeq, remains.SnapStart)
+	assert.Equal(t, rollbackSeq, remains.SnapEnd)
+	assert.Equal(t, [][]uint64{{vbucketUUID, 0}}, remains.FailOverLog)
+
+	// setMetaData caches rollbackMetadata verbatim as the vbucket's in-memory metadata (what OpaqueGet hands back
+	// to cbgt) until the next persist/load cycle - so it's expected to carry makeVbucketMetadataForSequence's
+	// lastSeq field, which cbgt never writes itself. That's harmless: cbgt's own json.Unmarshal into its metaData
+	// struct silently ignores unknown fields, and createCbgtCheckpoint always derives lastSeq from its own
+	// parameter, never from opaqueValue.
+	cachedMetadata, cachedLastSeq, err := dcpCommon.getMetaData(0)
+	require.NoError(t, err)
+	assert.Equal(t, rollbackSeq, cachedLastSeq)
+	assert.Equal(t, rollbackMetadata, cachedMetadata)
+}

--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -118,7 +118,7 @@ func (c *DCPCommon) setMetaData(vbucketId uint16, value []byte, mustPersist bool
 			return nil
 		}
 
-		err := c.persistCheckpoint(vbucketId, value)
+		err := c.persistCheckpoint(vbucketId, value, c.seqs[vbucketId])
 		if err != nil {
 			WarnfCtx(c.loggingCtx, "Unable to persist DCP metadata - will retry next snapshot. Error: %v", err)
 			return fmt.Errorf("Unable to persist DCP metadata")
@@ -167,38 +167,44 @@ func (c *DCPCommon) incrementCheckpointCount(vbucketId uint16) {
 	c.updatesSinceCheckpoint[vbucketId]++
 }
 
-// loadCheckpoint retrieves previously persisted DCP metadata.  Need to unmarshal metadata to determine last sequence processed.
-// We always restart the feed from the last persisted snapshot start (as opposed to a sequence we may have processed
-// midway through the checkpoint), because:
-//   - We don't otherwise persist the last sequence we processed
-//   - For SG feed processing, there's no harm if we receive feed events for mutations we've previously seen
-//   - The ongoing performance overhead of persisting last sequence outweighs the minor performance benefit of not reprocessing a few
-//     sequences in a checkpoint on startup
-func (c *DCPCommon) loadCheckpoint(vbNo uint16) (vbMetadata []byte, snapshotStartSeq uint64, snapshotEndSeq uint64, err error) {
+// loadCheckpoint retrieves previously persisted DCP metadata, along with the last sequence SG processed for the
+// vbucket, so the feed can resume from that sequence rather than the start of the last persisted snapshot.
+func (c *DCPCommon) loadCheckpoint(vbNo uint16) (rawMetadata []byte, lastSeq uint64, err error) {
 	rawValue, _, err := c.metaStore.GetRaw(c.loggingCtx, fmt.Sprintf("%s%d", c.checkpointPrefix, vbNo))
 	if err != nil {
 		// On a key not found error, metadata hasn't been persisted for this vbucket
 		if IsDocNotFoundError(err) {
-			return []byte{}, 0, 0, nil
-		} else {
-			return []byte{}, 0, 0, err
+			return nil, 0, nil
 		}
+		return nil, 0, err
 	}
 
-	var snapshotMetadata ShardedImportDCPMetadata
-	unmarshalErr := JSONUnmarshal(rawValue, &snapshotMetadata)
-	if unmarshalErr != nil {
-		return []byte{}, 0, 0, unmarshalErr
+	lastSeq, rawMetadata, err = readCbgtCheckpoint(rawValue)
+	if err != nil {
+		return nil, 0, err
 	}
-	if c.endSeqNos != nil && snapshotMetadata.SnapStart > c.endSeqNos[vbNo] {
-		return rawValue, c.endSeqNos[vbNo], c.endSeqNos[vbNo], nil
-	}
-	return rawValue, snapshotMetadata.SnapStart, snapshotMetadata.SnapEnd, nil
 
+	if endSeq, ok := c.endSeqForVbucket(vbNo); ok && lastSeq > endSeq {
+		lastSeq = endSeq
+	}
+	return rawMetadata, lastSeq, nil
+}
+
+// endSeqForVbucket looks up the configured one-shot-feed end sequence number for a vbucket, if any. It asserts if
+// endSeqNos was specified but doesn't cover this vbucket, which would mean it was built with the wrong vbucket count.
+func (c *DCPCommon) endSeqForVbucket(vbNo uint16) (endSeq uint64, ok bool) {
+	if c.endSeqNos == nil {
+		return 0, false
+	}
+	endSeq, ok = c.endSeqNos[vbNo]
+	if !ok {
+		AssertfCtx(c.loggingCtx, "vbno %d is not tracked by the expected endSeqNos %#+v. This means that endSeqNos was specified with the incorrect number of vBuckets.", vbNo, c.endSeqNos)
+	}
+	return endSeq, ok
 }
 
 func (c *DCPCommon) InitVbMeta(vbNo uint16) {
-	metadata, snapStart, _, err := c.loadCheckpoint(vbNo)
+	metadata, lastSeq, err := c.loadCheckpoint(vbNo)
 	c.m.Lock()
 	if err != nil {
 		WarnfCtx(c.loggingCtx, "Unexpected error attempting to load DCP checkpoint for vbucket %d.  Will restart DCP for that vbucket from zero.  Error: %v", vbNo, err)
@@ -206,7 +212,7 @@ func (c *DCPCommon) InitVbMeta(vbNo uint16) {
 		c.seqs[vbNo] = 0
 	} else {
 		c.meta[vbNo] = metadata
-		c.seqs[vbNo] = snapStart
+		c.seqs[vbNo] = lastSeq
 	}
 	c.m.Unlock()
 }
@@ -216,9 +222,15 @@ func (c *DCPCommon) InitVbMeta(vbNo uint16) {
 //	restarting w/ an older checkpoint:
 //	  - Would only result in some repeated entry processing, which is already handled by the indexer
 //	  - Is a relatively infrequent operation
-func (c *DCPCommon) persistCheckpoint(vbNo uint16, value []byte) error {
+func (c *DCPCommon) persistCheckpoint(vbNo uint16, value []byte, lastSeq uint64) error {
 	TracefCtx(c.loggingCtx, KeyDCP, "Persisting checkpoint for vbno %d", vbNo)
-	return c.metaStore.SetRaw(c.loggingCtx, fmt.Sprintf("%s%d", c.checkpointPrefix, vbNo), 0, nil, value)
+
+	persistedValue, err := createCbgtCheckpoint(value, lastSeq)
+	if err != nil {
+		return fmt.Errorf("unable to marshal DCP checkpoint metadata for vbno %d: %w", vbNo, err)
+	}
+
+	return c.metaStore.SetRaw(c.loggingCtx, fmt.Sprintf("%s%d", c.checkpointPrefix, vbNo), 0, nil, persistedValue)
 }
 
 // shouldProcessSequence checks the incoming sequence number against the expected end sequence number, and returns true
@@ -239,6 +251,28 @@ func (c *DCPCommon) shouldProcessSequence(vBucketID uint16, seq uint64) bool {
 		return true
 	}
 	return seq <= endSeq
+}
+
+// makeVbucketMetadataForSequence builds the marshalled CbgtCheckpoint for a vbucket that's now at exactly
+// sequence (i.e. seqStart/snapStart/snapEnd/lastSeq all equal sequence), for use as rollback metadata. seqEnd is
+// capped to the vbucket's expected end sequence number for one-shot feeds (endSeqNos), matching
+// shouldProcessSequence, and otherwise left unbounded.
+func (c *DCPCommon) makeVbucketMetadataForSequence(vbNo uint16, vbucketUUID uint64, sequence uint64) ([]byte, error) {
+	seqEnd := uint64(0xFFFFFFFFFFFFFFFF)
+	if endSeq, ok := c.endSeqForVbucket(vbNo); ok {
+		seqEnd = endSeq
+	}
+	checkpoint := CbgtCheckpoint{
+		cbgtOpaqueCheckpoint: cbgtOpaqueCheckpoint{
+			SeqStart:    sequence,
+			SeqEnd:      seqEnd,
+			SnapStart:   sequence,
+			SnapEnd:     sequence,
+			FailOverLog: [][]uint64{{vbucketUUID, 0}},
+		},
+		LastSeq: sequence,
+	}
+	return JSONMarshal(checkpoint)
 }
 
 // This updates the value stored in r.seqs with the given seq number for the given partition

--- a/base/dcp_common_test.go
+++ b/base/dcp_common_test.go
@@ -89,6 +89,45 @@ func TestDCPNameLength(t *testing.T) {
 	}
 }
 
+// TestDCPCommonCheckpointRoundTripShapes exercises persistCheckpoint followed by loadCheckpoint on a *DCPCommon -
+// i.e. through an actual metadata bucket, not just createCbgtCheckpoint/readCbgtCheckpoint directly - across the
+// same checkpoint shapes as TestCbgtCheckpointRoundTrip, verifying every field survives exactly.
+func TestDCPCommonCheckpointRoundTripShapes(t *testing.T) {
+	const lastSeq = uint64(18)
+	for _, testCase := range checkpointShapeTestCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx := TestCtx(t)
+			bucket := GetTestBucket(t)
+			defer bucket.Close(ctx)
+
+			dcpCommon, err := NewDCPCommon(ctx, DCPDestOptions{
+				MetadataStore:      bucket.GetSingleDataStore(),
+				MaxVbNo:            1,
+				PersistCheckpoints: true,
+				CheckpointPrefix:   "test_dcp_checkpoint_round_trip_shapes_" + testCase.name + "_",
+			})
+			require.NoError(t, err)
+
+			require.NoError(t, dcpCommon.persistCheckpoint(0, []byte(testCase.raw), lastSeq))
+
+			rawMetadata, extractedLastSeq, err := dcpCommon.loadCheckpoint(0)
+			require.NoError(t, err)
+			assert.Equal(t, lastSeq, extractedLastSeq)
+
+			var original map[string]any
+			require.NoError(t, JSONUnmarshal([]byte(testCase.raw), &original))
+			if len(original) == 0 {
+				assert.Len(t, rawMetadata, 0)
+				return
+			}
+
+			var remains map[string]any
+			require.NoError(t, JSONUnmarshal(rawMetadata, &remains))
+			assert.Equal(t, original, remains)
+		})
+	}
+}
+
 // TestFeedEventByteSliceCopy( ensures that the byte slices in the FeedEvent are copies and not the original ones - CBG-4540
 func TestFeedEventByteSliceCopy(t *testing.T) {
 	const (

--- a/base/dcp_dest.go
+++ b/base/dcp_dest.go
@@ -212,8 +212,12 @@ func (d *DCPDest) RollbackEx(partition string, vbucketUUID uint64, rollbackSeq u
 	if rollbackSeq == 0 {
 		vbucketUUID = 0
 	}
-	cbgtMeta := makeVbucketMetadataForSequence(vbucketUUID, rollbackSeq)
-	return d.rollbackEx(partitionToVbNo(d.loggingCtx, partition), vbucketUUID, rollbackSeq, cbgtMeta)
+	vbNo := partitionToVbNo(d.loggingCtx, partition)
+	cbgtMeta, err := d.makeVbucketMetadataForSequence(vbNo, vbucketUUID, rollbackSeq)
+	if err != nil {
+		return err
+	}
+	return d.rollbackEx(vbNo, vbucketUUID, rollbackSeq, cbgtMeta)
 }
 
 // TODO: Not implemented, review potential usage

--- a/base/dcp_receiver.go
+++ b/base/dcp_receiver.go
@@ -28,38 +28,3 @@ const MemcachedDataTypeRaw = 0
 func makeFeedEventForMCRequest(rq *gomemcached.MCRequest, opcode sgbucket.FeedOpcode) sgbucket.FeedEvent {
 	return makeFeedEvent(rq.Key, rq.Body, rq.DataType, rq.Cas, ExtractExpiryFromDCPMutation(rq), rq.VBucket, 0, 0, opcode)
 }
-
-// ShardedImportDCPMetadata is an internal struct that is exposed to enable json marshaling, used by sharded import feed. It differs from DCPMetadata because it must match the private struct used by cbgt.metadata.
-type ShardedImportDCPMetadata struct {
-	FailOverLog [][]uint64 `json:"failOverLog"`
-	SeqStart    uint64     `json:"seqStart"`
-	SeqEnd      uint64     `json:"seqEnd"`
-	SnapStart   uint64     `json:"snapStart"`
-	SnapEnd     uint64     `json:"snapEnd"`
-}
-
-// Generate marshalled vBucketMetadata for a vbucket from underlying components
-func makeVbucketMetadata(vbucketUUID uint64, sequence uint64, snapStart uint64, snapEnd uint64) []byte {
-	failOver := make([][]uint64, 1)
-	failOverEntry := []uint64{vbucketUUID, 0}
-	failOver[0] = failOverEntry
-	metadata := &ShardedImportDCPMetadata{
-		SeqStart:    sequence,
-		SeqEnd:      uint64(0xFFFFFFFFFFFFFFFF),
-		SnapStart:   snapStart,
-		SnapEnd:     snapEnd,
-		FailOverLog: failOver,
-	}
-	metadataBytes, err := JSONMarshal(metadata)
-	if err == nil {
-		return metadataBytes
-	} else {
-		return []byte{}
-	}
-}
-
-// Create vBucketMetadata, marshalled to []byte
-func makeVbucketMetadataForSequence(vbucketUUID uint64, sequence uint64) []byte {
-	return makeVbucketMetadata(vbucketUUID, sequence, sequence, sequence)
-
-}

--- a/base/dcp_sharded_test.go
+++ b/base/dcp_sharded_test.go
@@ -1592,7 +1592,7 @@ func TestShardedDCPCheckpointCleanup(t *testing.T) {
 		exists, err := metadataStore.Exists(ctx, checkpointName)
 		require.NoError(t, err)
 		require.False(t, exists, "Checkpoint should not exist before persistence", checkpointName)
-		require.NoError(t, dcpDest.persistCheckpoint(vb, []byte(`{"checkpoint": "data"}`)))
+		require.NoError(t, dcpDest.persistCheckpoint(vb, []byte(`{"checkpoint": "data"}`), 0))
 		exists, err = metadataStore.Exists(ctx, checkpointName)
 		require.NoError(t, err)
 		require.True(t, exists, "Checkpoint should exist after persistence", checkpointName)

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -2238,7 +2238,7 @@ func TestImportRollback(t *testing.T) {
 			vbNo, err := base.GetVbucketForKey(ctx, bucket, key)
 			require.NoError(t, err)
 			checkpointKey := fmt.Sprintf("%s%d", checkpointPrefix, vbNo)
-			var checkpointData base.ShardedImportDCPMetadata
+			var checkpointData base.CbgtCheckpoint
 			checkpointBytes, _, err := metaStore.GetRaw(ctx, checkpointKey)
 			require.NoError(t, err)
 			require.NoError(t, base.JSONUnmarshal(checkpointBytes, &checkpointData))
@@ -2247,6 +2247,7 @@ func TestImportRollback(t *testing.T) {
 			checkpointData.SnapEnd = 3000 + checkpointData.SnapEnd
 			checkpointData.SeqStart = 3000 + checkpointData.SeqStart
 			checkpointData.SeqEnd = 3000 + checkpointData.SeqEnd
+			checkpointData.LastSeq = 3000 + checkpointData.LastSeq
 			if testType == rollbackWithFailover {
 				existingVbUUID := checkpointData.FailOverLog[0][0]
 				checkpointData.FailOverLog = [][]uint64{{existingVbUUID + 1, 0}}
@@ -2334,7 +2335,7 @@ func TestImportRollbackMultiplePartitions(t *testing.T) {
 	// fetch the checkpoint for the vBucket 0 and 800, modify the checkpoint values to a higher sequence to
 	// trigger rollback upon stream open request
 	checkpointKey := fmt.Sprintf("%s%d", checkpointPrefix, 0)
-	var checkpointData base.ShardedImportDCPMetadata
+	var checkpointData base.CbgtCheckpoint
 	checkpointBytes, _, err := metaStore.GetRaw(ctx, checkpointKey)
 	require.NoError(t, err)
 	require.NoError(t, base.JSONUnmarshal(checkpointBytes, &checkpointData))
@@ -2342,6 +2343,7 @@ func TestImportRollbackMultiplePartitions(t *testing.T) {
 	checkpointData.SnapEnd = 3000 + checkpointData.SnapEnd
 	checkpointData.SeqStart = 3000 + checkpointData.SeqStart
 	checkpointData.SeqEnd = 3000 + checkpointData.SeqEnd
+	checkpointData.LastSeq = 3000 + checkpointData.LastSeq
 	existingVbUUID := checkpointData.FailOverLog[0][0]
 	checkpointData.FailOverLog = [][]uint64{{existingVbUUID + 1, 0}}
 
@@ -2352,7 +2354,7 @@ func TestImportRollbackMultiplePartitions(t *testing.T) {
 
 	// vBucket 800
 	checkpointKey = fmt.Sprintf("%s%d", checkpointPrefix, 800)
-	checkpointData = base.ShardedImportDCPMetadata{}
+	checkpointData = base.CbgtCheckpoint{}
 	checkpointBytes, _, err = metaStore.GetRaw(ctx, checkpointKey)
 	require.NoError(t, err)
 	require.NoError(t, base.JSONUnmarshal(checkpointBytes, &checkpointData))
@@ -2360,6 +2362,7 @@ func TestImportRollbackMultiplePartitions(t *testing.T) {
 	checkpointData.SnapEnd = 3000 + checkpointData.SnapEnd
 	checkpointData.SeqStart = 3000 + checkpointData.SeqStart
 	checkpointData.SeqEnd = 3000 + checkpointData.SeqEnd
+	checkpointData.LastSeq = 3000 + checkpointData.LastSeq
 	existingVbUUID = checkpointData.FailOverLog[0][0]
 	checkpointData.FailOverLog = [][]uint64{{existingVbUUID + 1, 0}}
 
@@ -2578,7 +2581,7 @@ func TestImportRollbackAllPartitions(t *testing.T) {
 	// fetch each vBucket checkpoint, modify the checkpoint values back to the bucket
 	for vbNo := range docPerVBucket {
 		checkpointKey := fmt.Sprintf("%s%d", checkpointPrefix, vbNo)
-		var checkpointData base.ShardedImportDCPMetadata
+		var checkpointData base.CbgtCheckpoint
 		checkpointBytes, _, err := metaStore.GetRaw(ctx, checkpointKey)
 		require.NoError(t, err)
 		require.NoError(t, base.JSONUnmarshal(checkpointBytes, &checkpointData))
@@ -2587,6 +2590,7 @@ func TestImportRollbackAllPartitions(t *testing.T) {
 		checkpointData.SnapEnd = 3000 + checkpointData.SnapEnd
 		checkpointData.SeqStart = 3000 + checkpointData.SeqStart
 		checkpointData.SeqEnd = 3000 + checkpointData.SeqEnd
+		checkpointData.LastSeq = 3000 + checkpointData.LastSeq
 		existingVbUUID := checkpointData.FailOverLog[0][0]
 		// mutate vbUUID to force rollback
 		checkpointData.FailOverLog = [][]uint64{{existingVbUUID + 1, 0}}


### PR DESCRIPTION
Unclean cherry pick of #8465 for 4.1.2

- `rest/importtest/import_test.go` — kept 4.1.2's literal vBucket `800`; `alternatePartitionVB` does not exist on this branch
- `base/cbgt_checkpoint_test.go` — swapped `sync_gateway/testing/{assert,require}` for `stretchr/testify`; the `testing/` wrapper packages (#8386) are not on 4.1.2
