### PR TITLE
[4.1.2 Backport] CBG-5557: fix TestReplicationStatusActions flake

### DIFF
--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -736,6 +736,11 @@ func TestReplicationStatusActions(t *testing.T) {
 			status := rt1.GetReplicationStatus(replicationID)
 			assert.Equal(c, db.ReplicationStateStopped, status.Status)
 			assert.Equal(c, "", status.LastSeqPull)
+			replications := rt1.GetReplications()
+			cfg, ok := replications[replicationID]
+			if assert.True(c, ok, "replication %q not found", replicationID) {
+				assert.Equal(c, db.ReplicationStateStopped, cfg.TargetState)
+			}
 		}, 10*time.Second, 100*time.Millisecond)
 
 		// Restart the replication

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1282,6 +1282,7 @@ func RequestByUser(method, resource, body, username string) *http.Request {
 }
 
 func RequireStatus(t testing.TB, response *TestResponse, expectedStatus int) {
+	t.Helper()
 	require.Equalf(t, expectedStatus, response.Code,
 		"Response status %d %q (expected %d %q)\nfor %s <%s> : %s",
 		response.Code, http.StatusText(response.Code),
@@ -1290,6 +1291,7 @@ func RequireStatus(t testing.TB, response *TestResponse, expectedStatus int) {
 }
 
 func AssertStatus(t testing.TB, response *TestResponse, expectedStatus int) bool {
+	t.Helper()
 	return assert.Equalf(t, expectedStatus, response.Code,
 		"Response status %d %q (expected %d %q)\nfor %s <%s> : %s",
 		response.Code, http.StatusText(response.Code),

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -372,6 +372,7 @@ func (rt *RestTester) WaitForActiveReplicatorCount(expCount int) {
 }
 
 func (rt *RestTester) WaitForReplicationStatusForDB(dbName string, replicationID string, targetStatus string) {
+	rt.TB().Helper()
 	var status db.ReplicationStatus
 	successFunc := func() bool {
 		status = rt.GetReplicationStatusForDB(dbName, replicationID)
@@ -381,10 +382,12 @@ func (rt *RestTester) WaitForReplicationStatusForDB(dbName string, replicationID
 }
 
 func (rt *RestTester) WaitForReplicationStatus(replicationID string, targetStatus string) {
+	rt.TB().Helper()
 	rt.WaitForReplicationStatusForDB("{{.db}}", replicationID, targetStatus)
 }
 
 func (rt *RestTester) GetReplications() (replications map[string]db.ReplicationCfg) {
+	rt.TB().Helper()
 	rawResponse := rt.SendAdminRequest("GET", "/{{.db}}/_replication/", "")
 	RequireStatus(rt.TB(), rawResponse, 200)
 	require.NoError(rt.TB(), base.JSONUnmarshal(rawResponse.Body.Bytes(), &replications))
@@ -392,10 +395,12 @@ func (rt *RestTester) GetReplications() (replications map[string]db.ReplicationC
 }
 
 func (rt *RestTester) GetReplicationStatus(replicationID string) (status db.ReplicationStatus) {
+	rt.TB().Helper()
 	return rt.GetReplicationStatusForDB("{{.db}}", replicationID)
 }
 
 func (rt *RestTester) GetReplicationStatusForDB(dbName string, replicationID string) (status db.ReplicationStatus) {
+	rt.TB().Helper()
 	rawResponse := rt.SendAdminRequest("GET", "/"+dbName+"/_replicationStatus/"+replicationID, "")
 	RequireStatus(rt.TB(), rawResponse, 200)
 	require.NoError(rt.TB(), base.JSONUnmarshal(rawResponse.Body.Bytes(), &status))


### PR DESCRIPTION
CBG-5557

Clean cherry pick of #8426 to 4.1.2

No `[4.1.2 Backport]` ticket exists for this fix, so the title carries the upstream ticket key.
Verified on CE with the rosmar backing store: `go build`, `go vet`, `golangci-lint run --config=.golangci-strict.yml --new-from-rev`, `golangci-lint fmt --diff` and the affected package tests. Integration tests against Couchbase Server were not run.

🤖 Opened with the `sync-gateway-backport` skill in [Claude Code](https://claude.com/claude-code)
