### PR TITLE
CBG-4775: Skip re-validating unchanged OIDC providers on database config updates.

### DIFF
--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -102,45 +102,50 @@ type OIDCOptions struct {
 // fetched during the next config validation pass.
 //
 // A provider is marked when it is absent from existing, or when a discovery-relevant field differs
-// from the running definition - so a config update that leaves a provider untouched does not re-run
-// discovery against a provider that was already accepted. Pass a nil existing map on database
-// creation, where there is no prior config and every provider is therefore new.
-//
-// Assignment is unconditional: provider pointers can be shared with a running DatabaseContext and
-// merged in place by base.ConfigMerge, so a flag left over from an earlier pass must be cleared
-// rather than left standing.
+// from the currently-configured definition - so a config update that leaves a provider untouched
+// does not re-run discovery against a provider that was already accepted. Pass a nil existing map
+// on database creation, where there is no prior config and every provider is therefore new.
 //
 // This decides only "new or changed". Whether validation runs at all is governed separately by the
 // disable_oidc_validation query parameter, which is ANDed with this flag during config validation.
+//
+// A nil receiver is a no-op, so callers can invoke this unconditionally.
 func (opts *OIDCOptions) SetRevalidationFlags(existing OIDCProviderMap) {
 	if opts == nil {
+		// DbConfig.OIDCConfig is nil for any config with no "oidc" section - most databases, and
+		// every partial update whose body omits one - so this is a routine input, not an edge case.
 		return
 	}
 	for name, provider := range opts.Providers {
-		if provider == nil {
-			continue
-		}
-		// Indexing a nil map is safe and yields ok == false, so a nil existing map marks every
-		// provider as new - which is exactly the database-creation case.
-		existingProvider, ok := existing[name]
-		provider.ForceRevalidation = !ok || ProviderDiscoveryConfigChanged(existingProvider, provider)
+		// Indexing a nil or incomplete existing map yields a nil, which counts as new.
+		provider.setRevalidationFlag(existing[name])
 	}
 }
 
-// ProviderDiscoveryConfigChanged reports whether any field affecting OIDC discovery or issuer
-// validation differs between a currently-running provider and an incoming one.
+// setRevalidationFlag marks this provider for OIDC discovery validation when it is new - signalled
+// by a nil existing - or when a field affecting discovery or issuer validation differs from the
+// currently-configured definition. A nil receiver is a no-op.
 //
-// InsecureSkipVerify is deliberately excluded: it is stamped server-side at database load from
-// Options.UnsupportedOptions.OidcTlsSkipVerify and is never present in a request body, so comparing
-// it would report every provider as changed whenever that option is enabled.
-func ProviderDiscoveryConfigChanged(existing, incoming *OIDCProvider) bool {
-	if existing == nil || incoming == nil {
-		return true
+// The assignment is unconditional so a flag left over from an earlier validation pass is cleared
+// rather than left standing: provider pointers can be shared with a running DatabaseContext and
+// merged in place by base.ConfigMerge.
+//
+// InsecureSkipVerify is deliberately excluded from the comparison: it is stamped server-side at
+// database load from Options.UnsupportedOptions.OidcTlsSkipVerify and is never present in a request
+// body, so comparing it would report every provider as changed whenever that option is enabled.
+func (op *OIDCProvider) setRevalidationFlag(existing *OIDCProvider) {
+	if op == nil {
+		// {"providers": {"myprovider": null}} unmarshals to a nil provider - nothing to mark.
+		return
 	}
-	return existing.Issuer != incoming.Issuer ||
-		existing.DiscoveryURI != incoming.DiscoveryURI ||
-		existing.DisableConfigValidation != incoming.DisableConfigValidation ||
-		base.ValDefault(existing.ClientID, "") != base.ValDefault(incoming.ClientID, "")
+	if existing == nil {
+		op.ForceRevalidation = true
+		return
+	}
+	op.ForceRevalidation = existing.Issuer != op.Issuer ||
+		existing.DiscoveryURI != op.DiscoveryURI ||
+		existing.DisableConfigValidation != op.DisableConfigValidation ||
+		base.ValDefault(existing.ClientID, "") != base.ValDefault(op.ClientID, "")
 }
 
 // OIDCClient represents client configurations to authenticate end-users

--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -188,11 +188,11 @@ type OIDCProvider struct {
 	// enabled by default.
 	InsecureSkipVerify bool
 
-	// SkipValidation is used internally during config validation to indicate this provider is
+	// ForceRevalidation is used internally during config validation to indicate this provider is
 	// already known/unchanged and does not need its discovery/issuer info re-checked on this
 	// validation pass. Defaults to false, so a provider validates by default unless something
 	// explicitly marks it as already-known. It must not be configurable or persisted.
-	SkipValidation bool `json:"-"`
+	ForceRevalidation bool `json:"-"`
 }
 
 type OIDCProviderMap map[string]*OIDCProvider

--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -109,22 +109,30 @@ type OIDCOptions struct {
 // This decides only "new or changed". Whether validation runs at all is governed separately by the
 // disable_oidc_validation query parameter, which is ANDed with this flag during config validation.
 //
+// A provider with no definition at all - {"providers": {"myprovider": null}} - is rejected rather
+// than skipped, so a caller cannot submit one and have it silently dropped when the database loads.
 // A nil receiver is a no-op, so callers can invoke this unconditionally.
-func (opts *OIDCOptions) SetRevalidationFlags(existing OIDCProviderMap) {
+func (opts *OIDCOptions) SetRevalidationFlags(existing OIDCProviderMap) error {
 	if opts == nil {
 		// DbConfig.OIDCConfig is nil for any config with no "oidc" section - most databases, and
 		// every partial update whose body omits one - so this is a routine input, not an edge case.
-		return
+		return nil
 	}
+	var multiError *base.MultiError
 	for name, provider := range opts.Providers {
+		if provider == nil {
+			multiError = multiError.Append(fmt.Errorf("OpenID Connect provider %q has no definition", name))
+			continue
+		}
 		// Indexing a nil or incomplete existing map yields a nil, which counts as new.
 		provider.setRevalidationFlag(existing[name])
 	}
+	return multiError.ErrorOrNil()
 }
 
 // setRevalidationFlag marks this provider for OIDC discovery validation when it is new - signalled
 // by a nil existing - or when a field affecting discovery or issuer validation differs from the
-// currently-configured definition. A nil receiver is a no-op.
+// currently-configured definition.
 //
 // The assignment is unconditional so a flag left over from an earlier validation pass is cleared
 // rather than left standing: provider pointers can be shared with a running DatabaseContext and
@@ -134,10 +142,6 @@ func (opts *OIDCOptions) SetRevalidationFlags(existing OIDCProviderMap) {
 // database load from Options.UnsupportedOptions.OidcTlsSkipVerify and is never present in a request
 // body, so comparing it would report every provider as changed whenever that option is enabled.
 func (op *OIDCProvider) setRevalidationFlag(existing *OIDCProvider) {
-	if op == nil {
-		// {"providers": {"myprovider": null}} unmarshals to a nil provider - nothing to mark.
-		return
-	}
 	if existing == nil {
 		op.ForceRevalidation = true
 		return

--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -98,6 +98,51 @@ type OIDCOptions struct {
 	DefaultProvider *string         `json:"default_provider,omitempty"` // Issuer used when not specified by client
 }
 
+// SetRevalidationFlags marks which of the configured providers need their OIDC discovery document
+// fetched during the next config validation pass.
+//
+// A provider is marked when it is absent from existing, or when a discovery-relevant field differs
+// from the running definition - so a config update that leaves a provider untouched does not re-run
+// discovery against a provider that was already accepted. Pass a nil existing map on database
+// creation, where there is no prior config and every provider is therefore new.
+//
+// Assignment is unconditional: provider pointers can be shared with a running DatabaseContext and
+// merged in place by base.ConfigMerge, so a flag left over from an earlier pass must be cleared
+// rather than left standing.
+//
+// This decides only "new or changed". Whether validation runs at all is governed separately by the
+// disable_oidc_validation query parameter, which is ANDed with this flag during config validation.
+func (opts *OIDCOptions) SetRevalidationFlags(existing OIDCProviderMap) {
+	if opts == nil {
+		return
+	}
+	for name, provider := range opts.Providers {
+		if provider == nil {
+			continue
+		}
+		// Indexing a nil map is safe and yields ok == false, so a nil existing map marks every
+		// provider as new - which is exactly the database-creation case.
+		existingProvider, ok := existing[name]
+		provider.ForceRevalidation = !ok || ProviderDiscoveryConfigChanged(existingProvider, provider)
+	}
+}
+
+// ProviderDiscoveryConfigChanged reports whether any field affecting OIDC discovery or issuer
+// validation differs between a currently-running provider and an incoming one.
+//
+// InsecureSkipVerify is deliberately excluded: it is stamped server-side at database load from
+// Options.UnsupportedOptions.OidcTlsSkipVerify and is never present in a request body, so comparing
+// it would report every provider as changed whenever that option is enabled.
+func ProviderDiscoveryConfigChanged(existing, incoming *OIDCProvider) bool {
+	if existing == nil || incoming == nil {
+		return true
+	}
+	return existing.Issuer != incoming.Issuer ||
+		existing.DiscoveryURI != incoming.DiscoveryURI ||
+		existing.DisableConfigValidation != incoming.DisableConfigValidation ||
+		base.ValDefault(existing.ClientID, "") != base.ValDefault(incoming.ClientID, "")
+}
+
 // OIDCClient represents client configurations to authenticate end-users
 // with an OpenID Connect provider.
 type OIDCClient struct {
@@ -188,10 +233,15 @@ type OIDCProvider struct {
 	// enabled by default.
 	InsecureSkipVerify bool
 
-	// ForceRevalidation is used internally during config validation to indicate this provider is
-	// already known/unchanged and does not need its discovery/issuer info re-checked on this
-	// validation pass. Defaults to false, so a provider validates by default unless something
-	// explicitly marks it as already-known. It must not be configurable or persisted.
+	// ForceRevalidation records whether this provider's OIDC discovery document must be re-fetched
+	// during the next config validation pass. It is set by OIDCOptions.SetRevalidationFlags
+	// immediately before validation runs, and is true only for providers that are new or whose
+	// discovery-relevant fields changed - so an unrelated config update does not re-run discovery
+	// against providers that were already accepted.
+	//
+	// Defaults to false, so any config-validation path that does not call SetRevalidationFlags
+	// performs no network discovery. json:"-" keeps it out of persisted configs and off the admin
+	// API surface; it must never be user-settable.
 	ForceRevalidation bool `json:"-"`
 }
 

--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -187,6 +187,10 @@ type OIDCProvider struct {
 	// should be disabled for this provider. TLS certificate verification is
 	// enabled by default.
 	InsecureSkipVerify bool
+
+	// ShouldValidate will be used during config validation. This will determine
+	// if the provider should be validated or not
+	ShouldValidate bool
 }
 
 type OIDCProviderMap map[string]*OIDCProvider

--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -188,9 +188,11 @@ type OIDCProvider struct {
 	// enabled by default.
 	InsecureSkipVerify bool
 
-	// ShouldValidate will be used during config validation. This will determine
-	// if the provider should be validated or not
-	ShouldValidate bool
+	// SkipValidation is used internally during config validation to indicate this provider is
+	// already known/unchanged and does not need its discovery/issuer info re-checked on this
+	// validation pass. Defaults to false, so a provider validates by default unless something
+	// explicitly marks it as already-known. It must not be configurable or persisted.
+	SkipValidation bool `json:"-"`
 }
 
 type OIDCProviderMap map[string]*OIDCProvider

--- a/auth/oidc_test.go
+++ b/auth/oidc_test.go
@@ -1257,3 +1257,153 @@ func TestJWTRolesChannels(t *testing.T) {
 		})
 	}
 }
+
+// TestSetRevalidationFlags covers the per-provider "new or changed" decision that gates OIDC
+// discovery during config validation. The nil-existing case is database creation, where every
+// provider is new by definition.
+func TestSetRevalidationFlags(t *testing.T) {
+	// newProvider builds a provider with the discovery-relevant fields populated, so each test case
+	// can vary exactly one of them.
+	newProvider := func() *OIDCProvider {
+		return &OIDCProvider{
+			JWTConfigCommon: JWTConfigCommon{
+				Issuer:   "https://issuer.example.com",
+				ClientID: base.Ptr("client-id"),
+			},
+			DiscoveryURI:            "https://issuer.example.com/.well-known/openid-configuration",
+			DisableConfigValidation: false,
+		}
+	}
+
+	tests := []struct {
+		name     string
+		existing OIDCProviderMap
+		incoming func() *OIDCProvider
+		expected bool
+	}{
+		{
+			name:     "nil existing map treats every provider as new",
+			existing: nil,
+			incoming: newProvider,
+			expected: true,
+		},
+		{
+			name:     "empty existing map treats every provider as new",
+			existing: OIDCProviderMap{},
+			incoming: newProvider,
+			expected: true,
+		},
+		{
+			name:     "provider absent by name is new",
+			existing: OIDCProviderMap{"other": newProvider()},
+			incoming: newProvider,
+			expected: true,
+		},
+		{
+			name:     "unchanged provider is not revalidated",
+			existing: OIDCProviderMap{"provider": newProvider()},
+			incoming: newProvider,
+			expected: false,
+		},
+		{
+			name:     "changed issuer forces revalidation",
+			existing: OIDCProviderMap{"provider": newProvider()},
+			incoming: func() *OIDCProvider {
+				p := newProvider()
+				p.Issuer = "https://other.example.com"
+				return p
+			},
+			expected: true,
+		},
+		{
+			name:     "changed discovery URI forces revalidation",
+			existing: OIDCProviderMap{"provider": newProvider()},
+			incoming: func() *OIDCProvider {
+				p := newProvider()
+				p.DiscoveryURI = "https://other.example.com/.well-known/openid-configuration"
+				return p
+			},
+			expected: true,
+		},
+		{
+			name:     "changed client ID forces revalidation",
+			existing: OIDCProviderMap{"provider": newProvider()},
+			incoming: func() *OIDCProvider {
+				p := newProvider()
+				p.ClientID = base.Ptr("other-client-id")
+				return p
+			},
+			expected: true,
+		},
+		{
+			name:     "changed disable_cfg_validation forces revalidation",
+			existing: OIDCProviderMap{"provider": newProvider()},
+			incoming: func() *OIDCProvider {
+				p := newProvider()
+				p.DisableConfigValidation = true
+				return p
+			},
+			expected: true,
+		},
+		{
+			name: "InsecureSkipVerify is excluded from the comparison",
+			existing: OIDCProviderMap{"provider": func() *OIDCProvider {
+				// Populated server-side at database load, never present on an incoming provider.
+				p := newProvider()
+				p.InsecureSkipVerify = true
+				return p
+			}()},
+			incoming: newProvider,
+			expected: false,
+		},
+		{
+			name:     "stale true is cleared for an unchanged provider",
+			existing: OIDCProviderMap{"provider": newProvider()},
+			incoming: func() *OIDCProvider {
+				p := newProvider()
+				p.ForceRevalidation = true // left over from an earlier validation pass
+				return p
+			},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			incoming := test.incoming()
+			opts := &OIDCOptions{Providers: OIDCProviderMap{"provider": incoming}}
+			opts.SetRevalidationFlags(test.existing)
+			assert.Equal(t, test.expected, incoming.ForceRevalidation)
+		})
+	}
+}
+
+// TestSetRevalidationFlagsNilSafety covers the nil inputs the config paths can genuinely produce:
+// a request body with no "oidc" key at all, and a providers map containing an explicit null.
+func TestSetRevalidationFlagsNilSafety(t *testing.T) {
+	t.Run("nil receiver", func(t *testing.T) {
+		var opts *OIDCOptions
+		require.NotPanics(t, func() { opts.SetRevalidationFlags(nil) })
+	})
+
+	t.Run("nil providers map", func(t *testing.T) {
+		opts := &OIDCOptions{}
+		require.NotPanics(t, func() { opts.SetRevalidationFlags(nil) })
+	})
+
+	t.Run("nil provider value is skipped", func(t *testing.T) {
+		opts := &OIDCOptions{Providers: OIDCProviderMap{"provider": nil}}
+		require.NotPanics(t, func() { opts.SetRevalidationFlags(nil) })
+	})
+}
+
+// TestProviderDiscoveryConfigChangedNilHandling checks that a missing provider on either side is
+// reported as changed, so a nil can never be mistaken for "unchanged" and silently skip validation.
+func TestProviderDiscoveryConfigChangedNilHandling(t *testing.T) {
+	provider := &OIDCProvider{
+		JWTConfigCommon: JWTConfigCommon{Issuer: "https://issuer.example.com", ClientID: base.Ptr("client-id")},
+	}
+	assert.True(t, ProviderDiscoveryConfigChanged(nil, provider))
+	assert.True(t, ProviderDiscoveryConfigChanged(provider, nil))
+	assert.True(t, ProviderDiscoveryConfigChanged(nil, nil))
+}

--- a/auth/oidc_test.go
+++ b/auth/oidc_test.go
@@ -1379,7 +1379,7 @@ func TestSetRevalidationFlags(t *testing.T) {
 }
 
 // TestSetRevalidationFlagsNilSafety covers the nil inputs the config paths can genuinely produce:
-// a request body with no "oidc" key at all, and a providers map containing an explicit null.
+// a config with no "oidc" section at all, and a providers map containing an explicit null.
 func TestSetRevalidationFlagsNilSafety(t *testing.T) {
 	t.Run("nil receiver", func(t *testing.T) {
 		var opts *OIDCOptions
@@ -1395,15 +1395,4 @@ func TestSetRevalidationFlagsNilSafety(t *testing.T) {
 		opts := &OIDCOptions{Providers: OIDCProviderMap{"provider": nil}}
 		require.NotPanics(t, func() { opts.SetRevalidationFlags(nil) })
 	})
-}
-
-// TestProviderDiscoveryConfigChangedNilHandling checks that a missing provider on either side is
-// reported as changed, so a nil can never be mistaken for "unchanged" and silently skip validation.
-func TestProviderDiscoveryConfigChangedNilHandling(t *testing.T) {
-	provider := &OIDCProvider{
-		JWTConfigCommon: JWTConfigCommon{Issuer: "https://issuer.example.com", ClientID: base.Ptr("client-id")},
-	}
-	assert.True(t, ProviderDiscoveryConfigChanged(nil, provider))
-	assert.True(t, ProviderDiscoveryConfigChanged(provider, nil))
-	assert.True(t, ProviderDiscoveryConfigChanged(nil, nil))
 }

--- a/auth/oidc_test.go
+++ b/auth/oidc_test.go
@@ -1372,27 +1372,38 @@ func TestSetRevalidationFlags(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			incoming := test.incoming()
 			opts := &OIDCOptions{Providers: OIDCProviderMap{"provider": incoming}}
-			opts.SetRevalidationFlags(test.existing)
+			require.NoError(t, opts.SetRevalidationFlags(test.existing))
 			assert.Equal(t, test.expected, incoming.ForceRevalidation)
 		})
 	}
 }
 
-// TestSetRevalidationFlagsNilSafety covers the nil inputs the config paths can genuinely produce:
-// a config with no "oidc" section at all, and a providers map containing an explicit null.
+// TestSetRevalidationFlagsNilSafety covers the nil inputs the config paths can genuinely produce.
+// A config with no "oidc" section at all is accepted as a no-op; a provider with no definition is
+// rejected rather than silently dropped.
 func TestSetRevalidationFlagsNilSafety(t *testing.T) {
 	t.Run("nil receiver", func(t *testing.T) {
 		var opts *OIDCOptions
-		require.NotPanics(t, func() { opts.SetRevalidationFlags(nil) })
+		require.NoError(t, opts.SetRevalidationFlags(nil))
 	})
 
 	t.Run("nil providers map", func(t *testing.T) {
 		opts := &OIDCOptions{}
-		require.NotPanics(t, func() { opts.SetRevalidationFlags(nil) })
+		require.NoError(t, opts.SetRevalidationFlags(nil))
 	})
 
-	t.Run("nil provider value is skipped", func(t *testing.T) {
+	t.Run("nil provider value is rejected", func(t *testing.T) {
 		opts := &OIDCOptions{Providers: OIDCProviderMap{"provider": nil}}
-		require.NotPanics(t, func() { opts.SetRevalidationFlags(nil) })
+		err := opts.SetRevalidationFlags(nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "provider")
+	})
+
+	t.Run("nil provider alongside a valid one is rejected", func(t *testing.T) {
+		valid := &OIDCProvider{
+			JWTConfigCommon: JWTConfigCommon{Issuer: "https://issuer.example.com", ClientID: base.Ptr("client-id")},
+		}
+		opts := &OIDCOptions{Providers: OIDCProviderMap{"valid": valid, "broken": nil}}
+		require.Error(t, opts.SetRevalidationFlags(nil))
 	})
 }

--- a/db/database.go
+++ b/db/database.go
@@ -790,21 +790,6 @@ func (context *DatabaseContext) GetOIDCProvider(providerName string) (*auth.OIDC
 	}
 }
 
-// ConfiguredOIDCProviders returns the OIDC providers this database was loaded with, exactly as
-// supplied in its config. Returns nil when the database has no OIDC configured.
-//
-// Prefer this over OIDCProviders when the question is "what was this database already configured
-// with". OIDCProviders is built in StartOnlineProcesses, so it is nil while the database is offline
-// and it omits providers skipped at load for having no issuer or client ID. Keying config
-// comparisons on this instead keeps their behaviour identical online and offline. For providers
-// present in both, the two maps hold the same pointers.
-func (context *DatabaseContext) ConfiguredOIDCProviders() auth.OIDCProviderMap {
-	if context.Options.OIDCOptions == nil {
-		return nil
-	}
-	return context.Options.OIDCOptions.Providers
-}
-
 // _stopOnlineProcesses is called to represent an error condition from startOnlineProcesses, or from DatabaseContext.Close. Most of the objects are not safe to close twice, since they have internal terminator objects and goroutines that wait on closed channels. Acquire the bucket lock, to avoid calling this function multiple times.
 func (db *DatabaseContext) _stopOnlineProcesses(ctx context.Context) {
 	db.mutationListener.Stop(ctx)

--- a/db/database.go
+++ b/db/database.go
@@ -790,35 +790,6 @@ func (context *DatabaseContext) GetOIDCProvider(providerName string) (*auth.OIDC
 	}
 }
 
-// OIDCValidationRequired marks providers that are new to this database's current config, or whose
-// discovery-relevant fields changed in place, as needing (re-)validation on this pass - e.g. when
-// removing one provider, another unchanged, already-accepted provider shouldn't have its
-// discovery/issuer info re-checked just because the config as a whole is being updated. An
-// unchanged, already-known provider is left at its default of not requiring validation.
-func (context *DatabaseContext) OIDCValidationRequired(oidcConfig *auth.OIDCOptions) {
-	if oidcConfig == nil {
-		return
-	}
-	for name, provider := range oidcConfig.Providers {
-		if provider == nil {
-			continue
-		}
-		existing, ok := context.OIDCProviders[name]
-		if !ok || oidcProviderDiscoveryConfigChanged(existing, provider) {
-			provider.ForceRevalidation = true
-		}
-	}
-}
-
-// oidcProviderDiscoveryConfigChanged reports whether any field that affects OIDC discovery/issuer
-// validation differs between the currently running provider and the incoming one.
-func oidcProviderDiscoveryConfigChanged(existing, incoming *auth.OIDCProvider) bool {
-	return existing.Issuer != incoming.Issuer ||
-		existing.DiscoveryURI != incoming.DiscoveryURI ||
-		existing.DisableConfigValidation != incoming.DisableConfigValidation ||
-		base.ValDefault(existing.ClientID, "") != base.ValDefault(incoming.ClientID, "")
-}
-
 // _stopOnlineProcesses is called to represent an error condition from startOnlineProcesses, or from DatabaseContext.Close. Most of the objects are not safe to close twice, since they have internal terminator objects and goroutines that wait on closed channels. Acquire the bucket lock, to avoid calling this function multiple times.
 func (db *DatabaseContext) _stopOnlineProcesses(ctx context.Context) {
 	db.mutationListener.Stop(ctx)
@@ -2506,6 +2477,12 @@ func (db *DatabaseContext) StartOnlineProcesses(ctx context.Context) (returnedEr
 		db.OIDCProviders = make(auth.OIDCProviderMap)
 
 		for name, provider := range db.Options.OIDCOptions.Providers {
+			if provider == nil {
+				// An explicit null in the providers map unmarshals to a nil provider. DbConfig.validate
+				// skips these too, but a config pairing one with a valid provider still passes validation.
+				base.WarnfCtx(ctx, "No provider definition for %q - skipping", base.UD(name))
+				continue
+			}
 			if provider.Issuer == "" || base.ValDefault(provider.ClientID, "") == "" {
 				// TODO: this duplicates a check in DbConfig.validate to avoid a backwards compatibility issue
 				base.WarnfCtx(ctx, "Issuer and Client ID not defined for provider %q - skipping", base.UD(name))

--- a/db/database.go
+++ b/db/database.go
@@ -785,11 +785,11 @@ func (context *DatabaseContext) GetOIDCProvider(providerName string) (*auth.OIDC
 	}
 }
 
-// OIDCValidationRequired marks providers that are already known to this database's current
-// config, and materially unchanged, as not needing re-validation - e.g. when removing one
-// provider, another unchanged, already-accepted provider shouldn't have its discovery/issuer
-// info re-checked just because the config as a whole is being updated. A provider that's new, or
-// whose discovery-relevant fields changed in place, is still validated.
+// OIDCValidationRequired marks providers that are new to this database's current config, or whose
+// discovery-relevant fields changed in place, as needing (re-)validation on this pass - e.g. when
+// removing one provider, another unchanged, already-accepted provider shouldn't have its
+// discovery/issuer info re-checked just because the config as a whole is being updated. An
+// unchanged, already-known provider is left at its default of not requiring validation.
 func (context *DatabaseContext) OIDCValidationRequired(oidcConfig *auth.OIDCOptions) {
 	if oidcConfig == nil {
 		return
@@ -799,8 +799,8 @@ func (context *DatabaseContext) OIDCValidationRequired(oidcConfig *auth.OIDCOpti
 			continue
 		}
 		existing, ok := context.OIDCProviders[name]
-		if ok && !oidcProviderDiscoveryConfigChanged(existing, provider) {
-			provider.SkipValidation = true
+		if !ok || oidcProviderDiscoveryConfigChanged(existing, provider) {
+			provider.ForceRevalidation = true
 		}
 	}
 }
@@ -810,7 +810,6 @@ func (context *DatabaseContext) OIDCValidationRequired(oidcConfig *auth.OIDCOpti
 func oidcProviderDiscoveryConfigChanged(existing, incoming *auth.OIDCProvider) bool {
 	return existing.Issuer != incoming.Issuer ||
 		existing.DiscoveryURI != incoming.DiscoveryURI ||
-		existing.InsecureSkipVerify != incoming.InsecureSkipVerify ||
 		existing.DisableConfigValidation != incoming.DisableConfigValidation ||
 		base.ValDefault(existing.ClientID, "") != base.ValDefault(incoming.ClientID, "")
 }

--- a/db/database.go
+++ b/db/database.go
@@ -785,15 +785,34 @@ func (context *DatabaseContext) GetOIDCProvider(providerName string) (*auth.OIDC
 	}
 }
 
+// OIDCValidationRequired marks providers that are already known to this database's current
+// config, and materially unchanged, as not needing re-validation - e.g. when removing one
+// provider, another unchanged, already-accepted provider shouldn't have its discovery/issuer
+// info re-checked just because the config as a whole is being updated. A provider that's new, or
+// whose discovery-relevant fields changed in place, is still validated.
 func (context *DatabaseContext) OIDCValidationRequired(oidcConfig *auth.OIDCOptions) {
 	if oidcConfig == nil {
 		return
 	}
 	for name, provider := range oidcConfig.Providers {
-		if _, ok := context.OIDCProviders[name]; !ok {
-			provider.ShouldValidate = true
+		if provider == nil {
+			continue
+		}
+		existing, ok := context.OIDCProviders[name]
+		if ok && !oidcProviderDiscoveryConfigChanged(existing, provider) {
+			provider.SkipValidation = true
 		}
 	}
+}
+
+// oidcProviderDiscoveryConfigChanged reports whether any field that affects OIDC discovery/issuer
+// validation differs between the currently running provider and the incoming one.
+func oidcProviderDiscoveryConfigChanged(existing, incoming *auth.OIDCProvider) bool {
+	return existing.Issuer != incoming.Issuer ||
+		existing.DiscoveryURI != incoming.DiscoveryURI ||
+		existing.InsecureSkipVerify != incoming.InsecureSkipVerify ||
+		existing.DisableConfigValidation != incoming.DisableConfigValidation ||
+		base.ValDefault(existing.ClientID, "") != base.ValDefault(incoming.ClientID, "")
 }
 
 // _stopOnlineProcesses is called to represent an error condition from startOnlineProcesses, or from DatabaseContext.Close. Most of the objects are not safe to close twice, since they have internal terminator objects and goroutines that wait on closed channels. Acquire the bucket lock, to avoid calling this function multiple times.

--- a/db/database.go
+++ b/db/database.go
@@ -790,15 +790,34 @@ func (context *DatabaseContext) GetOIDCProvider(providerName string) (*auth.OIDC
 	}
 }
 
+// OIDCValidationRequired marks providers that are already known to this database's current
+// config, and materially unchanged, as not needing re-validation - e.g. when removing one
+// provider, another unchanged, already-accepted provider shouldn't have its discovery/issuer
+// info re-checked just because the config as a whole is being updated. A provider that's new, or
+// whose discovery-relevant fields changed in place, is still validated.
 func (context *DatabaseContext) OIDCValidationRequired(oidcConfig *auth.OIDCOptions) {
 	if oidcConfig == nil {
 		return
 	}
 	for name, provider := range oidcConfig.Providers {
-		if _, ok := context.OIDCProviders[name]; !ok {
-			provider.ShouldValidate = true
+		if provider == nil {
+			continue
+		}
+		existing, ok := context.OIDCProviders[name]
+		if ok && !oidcProviderDiscoveryConfigChanged(existing, provider) {
+			provider.SkipValidation = true
 		}
 	}
+}
+
+// oidcProviderDiscoveryConfigChanged reports whether any field that affects OIDC discovery/issuer
+// validation differs between the currently running provider and the incoming one.
+func oidcProviderDiscoveryConfigChanged(existing, incoming *auth.OIDCProvider) bool {
+	return existing.Issuer != incoming.Issuer ||
+		existing.DiscoveryURI != incoming.DiscoveryURI ||
+		existing.InsecureSkipVerify != incoming.InsecureSkipVerify ||
+		existing.DisableConfigValidation != incoming.DisableConfigValidation ||
+		base.ValDefault(existing.ClientID, "") != base.ValDefault(incoming.ClientID, "")
 }
 
 // _stopOnlineProcesses is called to represent an error condition from startOnlineProcesses, or from DatabaseContext.Close. Most of the objects are not safe to close twice, since they have internal terminator objects and goroutines that wait on closed channels. Acquire the bucket lock, to avoid calling this function multiple times.

--- a/db/database.go
+++ b/db/database.go
@@ -785,6 +785,19 @@ func (context *DatabaseContext) GetOIDCProvider(providerName string) (*auth.OIDC
 	}
 }
 
+func (context *DatabaseContext) IsOIDCProviderRemoved(oidcConfig *auth.OIDCOptions) bool {
+	providerRemoved := false
+	existingProviderLen := len(context.OIDCProviders)
+	newProviderLen := len(context.OIDCProviders)
+	lenDiff := newProviderLen < existingProviderLen
+	for _, provider := range context.OIDCProviders {
+		if _, ok := oidcConfig.Providers[provider.Name]; ok && lenDiff {
+			providerRemoved = true
+		}
+	}
+	return providerRemoved
+}
+
 // _stopOnlineProcesses is called to represent an error condition from startOnlineProcesses, or from DatabaseContext.Close. Most of the objects are not safe to close twice, since they have internal terminator objects and goroutines that wait on closed channels. Acquire the bucket lock, to avoid calling this function multiple times.
 func (db *DatabaseContext) _stopOnlineProcesses(ctx context.Context) {
 	db.mutationListener.Stop(ctx)

--- a/db/database.go
+++ b/db/database.go
@@ -790,11 +790,11 @@ func (context *DatabaseContext) GetOIDCProvider(providerName string) (*auth.OIDC
 	}
 }
 
-// OIDCValidationRequired marks providers that are already known to this database's current
-// config, and materially unchanged, as not needing re-validation - e.g. when removing one
-// provider, another unchanged, already-accepted provider shouldn't have its discovery/issuer
-// info re-checked just because the config as a whole is being updated. A provider that's new, or
-// whose discovery-relevant fields changed in place, is still validated.
+// OIDCValidationRequired marks providers that are new to this database's current config, or whose
+// discovery-relevant fields changed in place, as needing (re-)validation on this pass - e.g. when
+// removing one provider, another unchanged, already-accepted provider shouldn't have its
+// discovery/issuer info re-checked just because the config as a whole is being updated. An
+// unchanged, already-known provider is left at its default of not requiring validation.
 func (context *DatabaseContext) OIDCValidationRequired(oidcConfig *auth.OIDCOptions) {
 	if oidcConfig == nil {
 		return
@@ -804,8 +804,8 @@ func (context *DatabaseContext) OIDCValidationRequired(oidcConfig *auth.OIDCOpti
 			continue
 		}
 		existing, ok := context.OIDCProviders[name]
-		if ok && !oidcProviderDiscoveryConfigChanged(existing, provider) {
-			provider.SkipValidation = true
+		if !ok || oidcProviderDiscoveryConfigChanged(existing, provider) {
+			provider.ForceRevalidation = true
 		}
 	}
 }
@@ -815,7 +815,6 @@ func (context *DatabaseContext) OIDCValidationRequired(oidcConfig *auth.OIDCOpti
 func oidcProviderDiscoveryConfigChanged(existing, incoming *auth.OIDCProvider) bool {
 	return existing.Issuer != incoming.Issuer ||
 		existing.DiscoveryURI != incoming.DiscoveryURI ||
-		existing.InsecureSkipVerify != incoming.InsecureSkipVerify ||
 		existing.DisableConfigValidation != incoming.DisableConfigValidation ||
 		base.ValDefault(existing.ClientID, "") != base.ValDefault(incoming.ClientID, "")
 }

--- a/db/database.go
+++ b/db/database.go
@@ -790,6 +790,21 @@ func (context *DatabaseContext) GetOIDCProvider(providerName string) (*auth.OIDC
 	}
 }
 
+// ConfiguredOIDCProviders returns the OIDC providers this database was loaded with, exactly as
+// supplied in its config. Returns nil when the database has no OIDC configured.
+//
+// Prefer this over OIDCProviders when the question is "what was this database already configured
+// with". OIDCProviders is built in StartOnlineProcesses, so it is nil while the database is offline
+// and it omits providers skipped at load for having no issuer or client ID. Keying config
+// comparisons on this instead keeps their behaviour identical online and offline. For providers
+// present in both, the two maps hold the same pointers.
+func (context *DatabaseContext) ConfiguredOIDCProviders() auth.OIDCProviderMap {
+	if context.Options.OIDCOptions == nil {
+		return nil
+	}
+	return context.Options.OIDCOptions.Providers
+}
+
 // _stopOnlineProcesses is called to represent an error condition from startOnlineProcesses, or from DatabaseContext.Close. Most of the objects are not safe to close twice, since they have internal terminator objects and goroutines that wait on closed channels. Acquire the bucket lock, to avoid calling this function multiple times.
 func (db *DatabaseContext) _stopOnlineProcesses(ctx context.Context) {
 	db.mutationListener.Stop(ctx)
@@ -2480,12 +2495,12 @@ func (db *DatabaseContext) StartOnlineProcesses(ctx context.Context) (returnedEr
 			if provider == nil {
 				// An explicit null in the providers map unmarshals to a nil provider. DbConfig.validate
 				// skips these too, but a config pairing one with a valid provider still passes validation.
-				base.WarnfCtx(ctx, "No provider definition for %q - skipping", base.UD(name))
+				base.WarnfCtx(ctx, "No provider definition for %q - skipping provider", base.UD(name))
 				continue
 			}
 			if provider.Issuer == "" || base.ValDefault(provider.ClientID, "") == "" {
 				// TODO: this duplicates a check in DbConfig.validate to avoid a backwards compatibility issue
-				base.WarnfCtx(ctx, "Issuer and Client ID not defined for provider %q - skipping", base.UD(name))
+				base.WarnfCtx(ctx, "Issuer and Client ID not defined for provider %q - skipping provider", base.UD(name))
 				continue
 			}
 			provider.Name = name

--- a/db/database.go
+++ b/db/database.go
@@ -790,6 +790,19 @@ func (context *DatabaseContext) GetOIDCProvider(providerName string) (*auth.OIDC
 	}
 }
 
+func (context *DatabaseContext) IsOIDCProviderRemoved(oidcConfig *auth.OIDCOptions) bool {
+	providerRemoved := false
+	existingProviderLen := len(context.OIDCProviders)
+	newProviderLen := len(context.OIDCProviders)
+	lenDiff := newProviderLen < existingProviderLen
+	for _, provider := range context.OIDCProviders {
+		if _, ok := oidcConfig.Providers[provider.Name]; ok && lenDiff {
+			providerRemoved = true
+		}
+	}
+	return providerRemoved
+}
+
 // _stopOnlineProcesses is called to represent an error condition from startOnlineProcesses, or from DatabaseContext.Close. Most of the objects are not safe to close twice, since they have internal terminator objects and goroutines that wait on closed channels. Acquire the bucket lock, to avoid calling this function multiple times.
 func (db *DatabaseContext) _stopOnlineProcesses(ctx context.Context) {
 	db.mutationListener.Stop(ctx)

--- a/db/database.go
+++ b/db/database.go
@@ -785,17 +785,15 @@ func (context *DatabaseContext) GetOIDCProvider(providerName string) (*auth.OIDC
 	}
 }
 
-func (context *DatabaseContext) IsOIDCProviderRemoved(oidcConfig *auth.OIDCOptions) bool {
-	providerRemoved := false
-	existingProviderLen := len(context.OIDCProviders)
-	newProviderLen := len(context.OIDCProviders)
-	lenDiff := newProviderLen < existingProviderLen
-	for _, provider := range context.OIDCProviders {
-		if _, ok := oidcConfig.Providers[provider.Name]; ok && lenDiff {
-			providerRemoved = true
+func (context *DatabaseContext) OIDCValidationRequired(oidcConfig *auth.OIDCOptions) {
+	if oidcConfig == nil {
+		return
+	}
+	for name, provider := range oidcConfig.Providers {
+		if _, ok := context.OIDCProviders[name]; !ok {
+			provider.ShouldValidate = true
 		}
 	}
-	return providerRemoved
 }
 
 // _stopOnlineProcesses is called to represent an error condition from startOnlineProcesses, or from DatabaseContext.Close. Most of the objects are not safe to close twice, since they have internal terminator objects and goroutines that wait on closed channels. Acquire the bucket lock, to avoid calling this function multiple times.

--- a/db/database.go
+++ b/db/database.go
@@ -790,17 +790,15 @@ func (context *DatabaseContext) GetOIDCProvider(providerName string) (*auth.OIDC
 	}
 }
 
-func (context *DatabaseContext) IsOIDCProviderRemoved(oidcConfig *auth.OIDCOptions) bool {
-	providerRemoved := false
-	existingProviderLen := len(context.OIDCProviders)
-	newProviderLen := len(context.OIDCProviders)
-	lenDiff := newProviderLen < existingProviderLen
-	for _, provider := range context.OIDCProviders {
-		if _, ok := oidcConfig.Providers[provider.Name]; ok && lenDiff {
-			providerRemoved = true
+func (context *DatabaseContext) OIDCValidationRequired(oidcConfig *auth.OIDCOptions) {
+	if oidcConfig == nil {
+		return
+	}
+	for name, provider := range oidcConfig.Providers {
+		if _, ok := context.OIDCProviders[name]; !ok {
+			provider.ShouldValidate = true
 		}
 	}
-	return providerRemoved
 }
 
 // _stopOnlineProcesses is called to represent an error condition from startOnlineProcesses, or from DatabaseContext.Close. Most of the objects are not safe to close twice, since they have internal terminator objects and goroutines that wait on closed channels. Acquire the bucket lock, to avoid calling this function multiple times.

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -64,8 +64,7 @@ func (h *handler) handleCreateDB() error {
 		}
 
 		validateReplications := true
-		oidcProvidersRemoved := false
-		if err := config.validate(h.ctx(), validateOIDC, validateReplications, oidcProvidersRemoved); err != nil {
+		if err := config.validate(h.ctx(), validateOIDC, validateReplications); err != nil {
 			return base.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
 
@@ -940,10 +939,10 @@ func (h *handler) handlePutDbConfig() (err error) {
 
 	validateOIDC := !h.getBoolQuery(paramDisableOIDCValidation)
 
-	providerRemoved := h.db.IsOIDCProviderRemoved(dbConfig.OIDCConfig)
+	h.db.OIDCValidationRequired(dbConfig.OIDCConfig)
 
 	validateReplications := true
-	err = dbConfig.validate(h.ctx(), validateOIDC, validateReplications, providerRemoved)
+	err = dbConfig.validate(h.ctx(), validateOIDC, validateReplications)
 	if err != nil {
 		return base.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
@@ -1395,8 +1394,7 @@ func (h *handler) handlePutCollectionConfigSync() error {
 		}
 
 		validateReplications := false
-		providersRemoved := false
-		if err := bucketDbConfig.validate(h.ctx(), !h.getBoolQuery(paramDisableOIDCValidation), validateReplications, providersRemoved); err != nil {
+		if err := bucketDbConfig.validate(h.ctx(), !h.getBoolQuery(paramDisableOIDCValidation), validateReplications); err != nil {
 			return nil, base.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
 
@@ -1546,8 +1544,7 @@ func (h *handler) handlePutCollectionConfigImportFilter() error {
 		}
 
 		validateReplications := false
-		providersRemoved := false
-		if err := bucketDbConfig.validate(h.ctx(), !h.getBoolQuery(paramDisableOIDCValidation), validateReplications, false); err != nil {
+		if err := bucketDbConfig.validate(h.ctx(), !h.getBoolQuery(paramDisableOIDCValidation), validateReplications); err != nil {
 			return nil, base.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
 

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -64,7 +64,8 @@ func (h *handler) handleCreateDB() error {
 		}
 
 		validateReplications := true
-		if err := config.validate(h.ctx(), validateOIDC, validateReplications); err != nil {
+		oidcProvidersRemoved := false
+		if err := config.validate(h.ctx(), validateOIDC, validateReplications, oidcProvidersRemoved); err != nil {
 			return base.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
 
@@ -939,8 +940,10 @@ func (h *handler) handlePutDbConfig() (err error) {
 
 	validateOIDC := !h.getBoolQuery(paramDisableOIDCValidation)
 
+	providerRemoved := h.db.IsOIDCProviderRemoved(dbConfig.OIDCConfig)
+
 	validateReplications := true
-	err = dbConfig.validate(h.ctx(), validateOIDC, validateReplications)
+	err = dbConfig.validate(h.ctx(), validateOIDC, validateReplications, providerRemoved)
 	if err != nil {
 		return base.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
@@ -1392,7 +1395,8 @@ func (h *handler) handlePutCollectionConfigSync() error {
 		}
 
 		validateReplications := false
-		if err := bucketDbConfig.validate(h.ctx(), !h.getBoolQuery(paramDisableOIDCValidation), validateReplications); err != nil {
+		providersRemoved := false
+		if err := bucketDbConfig.validate(h.ctx(), !h.getBoolQuery(paramDisableOIDCValidation), validateReplications, providersRemoved); err != nil {
 			return nil, base.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
 
@@ -1542,7 +1546,8 @@ func (h *handler) handlePutCollectionConfigImportFilter() error {
 		}
 
 		validateReplications := false
-		if err := bucketDbConfig.validate(h.ctx(), !h.getBoolQuery(paramDisableOIDCValidation), validateReplications); err != nil {
+		providersRemoved := false
+		if err := bucketDbConfig.validate(h.ctx(), !h.getBoolQuery(paramDisableOIDCValidation), validateReplications, false); err != nil {
 			return nil, base.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
 

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -945,14 +945,6 @@ func (h *handler) handlePutDbConfig() (err error) {
 
 	validateOIDC := !h.getBoolQuery(paramDisableOIDCValidation)
 
-	// Mark only the providers that are new or changed relative to the database's current config, so
-	// an update that leaves a provider untouched does not re-run discovery against it. Compared
-	// against the configured providers rather than the running ones, so an unchanged provider is
-	// skipped identically whether the database is online or offline.
-	if err := dbConfig.OIDCConfig.SetRevalidationFlags(h.db.ConfiguredOIDCProviders()); err != nil {
-		return base.NewHTTPError(http.StatusBadRequest, err.Error())
-	}
-
 	validateReplications := true
 	err = dbConfig.validate(h.ctx(), validateOIDC, validateReplications)
 	if err != nil {
@@ -979,6 +971,21 @@ func (h *handler) handlePutDbConfig() (err error) {
 		previousCollectionMap := bucketDbConfig.Scopes.CollectionMap()
 		previousAuditEnabled, _ = oldBucketDbConfig.IsAuditLoggingEnabled()
 
+		// Snapshot the persisted providers before the merge below, to compare against when deciding
+		// which providers need revalidating. This has to be a deep copy: oldBucketDbConfig is a
+		// shallow copy, so on a POST its provider map is the same one ConfigMerge mutates in place,
+		// and every provider would then compare as unchanged.
+		//
+		// The persisted config is the right basis rather than this node's loaded one - another node
+		// may have updated the config in the bucket and this node not polled it yet, which would
+		// otherwise mean comparing against a stale view.
+		var persistedOIDCProviders auth.OIDCProviderMap
+		if oldBucketDbConfig.OIDCConfig != nil {
+			if err := base.DeepCopyInefficient(&persistedOIDCProviders, oldBucketDbConfig.OIDCConfig.Providers); err != nil {
+				return nil, err
+			}
+		}
+
 		if h.rq.Method == http.MethodPost {
 			base.TracefCtx(h.ctx(), base.KeyConfig, "merging upserted config into bucket config")
 			if err := base.ConfigMerge(&bucketDbConfig.DbConfig, dbConfig); err != nil {
@@ -998,17 +1005,10 @@ func (h *handler) handlePutDbConfig() (err error) {
 		if err := dbConfig.validatePersistentDbConfig(); err != nil {
 			return nil, base.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
-		// Recompute against this database's configured providers now that the merge has happened, so
-		// this does not depend on base.ConfigMerge's pointer semantics to carry the flags across.
-		// Idempotent on the PUT path (same pointers, same answer), and it also catches a provider
-		// present in the bucket config but not in this node's loaded config - one added by a peer
-		// node since this node loaded.
-		//
-		// Compare against the database's own config, never oldBucketDbConfig: that is a shallow copy
-		// taken before ConfigMerge, so on a POST it aliases the merged provider map and every
-		// provider would compare as unchanged, silently disabling revalidation. h.db is captured at
-		// request start, so it stays stable across CAS retries of this closure.
-		if err := bucketDbConfig.OIDCConfig.SetRevalidationFlags(h.db.ConfiguredOIDCProviders()); err != nil {
+		// Mark only the providers that are new or changed relative to the persisted config, so an
+		// update that leaves a provider untouched does not re-run discovery against it. Done on the
+		// merged config, so on a POST it also covers providers carried over from the bucket.
+		if err := bucketDbConfig.OIDCConfig.SetRevalidationFlags(persistedOIDCProviders); err != nil {
 			return nil, base.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
 

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -64,8 +64,7 @@ func (h *handler) handleCreateDB() error {
 		}
 
 		validateReplications := true
-		oidcProvidersRemoved := false
-		if err := config.validate(h.ctx(), validateOIDC, validateReplications, oidcProvidersRemoved); err != nil {
+		if err := config.validate(h.ctx(), validateOIDC, validateReplications); err != nil {
 			return base.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
 
@@ -939,10 +938,10 @@ func (h *handler) handlePutDbConfig() (err error) {
 
 	validateOIDC := !h.getBoolQuery(paramDisableOIDCValidation)
 
-	providerRemoved := h.db.IsOIDCProviderRemoved(dbConfig.OIDCConfig)
+	h.db.OIDCValidationRequired(dbConfig.OIDCConfig)
 
 	validateReplications := true
-	err = dbConfig.validate(h.ctx(), validateOIDC, validateReplications, providerRemoved)
+	err = dbConfig.validate(h.ctx(), validateOIDC, validateReplications)
 	if err != nil {
 		return base.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
@@ -1394,8 +1393,7 @@ func (h *handler) handlePutCollectionConfigSync() error {
 		}
 
 		validateReplications := false
-		providersRemoved := false
-		if err := bucketDbConfig.validate(h.ctx(), !h.getBoolQuery(paramDisableOIDCValidation), validateReplications, providersRemoved); err != nil {
+		if err := bucketDbConfig.validate(h.ctx(), !h.getBoolQuery(paramDisableOIDCValidation), validateReplications); err != nil {
 			return nil, base.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
 
@@ -1545,8 +1543,7 @@ func (h *handler) handlePutCollectionConfigImportFilter() error {
 		}
 
 		validateReplications := false
-		providersRemoved := false
-		if err := bucketDbConfig.validate(h.ctx(), !h.getBoolQuery(paramDisableOIDCValidation), validateReplications, false); err != nil {
+		if err := bucketDbConfig.validate(h.ctx(), !h.getBoolQuery(paramDisableOIDCValidation), validateReplications); err != nil {
 			return nil, base.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
 

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -64,7 +64,8 @@ func (h *handler) handleCreateDB() error {
 		}
 
 		validateReplications := true
-		if err := config.validate(h.ctx(), validateOIDC, validateReplications); err != nil {
+		oidcProvidersRemoved := false
+		if err := config.validate(h.ctx(), validateOIDC, validateReplications, oidcProvidersRemoved); err != nil {
 			return base.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
 
@@ -938,8 +939,10 @@ func (h *handler) handlePutDbConfig() (err error) {
 
 	validateOIDC := !h.getBoolQuery(paramDisableOIDCValidation)
 
+	providerRemoved := h.db.IsOIDCProviderRemoved(dbConfig.OIDCConfig)
+
 	validateReplications := true
-	err = dbConfig.validate(h.ctx(), validateOIDC, validateReplications)
+	err = dbConfig.validate(h.ctx(), validateOIDC, validateReplications, providerRemoved)
 	if err != nil {
 		return base.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
@@ -1391,7 +1394,8 @@ func (h *handler) handlePutCollectionConfigSync() error {
 		}
 
 		validateReplications := false
-		if err := bucketDbConfig.validate(h.ctx(), !h.getBoolQuery(paramDisableOIDCValidation), validateReplications); err != nil {
+		providersRemoved := false
+		if err := bucketDbConfig.validate(h.ctx(), !h.getBoolQuery(paramDisableOIDCValidation), validateReplications, providersRemoved); err != nil {
 			return nil, base.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
 
@@ -1541,7 +1545,8 @@ func (h *handler) handlePutCollectionConfigImportFilter() error {
 		}
 
 		validateReplications := false
-		if err := bucketDbConfig.validate(h.ctx(), !h.getBoolQuery(paramDisableOIDCValidation), validateReplications); err != nil {
+		providersRemoved := false
+		if err := bucketDbConfig.validate(h.ctx(), !h.getBoolQuery(paramDisableOIDCValidation), validateReplications, false); err != nil {
 			return nil, base.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
 

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -943,13 +943,11 @@ func (h *handler) handlePutDbConfig() (err error) {
 
 	validateOIDC := !h.getBoolQuery(paramDisableOIDCValidation)
 
-	// Mark only the providers that are new or changed relative to the running database, so an update
-	// that leaves a provider untouched does not re-run discovery against it.
-	//
-	// h.db.OIDCProviders is populated by StartOnlineProcesses, so it is nil for an offline database
-	// and every provider is then treated as new. That is conservative, and matches the behaviour
-	// before per-provider revalidation was introduced.
-	dbConfig.OIDCConfig.SetRevalidationFlags(h.db.OIDCProviders)
+	// Mark only the providers that are new or changed relative to the database's current config, so
+	// an update that leaves a provider untouched does not re-run discovery against it. Compared
+	// against the configured providers rather than the running ones, so an unchanged provider is
+	// skipped identically whether the database is online or offline.
+	dbConfig.OIDCConfig.SetRevalidationFlags(h.db.ConfiguredOIDCProviders())
 
 	validateReplications := true
 	err = dbConfig.validate(h.ctx(), validateOIDC, validateReplications)
@@ -996,17 +994,17 @@ func (h *handler) handlePutDbConfig() (err error) {
 		if err := dbConfig.validatePersistentDbConfig(); err != nil {
 			return nil, base.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
-		// Recompute against the running providers now that the merge has happened, so this does not
-		// depend on base.ConfigMerge's pointer semantics to carry the flags across. Idempotent on
-		// the PUT path (same pointers, same answer), and it also catches a provider present in the
-		// bucket config but not in this node's running database - one added by a peer node since
-		// this node loaded its config.
+		// Recompute against this database's configured providers now that the merge has happened, so
+		// this does not depend on base.ConfigMerge's pointer semantics to carry the flags across.
+		// Idempotent on the PUT path (same pointers, same answer), and it also catches a provider
+		// present in the bucket config but not in this node's loaded config - one added by a peer
+		// node since this node loaded.
 		//
-		// Compare against h.db.OIDCProviders, never oldBucketDbConfig: that is a shallow copy taken
-		// before ConfigMerge, so on a POST it aliases the merged provider map and every provider
-		// would compare as unchanged, silently disabling revalidation. h.db is captured at request
-		// start, so it stays stable across CAS retries of this closure.
-		bucketDbConfig.OIDCConfig.SetRevalidationFlags(h.db.OIDCProviders)
+		// Compare against the database's own config, never oldBucketDbConfig: that is a shallow copy
+		// taken before ConfigMerge, so on a POST it aliases the merged provider map and every
+		// provider would compare as unchanged, silently disabling revalidation. h.db is captured at
+		// request start, so it stays stable across CAS retries of this closure.
+		bucketDbConfig.OIDCConfig.SetRevalidationFlags(h.db.ConfiguredOIDCProviders())
 
 		if err := bucketDbConfig.validateConfigUpdate(h.ctx(), oldBucketDbConfig, validateOIDC); err != nil {
 			return nil, base.NewHTTPError(http.StatusBadRequest, err.Error())

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -63,6 +63,10 @@ func (h *handler) handleCreateDB() error {
 			return base.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
 
+		// No database exists yet, so there is nothing to compare against: a nil existing map marks
+		// every provider as new, leaving OIDC validation governed solely by disable_oidc_validation.
+		config.OIDCConfig.SetRevalidationFlags(nil)
+
 		validateReplications := true
 		if err := config.validate(h.ctx(), validateOIDC, validateReplications); err != nil {
 			return base.NewHTTPError(http.StatusBadRequest, err.Error())
@@ -939,7 +943,13 @@ func (h *handler) handlePutDbConfig() (err error) {
 
 	validateOIDC := !h.getBoolQuery(paramDisableOIDCValidation)
 
-	h.db.OIDCValidationRequired(dbConfig.OIDCConfig)
+	// Mark only the providers that are new or changed relative to the running database, so an update
+	// that leaves a provider untouched does not re-run discovery against it.
+	//
+	// h.db.OIDCProviders is populated by StartOnlineProcesses, so it is nil for an offline database
+	// and every provider is then treated as new. That is conservative, and matches the behaviour
+	// before per-provider revalidation was introduced.
+	dbConfig.OIDCConfig.SetRevalidationFlags(h.db.OIDCProviders)
 
 	validateReplications := true
 	err = dbConfig.validate(h.ctx(), validateOIDC, validateReplications)
@@ -986,6 +996,18 @@ func (h *handler) handlePutDbConfig() (err error) {
 		if err := dbConfig.validatePersistentDbConfig(); err != nil {
 			return nil, base.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
+		// Recompute against the running providers now that the merge has happened, so this does not
+		// depend on base.ConfigMerge's pointer semantics to carry the flags across. Idempotent on
+		// the PUT path (same pointers, same answer), and it also catches a provider present in the
+		// bucket config but not in this node's running database - one added by a peer node since
+		// this node loaded its config.
+		//
+		// Compare against h.db.OIDCProviders, never oldBucketDbConfig: that is a shallow copy taken
+		// before ConfigMerge, so on a POST it aliases the merged provider map and every provider
+		// would compare as unchanged, silently disabling revalidation. h.db is captured at request
+		// start, so it stays stable across CAS retries of this closure.
+		bucketDbConfig.OIDCConfig.SetRevalidationFlags(h.db.OIDCProviders)
+
 		if err := bucketDbConfig.validateConfigUpdate(h.ctx(), oldBucketDbConfig, validateOIDC); err != nil {
 			return nil, base.NewHTTPError(http.StatusBadRequest, err.Error())
 		}

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -65,7 +65,9 @@ func (h *handler) handleCreateDB() error {
 
 		// No database exists yet, so there is nothing to compare against: a nil existing map marks
 		// every provider as new, leaving OIDC validation governed solely by disable_oidc_validation.
-		config.OIDCConfig.SetRevalidationFlags(nil)
+		if err := config.OIDCConfig.SetRevalidationFlags(nil); err != nil {
+			return base.NewHTTPError(http.StatusBadRequest, err.Error())
+		}
 
 		validateReplications := true
 		if err := config.validate(h.ctx(), validateOIDC, validateReplications); err != nil {
@@ -947,7 +949,9 @@ func (h *handler) handlePutDbConfig() (err error) {
 	// an update that leaves a provider untouched does not re-run discovery against it. Compared
 	// against the configured providers rather than the running ones, so an unchanged provider is
 	// skipped identically whether the database is online or offline.
-	dbConfig.OIDCConfig.SetRevalidationFlags(h.db.ConfiguredOIDCProviders())
+	if err := dbConfig.OIDCConfig.SetRevalidationFlags(h.db.ConfiguredOIDCProviders()); err != nil {
+		return base.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
 
 	validateReplications := true
 	err = dbConfig.validate(h.ctx(), validateOIDC, validateReplications)
@@ -1004,7 +1008,9 @@ func (h *handler) handlePutDbConfig() (err error) {
 		// taken before ConfigMerge, so on a POST it aliases the merged provider map and every
 		// provider would compare as unchanged, silently disabling revalidation. h.db is captured at
 		// request start, so it stays stable across CAS retries of this closure.
-		bucketDbConfig.OIDCConfig.SetRevalidationFlags(h.db.ConfiguredOIDCProviders())
+		if err := bucketDbConfig.OIDCConfig.SetRevalidationFlags(h.db.ConfiguredOIDCProviders()); err != nil {
+			return nil, base.NewHTTPError(http.StatusBadRequest, err.Error())
+		}
 
 		if err := bucketDbConfig.validateConfigUpdate(h.ctx(), oldBucketDbConfig, validateOIDC); err != nil {
 			return nil, base.NewHTTPError(http.StatusBadRequest, err.Error())

--- a/rest/config.go
+++ b/rest/config.go
@@ -750,11 +750,11 @@ func (dbConfig *DbConfig) validateChanges(ctx context.Context, old DbConfig) err
 }
 
 // validate checks the DbConfig for any invalid or unsupported values and return a http error. If validateReplications is true, return an error if any replications are not valid. Otherwise issue a warning.
-func (dbConfig *DbConfig) validate(ctx context.Context, validateOIDCConfig, validateReplications, providersRemoved bool) error {
-	return dbConfig.validateVersion(ctx, base.IsEnterpriseEdition(), validateOIDCConfig, validateReplications, providersRemoved)
+func (dbConfig *DbConfig) validate(ctx context.Context, validateOIDCConfig, validateReplications bool) error {
+	return dbConfig.validateVersion(ctx, base.IsEnterpriseEdition(), validateOIDCConfig, validateReplications)
 }
 
-func (dbConfig *DbConfig) validateVersion(ctx context.Context, isEnterpriseEdition, validateOIDCConfig, validateReplications, providersRemoved bool) error {
+func (dbConfig *DbConfig) validateVersion(ctx context.Context, isEnterpriseEdition, validateOIDCConfig, validateReplications bool) error {
 
 	var multiError *base.MultiError
 	// Make sure a non-zero compact_interval_days config is within the valid range
@@ -965,7 +965,7 @@ func (dbConfig *DbConfig) validateVersion(ctx context.Context, isEnterpriseEditi
 				continue
 			}
 			seenIssuers[oidc.Issuer]++
-			if validateOIDCConfig {
+			if validateOIDCConfig && oidc.ShouldValidate {
 				_, _, err := oidc.DiscoverConfig(ctx)
 				if err != nil {
 					multiError = multiError.Append(fmt.Errorf("failed to validate OIDC configuration for %s: %w", name, err))
@@ -973,7 +973,7 @@ func (dbConfig *DbConfig) validateVersion(ctx context.Context, isEnterpriseEditi
 				}
 			}
 		}
-		if validProviders == 0 && !providerRemoved {
+		if validProviders == 0 {
 			multiError = multiError.Append(fmt.Errorf("OpenID Connect defined in config, but no valid providers specified"))
 		}
 	}

--- a/rest/config.go
+++ b/rest/config.go
@@ -950,14 +950,14 @@ func (dbConfig *DbConfig) validateVersion(ctx context.Context, isEnterpriseEditi
 		validProviders := len(dbConfig.OIDCConfig.Providers)
 		for name, oidc := range dbConfig.OIDCConfig.Providers {
 			if oidc == nil {
-				base.WarnfCtx(ctx, "No provider definition for %q - skipping", base.UD(name))
+				base.WarnfCtx(ctx, "No provider definition for %q - skipping validation", base.UD(name))
 				validProviders--
 				continue
 			}
 			if oidc.Issuer == "" || base.ValDefault(oidc.ClientID, "") == "" {
 				// TODO: rather than being an error, this skips the current provider to avoid a backwards compatibility issue (previously valid
 				// configs becoming invalid). This also means it's duplicated in NewDatabaseContext.
-				base.WarnfCtx(ctx, "Issuer and Client ID not defined for provider %q - skipping", base.UD(name))
+				base.WarnfCtx(ctx, "Issuer and Client ID not defined for provider %q - skipping validation", base.UD(name))
 				validProviders--
 				continue
 			}

--- a/rest/config.go
+++ b/rest/config.go
@@ -965,7 +965,7 @@ func (dbConfig *DbConfig) validateVersion(ctx context.Context, isEnterpriseEditi
 				continue
 			}
 			seenIssuers[oidc.Issuer]++
-			if validateOIDCConfig && oidc.ShouldValidate {
+			if validateOIDCConfig && !oidc.SkipValidation {
 				_, _, err := oidc.DiscoverConfig(ctx)
 				if err != nil {
 					multiError = multiError.Append(fmt.Errorf("failed to validate OIDC configuration for %s: %w", name, err))

--- a/rest/config.go
+++ b/rest/config.go
@@ -965,7 +965,7 @@ func (dbConfig *DbConfig) validateVersion(ctx context.Context, isEnterpriseEditi
 				continue
 			}
 			seenIssuers[oidc.Issuer]++
-			if validateOIDCConfig && !oidc.SkipValidation {
+			if validateOIDCConfig && oidc.ForceRevalidation {
 				_, _, err := oidc.DiscoverConfig(ctx)
 				if err != nil {
 					multiError = multiError.Append(fmt.Errorf("failed to validate OIDC configuration for %s: %w", name, err))

--- a/rest/config.go
+++ b/rest/config.go
@@ -750,11 +750,11 @@ func (dbConfig *DbConfig) validateChanges(ctx context.Context, old DbConfig) err
 }
 
 // validate checks the DbConfig for any invalid or unsupported values and return a http error. If validateReplications is true, return an error if any replications are not valid. Otherwise issue a warning.
-func (dbConfig *DbConfig) validate(ctx context.Context, validateOIDCConfig, validateReplications bool) error {
-	return dbConfig.validateVersion(ctx, base.IsEnterpriseEdition(), validateOIDCConfig, validateReplications)
+func (dbConfig *DbConfig) validate(ctx context.Context, validateOIDCConfig, validateReplications, providersRemoved bool) error {
+	return dbConfig.validateVersion(ctx, base.IsEnterpriseEdition(), validateOIDCConfig, validateReplications, providersRemoved)
 }
 
-func (dbConfig *DbConfig) validateVersion(ctx context.Context, isEnterpriseEdition, validateOIDCConfig, validateReplications bool) error {
+func (dbConfig *DbConfig) validateVersion(ctx context.Context, isEnterpriseEdition, validateOIDCConfig, validateReplications, providersRemoved bool) error {
 
 	var multiError *base.MultiError
 	// Make sure a non-zero compact_interval_days config is within the valid range
@@ -973,7 +973,7 @@ func (dbConfig *DbConfig) validateVersion(ctx context.Context, isEnterpriseEditi
 				}
 			}
 		}
-		if validProviders == 0 {
+		if validProviders == 0 && !providerRemoved {
 			multiError = multiError.Append(fmt.Errorf("OpenID Connect defined in config, but no valid providers specified"))
 		}
 	}

--- a/rest/config.go
+++ b/rest/config.go
@@ -949,6 +949,11 @@ func (dbConfig *DbConfig) validateVersion(ctx context.Context, isEnterpriseEditi
 	if dbConfig.OIDCConfig != nil {
 		validProviders := len(dbConfig.OIDCConfig.Providers)
 		for name, oidc := range dbConfig.OIDCConfig.Providers {
+			if oidc == nil {
+				base.WarnfCtx(ctx, "No provider definition for %q - skipping", base.UD(name))
+				validProviders--
+				continue
+			}
 			if oidc.Issuer == "" || base.ValDefault(oidc.ClientID, "") == "" {
 				// TODO: rather than being an error, this skips the current provider to avoid a backwards compatibility issue (previously valid
 				// configs becoming invalid). This also means it's duplicated in NewDatabaseContext.

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -2929,6 +2929,47 @@ func newMockAuthServers(t *testing.T, names ...string) map[string]*mockAuthServe
 	return servers
 }
 
+// startProviderServer starts a mock OAuth2 server whose discovery document reports its issuer as
+// <url>/issuerName, and registers cleanup. A provider built with a different name against the same
+// server is therefore permanently invalid, since its issuer will never match what the server
+// answers as - see providerOn.
+func startProviderServer(t *testing.T, issuerName string) *mockAuthServer {
+	server, err := newMockAuthServer()
+	require.NoError(t, err, "Error creating mock oauth2 server")
+	server.Start()
+	t.Cleanup(server.Shutdown)
+	server.options.issuer = server.URL + "/" + issuerName
+	return server
+}
+
+// providerOn builds a provider named name whose issuer and discovery endpoint point at server.
+// Whether it validates depends on whether server was started with the same name.
+func providerOn(server *mockAuthServer, name string) *auth.OIDCProvider {
+	provider := mockProviderWith(name, mockProviderRegister{})
+	provider.Issuer = server.URL + "/" + name
+	provider.DiscoveryURI = auth.GetStandardDiscoveryEndpoint(provider.Issuer)
+	return provider
+}
+
+// updatePersistedConfig mutates the database config stored in the bucket without going through the
+// admin API, simulating a change made by another Sync Gateway node. The node under test keeps its
+// existing in-memory config, since nothing here triggers a reload.
+func updatePersistedConfig(t *testing.T, rt *RestTester, dbName string, mutator func(*DatabaseConfig)) {
+	sc := rt.ServerContext()
+	ctx := rt.Context()
+	_, err := sc.BootstrapContext.UpdateConfig(ctx, rt.Bucket().GetName(), sc.Config.Bootstrap.ConfigGroupID, dbName,
+		func(bucketDbConfig *DatabaseConfig) (*DatabaseConfig, error) {
+			mutator(bucketDbConfig)
+			version, err := GenerateDatabaseConfigVersionID(ctx, bucketDbConfig.Version, &bucketDbConfig.DbConfig)
+			if err != nil {
+				return nil, err
+			}
+			bucketDbConfig.Version = version
+			return bucketDbConfig, nil
+		})
+	require.NoError(t, err)
+}
+
 // makeProviderToken mints a JWT claiming to be issued by spec's own provider, signed by spec's own
 // mock server. Whether it actually authenticates depends on spec.truthful: a genuine mismatch
 // (truthful=false) makes real-time discovery fail regardless of any config-save-time validation skip.
@@ -3440,4 +3481,51 @@ func TestOIDCRevalidationConsistentWhenOffline(t *testing.T) {
 		Providers: auth.OIDCProviderMap{"provider1": changedProvider},
 	}
 	RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_config", string(base.MustJSONMarshal(t, &changedConfig))), http.StatusBadRequest)
+}
+
+// TestOIDCNoRevalidationForPeerAddedProvider asserts that a provider another node added to the
+// persisted config, which this node has not loaded yet, does not make an unrelated config update
+// re-run OIDC discovery.
+func TestOIDCNoRevalidationForPeerAddedProvider(t *testing.T) {
+	srv := startProviderServer(t, "other") // never answers as "peer"
+
+	rt := NewRestTester(t, &RestTesterConfig{PersistentConfig: true})
+	defer rt.Close()
+
+	// This node loads a database with no OIDC config at all.
+	RequireStatus(t, rt.CreateDatabase("db", rt.NewDbConfig()), http.StatusCreated)
+
+	// A peer node adds a provider whose discovery document contradicts its issuer.
+	updatePersistedConfig(t, rt, "db", func(cfg *DatabaseConfig) {
+		cfg.OIDCConfig = &auth.OIDCOptions{Providers: auth.OIDCProviderMap{"peer": providerOn(srv, "peer")}}
+	})
+	require.Nil(t, rt.GetDatabase().Options.OIDCOptions, "this node must still be unaware of the peer's provider")
+
+	// An update with nothing to do with OIDC must not be blocked by that provider.
+	unrelated := DbConfig{RevsLimit: base.Ptr(uint32(1234))}
+	RequireStatus(t, rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_config", string(base.MustJSONMarshal(t, &unrelated))), http.StatusCreated)
+}
+
+// TestOIDCRevalidationForProviderAbsentFromPersistedConfig asserts the other direction: a provider
+// that is new relative to the persisted config is validated, even when it happens to match a copy
+// this node still holds in memory.
+func TestOIDCRevalidationForProviderAbsentFromPersistedConfig(t *testing.T) {
+	srv := startProviderServer(t, "provider1")
+
+	rt := NewRestTester(t, &RestTesterConfig{PersistentConfig: true})
+	defer rt.Close()
+
+	dbConfig := rt.NewDbConfig()
+	dbConfig.OIDCConfig = &auth.OIDCOptions{Providers: auth.OIDCProviderMap{"provider1": providerOn(srv, "provider1")}}
+	RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
+
+	// A peer node removed the provider. This node has not polled for that yet, so it still holds it.
+	updatePersistedConfig(t, rt, "db", func(cfg *DatabaseConfig) { cfg.OIDCConfig = nil })
+	require.NotNil(t, rt.GetDatabase().Options.OIDCOptions, "this node must still hold the provider the peer removed")
+
+	// Discovery is now permanently broken for that provider.
+	srv.Shutdown()
+
+	// Re-adding it is an addition relative to the persisted config, so it must be validated - and fail.
+	RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_config", string(base.MustJSONMarshal(t, &dbConfig))), http.StatusBadRequest)
 }

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -3059,13 +3059,12 @@ func TestNoOIDCValidationOnRemoval(t *testing.T) {
 			tokens := make(map[string]string)
 
 			providers, defaultProvider := buildProviders(test.providers, servers)
-			oidcOptions := auth.OIDCOptions{
+
+			dbConfig := rt.NewDbConfig()
+			dbConfig.OIDCConfig = &auth.OIDCOptions{
 				Providers:       providers,
 				DefaultProvider: base.Ptr(defaultProvider),
 			}
-
-			dbConfig := rt.NewDbConfig()
-			dbConfig.OIDCConfig = &oidcOptions
 
 			// The invalid provider's issuer doesn't match its own discovery document (its mock server
 			// truthfully answers as a different provider), so validation must be disabled to allow
@@ -3077,7 +3076,7 @@ func TestNoOIDCValidationOnRemoval(t *testing.T) {
 			verifyProviderAuth(tt, rt, servers, test.providers, extraClaims, tokens)
 
 			updatedProviders, newDefaultProvider := buildProviders(test.updatedProviders, servers)
-			oidcOptions = auth.OIDCOptions{
+			dbConfig.OIDCConfig = &auth.OIDCOptions{
 				Providers:       updatedProviders,
 				DefaultProvider: base.Ptr(newDefaultProvider),
 			}
@@ -3128,12 +3127,12 @@ func TestCreateDBWithInvalidOIDCProvider(t *testing.T) {
 	RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusBadRequest)
 }
 
-// TestOIDCValidationSkippedOnInPlaceProviderChange demonstrates a gap in OIDCValidationRequired
-// (db/database.go): it only checks whether a provider's NAME is new, never whether an existing,
-// same-named provider's content (Issuer, DiscoveryURI, etc.) actually changed. So updating a
-// provider's issuer in-place - to something that no longer matches its own discovery document -
-// incorrectly skips re-validation, since the name alone is enough to mark it "already known".
-func TestOIDCValidationSkippedOnInPlaceProviderChange(t *testing.T) {
+// TestOIDCRevalidationOnInPlaceProviderChange verifies that changing an existing provider in place -
+// same name, but a discovery-relevant field altered - is re-validated rather than treated as
+// already-known. SetRevalidationFlags (auth/oidc.go) compares provider content, not just names, via
+// ProviderDiscoveryConfigChanged, so a changed Issuer must still be checked against its discovery
+// document even though the provider name was already present in the running config.
+func TestOIDCRevalidationOnInPlaceProviderChange(t *testing.T) {
 	mockAuthServer, err := newMockAuthServer()
 	require.NoError(t, err, "Error creating mock oauth2 server")
 	mockAuthServer.Start()
@@ -3154,9 +3153,8 @@ func TestOIDCValidationSkippedOnInPlaceProviderChange(t *testing.T) {
 	RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
 
 	// Update "provider1" in-place: same name, but the issuer now points somewhere that no longer
-	// matches what mockAuthServer actually answers as. The provider's content genuinely changed,
-	// so this should fail validation - but since OIDCValidationRequired only keys on the name, it
-	// wrongly treats "provider1" as already-known and skips re-validating it.
+	// matches what mockAuthServer actually answers as. The provider's content genuinely changed, so
+	// it must be re-validated and the update rejected.
 	changedProvider := mockProviderWith("provider1", mockProviderRegister{})
 	changedProvider.Issuer = mockAuthServer.URL + "/some-other-issuer"
 	changedProvider.DiscoveryURI = auth.GetStandardDiscoveryEndpoint(changedProvider.Issuer)
@@ -3171,9 +3169,10 @@ func TestOIDCValidationSkippedOnInPlaceProviderChange(t *testing.T) {
 
 // TestOIDCRevalidationSkippedWithTlsSkipVerify checks that resubmitting an OIDC provider's config
 // completely unchanged still succeeds, both with and without oidc_tls_skip_verify enabled.
-// existing.InsecureSkipVerify (db/database.go) is populated server-side from
-// db.Options.UnsupportedOptions.OidcTlsSkipVerify, but incoming.InsecureSkipVerify (parsed straight
-// from the request body) is never populated at all.
+// This is why ProviderDiscoveryConfigChanged (auth/oidc.go) deliberately excludes
+// InsecureSkipVerify: it is populated server-side from db.Options.UnsupportedOptions.OidcTlsSkipVerify
+// on the running provider, but is never populated on a provider parsed straight from a request body,
+// so comparing it would report every provider as changed whenever that option is enabled.
 func TestOIDCRevalidationSkippedWithTlsSkipVerify(t *testing.T) {
 	for _, oidcSkipTlsVerify := range []bool{true, false} {
 		t.Run(fmt.Sprintf("oidcSkipTlsVerify=%t", oidcSkipTlsVerify), func(t *testing.T) {
@@ -3224,9 +3223,9 @@ func TestOIDCRevalidationSkippedWithTlsSkipVerify(t *testing.T) {
 // TestOIDCValidationSkippedOnUnrelatedConfigUpsert checks that a database config update with
 // nothing to do with OIDC doesn't force revalidation of an existing, untouched provider.
 // A POST (upsert/merge) that doesn't mention "oidc" at all parses to a nil OIDCConfig, so
-// OIDCValidationRequired (db/database.go) has nothing to mark - but the existing provider still
-// gets merged back in from the persisted config and, since SkipRevalidation (json:"-") is never
-// persisted, defaults to false on every fresh deserialization regardless of history.
+// SetRevalidationFlags (auth/oidc.go) has nothing to mark on the incoming body. The existing
+// provider still gets merged back in from the persisted config, but it compares unchanged against
+// the running provider, so it is not re-validated as a side effect of an unrelated update.
 func TestOIDCValidationSkippedOnUnrelatedConfigUpsert(t *testing.T) {
 	mockAuthServer, err := newMockAuthServer()
 	require.NoError(t, err, "Error creating mock oauth2 server")
@@ -3251,10 +3250,166 @@ func TestOIDCValidationSkippedOnUnrelatedConfigUpsert(t *testing.T) {
 	RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/db/?disable_oidc_validation=true", string(base.MustJSONMarshal(t, &dbConfig))), http.StatusCreated)
 
 	// POST an update that's entirely unrelated to OIDC - the body has no "oidc" key at all, so
-	// OIDCValidationRequired has nothing to mark. The already-configured "invalidProvider" is
+	// SetRevalidationFlags has nothing to mark. The already-configured "invalidProvider" is
 	// merged back in unchanged and must not be re-validated as a side effect of this update.
 	unrelatedUpdate := DbConfig{
 		RevsLimit: base.Ptr(uint32(1000)),
 	}
 	RequireStatus(t, rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_config", string(base.MustJSONMarshal(t, &unrelatedUpdate))), http.StatusCreated)
+}
+
+// TestOIDCValidationSkippedOnSubResourceConfigUpdates checks that the sub-resource config endpoints -
+// sync function, import filter, and audit config - never re-run OIDC discovery. None of them can
+// change OIDC config, so none of them call SetRevalidationFlags, and ForceRevalidation therefore
+// stays at its default of false for every provider merged in from the persisted config. A database
+// carrying a provider whose discovery would fail must still accept all of these updates.
+func TestOIDCValidationSkippedOnSubResourceConfigUpdates(t *testing.T) {
+	mockAuthServer, err := newMockAuthServer()
+	require.NoError(t, err, "Error creating mock oauth2 server")
+	mockAuthServer.Start()
+	defer mockAuthServer.Shutdown()
+	mockAuthServer.options.issuer = mockAuthServer.URL + "/actual-issuer"
+
+	invalidProvider := mockProvider("invalidProvider")
+	invalidProvider.Issuer = mockAuthServer.URL + "/invalidProvider" // doesn't match mockAuthServer.options.issuer
+	invalidProvider.DiscoveryURI = auth.GetStandardDiscoveryEndpoint(invalidProvider.Issuer)
+
+	rt := NewRestTester(t, &RestTesterConfig{PersistentConfig: true})
+	defer rt.Close()
+
+	dbConfig := rt.NewDbConfig()
+	dbConfig.OIDCConfig = &auth.OIDCOptions{
+		Providers: auth.OIDCProviderMap{"invalidProvider": invalidProvider},
+	}
+
+	// disable_oidc_validation is required only to get the intentionally-invalid provider accepted at
+	// creation - it is deliberately not passed on any of the updates below.
+	RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/db/?disable_oidc_validation=true", string(base.MustJSONMarshal(t, &dbConfig))), http.StatusCreated)
+
+	// Make the discovery URL unreachable too, so any revalidation would fail loudly rather than
+	// merely mismatching.
+	mockAuthServer.Shutdown()
+
+	RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/_config/sync", `function(doc){channel(doc.channels);}`), http.StatusOK)
+	RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/_config/import_filter", `function(doc){return true;}`), http.StatusOK)
+	RequireStatus(t, rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_config/audit", `{"enabled":true}`), http.StatusOK)
+}
+
+// TestOIDCRevalidationSkippedOnIdenticalConfigResubmit checks the headline behaviour directly:
+// resubmitting a multi-provider config completely unchanged re-runs no discovery at all. The mock
+// servers are shut down before the update, so any provider that got revalidated would fail.
+func TestOIDCRevalidationSkippedOnIdenticalConfigResubmit(t *testing.T) {
+	servers := newMockAuthServers(t, "primary", "secondary")
+	servers["primary"].options.issuer = servers["primary"].URL + "/provider1"
+	servers["secondary"].options.issuer = servers["secondary"].URL + "/provider2"
+
+	buildConfig := func(rt *RestTester) *DbConfig {
+		provider1 := mockProviderWith("provider1", mockProviderRegister{})
+		provider1.Issuer = servers["primary"].URL + "/provider1"
+		provider1.DiscoveryURI = auth.GetStandardDiscoveryEndpoint(provider1.Issuer)
+
+		provider2 := mockProviderWith("provider2", mockProviderRegister{})
+		provider2.Issuer = servers["secondary"].URL + "/provider2"
+		provider2.DiscoveryURI = auth.GetStandardDiscoveryEndpoint(provider2.Issuer)
+
+		dbConfig := rt.NewDbConfig()
+		dbConfig.OIDCConfig = &auth.OIDCOptions{
+			Providers:       auth.OIDCProviderMap{"provider1": provider1, "provider2": provider2},
+			DefaultProvider: base.Ptr("provider1"),
+		}
+		return &dbConfig
+	}
+
+	rt := NewRestTester(t, &RestTesterConfig{PersistentConfig: true})
+	defer rt.Close()
+
+	// Both providers are valid, so creation validates them for real and succeeds.
+	RequireStatus(t, rt.CreateDatabase("db", *buildConfig(rt)), http.StatusCreated)
+
+	// Now make both discovery endpoints unreachable and resubmit the identical config. Nothing
+	// changed, so nothing should be revalidated.
+	servers["primary"].Shutdown()
+	servers["secondary"].Shutdown()
+
+	RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_config", string(base.MustJSONMarshal(t, buildConfig(rt)))), http.StatusCreated)
+}
+
+// TestOIDCNullProviderDefinition checks that an explicit null in the providers map is rejected or
+// skipped gracefully rather than panicking into a 500. A null unmarshals to a nil *OIDCProvider,
+// which both DbConfig.validate and the provider load in StartOnlineProcesses must tolerate - the
+// latter matters because a null paired with a valid provider still passes validation.
+func TestOIDCNullProviderDefinition(t *testing.T) {
+	mockAuthServer, err := newMockAuthServer()
+	require.NoError(t, err, "Error creating mock oauth2 server")
+	mockAuthServer.Start()
+	defer mockAuthServer.Shutdown()
+	mockAuthServer.options.issuer = mockAuthServer.URL + "/provider1"
+
+	validProvider := mockProviderWith("provider1", mockProviderRegister{})
+	validProvider.Issuer = mockAuthServer.URL + "/provider1"
+	validProvider.DiscoveryURI = auth.GetStandardDiscoveryEndpoint(validProvider.Issuer)
+
+	t.Run("null provider only", func(t *testing.T) {
+		rt := NewRestTester(t, &RestTesterConfig{PersistentConfig: true})
+		defer rt.Close()
+
+		dbConfig := rt.NewDbConfig()
+		dbConfig.OIDCConfig = &auth.OIDCOptions{
+			Providers: auth.OIDCProviderMap{"nullProvider": nil},
+		}
+
+		// The only provider is unusable, so validation reports no valid providers - a 400, not a 500.
+		RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusBadRequest)
+	})
+
+	t.Run("null provider alongside a valid one", func(t *testing.T) {
+		rt := NewRestTester(t, &RestTesterConfig{PersistentConfig: true})
+		defer rt.Close()
+
+		dbConfig := rt.NewDbConfig()
+		dbConfig.OIDCConfig = &auth.OIDCOptions{
+			Providers: auth.OIDCProviderMap{"provider1": validProvider, "nullProvider": nil},
+		}
+
+		// One provider is still valid, so validation passes and the database loads with the null
+		// entry skipped rather than dereferenced.
+		RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
+	})
+}
+
+// TestOIDCRevalidationOnOfflineDatabaseUpdate pins the behaviour for an offline database.
+// DatabaseContext.OIDCProviders is populated by StartOnlineProcesses, so it is nil while the
+// database is offline. SetRevalidationFlags then has nothing to compare against and marks every
+// provider as new, meaning an offline config update revalidates everything. That is conservative
+// rather than permissive, and matches the behaviour before per-provider revalidation existed.
+func TestOIDCRevalidationOnOfflineDatabaseUpdate(t *testing.T) {
+	mockAuthServer, err := newMockAuthServer()
+	require.NoError(t, err, "Error creating mock oauth2 server")
+	mockAuthServer.Start()
+	defer mockAuthServer.Shutdown()
+	mockAuthServer.options.issuer = mockAuthServer.URL + "/provider1"
+
+	provider := mockProviderWith("provider1", mockProviderRegister{})
+	provider.Issuer = mockAuthServer.URL + "/provider1"
+	provider.DiscoveryURI = auth.GetStandardDiscoveryEndpoint(provider.Issuer)
+
+	rt := NewRestTester(t, &RestTesterConfig{PersistentConfig: true})
+	defer rt.Close()
+
+	dbConfig := rt.NewDbConfig()
+	dbConfig.StartOffline = base.Ptr(true)
+	dbConfig.OIDCConfig = &auth.OIDCOptions{
+		Providers: auth.OIDCProviderMap{"provider1": provider},
+	}
+	RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
+
+	// The database is offline, so OIDCProviders is nil and "provider1" looks new even though it is
+	// byte-for-byte identical. It gets revalidated - which succeeds here, since the discovery
+	// endpoint is still reachable.
+	RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_config", string(base.MustJSONMarshal(t, &dbConfig))), http.StatusCreated)
+
+	// With the discovery endpoint unreachable, that same unchanged resubmit now fails - confirming
+	// the offline path really is revalidating rather than skipping.
+	mockAuthServer.Shutdown()
+	RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_config", string(base.MustJSONMarshal(t, &dbConfig))), http.StatusBadRequest)
 }

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -2881,3 +2881,63 @@ func TestPutDBConfigOIDC(t *testing.T) {
 	resp = BootstrapAdminRequest(t, sc, http.MethodPut, "/db/_config", validOIDCConfig)
 	resp.RequireStatus(http.StatusCreated)
 }
+
+func TestNoOIDCValidationOnRemoval(t *testing.T) {
+
+	const (
+		providerName        = "foo"
+		invalidProviderName = "invalid-provider"
+		subject             = "noah"
+		usernameClaim       = "username"
+		channelsClaim       = "channels"
+		testChannelName     = "test_channel"
+	)
+
+	providers := auth.OIDCProviderMap{
+		providerName:        mockProviderWith(providerName, mockProviderRegister{}, mockProviderUserPrefix{""}, mockProviderUsernameClaim{usernameClaim}, mockProviderChannelsClaim{channelsClaim}),
+		invalidProviderName: mockProvider(invalidProviderName),
+	}
+
+	mockAuthServer, err := newMockAuthServer()
+	require.NoError(t, err, "Error creating mock oauth2 server")
+	mockAuthServer.Start()
+	defer mockAuthServer.Shutdown()
+	mockAuthServer.options.issuer = mockAuthServer.URL + "/" + providerName
+	refreshProviderConfig(providers, mockAuthServer.URL)
+
+	mockAuthServer2, err := newMockAuthServer()
+	require.NoError(t, err, "Error creating mock oauth2 server")
+	mockAuthServer2.Start()
+	defer mockAuthServer2.Shutdown()
+	mockAuthServer2.options.issuer = mockAuthServer2.URL + "/" + providerName
+
+	rt := NewRestTester(t, &RestTesterConfig{PersistentConfig: true})
+	defer rt.Close()
+
+	oidcOptions := auth.OIDCOptions{Providers: providers, DefaultProvider: base.Ptr(providerName)}
+	dbConfig := rt.NewDbConfig()
+	dbConfig.OIDCConfig = &oidcOptions
+
+	// The invalid provider's issuer doesn't match its own discovery document (mockAuthServer always
+	// reports its single, fixed issuer regardless of which provider path is queried), so validation
+	// must be disabled to allow database creation to succeed with both providers configured.
+	RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/db/?disable_oidc_validation=true", string(base.MustJSONMarshal(t, &dbConfig))), http.StatusCreated)
+
+	// Sanity check that we can authenticate properly against the valid provider
+	jwt, err := mockAuthServer.makeToken(claimsAuthenticWithExtraClaims(map[string]any{
+		usernameClaim: subject,
+		channelsClaim: []string{testChannelName},
+	}))
+	require.NoError(t, err)
+
+	RequireStatus(t, rt.SendRequestWithHeaders(http.MethodPost, "/{{.db}}/_session", "{}", map[string]string{"Authorization": BearerToken + " " + jwt}), http.StatusOK)
+
+	// Now remove the valid provider from the config, leaving only the invalid provider still
+	// configured. This update should succeed without disable_oidc_validation, since the invalid
+	// provider isn't being added or changed - only removed/untouched providers are involved.
+	delete(oidcOptions.Providers, providerName)
+	dbConfig = rt.NewDbConfig()
+	dbConfig.OIDCConfig = &oidcOptions
+
+	RequireStatus(t, rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_config", string(base.MustJSONMarshal(t, &dbConfig))), http.StatusCreated)
+}

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -2985,7 +2985,7 @@ func TestNoOIDCValidationOnRemoval(t *testing.T) {
 			name: "remove a valid provider and default one remains",
 			providers: []providerSpec{
 				{name: provider1, server: "primary", options: validOpts, truthful: true, isDefault: true},
-				{name: provider2, server: "primary", options: validOpts},
+				{name: provider2, server: "secondary", options: validOpts, truthful: true},
 			},
 			updatedProviders: []providerSpec{
 				{name: provider1, server: "primary", options: validOpts, truthful: true},
@@ -2995,10 +2995,10 @@ func TestNoOIDCValidationOnRemoval(t *testing.T) {
 			name: "remove default provider and another valid one remains",
 			providers: []providerSpec{
 				{name: provider1, server: "primary", options: validOpts, truthful: true, isDefault: true},
-				{name: provider2, server: "primary", options: validOpts},
+				{name: provider2, server: "secondary", options: validOpts, truthful: true},
 			},
 			updatedProviders: []providerSpec{
-				{name: provider1, server: "primary", options: validOpts, truthful: true},
+				{name: provider2, server: "secondary", options: validOpts, truthful: true, isDefault: true},
 			},
 		},
 		{
@@ -3049,7 +3049,7 @@ func TestNoOIDCValidationOnRemoval(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
 
-			rt := NewRestTester(t, &RestTesterConfig{PersistentConfig: true})
+			rt := NewRestTester(tt, &RestTesterConfig{PersistentConfig: true})
 			defer rt.Close()
 
 			extraClaims := map[string]any{
@@ -3070,11 +3070,11 @@ func TestNoOIDCValidationOnRemoval(t *testing.T) {
 			// The invalid provider's issuer doesn't match its own discovery document (its mock server
 			// truthfully answers as a different provider), so validation must be disabled to allow
 			// database creation to succeed with both providers configured.
-			RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/db/?disable_oidc_validation=true", string(base.MustJSONMarshal(t, &dbConfig))), http.StatusCreated)
+			RequireStatus(tt, rt.SendAdminRequest(http.MethodPut, "/db/?disable_oidc_validation=true", string(base.MustJSONMarshal(tt, &dbConfig))), http.StatusCreated)
 
 			// Sanity check every provider in the initial config: valid ones authenticate, mismatched
 			// ones don't. Tokens minted here get reused after the update below.
-			verifyProviderAuth(t, rt, servers, test.providers, extraClaims, tokens)
+			verifyProviderAuth(tt, rt, servers, test.providers, extraClaims, tokens)
 
 			updatedProviders, newDefaultProvider := buildProviders(test.updatedProviders, servers)
 			oidcOptions = auth.OIDCOptions{
@@ -3082,12 +3082,12 @@ func TestNoOIDCValidationOnRemoval(t *testing.T) {
 				DefaultProvider: base.Ptr(newDefaultProvider),
 			}
 
-			RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_config", string(base.MustJSONMarshal(t, &dbConfig))), http.StatusCreated)
+			RequireStatus(tt, rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_config", string(base.MustJSONMarshal(tt, &dbConfig))), http.StatusCreated)
 
 			// Re-check every provider in the final config using the SAME tokens minted before the
 			// update where possible (only a genuinely new provider gets a freshly minted one here) -
 			// valid ones should still authenticate, mismatched ones still shouldn't.
-			verifyProviderAuth(t, rt, servers, test.updatedProviders, extraClaims, tokens)
+			verifyProviderAuth(tt, rt, servers, test.updatedProviders, extraClaims, tokens)
 
 			// Confirm the pre-update token for any provider that got removed entirely no longer
 			// authenticates - reusing the exact token from before the removal.
@@ -3095,9 +3095,76 @@ func TestNoOIDCValidationOnRemoval(t *testing.T) {
 				if _, stillPresent := updatedProviders[spec.name]; stillPresent {
 					continue
 				}
-				RequireStatus(t, rt.SendRequestWithHeaders(http.MethodPost, "/{{.db}}/_session", "{}", map[string]string{"Authorization": BearerToken + " " + tokens[spec.name]}), http.StatusUnauthorized)
+				RequireStatus(tt, rt.SendRequestWithHeaders(http.MethodPost, "/{{.db}}/_session", "{}", map[string]string{"Authorization": BearerToken + " " + tokens[spec.name]}), http.StatusUnauthorized)
 			}
 		})
 	}
 
+}
+
+// TestCreateDBWithInvalidOIDCProvider verifies that creating a brand new database with an OIDC
+// provider whose issuer doesn't match its own discovery document fails validation by default.
+// There's no existing database to compare against on creation, so every provider is inherently
+// new and must still be validated unless disable_oidc_validation is explicitly passed.
+func TestCreateDBWithInvalidOIDCProvider(t *testing.T) {
+	mockAuthServer, err := newMockAuthServer()
+	require.NoError(t, err, "Error creating mock oauth2 server")
+	mockAuthServer.Start()
+	defer mockAuthServer.Shutdown()
+	mockAuthServer.options.issuer = mockAuthServer.URL + "/actual-issuer"
+
+	invalidProvider := mockProvider("invalidProvider")
+	invalidProvider.Issuer = mockAuthServer.URL + "/invalidProvider" // doesn't match mockAuthServer.options.issuer
+	invalidProvider.DiscoveryURI = auth.GetStandardDiscoveryEndpoint(invalidProvider.Issuer)
+
+	rt := NewRestTester(t, &RestTesterConfig{PersistentConfig: true})
+	defer rt.Close()
+
+	dbConfig := rt.NewDbConfig()
+	dbConfig.OIDCConfig = &auth.OIDCOptions{
+		Providers: auth.OIDCProviderMap{"invalidProvider": invalidProvider},
+	}
+
+	RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusBadRequest)
+}
+
+// TestOIDCValidationSkippedOnInPlaceProviderChange demonstrates a gap in OIDCValidationRequired
+// (db/database.go): it only checks whether a provider's NAME is new, never whether an existing,
+// same-named provider's content (Issuer, DiscoveryURI, etc.) actually changed. So updating a
+// provider's issuer in-place - to something that no longer matches its own discovery document -
+// incorrectly skips re-validation, since the name alone is enough to mark it "already known".
+func TestOIDCValidationSkippedOnInPlaceProviderChange(t *testing.T) {
+	mockAuthServer, err := newMockAuthServer()
+	require.NoError(t, err, "Error creating mock oauth2 server")
+	mockAuthServer.Start()
+	defer mockAuthServer.Shutdown()
+	mockAuthServer.options.issuer = mockAuthServer.URL + "/provider1"
+
+	provider := mockProviderWith("provider1", mockProviderRegister{})
+	provider.Issuer = mockAuthServer.URL + "/provider1"
+	provider.DiscoveryURI = auth.GetStandardDiscoveryEndpoint(provider.Issuer)
+
+	rt := NewRestTester(t, &RestTesterConfig{PersistentConfig: true})
+	defer rt.Close()
+
+	dbConfig := rt.NewDbConfig()
+	dbConfig.OIDCConfig = &auth.OIDCOptions{
+		Providers: auth.OIDCProviderMap{"provider1": provider},
+	}
+	RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
+
+	// Update "provider1" in-place: same name, but the issuer now points somewhere that no longer
+	// matches what mockAuthServer actually answers as. The provider's content genuinely changed,
+	// so this should fail validation - but since OIDCValidationRequired only keys on the name, it
+	// wrongly treats "provider1" as already-known and skips re-validating it.
+	changedProvider := mockProviderWith("provider1", mockProviderRegister{})
+	changedProvider.Issuer = mockAuthServer.URL + "/some-other-issuer"
+	changedProvider.DiscoveryURI = auth.GetStandardDiscoveryEndpoint(changedProvider.Issuer)
+
+	updatedDbConfig := rt.NewDbConfig()
+	updatedDbConfig.OIDCConfig = &auth.OIDCOptions{
+		Providers: auth.OIDCProviderMap{"provider1": changedProvider},
+	}
+
+	RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_config", string(base.MustJSONMarshal(t, &updatedDbConfig))), http.StatusBadRequest)
 }

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -3371,9 +3371,27 @@ func TestOIDCNullProviderDefinition(t *testing.T) {
 			Providers: auth.OIDCProviderMap{"provider1": validProvider, "nullProvider": nil},
 		}
 
-		// One provider is still valid, so validation passes and the database loads with the null
-		// entry skipped rather than dereferenced.
+		// Rejected even though another provider is valid - a null would otherwise be accepted here
+		// and then silently dropped when the database loads.
+		RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusBadRequest)
+	})
+
+	t.Run("null provider rejected on config update", func(t *testing.T) {
+		rt := NewRestTester(t, &RestTesterConfig{PersistentConfig: true})
+		defer rt.Close()
+
+		dbConfig := rt.NewDbConfig()
+		dbConfig.OIDCConfig = &auth.OIDCOptions{
+			Providers: auth.OIDCProviderMap{"provider1": validProvider},
+		}
 		RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
+
+		// Adding a null provider to an existing database is rejected the same way as at creation.
+		updatedConfig := rt.NewDbConfig()
+		updatedConfig.OIDCConfig = &auth.OIDCOptions{
+			Providers: auth.OIDCProviderMap{"provider1": validProvider, "nullProvider": nil},
+		}
+		RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_config", string(base.MustJSONMarshal(t, &updatedConfig))), http.StatusBadRequest)
 	})
 }
 

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -3129,9 +3129,9 @@ func TestCreateDBWithInvalidOIDCProvider(t *testing.T) {
 
 // TestOIDCRevalidationOnInPlaceProviderChange verifies that changing an existing provider in place -
 // same name, but a discovery-relevant field altered - is re-validated rather than treated as
-// already-known. SetRevalidationFlags (auth/oidc.go) compares provider content, not just names, via
-// ProviderDiscoveryConfigChanged, so a changed Issuer must still be checked against its discovery
-// document even though the provider name was already present in the running config.
+// already-known. SetRevalidationFlags (auth/oidc.go) compares provider content, not just names, so a
+// changed Issuer must still be checked against its discovery document even though the provider name
+// was already present in the running config.
 func TestOIDCRevalidationOnInPlaceProviderChange(t *testing.T) {
 	mockAuthServer, err := newMockAuthServer()
 	require.NoError(t, err, "Error creating mock oauth2 server")
@@ -3169,7 +3169,7 @@ func TestOIDCRevalidationOnInPlaceProviderChange(t *testing.T) {
 
 // TestOIDCRevalidationSkippedWithTlsSkipVerify checks that resubmitting an OIDC provider's config
 // completely unchanged still succeeds, both with and without oidc_tls_skip_verify enabled.
-// This is why ProviderDiscoveryConfigChanged (auth/oidc.go) deliberately excludes
+// This is why the comparison in auth/oidc.go deliberately excludes
 // InsecureSkipVerify: it is populated server-side from db.Options.UnsupportedOptions.OidcTlsSkipVerify
 // on the running provider, but is never populated on a provider parsed straight from a request body,
 // so comparing it would report every provider as changed whenever that option is enabled.
@@ -3377,12 +3377,12 @@ func TestOIDCNullProviderDefinition(t *testing.T) {
 	})
 }
 
-// TestOIDCRevalidationOnOfflineDatabaseUpdate pins the behaviour for an offline database.
-// DatabaseContext.OIDCProviders is populated by StartOnlineProcesses, so it is nil while the
-// database is offline. SetRevalidationFlags then has nothing to compare against and marks every
-// provider as new, meaning an offline config update revalidates everything. That is conservative
-// rather than permissive, and matches the behaviour before per-provider revalidation existed.
-func TestOIDCRevalidationOnOfflineDatabaseUpdate(t *testing.T) {
+// TestOIDCRevalidationConsistentWhenOffline checks that an offline database skips revalidation for
+// an unchanged provider exactly as an online one does. SetRevalidationFlags compares against
+// DatabaseContext.ConfiguredOIDCProviders rather than OIDCProviders - the latter is populated only
+// by StartOnlineProcesses, so keying on it would make every offline config update revalidate every
+// provider, purely because of when the database happened to be updated.
+func TestOIDCRevalidationConsistentWhenOffline(t *testing.T) {
 	mockAuthServer, err := newMockAuthServer()
 	require.NoError(t, err, "Error creating mock oauth2 server")
 	mockAuthServer.Start()
@@ -3403,13 +3403,23 @@ func TestOIDCRevalidationOnOfflineDatabaseUpdate(t *testing.T) {
 	}
 	RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
 
-	// The database is offline, so OIDCProviders is nil and "provider1" looks new even though it is
-	// byte-for-byte identical. It gets revalidated - which succeeds here, since the discovery
-	// endpoint is still reachable.
+	// Make discovery unreachable, so anything that does get revalidated fails loudly.
+	mockAuthServer.Shutdown()
+
+	// Resubmitting the identical config against an offline database skips revalidation, exactly as
+	// it would if the database were online.
 	RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_config", string(base.MustJSONMarshal(t, &dbConfig))), http.StatusCreated)
 
-	// With the discovery endpoint unreachable, that same unchanged resubmit now fails - confirming
-	// the offline path really is revalidating rather than skipping.
-	mockAuthServer.Shutdown()
-	RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_config", string(base.MustJSONMarshal(t, &dbConfig))), http.StatusBadRequest)
+	// A genuine in-place change is still revalidated while offline, and fails because discovery is
+	// unreachable - so the skip above is change detection, not a blanket offline exemption.
+	changedProvider := mockProviderWith("provider1", mockProviderRegister{})
+	changedProvider.Issuer = mockAuthServer.URL + "/some-other-issuer"
+	changedProvider.DiscoveryURI = auth.GetStandardDiscoveryEndpoint(changedProvider.Issuer)
+
+	changedConfig := rt.NewDbConfig()
+	changedConfig.StartOffline = base.Ptr(true)
+	changedConfig.OIDCConfig = &auth.OIDCOptions{
+		Providers: auth.OIDCProviderMap{"provider1": changedProvider},
+	}
+	RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_config", string(base.MustJSONMarshal(t, &changedConfig))), http.StatusBadRequest)
 }

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -2882,62 +2882,222 @@ func TestPutDBConfigOIDC(t *testing.T) {
 	resp.RequireStatus(http.StatusCreated)
 }
 
+// providerSpec declaratively describes one OIDC provider for TestNoOIDCValidationOnRemoval: which
+// mock server it should be wired to, and whether that server should truthfully report this
+// provider's issuer from its discovery endpoint. A spec with truthful=false remains mismatched
+// against whatever its server is currently truthfully answering as - this is how "invalid"
+// providers are expressed, with no separate validity flag needed.
+type providerSpec struct {
+	name      string
+	server    string
+	options   []mockProviderOption
+	truthful  bool
+	isDefault bool
+}
+
+// buildProviders constructs an OIDCProviderMap from specs, wiring each provider's Issuer/DiscoveryURI
+// to the named mock server, and returns the name of the spec marked isDefault (if any).
+func buildProviders(specs []providerSpec, servers map[string]*mockAuthServer) (auth.OIDCProviderMap, string) {
+	providers := make(auth.OIDCProviderMap, len(specs))
+	var defaultProvider string
+	for _, spec := range specs {
+		provider := mockProviderWith(spec.name, spec.options...)
+		server := servers[spec.server]
+		provider.Issuer = server.URL + "/" + spec.name
+		provider.DiscoveryURI = auth.GetStandardDiscoveryEndpoint(provider.Issuer)
+		if spec.truthful {
+			server.options.issuer = provider.Issuer
+		}
+		if spec.isDefault {
+			defaultProvider = spec.name
+		}
+		providers[spec.name] = provider
+	}
+	return providers, defaultProvider
+}
+
+// newMockAuthServers starts one mock OAuth2 server per name, keyed by name, and registers cleanup.
+func newMockAuthServers(t *testing.T, names ...string) map[string]*mockAuthServer {
+	servers := make(map[string]*mockAuthServer, len(names))
+	for _, name := range names {
+		s, err := newMockAuthServer()
+		require.NoError(t, err, "Error creating mock oauth2 server")
+		s.Start()
+		t.Cleanup(s.Shutdown)
+		servers[name] = s
+	}
+	return servers
+}
+
+// makeProviderToken mints a JWT claiming to be issued by spec's own provider, signed by spec's own
+// mock server. Whether it actually authenticates depends on spec.truthful: a genuine mismatch
+// (truthful=false) makes real-time discovery fail regardless of any config-save-time validation skip.
+func makeProviderToken(t *testing.T, servers map[string]*mockAuthServer, spec providerSpec, extraClaims map[string]any) string {
+	server := servers[spec.server]
+	claims := claimsAuthenticWithExtraClaims(extraClaims)
+	claims.primaryClaims.Issuer = server.URL + "/" + spec.name
+	token, err := server.makeToken(claims)
+	require.NoError(t, err)
+	return token
+}
+
+// verifyProviderAuth checks each spec authenticates as expected (per spec.truthful). It reuses a
+// token from a prior call for the same provider name if one exists in tokens, and mints (and
+// records) a new one otherwise - so a token minted before a config change gets re-checked as-is
+// after the change, rather than re-derived.
+func verifyProviderAuth(t *testing.T, rt *RestTester, servers map[string]*mockAuthServer, specs []providerSpec, extraClaims map[string]any, tokens map[string]string) {
+	for _, spec := range specs {
+		token, ok := tokens[spec.name]
+		if !ok {
+			token = makeProviderToken(t, servers, spec, extraClaims)
+			tokens[spec.name] = token
+		}
+		expected := http.StatusUnauthorized
+		if spec.truthful {
+			expected = http.StatusOK
+		}
+		RequireStatus(t, rt.SendRequestWithHeaders(http.MethodPost, "/{{.db}}/_session", "{}", map[string]string{"Authorization": BearerToken + " " + token}), expected)
+	}
+}
+
 func TestNoOIDCValidationOnRemoval(t *testing.T) {
 
 	const (
-		providerName        = "foo"
-		invalidProviderName = "invalid-provider"
-		subject             = "noah"
-		usernameClaim       = "username"
-		channelsClaim       = "channels"
-		testChannelName     = "test_channel"
+		provider1       = "provider1"
+		provider2       = "provider2"
+		invalidProvider = "invalidProvider"
+		subject         = "noah"
+		usernameClaim   = "username"
+		channelsClaim   = "channels"
+		testChannelName = "test_channel"
 	)
 
-	providers := auth.OIDCProviderMap{
-		providerName:        mockProviderWith(providerName, mockProviderRegister{}, mockProviderUserPrefix{""}, mockProviderUsernameClaim{usernameClaim}, mockProviderChannelsClaim{channelsClaim}),
-		invalidProviderName: mockProvider(invalidProviderName),
+	validOpts := []mockProviderOption{mockProviderRegister{}, mockProviderUserPrefix{""}, mockProviderUsernameClaim{usernameClaim}, mockProviderChannelsClaim{channelsClaim}}
+
+	servers := newMockAuthServers(t, "primary", "secondary")
+
+	tests := []struct {
+		name             string
+		providers        []providerSpec
+		updatedProviders []providerSpec
+	}{
+		{
+			name: "remove a valid provider and default one remains",
+			providers: []providerSpec{
+				{name: provider1, server: "primary", options: validOpts, truthful: true, isDefault: true},
+				{name: provider2, server: "primary", options: validOpts},
+			},
+			updatedProviders: []providerSpec{
+				{name: provider1, server: "primary", options: validOpts, truthful: true},
+			},
+		},
+		{
+			name: "remove default provider and another valid one remains",
+			providers: []providerSpec{
+				{name: provider1, server: "primary", options: validOpts, truthful: true, isDefault: true},
+				{name: provider2, server: "primary", options: validOpts},
+			},
+			updatedProviders: []providerSpec{
+				{name: provider1, server: "primary", options: validOpts, truthful: true},
+			},
+		},
+		{
+			name: "remove valid provider and the invalid one remains",
+			providers: []providerSpec{
+				{name: provider1, server: "primary", options: validOpts, truthful: true, isDefault: true},
+				{name: invalidProvider, server: "primary"},
+			},
+			updatedProviders: []providerSpec{
+				{name: invalidProvider, server: "primary"},
+			},
+		},
+		{
+			name: "remove invalid provider and the default one remains",
+			providers: []providerSpec{
+				{name: provider1, server: "primary", options: validOpts, truthful: true, isDefault: true},
+				{name: invalidProvider, server: "primary"},
+			},
+			updatedProviders: []providerSpec{
+				{name: provider1, server: "primary", options: validOpts, truthful: true},
+			},
+		},
+		{
+			name: "remove valid provider and add new valid provider, while invalid remains",
+			providers: []providerSpec{
+				{name: provider1, server: "primary", options: validOpts, truthful: true, isDefault: true},
+				{name: invalidProvider, server: "primary"},
+			},
+			updatedProviders: []providerSpec{
+				{name: invalidProvider, server: "primary"},
+				{name: provider2, server: "secondary", options: validOpts, truthful: true},
+			},
+		},
+		{
+			name: "remove default provider and promote another valid provider to default, invalid remains",
+			providers: []providerSpec{
+				{name: provider1, server: "primary", options: validOpts, truthful: true, isDefault: true},
+				{name: invalidProvider, server: "primary"},
+				{name: provider2, server: "secondary", options: validOpts, truthful: true},
+			},
+			updatedProviders: []providerSpec{
+				{name: invalidProvider, server: "primary"},
+				{name: provider2, server: "secondary", options: validOpts, truthful: true, isDefault: true},
+			},
+		},
 	}
 
-	mockAuthServer, err := newMockAuthServer()
-	require.NoError(t, err, "Error creating mock oauth2 server")
-	mockAuthServer.Start()
-	defer mockAuthServer.Shutdown()
-	mockAuthServer.options.issuer = mockAuthServer.URL + "/" + providerName
-	refreshProviderConfig(providers, mockAuthServer.URL)
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
 
-	mockAuthServer2, err := newMockAuthServer()
-	require.NoError(t, err, "Error creating mock oauth2 server")
-	mockAuthServer2.Start()
-	defer mockAuthServer2.Shutdown()
-	mockAuthServer2.options.issuer = mockAuthServer2.URL + "/" + providerName
+			rt := NewRestTester(t, &RestTesterConfig{PersistentConfig: true})
+			defer rt.Close()
 
-	rt := NewRestTester(t, &RestTesterConfig{PersistentConfig: true})
-	defer rt.Close()
+			extraClaims := map[string]any{
+				usernameClaim: subject,
+				channelsClaim: []string{testChannelName},
+			}
+			tokens := make(map[string]string)
 
-	oidcOptions := auth.OIDCOptions{Providers: providers, DefaultProvider: base.Ptr(providerName)}
-	dbConfig := rt.NewDbConfig()
-	dbConfig.OIDCConfig = &oidcOptions
+			providers, defaultProvider := buildProviders(test.providers, servers)
+			oidcOptions := auth.OIDCOptions{
+				Providers:       providers,
+				DefaultProvider: base.Ptr(defaultProvider),
+			}
 
-	// The invalid provider's issuer doesn't match its own discovery document (mockAuthServer always
-	// reports its single, fixed issuer regardless of which provider path is queried), so validation
-	// must be disabled to allow database creation to succeed with both providers configured.
-	RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/db/?disable_oidc_validation=true", string(base.MustJSONMarshal(t, &dbConfig))), http.StatusCreated)
+			dbConfig := rt.NewDbConfig()
+			dbConfig.OIDCConfig = &oidcOptions
 
-	// Sanity check that we can authenticate properly against the valid provider
-	jwt, err := mockAuthServer.makeToken(claimsAuthenticWithExtraClaims(map[string]any{
-		usernameClaim: subject,
-		channelsClaim: []string{testChannelName},
-	}))
-	require.NoError(t, err)
+			// The invalid provider's issuer doesn't match its own discovery document (its mock server
+			// truthfully answers as a different provider), so validation must be disabled to allow
+			// database creation to succeed with both providers configured.
+			RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/db/?disable_oidc_validation=true", string(base.MustJSONMarshal(t, &dbConfig))), http.StatusCreated)
 
-	RequireStatus(t, rt.SendRequestWithHeaders(http.MethodPost, "/{{.db}}/_session", "{}", map[string]string{"Authorization": BearerToken + " " + jwt}), http.StatusOK)
+			// Sanity check every provider in the initial config: valid ones authenticate, mismatched
+			// ones don't. Tokens minted here get reused after the update below.
+			verifyProviderAuth(t, rt, servers, test.providers, extraClaims, tokens)
 
-	// Now remove the valid provider from the config, leaving only the invalid provider still
-	// configured. This update should succeed without disable_oidc_validation, since the invalid
-	// provider isn't being added or changed - only removed/untouched providers are involved.
-	delete(oidcOptions.Providers, providerName)
-	dbConfig = rt.NewDbConfig()
-	dbConfig.OIDCConfig = &oidcOptions
+			updatedProviders, newDefaultProvider := buildProviders(test.updatedProviders, servers)
+			oidcOptions = auth.OIDCOptions{
+				Providers:       updatedProviders,
+				DefaultProvider: base.Ptr(newDefaultProvider),
+			}
 
-	RequireStatus(t, rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_config", string(base.MustJSONMarshal(t, &dbConfig))), http.StatusCreated)
+			RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_config", string(base.MustJSONMarshal(t, &dbConfig))), http.StatusCreated)
+
+			// Re-check every provider in the final config using the SAME tokens minted before the
+			// update where possible (only a genuinely new provider gets a freshly minted one here) -
+			// valid ones should still authenticate, mismatched ones still shouldn't.
+			verifyProviderAuth(t, rt, servers, test.updatedProviders, extraClaims, tokens)
+
+			// Confirm the pre-update token for any provider that got removed entirely no longer
+			// authenticates - reusing the exact token from before the removal.
+			for _, spec := range test.providers {
+				if _, stillPresent := updatedProviders[spec.name]; stillPresent {
+					continue
+				}
+				RequireStatus(t, rt.SendRequestWithHeaders(http.MethodPost, "/{{.db}}/_session", "{}", map[string]string{"Authorization": BearerToken + " " + tokens[spec.name]}), http.StatusUnauthorized)
+			}
+		})
+	}
+
 }

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -3168,3 +3168,93 @@ func TestOIDCValidationSkippedOnInPlaceProviderChange(t *testing.T) {
 
 	RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_config", string(base.MustJSONMarshal(t, &updatedDbConfig))), http.StatusBadRequest)
 }
+
+// TestOIDCRevalidationSkippedWithTlsSkipVerify checks that resubmitting an OIDC provider's config
+// completely unchanged still succeeds, both with and without oidc_tls_skip_verify enabled.
+// existing.InsecureSkipVerify (db/database.go) is populated server-side from
+// db.Options.UnsupportedOptions.OidcTlsSkipVerify, but incoming.InsecureSkipVerify (parsed straight
+// from the request body) is never populated at all.
+func TestOIDCRevalidationSkippedWithTlsSkipVerify(t *testing.T) {
+	for _, oidcSkipTlsVerify := range []bool{true, false} {
+		t.Run(fmt.Sprintf("oidcSkipTlsVerify=%t", oidcSkipTlsVerify), func(t *testing.T) {
+			// A fresh server per subtest, since it gets shut down mid-test below.
+			mockAuthServer, err := newMockAuthServer()
+			require.NoError(t, err, "Error creating mock oauth2 server")
+			mockAuthServer.Start()
+			defer mockAuthServer.Shutdown()
+			mockAuthServer.options.issuer = mockAuthServer.URL + "/provider1"
+
+			providers := auth.OIDCProviderMap{
+				"provider1": mockProviderWith("provider1", mockProviderRegister{}),
+			}
+			refreshProviderConfig(providers, mockAuthServer.URL)
+			rt := NewRestTester(t, &RestTesterConfig{PersistentConfig: true})
+			defer rt.Close()
+
+			dbConfig := rt.NewDbConfig()
+			dbConfig.OIDCConfig = &auth.OIDCOptions{
+				Providers: providers,
+			}
+			dbConfig.Unsupported = &db.UnsupportedOptions{OidcTlsSkipVerify: oidcSkipTlsVerify}
+
+			RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
+
+			// Make the discovery URL unreachable, so a wrongly-forced revalidation would fail.
+			mockAuthServer.Shutdown()
+
+			// Resubmit "provider1" completely unchanged (same Issuer/DiscoveryURI/ClientID as at
+			// creation). The update should succeed regardless of oidcSkipTlsVerify, since nothing
+			// about the provider actually changed - even though its discovery URL is now unreachable.
+			updatedProviders := auth.OIDCProviderMap{
+				"provider1": mockProviderWith("provider1", mockProviderRegister{}),
+			}
+			refreshProviderConfig(updatedProviders, mockAuthServer.URL)
+
+			updatedDbConfig := rt.NewDbConfig()
+			updatedDbConfig.OIDCConfig = &auth.OIDCOptions{
+				Providers: updatedProviders,
+			}
+			updatedDbConfig.Unsupported = &db.UnsupportedOptions{OidcTlsSkipVerify: oidcSkipTlsVerify}
+
+			RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_config", string(base.MustJSONMarshal(t, &updatedDbConfig))), http.StatusCreated)
+		})
+	}
+}
+
+// TestOIDCValidationSkippedOnUnrelatedConfigUpsert checks that a database config update with
+// nothing to do with OIDC doesn't force revalidation of an existing, untouched provider.
+// A POST (upsert/merge) that doesn't mention "oidc" at all parses to a nil OIDCConfig, so
+// OIDCValidationRequired (db/database.go) has nothing to mark - but the existing provider still
+// gets merged back in from the persisted config and, since SkipRevalidation (json:"-") is never
+// persisted, defaults to false on every fresh deserialization regardless of history.
+func TestOIDCValidationSkippedOnUnrelatedConfigUpsert(t *testing.T) {
+	mockAuthServer, err := newMockAuthServer()
+	require.NoError(t, err, "Error creating mock oauth2 server")
+	mockAuthServer.Start()
+	defer mockAuthServer.Shutdown()
+	mockAuthServer.options.issuer = mockAuthServer.URL + "/actual-issuer"
+
+	invalidProvider := mockProvider("invalidProvider")
+	invalidProvider.Issuer = mockAuthServer.URL + "/invalidProvider" // doesn't match mockAuthServer.options.issuer
+	invalidProvider.DiscoveryURI = auth.GetStandardDiscoveryEndpoint(invalidProvider.Issuer)
+
+	rt := NewRestTester(t, &RestTesterConfig{PersistentConfig: true})
+	defer rt.Close()
+
+	dbConfig := rt.NewDbConfig()
+	dbConfig.OIDCConfig = &auth.OIDCOptions{
+		Providers: auth.OIDCProviderMap{"invalidProvider": invalidProvider},
+	}
+
+	// disable_oidc_validation is required here purely to get the intentionally-invalid provider
+	// accepted in the first place - it's not used again below.
+	RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/db/?disable_oidc_validation=true", string(base.MustJSONMarshal(t, &dbConfig))), http.StatusCreated)
+
+	// POST an update that's entirely unrelated to OIDC - the body has no "oidc" key at all, so
+	// OIDCValidationRequired has nothing to mark. The already-configured "invalidProvider" is
+	// merged back in unchanged and must not be re-validated as a side effect of this update.
+	unrelatedUpdate := DbConfig{
+		RevsLimit: base.Ptr(uint32(1000)),
+	}
+	RequireStatus(t, rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_config", string(base.MustJSONMarshal(t, &unrelatedUpdate))), http.StatusCreated)
+}


### PR DESCRIPTION
CBG-4775

Previously, any `_config` update revalidated *every* configured OIDC provider's discovery/issuer info, even providers that weren't being added or changed. This meant, e.g., removing one OIDC provider could fail with a validation error (or panic) because of an unrelated, already-accepted provider - even though that provider wasn't part of the update.

- Add `OIDCProvider.ShouldValidate` (`auth/oidc.go`) and `DatabaseContext.OIDCValidationRequired` (`db/database.go`), called from `handlePutDbConfig` (`rest/admin_api.go`) before config validation runs. Only providers not already known to the running database get flagged for validation; `rest/config.go`'s discovery check is now gated on this flag.
- Add `TestNoOIDCValidationOnRemoval` (`rest/oidc_api_test.go`): table-driven coverage for removing a default/non-default provider while others remain, removing/adding providers alongside a permanently-invalid one, and promoting a different provider to default - verified by reusing pre/post-update JWTs to confirm removed providers stop authenticating and surviving/promoted ones keep working.  

## Pre-review checklist
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/1024/
- [x] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/1044/
- [x] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/1060/

<!--
Automated review runs on every non-draft PR raised from this repo (forks are not reviewed automatically).
  - Re-run it, or ask a follow-up, by commenting `@droid <question>`
  - Suppress it with the `droid-skip` label, or `WIP`/`DO NOT MERGE` in the title
-->
