### PR TITLE
CBG-5969: fix staticcheck single-case select warnings

### DIFF
--- a/.golangci-strict.yml
+++ b/.golangci-strict.yml
@@ -77,7 +77,6 @@ linters:
         - -QF1010 # Convert slice of bytes to string when printing it.
         - -QF1011 # Omit redundant type from variable declaration.
         - -QF1012 # Use 'fmt.Fprintf(x, ...)' instead of 'x.Write(fmt.Sprintf(...))'.
-        - -S1000 # Use plain channel send or receive instead of single-case select.
         - -S1002 # Omit comparison with boolean constant.
         - -S1005 # unnecssary assignment to the blank identifier
         - -S1007 # Simplify regular expression by using raw string literal.

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -1004,31 +1005,60 @@ func TestChannelQueryCancellation(t *testing.T) {
 	assert.Equal(t, initialQueryCount+1, finalQueryCount)
 }
 
-// Test race condition causing skipped sequences in changes feed.  Channel feeds are processed sequentially
-// in the main changes.go iteration loop, without a lock on the underlying channel caches.  The following
-// sequence is possible while running a changes feed for channels "A", "B":
-//  1. Sequence 100, Channel A arrives, and triggers changes loop iteration
-//  2. Changes loop calls changes.changesFeed(A) - gets 100
-//  3. Sequence 101, Channel A arrives
-//  4. Sequence 102, Channel B arrives
-//  5. Changes loop calls changes.changesFeed(B) - gets 102
-//  6. Changes sends 100, 102, and sets since=102
+// drainFeed reads numEntries new entries from feed, skipping the nils continuous feeds send after
+// each iteration, and returns them appended to entries. Fails the test if numEntries aren't
+// received within maxWaitTime.
+func drainFeed(t *testing.T, entries []*ChangeEntry, feed <-chan *ChangeEntry, numEntries int, maxWaitTime time.Duration) []*ChangeEntry {
+	timeout := time.After(maxWaitTime)
+	received := 0
+	for received < numEntries {
+		select {
+		case entry, ok := <-feed:
+			require.True(t, ok, "feed closed unexpectedly")
+			if entry == nil {
+				continue
+			}
+			entries = append(entries, entry)
+			received++
+		case <-timeout:
+			require.FailNow(t, fmt.Sprintf("timed out waiting for %d entries, only received %d: %s", numEntries, received, formatChangeSequences(entries)))
+		}
+	}
+	return entries
+}
+
+// Test race condition that could cause skipped sequences in the changes feed.  Channel feeds are processed
+// sequentially in the main changes.go iteration loop, without a lock on the underlying channel caches.  The
+// following sequence occurs while running a continuous changes feed for channels "Even", "Odd":
+//  1. Sequence 4, channel "Even" arrives, and triggers a changes loop iteration
+//  2. Changes loop calls changesFeed("Even") - gets 4
+//  3. Sequence 6, channel "Even" arrives, but is delayed (blocked below via a LeakyBucket
+//     WriteWithXattrCallback)
+//  4. Sequences 5 and 7, channel "Odd" arrive
+//  5. Changes loop calls changesFeed("Odd") - gets 5 and 7
+//  6. Changes sends 4, 5, 7, tracks 6 as a skipped sequence, and holds since at 5 (the highest
+//     contiguous sequence) until 6 arrives
 //
-// Here 101 is skipped, and never gets sent.  There are a number of ways a sufficient delay between #2 and #5
-// could be introduced in a real-world scenario
-//   - there are channels C,D,E,F,G with large caches that get processed between A and B
-//
-// To test, uncomment the following
-// lines at the start of changesFeed() in changes.go to simulate slow processing:
-//
-//	base.Infof(base.KeyChanges, "Simulate slow processing time for channel %s - sleeping for 100 ms", channel)
-//	time.Sleep(100 * time.Millisecond)
+// If 6 were simply dropped from since tracking instead of being tracked as skipped, it would never get sent
+// once it finally arrived. Sequence 7 is sent with a compound sequence ID (triggered by 5) to reflect that
+// since is still held at 5; 6 is then sent on its own once unblocked, filling the gap - see the
+// verifyChangesFullSequences assertion below.
 func TestChannelRace(t *testing.T) {
 	base.LongRunningTest(t)
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges)
 
-	db, ctx := setupTestDBWithCacheOptions(t, shortWaitCache())
+	// blockDoc6 delays the underlying write of sequence 6 until the test closes it below, so sequences 5
+	// and 7 are guaranteed to be processed by the changes loop while 6 is still not visible.
+	blockDoc6 := make(chan struct{})
+	leakyConfig := base.LeakyBucketConfig{
+		WriteWithXattrCallback: func(key string) {
+			if key == "doc-6" {
+				<-blockDoc6
+			}
+		},
+	}
+	db, ctx := setupTestLeakyDBWithCacheOptions(t, shortWaitCache(), leakyConfig)
 	defer db.Close(ctx)
 
 	// Create a user with access to channels "Odd", "Even"
@@ -1061,65 +1091,44 @@ func TestChannelRace(t *testing.T) {
 	feed, err := dbCollection.MultiChangesFeed(ctx, base.SetOf("Even", "Odd"), options)
 	assert.True(t, err == nil)
 
-	// Go-routine to drain the feed channel and write to an array for use by assertions
-	var changes struct {
-		lock    sync.RWMutex
-		entries []*ChangeEntry
-	}
-	changes.entries = make([]*ChangeEntry, 0, 50)
-	go func() {
-		for entry := range feed {
-			// feed sends nil after each continuous iteration
-			if entry == nil {
-				continue
-			}
-			log.Println("Changes entry:", entry.Seq)
-			changes.lock.Lock()
-			changes.entries = append(changes.entries, entry)
-			changes.lock.Unlock()
-		}
-		log.Println("Closing feed")
-	}()
-
-	changesLen := func() int {
-		changes.lock.RLock()
-		defer changes.lock.RUnlock()
-		return len(changes.entries)
-	}
+	// The output channel of MultiChangesFeed is buffered (currently 50 entries), well beyond the 9
+	// entries used in this test, so draining it synchronously between writes below - rather than
+	// continuously via a background goroutine - doesn't affect the internal processing being tested.
+	var entries []*ChangeEntry
 
 	// Wait for the initial sequences to arrive as expected
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Equal(c, 3, changesLen())
-	}, 5*time.Second, 10*time.Millisecond)
+	entries = drainFeed(t, entries, feed, 3, 5*time.Second)
 
 	// Send update to trigger the start of the next changes iteration
 	WriteDirect(t, collection, []string{"Even"}, 4)
-	time.Sleep(150 * time.Millisecond)
-	// After read of "Even" channel, but before read of "Odd" channel, send three new entries
+	entries = drainFeed(t, entries, feed, 1, 5*time.Second)
+
+	// Sequence 6's write blocks on blockDoc6 (see leakyConfig above), so it won't become visible to the
+	// change cache until that channel is closed below.
+	var write6Wg sync.WaitGroup
+	write6Wg.Go(func() {
+		WriteDirect(t, collection, []string{"Even"}, 6)
+	})
+
+	// Sequences 5 and 7 ("Odd") arrive and get processed while 6 is still blocked, advancing the
+	// continuous changes feed's since value to 7 without having seen 6.
 	WriteDirect(t, collection, []string{"Odd"}, 5)
-	WriteDirect(t, collection, []string{"Even"}, 6)
 	WriteDirect(t, collection, []string{"Odd"}, 7)
+	entries = drainFeed(t, entries, feed, 2, 5*time.Second)
 
-	time.Sleep(100 * time.Millisecond)
-
-	// At this point we've haven't sent sequence 6, but the continuous changes feed has since=7
+	// Unblock sequence 6, and confirm below that it isn't skipped once it becomes visible.
+	close(blockDoc6)
+	write6Wg.Wait()
 
 	// Write a few more to validate that we're not catching up on the missing '6' later
 	WriteDirect(t, collection, []string{"Even"}, 8)
 	WriteDirect(t, collection, []string{"Odd"}, 9)
 
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Equal(c, 9, changesLen())
-	}, 5*time.Second, 10*time.Millisecond)
+	entries = drainFeed(t, entries, feed, 3, 5*time.Second)
 
-	changes.lock.RLock()
-	assert.True(t, verifyChangesFullSequences(changes.entries, []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"}))
-	changesString := ""
-	for _, change := range changes.entries {
-		changesString = fmt.Sprintf("%s%d, ", changesString, change.Seq.Seq)
-	}
-	changes.lock.RUnlock()
-	fmt.Println("changes: ", changesString)
+	// Sequence 7 is sent with a compound sequence ID (triggered by 5, the highest contiguous sequence at
+	// the time) since 6 was still outstanding; 6 is then sent on its own once it arrives, filling the gap.
+	assert.True(t, verifyChangesFullSequences(entries, []string{"1", "2", "3", "4", "5", "5::7", "6", "8", "9"}))
 }
 
 // Test that housekeeping goroutines get terminated when change cache is stopped
@@ -1234,18 +1243,27 @@ func verifyCacheSequences(singleCache SingleChannelCache, sequences []uint64) bo
 // verifyChangesFullSequences compares for a full match on sequence, including compound elements)
 func verifyChangesFullSequences(changes []*ChangeEntry, sequences []string) bool {
 	if len(changes) != len(sequences) {
-		log.Printf("verifyChangesFullSequences: changes size (%v) not equals to sequences size (%v)",
-			len(changes), len(sequences))
+		log.Printf("verifyChangesFullSequences: changes size (%v) not equals to sequences size (%v), changes=%s",
+			len(changes), len(sequences), formatChangeSequences(changes))
 		return false
 	}
 	for index, seq := range sequences {
 		if changes[index].Seq.String() != seq {
 			log.Printf("verifyChangesFullSequences: sequence mismatch at index %v, changes=%s, sequences=%s",
-				index, changes[index].Seq.String(), seq)
+				index, formatChangeSequences(changes), seq)
 			return false
 		}
 	}
 	return true
+}
+
+// formatChangeSequences renders the sequence numbers of changes for diagnostic logging.
+func formatChangeSequences(changes []*ChangeEntry) string {
+	seqs := make([]string, 0, len(changes))
+	for _, change := range changes {
+		seqs = append(seqs, change.Seq.String())
+	}
+	return strings.Join(seqs, ", ")
 }
 
 // verifyChangesSequencesIgnoreOrder compares for a match on sequence number only and ignores sequenceID order

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -1060,38 +1060,37 @@ func TestChannelRace(t *testing.T) {
 	options.Wait = true
 	feed, err := dbCollection.MultiChangesFeed(ctx, base.SetOf("Even", "Odd"), options)
 	assert.True(t, err == nil)
-	feedClosed := false
 
-	// Go-routine to work the feed channel and write to an array for use by assertions
+	// Go-routine to drain the feed channel and write to an array for use by assertions
 	var changes struct {
 		lock    sync.RWMutex
 		entries []*ChangeEntry
 	}
 	changes.entries = make([]*ChangeEntry, 0, 50)
 	go func() {
-		for feedClosed == false {
-			entry, ok := <-feed
-			if ok {
-				// feed sends nil after each continuous iteration
-				if entry != nil {
-					log.Println("Changes entry:", entry.Seq)
-					changes.lock.Lock()
-					changes.entries = append(changes.entries, entry)
-					changes.lock.Unlock()
-				}
-			} else {
-				log.Println("Closing feed")
-				feedClosed = true
+		for entry := range feed {
+			// feed sends nil after each continuous iteration
+			if entry == nil {
+				continue
 			}
+			log.Println("Changes entry:", entry.Seq)
+			changes.lock.Lock()
+			changes.entries = append(changes.entries, entry)
+			changes.lock.Unlock()
 		}
+		log.Println("Closing feed")
 	}()
 
-	// Wait for processing of two channels (100 ms each)
-	time.Sleep(250 * time.Millisecond)
-	// Validate the initial sequences arrive as expected
-	changes.lock.RLock()
-	assert.Len(t, changes.entries, 3)
-	changes.lock.RUnlock()
+	changesLen := func() int {
+		changes.lock.RLock()
+		defer changes.lock.RUnlock()
+		return len(changes.entries)
+	}
+
+	// Wait for the initial sequences to arrive as expected
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, 3, changesLen())
+	}, 5*time.Second, 10*time.Millisecond)
 
 	// Send update to trigger the start of the next changes iteration
 	WriteDirect(t, collection, []string{"Even"}, 4)
@@ -1108,9 +1107,12 @@ func TestChannelRace(t *testing.T) {
 	// Write a few more to validate that we're not catching up on the missing '6' later
 	WriteDirect(t, collection, []string{"Even"}, 8)
 	WriteDirect(t, collection, []string{"Odd"}, 9)
-	time.Sleep(750 * time.Millisecond)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, 9, changesLen())
+	}, 5*time.Second, 10*time.Millisecond)
+
 	changes.lock.RLock()
-	assert.Len(t, changes.entries, 9)
 	assert.True(t, verifyChangesFullSequences(changes.entries, []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"}))
 	changesString := ""
 	for _, change := range changes.entries {

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -1070,20 +1070,18 @@ func TestChannelRace(t *testing.T) {
 	changes.entries = make([]*ChangeEntry, 0, 50)
 	go func() {
 		for feedClosed == false {
-			select {
-			case entry, ok := <-feed:
-				if ok {
-					// feed sends nil after each continuous iteration
-					if entry != nil {
-						log.Println("Changes entry:", entry.Seq)
-						changes.lock.Lock()
-						changes.entries = append(changes.entries, entry)
-						changes.lock.Unlock()
-					}
-				} else {
-					log.Println("Closing feed")
-					feedClosed = true
+			entry, ok := <-feed
+			if ok {
+				// feed sends nil after each continuous iteration
+				if entry != nil {
+					log.Println("Changes entry:", entry.Seq)
+					changes.lock.Lock()
+					changes.entries = append(changes.entries, entry)
+					changes.lock.Unlock()
 				}
+			} else {
+				log.Println("Closing feed")
+				feedClosed = true
 			}
 		}
 	}()

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -550,19 +550,19 @@ func TestChannelCacheBackfill(t *testing.T) {
 	// verify insert at start (PBS)
 	pbsCache, err := db.changeCache.getChannelCache().getSingleChannelCache(ctx, channels.NewID("PBS", collectionID))
 	require.NoError(t, err)
-	assert.True(t, verifyCacheSequences(pbsCache, []uint64{3, 5, 6}))
+	verifyCacheSequences(t, pbsCache, []uint64{3, 5, 6})
 	// verify insert at middle (ABC)
 	abcCache, err := db.changeCache.getChannelCache().getSingleChannelCache(ctx, channels.NewID("ABC", collectionID))
 	require.NoError(t, err)
-	assert.True(t, verifyCacheSequences(abcCache, []uint64{1, 2, 3, 5, 6}))
+	verifyCacheSequences(t, abcCache, []uint64{1, 2, 3, 5, 6})
 	// verify insert at end (NBC)
 	nbcCache, err := db.changeCache.getChannelCache().getSingleChannelCache(ctx, channels.NewID("NBC", collectionID))
 	require.NoError(t, err)
-	assert.True(t, verifyCacheSequences(nbcCache, []uint64{1, 3}))
+	verifyCacheSequences(t, nbcCache, []uint64{1, 3})
 	// verify insert to empty cache (TBS)
 	tbsCache, err := db.changeCache.getChannelCache().getSingleChannelCache(ctx, channels.NewID("TBS", collectionID))
 	require.NoError(t, err)
-	assert.True(t, verifyCacheSequences(tbsCache, []uint64{3}))
+	verifyCacheSequences(t, tbsCache, []uint64{3})
 
 	// verify changes has three entries (needs to resend all since previous LowSeq, which
 	// will be the late arriver (3) along with 5, 6)
@@ -844,7 +844,7 @@ func TestLowSequenceHandlingWithAccessGrant(t *testing.T) {
 	err = appendFromFeed(&changes, feed, 3, defaultWaitForSequence)
 	require.NoError(t, err)
 	assert.Len(t, changes, 3)
-	assert.True(t, verifyChangesFullSequences(changes, []string{"1", "2", "2::6"}))
+	verifyChangesFullSequences(t, changes, []string{"1", "2", "2::6"})
 
 	_, incrErr := dbCollection.dataStore.Incr(ctx, db.MetadataKeys.SyncSeqKey(), 7, 7, 0)
 	require.NoError(t, incrErr)
@@ -874,7 +874,7 @@ func TestLowSequenceHandlingWithAccessGrant(t *testing.T) {
 	//                                                // MISSING 2::8
 	//   {Seq:2::9, ID:doc-9, Changes:[map[rev:1-a]]}
 	// ]
-	assert.True(t, verifyChangesFullSequences(changes, []string{"1", "2", "2::6", "2:8:5", "2:8:6", "2::8", "2::9"}))
+	verifyChangesFullSequences(t, changes, []string{"1", "2", "2::6", "2:8:5", "2:8:6", "2::8", "2::9"})
 	// Notes:
 	// 1. 2::8 is the user sequence
 	// 2. The duplicate send of sequence '6' is the standard behaviour when a channel is added - we don't know
@@ -1009,6 +1009,7 @@ func TestChannelQueryCancellation(t *testing.T) {
 // each iteration, and returns them appended to entries. Fails the test if numEntries aren't
 // received within maxWaitTime.
 func drainFeed(t *testing.T, entries []*ChangeEntry, feed <-chan *ChangeEntry, numEntries int, maxWaitTime time.Duration) []*ChangeEntry {
+	ctx := base.TestCtx(t)
 	timeout := time.After(maxWaitTime)
 	received := 0
 	for received < numEntries {
@@ -1018,6 +1019,7 @@ func drainFeed(t *testing.T, entries []*ChangeEntry, feed <-chan *ChangeEntry, n
 			if entry == nil {
 				continue
 			}
+			base.DebugfCtx(ctx, base.KeySGTest, "drainFeed: received change entry %v", entry.Seq)
 			entries = append(entries, entry)
 			received++
 		case <-timeout:
@@ -1128,7 +1130,7 @@ func TestChannelRace(t *testing.T) {
 
 	// Sequence 7 is sent with a compound sequence ID (triggered by 5, the highest contiguous sequence at
 	// the time) since 6 was still outstanding; 6 is then sent on its own once it arrives, filling the gap.
-	assert.True(t, verifyChangesFullSequences(entries, []string{"1", "2", "3", "4", "5", "5::7", "6", "8", "9"}))
+	verifyChangesFullSequences(t, entries, []string{"1", "2", "3", "4", "5", "5::7", "6", "8", "9"})
 }
 
 // Test that housekeeping goroutines get terminated when change cache is stopped
@@ -1218,52 +1220,36 @@ func shortWaitCache() CacheOptions {
 	return cacheOptions
 }
 
-func verifyCacheSequences(singleCache SingleChannelCache, sequences []uint64) bool {
-
+// verifyCacheSequences asserts a full match on the sequences stored in singleCache's log.
+func verifyCacheSequences(t *testing.T, singleCache SingleChannelCache, sequences []uint64) {
+	t.Helper()
 	cache, ok := singleCache.(*singleChannelCacheImpl)
-	if !ok {
-		return false
+	require.True(t, ok, "expected *singleChannelCacheImpl, got %T", singleCache)
+	actualSequences := make([]uint64, 0, len(cache.logs))
+	for _, entry := range cache.logs {
+		actualSequences = append(actualSequences, entry.Sequence)
 	}
-	if len(cache.logs) != len(sequences) {
-
-		log.Printf("verifyCacheSequences: cache size (%v) not equals to sequences size (%v)",
-			len(cache.logs), len(sequences))
-		return false
-	}
-	for index, seq := range sequences {
-		if cache.logs[index].Sequence != seq {
-			log.Printf("verifyCacheSequences: sequence mismatch at index %v, cache=%v, sequences=%v",
-				index, cache.logs[index].Sequence, seq)
-			return false
-		}
-	}
-	return true
+	require.Equal(t, sequences, actualSequences)
 }
 
-// verifyChangesFullSequences compares for a full match on sequence, including compound elements)
-func verifyChangesFullSequences(changes []*ChangeEntry, sequences []string) bool {
-	if len(changes) != len(sequences) {
-		log.Printf("verifyChangesFullSequences: changes size (%v) not equals to sequences size (%v), changes=%s",
-			len(changes), len(sequences), formatChangeSequences(changes))
-		return false
-	}
-	for index, seq := range sequences {
-		if changes[index].Seq.String() != seq {
-			log.Printf("verifyChangesFullSequences: sequence mismatch at index %v, changes=%s, sequences=%s",
-				index, formatChangeSequences(changes), seq)
-			return false
-		}
-	}
-	return true
+// verifyChangesFullSequences asserts a full match on sequence, including compound elements.
+func verifyChangesFullSequences(t *testing.T, changes []*ChangeEntry, sequences []string) {
+	t.Helper()
+	require.Equal(t, sequences, changeSequences(changes))
 }
 
-// formatChangeSequences renders the sequence numbers of changes for diagnostic logging.
-func formatChangeSequences(changes []*ChangeEntry) string {
+// changeSequences returns the sequence number of each change, in order.
+func changeSequences(changes []*ChangeEntry) []string {
 	seqs := make([]string, 0, len(changes))
 	for _, change := range changes {
 		seqs = append(seqs, change.Seq.String())
 	}
-	return strings.Join(seqs, ", ")
+	return seqs
+}
+
+// formatChangeSequences renders the sequence numbers of changes for diagnostic logging.
+func formatChangeSequences(changes []*ChangeEntry) string {
+	return strings.Join(changeSequences(changes), ", ")
 }
 
 // verifyChangesSequencesIgnoreOrder compares for a match on sequence number only and ignores sequenceID order

--- a/tools/cache_perf_tool/main.go
+++ b/tools/cache_perf_tool/main.go
@@ -225,14 +225,8 @@ func main() {
 	ticker := time.NewTicker(*timeToRun)
 	defer ticker.Stop()
 
-outerloop:
-	for {
-		select {
-		case <-ticker.C:
-			cancelFunc(errors.New("test duration complete"))
-			break outerloop
-		}
-	}
+	<-ticker.C
+	cancelFunc(errors.New("test duration complete"))
 
 	workerFunc := func() (shouldRetry bool, err error, val any) {
 		return numGoroutines.Load() != int32(0), nil, val

--- a/tools/cache_perf_tool/main.go
+++ b/tools/cache_perf_tool/main.go
@@ -222,10 +222,7 @@ func main() {
 	defer printEndofTestStatsFile(ctx, dbContext)
 
 	// duration of test logic
-	ticker := time.NewTicker(*timeToRun)
-	defer ticker.Stop()
-
-	<-ticker.C
+	time.Sleep(*timeToRun)
 	cancelFunc(errors.New("test duration complete"))
 
 	workerFunc := func() (shouldRetry bool, err error, val any) {


### PR DESCRIPTION
CBG-5969: fix staticcheck single-case select warnings

silences warnings for gopls especially.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/1031/