### PR TITLE
CBG-5666 Wait for heartbeat doc removal

### DIFF
--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -907,7 +907,7 @@ func WaitForBackgroundManagerHeartbeatDocRemoval[O any](t testing.TB, mgr *Backg
 	ctx := base.TestCtx(t)
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		exists, ok := mgr.clusterAwareOptions.metadataStore.Exists(ctx, mgr.clusterAwareOptions.HeartbeatDocID())
-		require.NoError(t, ok)
+		require.NoError(c, ok)
 		assert.False(c, exists, "BackgroundManager heartbeat document was not removed in expected time")
 	}, 10*time.Second, 10*time.Millisecond)
 }

--- a/rest/utilities_testing_attachment.go
+++ b/rest/utilities_testing_attachment.go
@@ -25,7 +25,11 @@ import (
 // is reached. Fails test harness if it is not reached within timeout.
 func (rt *RestTester) WaitForAttachmentCompactionStatus(expectedState db.BackgroundProcessState) db.AttachmentManagerResponse {
 	rt.TB().Helper()
-	return waitForBackgroundManagerState[db.AttachmentManagerResponse](rt, "/{{.db}}/_compact?type=attachment", expectedState)
+	response := waitForBackgroundManagerState[db.AttachmentManagerResponse](rt, "/{{.db}}/_compact?type=attachment", expectedState)
+	if !slices.Contains([]db.BackgroundProcessState{db.BackgroundProcessStateRunning, db.BackgroundProcessStateStopping}, expectedState) {
+		db.WaitForBackgroundManagerHeartbeatDocRemoval(rt.TB(), rt.GetDatabase().AttachmentCompactionManager)
+	}
+	return response
 }
 
 func CreateLegacyAttachmentDoc(t *testing.T, ctx context.Context, collection *db.DatabaseCollectionWithUser, docID string, body []byte, attID string, attBody []byte) string {

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -505,11 +505,19 @@ func waitForBackgroundManagerState[T backgroundManagerResponse](rt *RestTester, 
 	return response
 }
 
+// GetActiveDatabase returns the DatabaseContext for dbName, expanding the "{{.db}}" template if used.
+func (rt *RestTester) GetActiveDatabase(dbName string) *db.DatabaseContext {
+	rt.TB().Helper()
+	dbc, err := rt.ServerContext().GetActiveDatabase(rt.mustTemplateResource(dbName))
+	require.NoError(rt.TB(), err)
+	return dbc
+}
+
 func (rt *RestTester) waitForResyncDCPStatus(status db.BackgroundProcessState, dbName string) db.ResyncManagerResponseDCP {
 	rt.TB().Helper()
 	resyncStatus := waitForBackgroundManagerState[db.ResyncManagerResponseDCP](rt, "/"+dbName+"/_resync", status)
 	if !slices.Contains([]db.BackgroundProcessState{db.BackgroundProcessStateRunning, db.BackgroundProcessStateStopping}, status) {
-		db.WaitForBackgroundManagerHeartbeatDocRemoval(rt.TB(), rt.GetDatabase().ResyncManager)
+		db.WaitForBackgroundManagerHeartbeatDocRemoval(rt.TB(), rt.GetActiveDatabase(dbName).ResyncManager)
 	}
 	return resyncStatus
 }
@@ -518,7 +526,11 @@ func (rt *RestTester) waitForResyncDCPStatus(status db.BackgroundProcessState, d
 // the REST API until that state is reached. Fails test harness if it is not reached within timeout.
 func (rt *RestTester) WaitForTombstoneCompactionStatus(state db.BackgroundProcessState) db.TombstoneManagerResponse {
 	rt.TB().Helper()
-	return waitForBackgroundManagerState[db.TombstoneManagerResponse](rt, "/{{.db}}/_compact", state)
+	response := waitForBackgroundManagerState[db.TombstoneManagerResponse](rt, "/{{.db}}/_compact", state)
+	if !slices.Contains([]db.BackgroundProcessState{db.BackgroundProcessStateRunning, db.BackgroundProcessStateStopping}, state) {
+		db.WaitForBackgroundManagerHeartbeatDocRemoval(rt.TB(), rt.GetDatabase().TombstoneCompactionManager)
+	}
+	return response
 }
 
 // WaitForMetadataMigrationStatus waits for the expectedState of the metadata migration background job to be reached by polling
@@ -532,7 +544,11 @@ func (rt *RestTester) WaitForMetadataMigrationStatus(status db.BackgroundProcess
 // the REST API until that state is reached on the named db. Fails test harness if it is not reached within timeout.
 func (rt *RestTester) WaitForMetadataMigrationStatusForDB(status db.BackgroundProcessState, dbName string) db.MigrationManagerResponse {
 	rt.TB().Helper()
-	return waitForBackgroundManagerState[db.MigrationManagerResponse](rt, "/"+dbName+"/_metadata_migration", status)
+	response := waitForBackgroundManagerState[db.MigrationManagerResponse](rt, "/"+dbName+"/_metadata_migration", status)
+	if !slices.Contains([]db.BackgroundProcessState{db.BackgroundProcessStateRunning, db.BackgroundProcessStateStopping}, status) {
+		db.WaitForBackgroundManagerHeartbeatDocRemoval(rt.TB(), rt.GetActiveDatabase(dbName).MetadataMigrationManager)
+	}
+	return response
 }
 
 // UpdatePersistedBucketName will update the persisted config bucket name to name specified in parameters


### PR DESCRIPTION
CBG-5666 Wait for heartbeat doc removal

Fixes TestAttachmentCompactionAPI flake where reset immediately after stop could race a still-present heartbeat doc.

I've considered whether a better fix is to swap deleting the order of deleting the heartbeat doc and the status. I think this probably doesn't matter and this test only started failing when it was run with rosmar. Other background managers do already wait for heartbeat docs. Relevant production code: https://github.com/couchbase/sync_gateway/blob/41239eecf74f2da2c17932fcbfba42ec526950c6/db/background_mgr.go#L350-L360

```
2026-08-04T19:18:48.383Z [INF] c:#039 db:db Starting first phase of attachment compaction (mark phase) with compactionID: "fa356191-f82b-4eb7-8e22-7550339ed53e"
2026-08-04T19:18:48.383Z [INF] c:#039 db:db [Compaction Mark: fa356191-f82b-4eb7-8e22-7550339ed53e] Starting DCP feed for mark phase of attachment compaction
2026-08-04T19:18:48.386Z [INF] HTTP: c:#040 db:db POST http://127.0.0.1/db/_compact?type=attachment (as ADMIN)
2026-08-04T19:18:48.387Z [INF] HTTP: c:#040 db:db #040: 503 Process already running
2026-08-04T19:18:48.387Z [INF] HTTP: c:#040 db:db #040:     --> 503 Process already running  (0.8 ms)
2026-08-04T19:18:48.389Z [INF] c:#039 db:db [Compaction Mark: fa356191-f82b-4eb7-8e22-7550339ed53e] Mark phase of attachment compaction completed. Marked 3 attachments
2026-08-04T19:18:48.390Z [INF] c:#039 db:db Starting second phase of attachment compaction (sweep phase) with compactionID: "fa356191-f82b-4eb7-8e22-7550339ed53e"
2026-08-04T19:18:48.390Z [INF] c:#039 db:db [Compaction Sweep: fa356191-f82b-4eb7-8e22-7550339ed53e] Starting DCP feed for sweep phase of attachment compaction
2026-08-04T19:18:48.392Z [INF] c:#039 db:db [Compaction Sweep: fa356191-f82b-4eb7-8e22-7550339ed53e] Sweep phase of attachment compaction completed. Deleted 2 attachments
2026-08-04T19:18:48.392Z [INF] HTTP: c:#041 db:db GET http://127.0.0.1/db/_compact?type=attachment (as ADMIN)
2026-08-04T19:18:48.392Z [INF] c:#039 db:db Starting third phase of attachment compaction (cleanup phase) with compactionID: "fa356191-f82b-4eb7-8e22-7550339ed53e"
2026-08-04T19:18:48.393Z [INF] c:#039 db:db [Compaction Cleanup: fa356191-f82b-4eb7-8e22-7550339ed53e] Starting DCP feed for cleanup phase of attachment compaction
2026-08-04T19:18:48.395Z [INF] c:#039 db:db [Compaction Cleanup: fa356191-f82b-4eb7-8e22-7550339ed53e] Cleanup phase of attachment compaction completed
2026/08/04 19:18:48 TEST: Memory high water mark increased to 14.37 MB (heap: 13.21 MB stack: 1.16 MB)
2026-08-04T19:18:48.889Z [INF] HTTP: c:#042 db:db GET http://127.0.0.1/db/_compact?type=attachment (as ADMIN)
2026-08-04T19:18:48.895Z [INF] HTTP: c:#043 db:db GET http://127.0.0.1/db/_compact?type=attachment (as ADMIN)
2026-08-04T19:18:48.902Z [INF] HTTP: c:#044 db:db POST http://127.0.0.1/db/_compact?type=attachment (as ADMIN)
2026-08-04T19:18:48.903Z [INF] c:#044 db:db Attachment Compaction: Starting new compaction run with compact ID: "5a0b6b48-b87e-4884-ab95-8641157a625b"
2026-08-04T19:18:48.904Z [INF] c:#044 db:db Starting first phase of attachment compaction (mark phase) with compactionID: "5a0b6b48-b87e-4884-ab95-8641157a625b"
2026-08-04T19:18:48.904Z [INF] c:#044 db:db [Compaction Mark: 5a0b6b48-b87e-4884-ab95-8641157a625b] Starting DCP feed for mark phase of attachment compaction
2026-08-04T19:18:48.910Z [INF] HTTP: c:#045 db:db POST http://127.0.0.1/db/_compact?type=attachment&action=stop (as ADMIN)
2026-08-04T19:18:48.913Z [INF] c:#044 db:db [Compaction Mark: 5a0b6b48-b87e-4884-ab95-8641157a625b] Mark phase of attachment compaction was terminated. Marked 1 attachments
2026-08-04T19:18:48.915Z [INF] HTTP: c:#046 db:db GET http://127.0.0.1/db/_compact?type=attachment (as ADMIN)
2026-08-04T19:18:48.918Z [INF] HTTP: c:#047 db:db POST http://127.0.0.1/db/_compact?type=attachment&reset=true (as ADMIN)
2026-08-04T19:18:48.918Z [INF] HTTP: c:#047 db:db #047: 503 Process stop still in progress - please wait before restarting
2026-08-04T19:18:48.918Z [INF] HTTP: c:#047 db:db #047:     --> 503 Process stop still in progress - please wait before restarting  (0.7 ms)
    attachment_compaction_api_test.go:41: 
        	Error Trace:	/home/runner/work/sync_gateway/sync_gateway/rest/utilities_testing.go:1289
        	            				/home/runner/work/sync_gateway/sync_gateway/rest/attachmentcompactiontest/attachment_compaction_api_test.go:41
        	            				/home/runner/work/sync_gateway/sync_gateway/rest/attachmentcompactiontest/attachment_compaction_api_test.go:120
        	            				/opt/hostedtoolcache/go/1.26.5/x64/src/runtime/asm_amd64.s:1771
        	Error:      	Not equal: 
        	            	expected: 200
        	            	actual  : 503
        	Test:       	TestAttachmentCompactionAPI
        	Messages:   	Response status 503 "Service Unavailable" (expected 200 "OK")
        	            	for POST <http://127.0.0.1/db/_compact?type=attachment&reset=true> : {"error":"Service Unavailable","reason":"Process stop still in progress - please wait before restarting"}
--- FAIL: TestAttachmentCompactionAPI (0.63s)
```


## Pre-review checklist
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/1030/

<!--
Automated review runs on every non-draft PR raised from this repo (forks are not reviewed automatically).
  - Re-run it, or ask a follow-up, by commenting `@droid <question>`
  - Suppress it with the `droid-skip` label, or `WIP`/`DO NOT MERGE` in the title
-->
