### PR TITLE
[4.1.2 Backport] CBG-5517: avoid data race/crash in RestTester.closed

### DIFF
--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -136,7 +136,7 @@ type RestTester struct {
 	metricsHandlerOnce      sync.Once
 	DiagnosticHandler       http.Handler
 	diagnosticHandlerOnce   sync.Once
-	closed                  bool
+	closed                  atomic.Bool
 }
 
 func (rt *RestTester) TB() testing.TB {
@@ -204,9 +204,8 @@ func NewRestTesterMultipleCollections(tb testing.TB, restConfig *RestTesterConfi
 func (rt *RestTester) Bucket() base.Bucket {
 	if rt.TB() == nil {
 		panic("RestTester not properly initialized please use NewRestTester function")
-	} else if rt.closed {
-		panic("RestTester was closed!")
 	}
+	require.False(rt.TB(), rt.closed.Load(), "RestTester was closed!")
 
 	if rt.TestBucket != nil {
 		return rt.TestBucket.Bucket
@@ -674,7 +673,7 @@ func (rt *RestTester) Close() {
 		panic("RestTester not properly initialized please use NewRestTester function")
 	}
 	ctx := rt.Context() // capture ctx before closing rt
-	rt.closed = true
+	require.True(rt.TB(), rt.closed.CompareAndSwap(false, true), "RestTester already closed")
 	if rt.RestTesterServerContext != nil {
 		rt.RestTesterServerContext.Close(ctx)
 	}


### PR DESCRIPTION
CBG-5517

Clean cherry pick of #8397 to 4.1.2

No `[4.1.2 Backport]` ticket exists for this fix, so the title carries the upstream ticket key.
Verified on CE with the rosmar backing store: `go build`, `go vet`, `golangci-lint run --config=.golangci-strict.yml --new-from-rev`, `golangci-lint fmt --diff` and the affected package tests. Integration tests against Couchbase Server were not run.

🤖 Opened with the `sync-gateway-backport` skill in [Claude Code](https://claude.com/claude-code)
