### PR TITLE
[4.1.2 Backport] CBG-5578: fix flake in TestISGRRunAsNonExistentUserPushesAsAdmin

### DIFF
--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -474,7 +474,7 @@ func (dbc *DatabaseContext) startReplications(ctx context.Context) {
 				return
 			}
 
-			err := dbc.SGReplicateMgr.StartReplications(dbc.SGReplicateMgr.loggingCtx) // TODO: use dbc.SGReplicateMgr.loggingCtx, if that is not removed ?
+			err := dbc.SGReplicateMgr.startReplications(dbc.SGReplicateMgr.loggingCtx)
 			if err != nil {
 				base.ErrorfCtx(dbc.SGReplicateMgr.loggingCtx, "Error starting %q Inter-Sync Gateway Replications: %v", dbc.Name, err)
 			}
@@ -526,9 +526,9 @@ func (m *sgReplicateManager) StartLocalNode(nodeUUID string, heartbeater base.He
 	return heartbeater.RegisterListener(m.heartbeatListener)
 }
 
-// StartReplications performs an initial retrieval of the cluster config, starts any replications
+// startReplications performs an initial retrieval of the cluster config, starts any replications
 // assigned to this node, and starts the process to monitor future changes to the cluster config.
-func (m *sgReplicateManager) StartReplications(ctx context.Context) error {
+func (m *sgReplicateManager) startReplications(ctx context.Context) error {
 
 	replications, err := m.GetReplications()
 	if err != nil {

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -7171,12 +7171,8 @@ func TestReplicatorDeprecatedCredentials(t *testing.T) {
 	adminSrv := httptest.NewServer(passiveRT.TestPublicHandler())
 	defer adminSrv.Close()
 
-	activeRT := rest.NewRestTester(t, nil)
+	activeRT := rest.NewRestTester(t, &rest.RestTesterConfig{SgReplicateEnabled: true})
 	defer activeRT.Close()
-	activeCtx := activeRT.Context()
-
-	err := activeRT.GetDatabase().SGReplicateMgr.StartReplications(activeCtx)
-	require.NoError(t, err)
 
 	docID := "test"
 	version := activeRT.PutDoc(docID, `{"prop":true}`)
@@ -7203,7 +7199,7 @@ func TestReplicatorDeprecatedCredentials(t *testing.T) {
 	rest.RequireStatus(t, resp, 200)
 
 	var config db.ReplicationConfig
-	err = json.Unmarshal(resp.BodyBytes(), &config)
+	err := json.Unmarshal(resp.BodyBytes(), &config)
 	require.NoError(t, err)
 	assert.Equal(t, "alice", config.Username)
 	assert.Equal(t, base.RedactedStr, config.Password)
@@ -7446,7 +7442,7 @@ function (doc) {
 			adminSrv := httptest.NewServer(passiveRT.TestAdminHandler())
 			defer adminSrv.Close()
 
-			activeRT := rest.NewRestTester(t, rtConfig)
+			activeRT := rest.NewRestTester(t, &rest.RestTesterConfig{SyncFn: rtConfig.SyncFn, SgReplicateEnabled: true})
 			defer activeRT.Close()
 
 			for _, rt := range []*rest.RestTester{passiveRT, activeRT} {
@@ -7504,9 +7500,6 @@ function (doc) {
 			resp = activeRT.SendAdminRequest("PUT", "/{{.db}}/_replication/"+replName, replConf)
 			rest.RequireStatus(t, resp, http.StatusCreated)
 
-			activeCtx := activeRT.Context()
-			err := activeRT.GetDatabase().SGReplicateMgr.StartReplications(activeCtx)
-			require.NoError(t, err)
 			activeRT.WaitForReplicationStatus(replName, db.ReplicationStateRunning)
 
 			base.RequireWaitForStat(t, receiverRT.GetDatabase().DbStats.Database().NumDocWrites.Value, 6)
@@ -7520,7 +7513,7 @@ function (doc) {
 			}
 
 			// Stop and remove replicator (to stop checkpointing after teardown causing panic)
-			_, _, err = activeRT.GetDatabase().SGReplicateMgr.PutReplicationStatus(activeRT.Context(), replName, "stop")
+			_, _, err := activeRT.GetDatabase().SGReplicateMgr.PutReplicationStatus(activeRT.Context(), replName, "stop")
 			require.NoError(t, err)
 			activeRT.WaitForReplicationStatus(replName, db.ReplicationStateStopped)
 			err = activeRT.GetDatabase().SGReplicateMgr.DeleteReplication(replName)
@@ -8097,9 +8090,6 @@ func TestISGRRunAsNonExistentUserPushesAsAdmin(t *testing.T) {
 		"/{{.db}}/_replication/"+repl1Name, replConf)
 	rest.RequireStatus(t, configResp, http.StatusCreated)
 
-	// StartReplications will error initialising the replicator but will not return an error
-	require.NoError(t, activeRT.GetDatabase().SGReplicateMgr.StartReplications(activeRT.Context()))
-
 	activeRT.WaitForReplicationStatus(repl1Name, db.ReplicationStateError)
 
 	resp := passiveRT.SendAdminRequest(http.MethodGet,
@@ -8188,9 +8178,8 @@ func TestISGRRunAsNonExistentUserReplicationConfigInDbConfig(t *testing.T) {
 
 	// Define the replication inline in the DatabaseConfig
 	// rather than creating it through the admin REST API.
-	// initial_state "stopped" prevents it from running before we call
-	// StartReplications, while still exercising the initialisation path that
-	// validates run_as.
+	// initial_state "stopped" prevents it from running, while still exercising
+	// the initialisation path that validates run_as.
 	activeRT := rest.NewRestTester(t, &rest.RestTesterConfig{
 		SyncFn:             syncFn,
 		SgReplicateEnabled: true,
@@ -8217,10 +8206,6 @@ func TestISGRRunAsNonExistentUserReplicationConfigInDbConfig(t *testing.T) {
 	docID := "private_doc_" + rest.SafeDocumentName(t, t.Name())
 	activeRT.PutDoc(docID, `{"channels":["`+privateChannel+`"],"content":"secret"}`)
 	activeRT.WaitForPendingChanges()
-
-	// StartReplications initialises the replicator; it errors on the missing
-	// run_as user but does not surface an error to the caller.
-	require.NoError(t, activeRT.GetDatabase().SGReplicateMgr.StartReplications(activeRT.Context()))
 
 	activeRT.WaitForReplicationStatus(replName, db.ReplicationStateError)
 


### PR DESCRIPTION
CBG-5578

Clean cherry pick of #8442 to 4.1.2

No `[4.1.2 Backport]` ticket exists for this fix, so the title carries the upstream ticket key.
Verified on CE with the rosmar backing store: `go build`, `go vet`, `golangci-lint run --config=.golangci-strict.yml --new-from-rev`, `golangci-lint fmt --diff` and the affected package tests. Integration tests against Couchbase Server were not run.

🤖 Opened with the `sync-gateway-backport` skill in [Claude Code](https://claude.com/claude-code)
