### PR TITLE
CBG-5662 support ghcr.io images in start_cbs.py

### DIFF
--- a/integration-test/start_cbs.py
+++ b/integration-test/start_cbs.py
@@ -201,6 +201,10 @@ def main() -> None:
         # A version containing '/' is a full docker image reference (e.g.
         # ghcr.io/cb-vanilla/server:8.1.0), not a plain version string - pull it directly via
         # docker.image instead of letting cbdinocluster resolve 'version' against its registries.
+        # 'version' is still set to the same raw string in this case: cbdinocluster's node
+        # deployment (getImagesForNodeGrps) skips version resolution entirely whenever
+        # docker.image is set, so 'version' is never parsed there and is only used as a label -
+        # find_reusable_cluster() below reads it back to decide whether to reuse a cluster.
         node_docker_block = ""
         if "/" in opts.version:
             node_docker_block = f"    docker:\n      image: {opts.version}\n"

--- a/integration-test/start_cbs.py
+++ b/integration-test/start_cbs.py
@@ -198,15 +198,27 @@ def main() -> None:
     if cluster_id is None:
         services = ", ".join(s.strip() for s in opts.services.split(",") if s.strip())
 
-        yaml_content = textwrap.dedent(f"""\
-            nodes:
-              - count: {opts.nodes}
-                version: {opts.version}
-                services: [{services}]
-            docker:
-                kv-memory: {opts.kv_memory_mb}
-                index-memory: {opts.index_memory_mb}
-        """)
+        # A version containing '/' is a full docker image reference (e.g.
+        # ghcr.io/cb-vanilla/server:8.1.0), not a plain version string - pull it directly via
+        # docker.image instead of letting cbdinocluster resolve 'version' against its registries.
+        node_docker_block = ""
+        if "/" in opts.version:
+            node_docker_block = f"    docker:\n      image: {opts.version}\n"
+
+        yaml_content = (
+            textwrap.dedent(f"""\
+                nodes:
+                  - count: {opts.nodes}
+                    version: {opts.version}
+                    services: [{services}]
+            """)
+            + node_docker_block
+            + textwrap.dedent(f"""\
+                docker:
+                    kv-memory: {opts.kv_memory_mb}
+                    index-memory: {opts.index_memory_mb}
+            """)
+        )
 
         with tempfile.NamedTemporaryFile(
             mode="w", suffix=".yaml", delete=False, prefix="cbdino-sg-"


### PR DESCRIPTION
CBG-5662 support ghcr.io images in start_cbs.py

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/1027
