### PR TITLE
[4.1.2 Backport] CBG-5658: fix flaky TestBlipSendConcurrentRevs

### DIFF
--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1135,11 +1135,29 @@ func TestBlipSendConcurrentRevs(t *testing.T) {
 	const (
 		maxConcurrentRevs    = 10
 		concurrentSendRevNum = 50
+		// Once all maxConcurrentRevs slots are held, every remaining rev has to wait for one.
+		expectedThrottledRevs = concurrentSendRevNum - maxConcurrentRevs
 	)
-	rt := NewRestTester(t, &RestTesterConfig{
+	docIDPrefix := t.Name() + "-"
+
+	var rt *RestTester
+	throttledRevs := func() int64 {
+		return rt.GetDatabase().DbStats.CBLReplicationPush().WriteThrottledCount.Value()
+	}
+	rt = NewRestTester(t, &RestTesterConfig{
 		LeakyBucketConfig: &base.LeakyBucketConfig{
-			UpdateCallback: func(_ string) {
-				time.Sleep(time.Millisecond * 5) // slow down rosmar - it's too quick to be throttled
+			// Hold each rev inside its throttle slot until all of the remaining revs have been
+			// throttled waiting for a slot. Without this the test relies on the client being able
+			// to push more than maxConcurrentRevs revs to the server in the time it takes the
+			// server to write one, which isn't true on a slow or busy machine (CBG-3741).
+			UpdateCallback: func(docID string) {
+				if !strings.HasPrefix(docID, docIDPrefix) {
+					return
+				}
+				deadline := time.Now().Add(time.Second * 20)
+				for throttledRevs() < expectedThrottledRevs && time.Now().Before(deadline) {
+					time.Sleep(time.Millisecond)
+				}
 			},
 		},
 		maxConcurrentRevs: base.Ptr(maxConcurrentRevs),
@@ -1154,13 +1172,11 @@ func TestBlipSendConcurrentRevs(t *testing.T) {
 	defer bt.Close()
 
 	wg := sync.WaitGroup{}
-	wg.Add(concurrentSendRevNum)
 	for i := range concurrentSendRevNum {
-		docID := fmt.Sprintf("%s-%d", t.Name(), i)
-		go func() {
-			defer wg.Done()
+		docID := fmt.Sprintf("%s%d", docIDPrefix, i)
+		wg.Go(func() {
 			bt.SendRev(docID, "1-abc", []byte(`{"key": "val", "channels": ["user1"]}`), blip.Properties{})
-		}()
+		})
 	}
 
 	base.WaitWithTimeout(t, &wg, time.Second*30)
@@ -1169,7 +1185,7 @@ func TestBlipSendConcurrentRevs(t *testing.T) {
 	throttleTime := rt.GetDatabase().DbStats.CBLReplicationPush().WriteThrottledTime.Value()
 	throttleDuration := time.Duration(throttleTime) * time.Nanosecond
 
-	assert.Greater(t, throttleCount, int64(0), "Expected throttled revs")
+	assert.Equal(t, int64(expectedThrottledRevs), throttleCount, "Expected throttled revs")
 	assert.Greater(t, throttleTime, int64(0), "Expected non-zero throttled revs time")
 
 	t.Logf("Throttled revs: %d, Throttled duration: %s", throttleCount, throttleDuration)


### PR DESCRIPTION
CBG-5658

Clean cherry pick of #8503 to 4.1.2

No `[4.1.2 Backport]` ticket exists for this fix, so the title carries the upstream ticket key.
Verified on CE with the rosmar backing store: `go build`, `go vet`, `golangci-lint run --config=.golangci-strict.yml --new-from-rev`, `golangci-lint fmt --diff` and the affected package tests. Integration tests against Couchbase Server were not run.

🤖 Opened with the `sync-gateway-backport` skill in [Claude Code](https://claude.com/claude-code)
