### PR TITLE
CBG-5547 fix assertion and log tagging in WaitForPullNoRevMessage

### DIFF
--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -2114,10 +2114,9 @@ func (btcc *BlipTesterCollectionClient) WaitForPullNoRevMessage(docID string, ve
 				matches = append(matches, m)
 			}
 		}
-		if !assert.NotEmpty(c, matches, "norev message not found for docID %q version %v in pull replication messages", docID, version) {
+		if !assert.Len(c, matches, 1, "expected exactly one norev message for docID %q version %v in pull replication messages, got %d", docID, version, len(matches)) {
 			return
 		}
-		require.Len(btcc.TB(), matches, 1, "expected exactly one norev message for docID %q version %v, got %d", docID, version, len(matches))
 		msg = matches[0]
 	}, 10*time.Second, 5*time.Millisecond, "BlipTesterClient timed out waiting for pull norev message")
 	return msg
@@ -2349,7 +2348,7 @@ func (btcc *BlipTesterCollectionClient) addRev(ctx context.Context, docID string
 	// the raw pull replication message log directly.
 	if opts.isNoRev && newBody == nil && hasLocalDoc && doc._latestRev(btcc.TB()).body != nil {
 		require.Equal(btcc.TB(), db.MessageNoRev, opts.msg.Profile(), "only norev messages should hit this bodyless-clobber guard")
-		base.DebugfCtx(ctx, base.KeySGTest, "Ignoring norev body for docID %q: no body for version %#v", docID, opts.incomingVersion)
+		base.DebugfCtx(ctx, base.KeySGTest, "Ignoring norev body for docID %s: no body for version %#v", base.UD(docID), opts.incomingVersion)
 		return
 	}
 	newVersion.CV = *updatedHLV.ExtractCurrentVersionFromHLV()


### PR DESCRIPTION
CBG-5547

Follow-up to #8459, from Copilot review comments raised on its 4.1.2 backport (#8538).

`WaitForPullNoRevMessage` used `require.Len(btcc.TB(), ...)` inside a `require.EventuallyWithT` callback. `require` calls `FailNow`, which aborts from the polling goroutine and bypasses the `CollectT` accumulator, so the "exactly one norev message" check could not be retried past a transient duplicate. The two assertions collapse into a single `assert.Len(c, matches, 1, ...)`, which covers both the not-found and more-than-one cases and keeps the polling behaviour.

The doc ID in the norev debug log is now wrapped in `base.UD()`. The assertion message is not — that convention is for logging output only.

Verified on CE with the rosmar backing store: `go build ./...`, `go vet ./rest/`, `go test -run 'TestBlipConflictResolution|TestBlipNoRev|TestBlipPullConflict' ./rest/`, `golangci-lint run --config=.golangci-strict.yml --new-from-rev=origin/main ./rest/...` and `golangci-lint fmt --config=.golangci-strict.yml --diff ./rest/...`.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
