### PR TITLE
Allow checkout from a specific hash

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -253,29 +253,23 @@ pipeline {
             // archive non-verbose outputs upon failure for inspection (each verbose output is conditionally archived on stage failure)
             archiveArtifacts excludes: 'verbose_*.out', artifacts: '*.out', fingerprint: false, allowEmptyArchive: true
             script {
-                if ("${env.BRANCH_NAME}" == 'main') {
-                    def slackUtils = load('integration-test/slackUtils.groovy')
-                    slackUtils.slackSendFailure('main SGW pipeline', 'unstable', env.BUILD_URL)
-                }
+                def slackUtils = load('integration-test/slackUtils.groovy')
+                slackUtils.slackSendFailure('main SGW pipeline', 'unstable', env.BUILD_URL)
             }
         }
         failure {
             // archive non-verbose outputs upon failure for inspection (each verbose output is conditionally archived on stage failure)
             archiveArtifacts excludes: 'verbose_*.out', artifacts: '*.out', fingerprint: false, allowEmptyArchive: true
             script {
-                if ("${env.BRANCH_NAME}" == 'main') {
-                    def slackUtils = load('integration-test/slackUtils.groovy')
-                    slackUtils.slackSendFailure('main SGW pipeline', 'build failure', env.BUILD_URL)
-                }
+                def slackUtils = load('integration-test/slackUtils.groovy')
+                slackUtils.slackSendFailure('main SGW pipeline', 'build failure', env.BUILD_URL)
             }
         }
         aborted {
             archiveArtifacts excludes: 'verbose_*.out', artifacts: '*.out', fingerprint: false, allowEmptyArchive: true
             script {
-                if ("${env.BRANCH_NAME}" == 'main') {
-                    def slackUtils = load('integration-test/slackUtils.groovy')
-                    slackUtils.slackSendFailure('main SGW pipeline', 'aborted', env.BUILD_URL)
-                }
+                def slackUtils = load('integration-test/slackUtils.groovy')
+                slackUtils.slackSendFailure('main SGW pipeline', 'unstable', env.BUILD_URL)
             }
         }
         cleanup {

--- a/integration-test/e2e/Jenkinsfile
+++ b/integration-test/e2e/Jenkinsfile
@@ -122,11 +122,18 @@ pipeline {
         stage('Checkout Scm') {
             steps {
                 cleanWs(disableDeferredWipeout: false)
-                git(
-                    url: 'git@github.com:couchbase/sync_gateway.git',
-                    branch: "${params.SG_COMMIT}",
-                    credentialsId: 'CB_SG_Robot_Github_SSH_Key'
-                )
+                // SG_COMMIT may be an arbitrary commit SHA rather than a branch name. The build
+                // chooser only resolves a branch spec against existing remote-tracking refs, so a
+                // bare SHA won't resolve unless it's fetched into a ref of the same name.
+                checkout([
+                    $class: 'GitSCM',
+                    branches: [[name: params.SG_COMMIT]],
+                    userRemoteConfigs: [[
+                        url: 'git@github.com:couchbase/sync_gateway.git',
+                        credentialsId: 'CB_SG_Robot_Github_SSH_Key',
+                        refspec: "+${params.SG_COMMIT}:refs/remotes/origin/${params.SG_COMMIT}"
+                    ]]
+                ])
             }
         }
         stage('Run E2E Tests') {


### PR DESCRIPTION
Allow checkout from a specific hash.

When Couchbase Lite E2E is run, it gets a hash from a checkout like abc123 which was not able to be checked out:

Added https://jenkins.sgwdev.com/job/Couchbase%20Lite%20E2E%20jenkins%20testing/29 and https://jenkins.sgwdev.com/job/Couchbase%20Lite%20E2E%20jenkins%20testing/28 for fixing the checkout.

need to use `$class: 'GitSCM'` to have access to refspec.
