### PR TITLE
CBG-5616: Correct USE INDEX hints for QueryPrincipals 

### DIFF
--- a/db/indexes.go
+++ b/db/indexes.go
@@ -482,6 +482,16 @@ func replaceIndexTokensQuery(statement string, idx SGIndex, numPartitions uint32
 	return strings.Replace(statement, indexToken, idx.fullIndexName(numPartitions), -1)
 }
 
+// replaceIndexTokensQueryMultiIdx is replaceIndexTokensQuery for a query that hints more than one
+// index, so N1QL can union-scan them.
+func replaceIndexTokensQueryMultiIdx(statement string, idxs []SGIndex, numPartitions uint32) string {
+	indexNames := make([]string, 0, len(idxs))
+	for _, idx := range idxs {
+		indexNames = append(indexNames, idx.fullIndexName(numPartitions))
+	}
+	return strings.Replace(statement, indexToken, strings.Join(indexNames, ","), -1)
+}
+
 // GetIndexName returns names of the indexes that would be created for specific options.
 func GetIndexNames(options InitializeIndexOptions, indexDefs map[SGIndexType]SGIndex) []string {
 	indexNames := make([]string, 0)

--- a/db/indextest/indextest_test.go
+++ b/db/indextest/indextest_test.go
@@ -141,6 +141,14 @@ func TestAllPrincipalIDs(t *testing.T) {
 				userStatement, _ := database.BuildUsersQuery("", 0)
 				requireCoveredQuery(t, database, userStatement, !testCase.useLegacySyncDocsIndex)
 			})
+			t.Run("principalsQueryScansPrincipalIndexes", func(t *testing.T) {
+				expectedIndexes := []string{"sg_users_x1", "sg_roles_x1"}
+				if testCase.useLegacySyncDocsIndex {
+					expectedIndexes = []string{"sg_syncDocs_x1"}
+				}
+				principalsStatement, params := database.BuildPrincipalsQuery("", 0)
+				requireQueryScansIndexes(t, database, principalsStatement, params, expectedIndexes)
+			})
 
 			authenticator := database.Authenticator(ctx)
 

--- a/db/indextest/util.go
+++ b/db/indextest/util.go
@@ -105,11 +105,14 @@ func requireQueryScansIndexes(t *testing.T, database *db.Database, statement str
 	plan, explainErr := n1QLStore.ExplainQuery(base.TestCtx(t), statement, params)
 	require.NoError(t, explainErr, "Error generating explain for %+v", statement)
 
-	planJSON, err := base.JSONMarshal(plan)
-	require.NoError(t, err)
-	hints, _ := plan["optimizer_hints"].(map[string]any)
-	_, hasHintErrors := hints["hints_with_error"]
-	require.False(t, hasHintErrors, "query hints an index that does not exist. Plan: %s", planJSON)
+	planJSON := base.MustJSONMarshal(t, plan)
+	var explain struct {
+		OptimizerHints struct {
+			HintsWithError []string `json:"hints_with_error"`
+		} `json:"optimizer_hints"`
+	}
+	require.NoError(t, base.JSONUnmarshal(planJSON, &explain))
+	require.Empty(t, explain.OptimizerHints.HintsWithError, "query hints an index that does not exist. Plan: %s", planJSON)
 	require.ElementsMatch(t, expectedIndexes, db.ScannedIndexesFromPlan(plan), "Plan: %s", planJSON)
 }
 

--- a/db/indextest/util.go
+++ b/db/indextest/util.go
@@ -96,6 +96,23 @@ func requireCoveredQuery(t *testing.T, database *db.Database, statement string, 
 	require.Equal(t, isCovered, covered, "query covered by index; expectedToBeCovered: %t, Plan: %s", isCovered, planJSON)
 }
 
+// requireQueryScansIndexes asserts the query is served by exactly the given indexes. A hint naming
+// a missing index is dropped by the server, so check the plan rather than the statement.
+func requireQueryScansIndexes(t *testing.T, database *db.Database, statement string, params map[string]any, expectedIndexes []string) {
+	t.Helper()
+	n1QLStore, ok := base.AsN1QLStore(database.MetadataStore)
+	require.True(t, ok)
+	plan, explainErr := n1QLStore.ExplainQuery(base.TestCtx(t), statement, params)
+	require.NoError(t, explainErr, "Error generating explain for %+v", statement)
+
+	planJSON, err := base.JSONMarshal(plan)
+	require.NoError(t, err)
+	hints, _ := plan["optimizer_hints"].(map[string]any)
+	_, hasHintErrors := hints["hints_with_error"]
+	require.False(t, hasHintErrors, "query hints an index that does not exist. Plan: %s", planJSON)
+	require.ElementsMatch(t, expectedIndexes, db.ScannedIndexesFromPlan(plan), "Plan: %s", planJSON)
+}
+
 // createOldNonXattrIndexes creates non-xattr SG indexes (e.g. sg_access_1) on each provided datastore,
 // simulating a bucket that was previously used with a non-xattr SG deployment.
 func createOldNonXattrIndexes(t *testing.T, datastores ...base.DataStore) {

--- a/db/query.go
+++ b/db/query.go
@@ -594,11 +594,6 @@ func (context *DatabaseContext) QueryPrincipals(ctx context.Context, startKey st
 		return context.ViewQueryWithStats(ctx, context.MetadataStore, DesignDocSyncGateway(), ViewPrincipals, opts)
 	}
 
-	queryStatement := replaceIndexTokensQuery(QueryPrincipals.statement, sgIndexes[IndexSyncDocs], context.numIndexPartitions())
-
-	params := make(map[string]any)
-	params[QueryParamStartKey] = startKey
-
 	// N1QL Query. context.MetadataStore is a dual-collection wrapper for an opted-in database.
 	// While its migration is in flight, query both keystores and merge in SG (LIMIT is handled
 	// internally by dualMetadataN1QLQuery). Once complete — or for a database that never opted in
@@ -608,15 +603,34 @@ func (context *DatabaseContext) QueryPrincipals(ctx context.Context, startKey st
 	metadataStore := context.MetadataStore
 	if ms, ok := metadataStore.(*base.MetadataStore); ok {
 		if !ms.MigrationComplete() {
+			queryStatement, params := context.BuildPrincipalsQuery(startKey, 0)
 			return dualMetadataN1QLQuery[PrincipalRow](ctx, ms, QueryPrincipals.name, queryStatement, params, base.RequestPlus, QueryPrincipals.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold, limit)
 		}
 		metadataStore = ms.Primary()
 	}
 
+	queryStatement, params := context.BuildPrincipalsQuery(startKey, limit)
+	return N1QLQueryWithStats(ctx, metadataStore, QueryPrincipals.name, queryStatement, params, base.RequestPlus, QueryPrincipals.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold)
+}
+
+// BuildPrincipalsQuery builds the query statement and query parameters for a Principals N1QL query.
+// Also used by unit tests to validate the query hints indexes that exist.
+func (context *DatabaseContext) BuildPrincipalsQuery(startKey string, limit int) (string, map[string]any) {
+	// This query spans user and role docs, so hint both principal indexes and let N1QL union scan
+	// them. A hint naming an index that was not created is dropped, giving a sequential scan.
+	principalIndexes := []SGIndex{sgIndexes[IndexUser], sgIndexes[IndexRole]}
+	if context.UseLegacySyncDocsIndex() {
+		principalIndexes = []SGIndex{sgIndexes[IndexSyncDocs]}
+	}
+	queryStatement := replaceIndexTokensQueryMultiIdx(QueryPrincipals.statement, principalIndexes, context.numIndexPartitions())
+
+	params := make(map[string]any)
+	params[QueryParamStartKey] = startKey
+
 	if limit > 0 {
 		queryStatement = fmt.Sprintf("%s LIMIT %d", queryStatement, limit)
 	}
-	return N1QLQueryWithStats(ctx, metadataStore, QueryPrincipals.name, queryStatement, params, base.RequestPlus, QueryPrincipals.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold)
+	return queryStatement, params
 }
 
 // Query to retrieve user details, using the syncDocs or users index

--- a/db/query.go
+++ b/db/query.go
@@ -576,7 +576,7 @@ func (c *DatabaseCollection) QueryResync(ctx context.Context, limit int, startSe
 	return c.QueryChannels(ctx, channels.UserStarChannel, startSeq, endSeq, limit, false)
 }
 
-// Query to retrieve the set of user and role doc ids, using the syncDocs index
+// Query to retrieve the set of user and role doc ids, using the syncDocs index or the user and role indexes
 func (context *DatabaseContext) QueryPrincipals(ctx context.Context, startKey string, limit int) (sgbucket.QueryResultIterator, error) {
 
 	// View Query

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -533,6 +533,30 @@ func IsCovered(plan map[string]any) bool {
 	return true
 }
 
+// ScannedIndexesFromPlan returns the indexes scanned by an EXPLAIN plan, traversing the nested
+// operators like IsCovered does. A query served without an index reports "#sequentialscan".
+func ScannedIndexesFromPlan(plan map[string]any) []string {
+	var indexes []string
+	if _, isOperator := plan["#operator"]; isOperator {
+		if indexName, ok := plan["index"].(string); ok {
+			indexes = append(indexes, indexName)
+		}
+	}
+	for _, value := range plan {
+		switch value := value.(type) {
+		case map[string]any:
+			indexes = append(indexes, ScannedIndexesFromPlan(value)...)
+		case []any:
+			for _, arrayValue := range value {
+				if jsonArrayValue, ok := arrayValue.(map[string]any); ok {
+					indexes = append(indexes, ScannedIndexesFromPlan(jsonArrayValue)...)
+				}
+			}
+		}
+	}
+	return indexes
+}
+
 // If certain environment variables are set, for example to turn on XATTR support, then update
 // the DatabaseContextOptions accordingly
 func AddOptionsFromEnvironmentVariables(dbcOptions *DatabaseContextOptions) {


### PR DESCRIPTION
CBG-5616

Fixes flake in `TestQueryPrincipalsDualMetadataStore/QueryPrincipals`

A test issue where `AllPrincipalIDs` could end up running a sequential scan because the `USE INDEX` hint was incorrectly referring to the legacy sync docs index for a dual metadata store instead of the user and role indexes.

There are no real-world codepaths that can run into this, since the code is gated behind a `UseViews` check - which is not compatible with the system scoped metadata feature so cannot be hit.

Commit message has more detail about the failure/test flake.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/1012/

<!--
Automated review runs on every non-draft PR raised from this repo (forks are not reviewed automatically).
  - Re-run it, or ask a follow-up, by commenting `@droid <question>`
  - Suppress it with the `droid-skip` label, or `WIP`/`DO NOT MERGE` in the title
-->
