### PR TITLE
[4.1.2 Backport] CBG-4713: fix TestMultiCollectionImportRemoveCollection flake

### DIFF
--- a/rest/importtest/collections_import_test.go
+++ b/rest/importtest/collections_import_test.go
@@ -425,7 +425,7 @@ func TestMultiCollectionImportRemoveCollection(t *testing.T) {
 
 	rt.WaitForChanges(docCount*2, "/{{.keyspace}}/_changes", "", true)
 	// there should be 10 documents datastore1_{10..19}
-	require.Equal(t, int64(docCount), rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value())
+	base.RequireWaitForStat(t, rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value, int64(docCount))
 
 	// Get the import version from the persisted config to ensure it didn't change
 	updatedImportVersion := GetImportVersion(t, rt, dbName)


### PR DESCRIPTION
CBG-4713

Clean cherry pick of #8408 to 4.1.2

No `[4.1.2 Backport]` ticket exists for this fix, so the title carries the upstream ticket key.
Verified on CE with the rosmar backing store: `go build`, `go vet`, `golangci-lint run --config=.golangci-strict.yml --new-from-rev`, `golangci-lint fmt --diff` and the affected package tests. Integration tests against Couchbase Server were not run.

🤖 Opened with the `sync-gateway-backport` skill in [Claude Code](https://claude.com/claude-code)
