### PR TITLE
[4.1.2 Backport] CBG-4920: Fix flaky TestActiveReplicatorHLVConflictCustom

### DIFF
--- a/rest/replicatortest/replicator_conflict_test.go
+++ b/rest/replicatortest/replicator_conflict_test.go
@@ -1647,12 +1647,20 @@ func TestActiveReplicatorHLVConflictCustom(t *testing.T) {
 				require.NoError(t, err)
 				defer func() { require.NoError(t, ar.Stop()) }()
 
-				// Start the replicator
-				require.NoError(t, ar.Start(ctx1))
+				// Start push before pull: rt2 has no resolver, so it deterministically 409s the
+				// still-untouched local rev. Starting both together races that against pull
+				// resolving (and overwriting) the local doc first, making DocWriteConflict flaky.
+				require.NoError(t, ar.Push.Start(ctx1))
+				require.EventuallyWithT(t, func(c *assert.CollectT) {
+					status := ar.GetStatus(ctx1)
+					assert.Equal(c, 1, int(status.PushReplicationStatus.DocWriteConflict))
+				}, 10*time.Second, 100*time.Millisecond)
 
+				require.NoError(t, ar.Pull.Start(ctx1))
 				require.EventuallyWithT(t, func(c *assert.CollectT) {
 					status := ar.GetStatus(ctx1)
 					assert.Equal(c, 1, int(status.PullReplicationStatus.DocsRead))
+					// resolving/republishing must not register as a second conflict
 					assert.Equal(c, 1, int(status.PushReplicationStatus.DocWriteConflict))
 					if testCase.expectedDocPushResolved {
 						assert.Equal(c, 1, int(status.PushReplicationStatus.DocsWritten))


### PR DESCRIPTION
CBG-4920

Clean cherry pick of #8466 to 4.1.2

No `[4.1.2 Backport]` ticket exists for this fix, so the title carries the upstream ticket key.
Verified on CE with the rosmar backing store: `go build`, `go vet`, `golangci-lint run --config=.golangci-strict.yml --new-from-rev`, `golangci-lint fmt --diff` and the affected package tests. Integration tests against Couchbase Server were not run.

🤖 Opened with the `sync-gateway-backport` skill in [Claude Code](https://claude.com/claude-code)
