### PR TITLE
[4.1.2 Backport] CBG-5001: fix flaky BLIP revocation pull tests

### DIFF
--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -2267,16 +2267,15 @@ func TestRevocationMessage(t *testing.T) {
 		revocationTester, rt := InitScenario(t, nil)
 		defer rt.Close()
 
+		revocationTester.addRoleChannel("foo", "A")
+		revocationTester.addRole("user", "foo")
+
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
 			Username:        "user",
 			ClientDeltas:    false,
 			SendRevocations: true,
 		})
 		defer btc.Close()
-
-		// Add channel to role and role to user
-		revocationTester.addRoleChannel("foo", "A")
-		revocationTester.addRole("user", "foo")
 
 		// Skip to seq 4 and then create doc in channel A
 		revocationTester.fillToSeq(4)
@@ -2377,16 +2376,15 @@ func TestRevocationNoRev(t *testing.T) {
 		revocationTester, rt := InitScenario(t, nil)
 		defer rt.Close()
 
+		revocationTester.addRoleChannel("foo", "A")
+		revocationTester.addRole("user", "foo")
+
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
 			Username:        "user",
 			ClientDeltas:    false,
 			SendRevocations: true,
 		})
 		defer btc.Close()
-
-		// Add channel to role and role to user
-		revocationTester.addRoleChannel("foo", "A")
-		revocationTester.addRole("user", "foo")
 
 		// Skip to seq 4 and then create doc in channel A
 		revocationTester.fillToSeq(4)
@@ -2470,16 +2468,15 @@ func TestRevocationGetSyncDataError(t *testing.T) {
 
 		defer rt.Close()
 
+		revocationTester.addRoleChannel("foo", "A")
+		revocationTester.addRole("user", "foo")
+
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
 			Username:        "user",
 			ClientDeltas:    false,
 			SendRevocations: true,
 		})
 		defer btc.Close()
-
-		// Add channel to role and role to user
-		revocationTester.addRoleChannel("foo", "A")
-		revocationTester.addRole("user", "foo")
 
 		// Skip to seq 4 and then create doc in channel A
 		revocationTester.fillToSeq(4)


### PR DESCRIPTION
CBG-5001

Clean cherry pick of #8494 to 4.1.2

No `[4.1.2 Backport]` ticket exists for this fix, so the title carries the upstream ticket key.
Verified on CE with the rosmar backing store: `go build`, `go vet`, `golangci-lint run --config=.golangci-strict.yml --new-from-rev`, `golangci-lint fmt --diff` and the affected package tests. Integration tests against Couchbase Server were not run.

🤖 Opened with the `sync-gateway-backport` skill in [Claude Code](https://claude.com/claude-code)
