### PR TITLE
[4.1.2 Backport] CBG-5556: fix TestDCPCheckpointCleanup panic

### DIFF
--- a/base/dcp_client_test.go
+++ b/base/dcp_client_test.go
@@ -956,8 +956,7 @@ func TestDCPCheckpointCleanup(t *testing.T) {
 	foundDocs := make(chan string, len(dataStores))
 	callback := func(event sgbucket.FeedEvent) bool {
 		if strings.HasSuffix(string(event.Key), "_doc") {
-			mutationCount.Add(1)
-			if mutationCount.Load() == uint64(len(dataStores)) {
+			if mutationCount.Add(1) == uint64(len(dataStores)) {
 				close(foundDocs)
 			}
 		}


### PR DESCRIPTION
CBG-5556

Clean cherry pick of #8425 to 4.1.2

No `[4.1.2 Backport]` ticket exists for this fix, so the title carries the upstream ticket key.
Verified on CE with the rosmar backing store: `go build`, `go vet`, `golangci-lint run --config=.golangci-strict.yml --new-from-rev`, `golangci-lint fmt --diff` and the affected package tests. Integration tests against Couchbase Server were not run.

🤖 Opened with the `sync-gateway-backport` skill in [Claude Code](https://claude.com/claude-code)
