### PR TITLE
[4.1.2 Backport] CBG-5506: Fix flaky TestActiveReplicatorConflictPreUpgradedVersion tests

### DIFF
--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -786,6 +786,7 @@ func AssertWaitForStat(t testing.TB, getStatFunc func() int64, expected int64) (
 
 // RequireWaitForStat will retry for up to 20 seconds until the result of getStatFunc is equal to the expected value.
 func RequireWaitForStat(t testing.TB, getStatFunc func() int64, expected int64) (val int64) {
+	t.Helper()
 	require.NotNil(t, getStatFunc, "Function for RequireWaitForStat cannot be nil")
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		val = getStatFunc()

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -785,12 +785,12 @@ func AssertWaitForStat(t testing.TB, getStatFunc func() int64, expected int64) (
 }
 
 // RequireWaitForStat will retry for up to 20 seconds until the result of getStatFunc is equal to the expected value.
-func RequireWaitForStat(t testing.TB, getStatFunc func() int64, expected int64) (val int64) {
+func RequireWaitForStat(t testing.TB, getStatFunc func() int64, expected int64, msgAndArgs ...any) (val int64) {
 	t.Helper()
 	require.NotNil(t, getStatFunc, "Function for RequireWaitForStat cannot be nil")
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		val = getStatFunc()
-		assert.Equal(c, expected, val)
+		assert.Equal(c, expected, val, msgAndArgs...)
 	}, 20*time.Second, 100*time.Millisecond)
 	return val
 }

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -2888,8 +2888,7 @@ func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
 
 		// rev assertions
 		base.RequireWaitForStat(t, rt2.GetDatabase().DbStats.CBLReplicationPull().RevSendCount.Value, startNumRevsSentTotal+numRT2DocsInitial)
-		base.RequireWaitForStat(t, func() int64 { return pullCheckpointer.Stats().ProcessedSequenceCount }, numRT2DocsInitial)
-		base.RequireWaitForStat(t, func() int64 { return pullCheckpointer.Stats().ExpectedSequenceCount }, numRT2DocsInitial)
+		requireCheckpointSequence(t, pullCheckpointer, numRT2DocsInitial)
 
 		// checkpoint assertions
 		assert.Equal(t, int64(0), pullCheckpointer.Stats().GetCheckpointHitCount)
@@ -2946,8 +2945,7 @@ func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
 
 		// make sure rt2 thinks it has sent all of the revs via a 2.x replicator
 		base.RequireWaitForStat(t, rt2.GetDatabase().DbStats.CBLReplicationPull().RevSendCount.Value, startNumRevsSentTotal+numRT2DocsTotal)
-		base.RequireWaitForStat(t, func() int64 { return pullCheckpointer.Stats().ProcessedSequenceCount }, numRT2DocsTotal-numRT2DocsInitial)
-		base.RequireWaitForStat(t, func() int64 { return pullCheckpointer.Stats().ExpectedSequenceCount }, numRT2DocsTotal-numRT2DocsInitial)
+		requireCheckpointSequence(t, pullCheckpointer, numRT2DocsTotal-numRT2DocsInitial)
 
 		// assert the second active replicator stats
 		assert.Equal(t, int64(1), pullCheckpointer.Stats().GetCheckpointHitCount)
@@ -3056,8 +3054,7 @@ func TestActiveReplicatorPullFromCheckpointIgnored(t *testing.T) {
 
 		// rev assertions
 		base.RequireWaitForStat(t, rt2.GetDatabase().DbStats.CBLReplicationPull().RevSendCount.Value, 0)
-		base.RequireWaitForStat(t, func() int64 { return pullCheckpointer.Stats().ProcessedSequenceCount }, 0)
-		base.RequireWaitForStat(t, func() int64 { return pullCheckpointer.Stats().ExpectedSequenceCount }, 0)
+		requireCheckpointSequence(t, pullCheckpointer, 0)
 
 		// checkpoint assertions
 		assert.Equal(t, int64(0), pullCheckpointer.Stats().GetCheckpointHitCount)
@@ -3097,8 +3094,7 @@ func TestActiveReplicatorPullFromCheckpointIgnored(t *testing.T) {
 
 		// make sure rt2 thinks it has sent all of the revs via a 2.x replicator
 		base.RequireWaitForStat(t, rt2.GetDatabase().DbStats.CBLReplicationPull().RevSendCount.Value, 0)
-		base.RequireWaitForStat(t, func() int64 { return pullCheckpointer.Stats().ProcessedSequenceCount }, 0)
-		base.RequireWaitForStat(t, func() int64 { return pullCheckpointer.Stats().ExpectedSequenceCount }, 0)
+		requireCheckpointSequence(t, pullCheckpointer, 0)
 
 		// assert the second active replicator stats
 		assert.Equal(t, int64(1), pullCheckpointer.Stats().GetCheckpointHitCount)
@@ -3446,8 +3442,7 @@ func TestActiveReplicatorPushFromCheckpoint(t *testing.T) {
 
 		// make sure the new replicator has only sent new mutations
 		base.RequireWaitForStat(t, ar.Push.GetStats().SendRevCount.Value, numRT1DocsTotal-numRT1DocsInitial)
-		base.RequireWaitForStat(t, func() int64 { return pushCheckpointer.Stats().ProcessedSequenceCount }, numRT1DocsTotal-numRT1DocsInitial)
-		base.RequireWaitForStat(t, func() int64 { return pushCheckpointer.Stats().ExpectedSequenceCount }, numRT1DocsTotal-numRT1DocsInitial)
+		requireCheckpointSequence(t, pushCheckpointer, numRT1DocsTotal-numRT1DocsInitial)
 
 		// assert the second active replicator stats
 		assert.Equal(t, int64(1), pushCheckpointer.Stats().GetCheckpointHitCount)
@@ -3544,6 +3539,7 @@ func TestActiveReplicatorEdgeCheckpointNameCollisions(t *testing.T) {
 		}
 
 		edge1PullCheckpointer := edge1Replicator.Pull.GetSingleCollection(t).Checkpointer
+		requireCheckpointSequence(t, edge1PullCheckpointer, numRT1DocsInitial)
 		edge1PullCheckpointer.CheckpointNow()
 
 		// one _changes from seq:0 with initial number of docs sent
@@ -3552,8 +3548,6 @@ func TestActiveReplicatorEdgeCheckpointNameCollisions(t *testing.T) {
 
 		// rev assertions
 		base.RequireWaitForStat(t, edge1Replicator.Pull.GetStats().HandleRevCount.Value, startNumRevsHandledTotal+numRT1DocsInitial)
-		base.RequireWaitForStat(t, func() int64 { return edge1PullCheckpointer.Stats().ProcessedSequenceCount }, numRT1DocsInitial)
-		base.RequireWaitForStat(t, func() int64 { return edge1PullCheckpointer.Stats().ExpectedSequenceCount }, numRT1DocsInitial)
 
 		// checkpoint assertions
 		assert.Equal(t, int64(0), edge1PullCheckpointer.Stats().GetCheckpointHitCount)
@@ -3589,6 +3583,7 @@ func TestActiveReplicatorEdgeCheckpointNameCollisions(t *testing.T) {
 		changesResults = edge2.WaitForChanges(numRT1DocsInitial, "/{{.keyspace}}/_changes?since=0", "", true)
 
 		edge2PullCheckpointer := edge2Replicator.Pull.GetSingleCollection(t).Checkpointer
+		requireCheckpointSequence(t, edge2PullCheckpointer, numRT1DocsInitial)
 		edge2PullCheckpointer.CheckpointNow()
 
 		// make sure that edge 2 didn't use a checkpoint
@@ -3622,6 +3617,7 @@ func TestActiveReplicatorEdgeCheckpointNameCollisions(t *testing.T) {
 		changesResults.RequireDocIDs(t, []string{fmt.Sprintf("%s%d", docIDPrefix, numRT1DocsInitial)})
 
 		edge1Checkpointer2 := edge1Replicator2.Pull.GetSingleCollection(t).Checkpointer
+		requireCheckpointSequence(t, edge1Checkpointer2, 1)
 		edge1Checkpointer2.CheckpointNow()
 		if rt2.GetDatabase().OnlyDefaultCollection() {
 			assert.Equal(t, int64(1), edge1Checkpointer2.Stats().GetCheckpointHitCount)
@@ -4530,8 +4526,7 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 
 		// rev assertions
 		base.RequireWaitForStat(t, rt2.GetDatabase().DbStats.CBLReplicationPull().RevSendCount.Value, startNumRevsSentTotal+1)
-		base.RequireWaitForStat(t, func() int64 { return pullCheckpointer.Stats().ProcessedSequenceCount }, 1)
-		base.RequireWaitForStat(t, func() int64 { return pullCheckpointer.Stats().ExpectedSequenceCount }, 1)
+		requireCheckpointSequence(t, pullCheckpointer, 1)
 
 		// checkpoint assertions
 		assert.Equal(t, int64(0), pullCheckpointer.Stats().GetCheckpointHitCount)
@@ -4585,8 +4580,7 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 
 		// make sure rt2 thinks it has sent all of the revs via a 2.x replicator
 		base.RequireWaitForStat(t, rt2.GetDatabase().DbStats.CBLReplicationPull().RevSendCount.Value, startNumRevsSentTotal+2)
-		base.RequireWaitForStat(t, func() int64 { return pullCheckpointer.Stats().ProcessedSequenceCount }, 1)
-		base.RequireWaitForStat(t, func() int64 { return pullCheckpointer.Stats().ExpectedSequenceCount }, 1)
+		requireCheckpointSequence(t, pullCheckpointer, 1)
 
 		// assert the second active replicator stats
 		assert.Equal(t, int64(1), pullCheckpointer.Stats().GetCheckpointMissCount)
@@ -4690,8 +4684,7 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 
 		// rev assertions
 		base.RequireWaitForStat(t, ar.Push.GetStats().SendRevCount.Value, startNumRevsSentTotal+1)
-		base.RequireWaitForStat(t, func() int64 { return pushCheckpointer.Stats().ProcessedSequenceCount }, 1)
-		base.RequireWaitForStat(t, func() int64 { return pushCheckpointer.Stats().ExpectedSequenceCount }, 1)
+		requireCheckpointSequence(t, pushCheckpointer, 1)
 
 		// checkpoint assertions
 		assert.Equal(t, int64(0), pushCheckpointer.Stats().GetCheckpointHitCount)
@@ -4753,8 +4746,7 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 
 		// make sure the replicator has resent the rev
 		base.RequireWaitForStat(t, ar.Push.GetStats().SendRevCount.Value, startNumRevsSentTotal+1)
-		base.RequireWaitForStat(t, func() int64 { return pushCheckpointer.Stats().ProcessedSequenceCount }, 1)
-		base.RequireWaitForStat(t, func() int64 { return pushCheckpointer.Stats().ExpectedSequenceCount }, 1)
+		requireCheckpointSequence(t, pushCheckpointer, 1)
 
 		// assert the second active replicator stats
 		assert.Equal(t, int64(1), pushCheckpointer.Stats().GetCheckpointMissCount)
@@ -4844,6 +4836,7 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 
 		// Since we bumped the checkpointer interval, we're only setting checkpoints on replicator close.
 		assert.Equal(t, int64(0), pushCheckpointer.Stats().SetCheckpointCount)
+		requireCheckpointSequence(t, pushCheckpointer, 1)
 		pushCheckpointer.CheckpointNow()
 		assert.Equal(t, int64(1), pushCheckpointer.Stats().SetCheckpointCount)
 
@@ -4872,6 +4865,7 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 		assert.Equal(t, "activeRT", doc2Body["source"])
 
 		assert.Equal(t, int64(1), pushCheckpointer.Stats().SetCheckpointCount)
+		requireCheckpointSequence(t, pushCheckpointer, 2)
 		pushCheckpointer.CheckpointNow()
 		assert.Equal(t, int64(2), pushCheckpointer.Stats().SetCheckpointCount)
 
@@ -4909,13 +4903,9 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 		assert.Equal(t, "activeRT", doc2Body["source"])
 
 		assert.Equal(t, int64(0), pushCheckpointer.Stats().SetCheckpointCount)
-		// wait for checkpoint set count to reach 1, there is small window between rev being sent to passive and awaiting
-		// response before adding sequence to processed sequence list. So calling CheckpointNow before this sent rev is
-		// added to processed sequences will mean CheckpointNow is a no-op. So we should wait for checkpoint count to increment.
-		base.RequireWaitForStat(t, func() int64 {
-			pushCheckpointer.CheckpointNow()
-			return pushCheckpointer.Stats().SetCheckpointCount
-		}, 1)
+		requireCheckpointSequence(t, pushCheckpointer, 1)
+		pushCheckpointer.CheckpointNow()
+		assert.Equal(t, int64(1), pushCheckpointer.Stats().SetCheckpointCount)
 		assert.NoError(t, ar.Stop())
 	})
 }
@@ -5004,11 +4994,13 @@ func TestActiveReplicatorRecoverFromMismatchedRev(t *testing.T) {
 
 		pushCheckpointer := ar.Push.GetSingleCollection(t).Checkpointer
 		assert.Equal(t, int64(0), pushCheckpointer.Stats().SetCheckpointCount)
+		requireCheckpointSequence(t, pushCheckpointer, 1)
 		pushCheckpointer.CheckpointNow()
 		assert.Equal(t, int64(1), pushCheckpointer.Stats().SetCheckpointCount)
 
 		pullCheckpointer := ar.Pull.GetSingleCollection(t).Checkpointer
 		assert.Equal(t, int64(0), pullCheckpointer.Stats().SetCheckpointCount)
+		requireCheckpointSequence(t, pullCheckpointer, 1)
 		pullCheckpointer.CheckpointNow()
 		assert.Equal(t, int64(1), pullCheckpointer.Stats().SetCheckpointCount)
 	})
@@ -5179,8 +5171,7 @@ func TestActiveReplicatorPullModifiedHash(t *testing.T) {
 
 		// rev assertions
 		base.RequireWaitForStat(t, rt2.GetDatabase().DbStats.CBLReplicationPull().RevSendCount.Value, startNumRevsSentTotal+numDocsPerChannelInitial)
-		base.RequireWaitForStat(t, func() int64 { return pullCheckpointer.Stats().ProcessedSequenceCount }, numDocsPerChannelInitial)
-		base.RequireWaitForStat(t, func() int64 { return pullCheckpointer.Stats().ExpectedSequenceCount }, numDocsPerChannelInitial)
+		requireCheckpointSequence(t, pullCheckpointer, numDocsPerChannelInitial)
 
 		// checkpoint assertions
 		assert.Equal(t, int64(0), pullCheckpointer.Stats().GetCheckpointHitCount)
@@ -5239,8 +5230,7 @@ func TestActiveReplicatorPullModifiedHash(t *testing.T) {
 
 		// make sure rt2 thinks it has sent all of the revs via a 2.x replicator
 		base.RequireWaitForStat(t, rt2.GetDatabase().DbStats.CBLReplicationPull().RevSendCount.Value, startNumRevsSentTotal+int64(expectedTotalDocs))
-		base.RequireWaitForStat(t, func() int64 { return pullCheckpointer.Stats().ProcessedSequenceCount }, int64(expectedChan2Docs))
-		base.RequireWaitForStat(t, func() int64 { return pullCheckpointer.Stats().ExpectedSequenceCount }, int64(expectedChan2Docs))
+		requireCheckpointSequence(t, pullCheckpointer, int64(expectedChan2Docs))
 
 		// assert the second active replicator stats
 		assert.Equal(t, int64(0), pullCheckpointer.Stats().GetCheckpointHitCount)

--- a/rest/replicatortest/replicator_test_helper.go
+++ b/rest/replicatortest/replicator_test_helper.go
@@ -70,6 +70,15 @@ func updateDoc(rt *rest.RestTester, docID string, version rest.DocVersion, bodyV
 	return updatedVersion
 }
 
+// requireCheckpointSequence waits for the checkpointer's processed and expected sequence counts to reach
+// expectedSeqCount. This avoids the race where WaitForChanges returns after the document write but before
+// the checkpointer's BLIP callback has recorded the sequence.
+func requireCheckpointSequence(t *testing.T, checkpointer *db.Checkpointer, expectedSeqCount int64) {
+	t.Helper()
+	base.RequireWaitForStat(t, func() int64 { return checkpointer.Stats().ProcessedSequenceCount }, expectedSeqCount, "ProcessedSequenceCount")
+	base.RequireWaitForStat(t, func() int64 { return checkpointer.Stats().ExpectedSequenceCount }, expectedSeqCount, "ExpectedSequenceCount")
+}
+
 func getTestRevpos(t *testing.T, doc db.Body, attachmentKey string) (revpos int) {
 	attachments := db.GetBodyAttachments(doc)
 	if attachments == nil {

--- a/rest/replicatortest/replicator_test_legacy_rev_test.go
+++ b/rest/replicatortest/replicator_test_legacy_rev_test.go
@@ -767,10 +767,16 @@ func TestActiveReplicatorConflictPreUpgradedVersionEachSide(t *testing.T) {
 				require.NoError(t, ar.Start(ctx1))
 
 				if tc.activeWins {
-					base.RequireWaitForStat(t, func() int64 {
-						return replicationStats.ConflictResolvedLocalCount.Value()
-					}, 1)
-					verPostConflictRes, _ := rt1.GetDoc(docID)
+					// ConflictResolvedLocalCount is incremented inside the updateAndReturnDoc callback,
+					// before the CAS write commits. A plain GetDoc after RequireWaitForStat can still
+					// see the pre-resolution rev. Poll both the stat and the version change together so
+					// verPostConflictRes is always the committed post-resolution rev when we use it below.
+					var verPostConflictRes rest.DocVersion
+					require.EventuallyWithT(t, func(c *assert.CollectT) {
+						assert.Equal(c, int64(1), replicationStats.ConflictResolvedLocalCount.Value())
+						verPostConflictRes, _ = rt1.GetDoc(docID)
+						assert.NotEqual(c, legacyRevRT1, verPostConflictRes.RevTreeID)
+					}, 10*time.Second, 50*time.Millisecond)
 					rt2.WaitForLegacyRev(docID, verPostConflictRes.RevTreeID, []byte(`{"channels":["alice"],"source":"rt1"}`))
 					rt2Doc := rt2.GetDocument(docID)
 					rest.RequireHistoryContains(t, rt2Doc.History, []string{initLegacyRevRT2, legacyRevRT2, verPostConflictRes.RevTreeID})

--- a/rest/replicatortest/replicator_test_legacy_rev_test.go
+++ b/rest/replicatortest/replicator_test_legacy_rev_test.go
@@ -948,11 +948,18 @@ func TestActiveReplicatorConflictPreUpgradedVersionOneSide(t *testing.T) {
 				require.NoError(t, ar.Start(ctx1))
 
 				if tc.activePeerHasPostUpgradeVersion {
-					base.RequireWaitForStat(t, func() int64 {
-						return replicationStats.ConflictResolvedLocalCount.Value()
-					}, 1)
-					replicatedDoc := rt1.GetDocument(docID)
-					verPostConflictRes := replicatedDoc.ExtractDocVersion()
+					// ConflictResolvedLocalCount is incremented inside the updateAndReturnDoc callback,
+					// before the CAS write commits. A plain GetDocument after RequireWaitForStat can still
+					// see the pre-resolution rev. Poll both the stat and the version change together so
+					// verPostConflictRes is always the committed post-resolution rev when we use it below.
+					var replicatedDoc *db.Document
+					var verPostConflictRes rest.DocVersion
+					require.EventuallyWithT(t, func(c *assert.CollectT) {
+						assert.Equal(c, int64(1), replicationStats.ConflictResolvedLocalCount.Value())
+						replicatedDoc = rt1.GetDocument(docID)
+						verPostConflictRes = replicatedDoc.ExtractDocVersion()
+						assert.NotEqual(c, legacyRevRT1, verPostConflictRes.RevTreeID)
+					}, 10*time.Second, 50*time.Millisecond)
 					// wait for this resolution to be pushed back to passive peer
 					rt2.WaitForVersion(docID, verPostConflictRes)
 

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2346,12 +2346,14 @@ func RequireDocVersionNotNil(t *testing.T, version DocVersion) {
 
 // RequireDocVersionEqual calls t.Fail if two document versions are not equal.
 func RequireDocVersionEqual(t testing.TB, expected, actual DocVersion) {
+	t.Helper()
 	require.Equal(t, expected.CV, actual.CV, "Versions mismatch.  Expected: %v, Actual: %v", expected, actual)
 	require.Equal(t, expected.RevTreeID, actual.RevTreeID, "Versions mismatch.  Expected: %v, Actual: %v", expected, actual)
 }
 
 // RequireHistoryContains fails test if rev tree does not contain all expected revIDs
 func RequireHistoryContains(t *testing.T, docHistory db.RevTree, expHistoryIDs []string) {
+	t.Helper()
 	require.Lenf(t, docHistory, len(expHistoryIDs), "Expected history to contain %d revIDs, but it had %d.  History: %v", len(expHistoryIDs), len(docHistory), docHistory)
 	for _, revID := range expHistoryIDs {
 		_, ok := docHistory[revID]
@@ -2361,6 +2363,7 @@ func RequireHistoryContains(t *testing.T, docHistory db.RevTree, expHistoryIDs [
 
 // RequireDocRevTreeEqual fails test if rev tree id's are not equal
 func RequireDocRevTreeEqual(t *testing.T, expected, actual DocVersion) {
+	t.Helper()
 	require.Equal(t, expected.RevTreeID, actual.RevTreeID)
 }
 

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -134,6 +134,7 @@ func (rt *RestTester) GetDocument(docID string) *db.Document {
 
 // WaitForLegacyRev waits for a legacy revision ID (1-abc) to exist. If the document is not found, the test will fail.
 func (rt *RestTester) WaitForLegacyRev(docID, legacyRevID string, expectedBody []byte) *db.Document {
+	rt.TB().Helper()
 	rt.WaitForVersionRevIDOnly(docID, db.DocVersion{RevTreeID: legacyRevID})
 	doc := rt.GetDocument(docID)
 	encodedCV, err := db.LegacyRevToRevTreeEncodedVersion(legacyRevID)
@@ -219,6 +220,7 @@ func (rt *RestTester) GetAllDBsVerbose() []DbSummary {
 
 // WaitForVersion retries a GET for a given document version until it returns 200 or 201 for a given document and revision. If version is not found, the test will fail.
 func (rt *RestTester) WaitForVersion(docID string, version DocVersion) {
+	rt.TB().Helper()
 	if version.RevTreeID == "" {
 		require.NotEqual(rt.TB(), "", version.CV.String(), "Expected CV if RevTreeID is empty for version %#v in WaitForVersion", version)
 	}
@@ -230,7 +232,7 @@ func (rt *RestTester) WaitForVersion(docID string, version DocVersion) {
 		var body db.Body
 		require.NoError(rt.TB(), base.JSONUnmarshal(rawResponse.Body.Bytes(), &body))
 		if version.RevTreeID != "" {
-			assert.Equal(c, version.RevTreeID, body.ExtractRev())
+			assert.Equal(c, version.RevTreeID, body.ExtractRev(), "docID: %s", docID)
 		}
 		if version.CV.IsEmpty() {
 			return
@@ -238,17 +240,19 @@ func (rt *RestTester) WaitForVersion(docID string, version DocVersion) {
 		if !assert.Contains(c, body, db.BodyCV) {
 			return
 		}
-		assert.Equal(c, version.CV.String(), body[db.BodyCV].(string))
+		assert.Equal(c, version.CV.String(), body[db.BodyCV].(string), "docID: %s", docID)
 	}, 10*time.Second, 50*time.Millisecond)
 }
 
 func (rt *RestTester) WaitForVersionRevIDOnly(docID string, version DocVersion) {
+	rt.TB().Helper()
 	version.CV = db.Version{} // empty cv so WaitForVersion only asserts on revID
 	rt.WaitForVersion(docID, version)
 }
 
 // WaitForCV waits for the document's current version to match the expectedVersion. Fails the test harness. WaitForVersion should be used in the general case to test revtree and and cv behavior.
 func (rt *RestTester) WaitForVersionHLVOnly(docID string, version DocVersion) {
+	rt.TB().Helper()
 	version.RevTreeID = ""
 	rt.WaitForVersion(docID, version)
 }


### PR DESCRIPTION
CBG-5506

Clean cherry pick of #8392 and #8457 to 4.1.2

No `[4.1.2 Backport]` ticket exists for this fix, so the title carries the upstream ticket key.
Verified on CE with the rosmar backing store: `go build`, `go vet`, `golangci-lint run --config=.golangci-strict.yml --new-from-rev`, `golangci-lint fmt --diff` and the affected package tests. Integration tests against Couchbase Server were not run.

🤖 Opened with the `sync-gateway-backport` skill in [Claude Code](https://claude.com/claude-code)
