### PR TITLE
allow E2E pipeline from main integration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,17 @@
+import jenkins.model.Jenkins
+
+@NonCPS
+def jenkinsServerEnvVar(String name) {
+    def envVarsNodePropertyList = Jenkins.instance.globalNodeProperties.getAll(hudson.slaves.EnvironmentVariablesNodeProperty)
+    if (envVarsNodePropertyList && envVarsNodePropertyList[0]) {
+        def value = envVarsNodePropertyList[0].envVars.get(name)
+        if (value) {
+            return value
+        }
+    }
+    return "ERROR: ${name} is not configured as a Jenkins global environment variable"
+}
+
 pipeline {
     agent { label 'sgw-pipeline-ec2' }
 
@@ -217,11 +231,15 @@ pipeline {
                                         [backingStore: 'cbs', testDirectory: 'tests/dev_e2e'],
                                         [backingStore: 'cbs', testDirectory: 'tests/QE'],
                                     ]
+                                    def couchbaseLiteVersion = jenkinsServerEnvVar('DEFAULT_COUCHBASE_LITE_VERSION')
+                                    def couchbaseServerVersion = jenkinsServerEnvVar('DEFAULT_COUCHBASE_SERVER_VERSION')
                                     e2eModes.each { mode ->
                                         build job: 'Couchbase Lite E2E', wait: false, parameters: [
                                             string(name: 'SG_COMMIT', value: env.SG_COMMIT),
                                             string(name: 'BACKING_STORE', value: mode.backingStore),
                                             string(name: 'TEST_DIRECTORY', value: mode.testDirectory),
+                                            string(name: 'COUCHBASE_LITE_VERSION', value: couchbaseLiteVersion),
+                                            string(name: 'COUCHBASE_SERVER_VERSION', value: couchbaseServerVersion),
                                         ]
                                     }
                                 }


### PR DESCRIPTION
allow E2E pipeline from main integration - the code to https://github.com/couchbase/sync_gateway/blob/main/integration-test/e2e/Jenkinsfile#L44 only works when the UI is used.

I'm somewhat sure this will work, but not 100% until I merge.