### PR TITLE
[4.1.2 Backport] CBG-4622: fix race in TestBlipDeltaSyncPullResend

### DIFF
--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -14,6 +14,7 @@ import (
 	"encoding/base64"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/couchbase/go-blip"
 	"github.com/couchbase/sync_gateway/base"
@@ -489,19 +490,27 @@ func TestBlipDeltaSyncPullResend(t *testing.T) {
 			expectedDocVersion2RevID = docVersion2.CV.String()
 		}
 		var revMsgs []*blip.Message
-		for _, msg := range client.pullReplication.GetMessages() {
-			if msg.Profile() != db.RevMessageRev {
-				continue
+		// We must use require.EventuallyWithT to poll the messages list here. While WaitForVersion
+		// guarantees that the client's document store has been updated (via addRev), the raw BLIP message
+		// itself is appended to pullReplication.GetMessages() via a defer hook after handleRev exits.
+		// Polling prevents a race condition where WaitForVersion returns but the final accepted full-body
+		// message is not yet appended to the replication messages log.
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			revMsgs = nil
+			for _, msg := range client.pullReplication.GetMessages() {
+				if msg.Profile() != db.RevMessageRev {
+					continue
+				}
+				if msg.Properties[db.RevMessageID] != docID {
+					continue
+				}
+				if msg.Properties[db.RevMessageRev] != expectedDocVersion2RevID {
+					continue
+				}
+				revMsgs = append(revMsgs, msg)
 			}
-			if msg.Properties[db.RevMessageID] != docID {
-				continue
-			}
-			if msg.Properties[db.RevMessageRev] != expectedDocVersion2RevID {
-				continue
-			}
-			revMsgs = append(revMsgs, msg)
-		}
-		require.Len(t, revMsgs, 2, client.pullReplication.GetAllMessagesSummary())
+			assert.Len(c, revMsgs, 2)
+		}, 5*time.Second, 5*time.Millisecond, client.pullReplication.GetAllMessagesSummary())
 		var serialNumber []blip.MessageNumber
 		for _, msg := range revMsgs {
 			serialNumber = append(serialNumber, msg.SerialNumber())


### PR DESCRIPTION
CBG-4622

Clean cherry pick of #8493 to 4.1.2

Note: `TestBlipDeltaSyncPullResend` and `TestBlipDeltaSyncPushAttachment` skip on CE because delta sync is EE-only, so this fix was not exercised locally.

No `[4.1.2 Backport]` ticket exists for this fix, so the title carries the upstream ticket key.
Verified on CE with the rosmar backing store: `go build`, `go vet`, `golangci-lint run --config=.golangci-strict.yml --new-from-rev`, `golangci-lint fmt --diff` and the affected package tests. Integration tests against Couchbase Server were not run.

🤖 Opened with the `sync-gateway-backport` skill in [Claude Code](https://claude.com/claude-code)
