### PR TITLE
CBG-5675 CI: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,12 +32,12 @@ concurrency:
   cancel-in-progress: ${{ !contains(github.ref, 'release/') && !contains(github.ref, 'main') }}
 
 env:
-  ACTIONS_CHECKOUT_VERSION: &actions_checkout_version actions/checkout@v6
-  ACTIONS_SETUP_GO_VERSION: &actions_setup_go_version actions/setup-go@v6
-  ACTIONS_RUFF_VERSION: &actions_ruff_version astral-sh/ruff-action@v4.0.0
+  ACTIONS_CHECKOUT_VERSION: &actions_checkout_version actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+  ACTIONS_SETUP_GO_VERSION: &actions_setup_go_version actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+  ACTIONS_RUFF_VERSION: &actions_ruff_version astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b # v4.0.0
   GO_VERSION: &go_version 1.26.5
   GOTESTSUM_VERSION: 1.13.0
-  GO_TEST_ANNOTATIONS_VERSION: &go_test_annotations_version guyarb/golang-test-annotations@v0.9.0
+  GO_TEST_ANNOTATIONS_VERSION: &go_test_annotations_version guyarb/golang-test-annotations@96fc379b171c49932041d6c789e73331a7bdeec1 # v0.9.0
 
 jobs:
   build:
@@ -70,7 +70,7 @@ jobs:
         with:
           go-version: *go_version
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: v2.12.2
           args: --config=.golangci-strict.yml
@@ -118,7 +118,7 @@ jobs:
         run: gotestsum --format standard-verbose --raw-command -- cat test.json > test.log 2>&1 || true
       - name: Upload test logs artifact
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-logs-${{ github.job }}-${{ matrix.name || matrix.os || 'default' }}
           path: test.log
@@ -154,7 +154,7 @@ jobs:
         run: gotestsum --format standard-verbose --raw-command -- cat test.json > test.log 2>&1 || true
       - name: Upload test logs artifact
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-logs-${{ github.job }}
           path: test.log
@@ -191,7 +191,7 @@ jobs:
         run: gotestsum --format standard-verbose --raw-command -- cat test.json > test.log 2>&1 || true
       - name: Upload test logs artifact
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-logs-${{ github.job }}
           path: test.log
@@ -226,7 +226,7 @@ jobs:
         run: gotestsum --format standard-verbose --raw-command -- cat test.json > test.log 2>&1 || true
       - name: Upload test logs artifact
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-logs-${{ github.job }}
           path: test.log
@@ -264,7 +264,7 @@ jobs:
         run: gotestsum --format standard-verbose --raw-command -- cat test.json > test.log 2>&1 || true
       - name: Upload test logs artifact
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-logs-${{ github.job }}
           path: test.log
@@ -291,7 +291,7 @@ jobs:
         os: [macos-latest, windows-latest, ubuntu-latest]
     steps:
       - uses: *actions_checkout_version
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
       - name: Run test
         run: |
           uv run -- pytest
@@ -332,7 +332,7 @@ jobs:
         run: gotestsum --format standard-verbose --raw-command -- cat test.json > test.log 2>&1 || true
       - name: Upload test logs artifact
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-logs-${{ github.job }}-${{ matrix.name || matrix.os || 'default' }}
           path: test.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,12 +32,18 @@ concurrency:
   cancel-in-progress: ${{ !contains(github.ref, 'release/') && !contains(github.ref, 'main') }}
 
 env:
+  # Pinned action versions, referenced by the steps below through their YAML anchors.
   ACTIONS_CHECKOUT_VERSION: &actions_checkout_version actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
   ACTIONS_SETUP_GO_VERSION: &actions_setup_go_version actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+  ACTIONS_UPLOAD_ARTIFACT_VERSION: &actions_upload_artifact_version actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
   ACTIONS_RUFF_VERSION: &actions_ruff_version astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b # v4.0.0
+  ACTIONS_SETUP_UV_VERSION: &actions_setup_uv_version astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+  ACTIONS_GOLANGCI_LINT_VERSION: &actions_golangci_lint_version golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+  # tag for repo at v1 is not updated
+  ACTIONS_GOVULNCHECK_VERSION: &actions_govulncheck_version golang/govulncheck-action@31f7c5463448f83528bd771c2d978d940080c9fd
+  ACTIONS_GO_TEST_ANNOTATIONS_VERSION: &actions_go_test_annotations_version guyarb/golang-test-annotations@96fc379b171c49932041d6c789e73331a7bdeec1 # v0.9.0
   GO_VERSION: &go_version 1.26.5
   GOTESTSUM_VERSION: 1.13.0
-  GO_TEST_ANNOTATIONS_VERSION: &go_test_annotations_version guyarb/golang-test-annotations@96fc379b171c49932041d6c789e73331a7bdeec1 # v0.9.0
 
 jobs:
   build:
@@ -70,7 +76,7 @@ jobs:
         with:
           go-version: *go_version
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+        uses: *actions_golangci_lint_version
         with:
           version: v2.12.2
           args: --config=.golangci-strict.yml
@@ -109,7 +115,7 @@ jobs:
         run: .github/scripts/test-summary.sh
       - name: Annotate Failures
         if: always()
-        uses: *go_test_annotations_version
+        uses: *actions_go_test_annotations_version
         with:
           test-results: test.json
       - name: Render test log
@@ -118,7 +124,7 @@ jobs:
         run: gotestsum --format standard-verbose --raw-command -- cat test.json > test.log 2>&1 || true
       - name: Upload test logs artifact
         if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: *actions_upload_artifact_version
         with:
           name: test-logs-${{ github.job }}-${{ matrix.name || matrix.os || 'default' }}
           path: test.log
@@ -145,7 +151,7 @@ jobs:
         run: .github/scripts/test-summary.sh
       - name: Annotate Failures
         if: always()
-        uses: *go_test_annotations_version
+        uses: *actions_go_test_annotations_version
         with:
           test-results: test.json
       - name: Render test log
@@ -154,7 +160,7 @@ jobs:
         run: gotestsum --format standard-verbose --raw-command -- cat test.json > test.log 2>&1 || true
       - name: Upload test logs artifact
         if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: *actions_upload_artifact_version
         with:
           name: test-logs-${{ github.job }}
           path: test.log
@@ -182,7 +188,7 @@ jobs:
         run: .github/scripts/test-summary.sh
       - name: Annotate Failures
         if: always()
-        uses: *go_test_annotations_version
+        uses: *actions_go_test_annotations_version
         with:
           test-results: test.json
       - name: Render test log
@@ -191,7 +197,7 @@ jobs:
         run: gotestsum --format standard-verbose --raw-command -- cat test.json > test.log 2>&1 || true
       - name: Upload test logs artifact
         if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: *actions_upload_artifact_version
         with:
           name: test-logs-${{ github.job }}
           path: test.log
@@ -217,7 +223,7 @@ jobs:
         run: .github/scripts/test-summary.sh
       - name: Annotate Failures
         if: always()
-        uses: *go_test_annotations_version
+        uses: *actions_go_test_annotations_version
         with:
           test-results: test.json
       - name: Render test log
@@ -226,7 +232,7 @@ jobs:
         run: gotestsum --format standard-verbose --raw-command -- cat test.json > test.log 2>&1 || true
       - name: Upload test logs artifact
         if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: *actions_upload_artifact_version
         with:
           name: test-logs-${{ github.job }}
           path: test.log
@@ -255,7 +261,7 @@ jobs:
         run: .github/scripts/test-summary.sh
       - name: Annotate Failures
         if: always()
-        uses: *go_test_annotations_version
+        uses: *actions_go_test_annotations_version
         with:
           test-results: test.json
       - name: Render test log
@@ -264,7 +270,7 @@ jobs:
         run: gotestsum --format standard-verbose --raw-command -- cat test.json > test.log 2>&1 || true
       - name: Upload test logs artifact
         if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: *actions_upload_artifact_version
         with:
           name: test-logs-${{ github.job }}
           path: test.log
@@ -291,7 +297,7 @@ jobs:
         os: [macos-latest, windows-latest, ubuntu-latest]
     steps:
       - uses: *actions_checkout_version
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+      - uses: *actions_setup_uv_version
       - name: Run test
         run: |
           uv run -- pytest
@@ -323,7 +329,7 @@ jobs:
         run: .github/scripts/test-summary.sh
       - name: Annotate Failures
         if: always()
-        uses: *go_test_annotations_version
+        uses: *actions_go_test_annotations_version
         with:
           test-results: test.json
       - name: Render test log
@@ -332,7 +338,7 @@ jobs:
         run: gotestsum --format standard-verbose --raw-command -- cat test.json > test.log 2>&1 || true
       - name: Upload test logs artifact
         if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: *actions_upload_artifact_version
         with:
           name: test-logs-${{ github.job }}-${{ matrix.name || matrix.os || 'default' }}
           path: test.log
@@ -353,8 +359,7 @@ jobs:
     name: Run govulncheck
     steps:
       - id: govulncheck
-        # tag for repo at v1 is not updated
-        uses: golang/govulncheck-action@31f7c5463448f83528bd771c2d978d940080c9fd
+        uses: *actions_govulncheck_version
         with:
-           go-version-input: *go_version
-           go-package: ./...
+          go-version-input: *go_version
+          go-package: ./...

--- a/.github/workflows/claude-review-ben.yaml
+++ b/.github/workflows/claude-review-ben.yaml
@@ -20,6 +20,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.issue.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  # Pinned action versions, referenced by the steps below through their YAML anchors.
+  ACTIONS_CHECKOUT_VERSION: &actions_checkout_version actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+  ACTIONS_CLAUDE_CODE_VERSION: &actions_claude_code_version anthropics/claude-code-action@c038e4dcdedfbbca18dfb17df35a17e40ded4ddc # v1.0.186
+
 jobs:
   claude-review-ben:
     # issue_comment always runs in the base repo with access to secrets, including for comments on
@@ -41,11 +46,11 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: *actions_checkout_version
         with:
           fetch-depth: 1
       - name: Run Claude Review
-        uses: anthropics/claude-code-action@c038e4dcdedfbbca18dfb17df35a17e40ded4ddc # v1.0.186
+        uses: *actions_claude_code_version
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # The Claude GitHub App is not installed on this repo, so Claude authenticates to GitHub

--- a/.github/workflows/claude-review-ben.yaml
+++ b/.github/workflows/claude-review-ben.yaml
@@ -41,11 +41,11 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
       - name: Run Claude Review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@c038e4dcdedfbbca18dfb17df35a17e40ded4ddc # v1.0.186
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # The Claude GitHub App is not installed on this repo, so Claude authenticates to GitHub

--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -27,6 +27,11 @@ concurrency:
     }}
   cancel-in-progress: true
 
+env:
+  # Pinned action versions, referenced by the steps below through their YAML anchors.
+  ACTIONS_CHECKOUT_VERSION: &actions_checkout_version actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+  ACTIONS_DROID_VERSION: &actions_droid_version Factory-AI/droid-action@07a08ac9ba352c395d921fbc4c310e6d1ee850a1 # v4
+
 jobs:
   droid:
     if: |
@@ -50,12 +55,12 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: *actions_checkout_version
         with:
           fetch-depth: 1
 
       - name: Run Droid Review
-        uses: Factory-AI/droid-action@07a08ac9ba352c395d921fbc4c310e6d1ee850a1 # v4
+        uses: *actions_droid_version
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
           review_model: gpt-5.2

--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -50,12 +50,12 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
 
       - name: Run Droid Review
-        uses: Factory-AI/droid-action@07a08ac9ba352c395d921fbc4c310e6d1ee850a1 # v4.0.0
+        uses: Factory-AI/droid-action@07a08ac9ba352c395d921fbc4c310e6d1ee850a1 # v4
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
           review_model: gpt-5.2

--- a/.github/workflows/manifestvalidation.yml
+++ b/.github/workflows/manifestvalidation.yml
@@ -39,7 +39,7 @@ jobs:
   manifest_validation:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Ensure manifest product-config properties are sorted
         id: validate
         run: |

--- a/.github/workflows/manifestvalidation.yml
+++ b/.github/workflows/manifestvalidation.yml
@@ -35,11 +35,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ !contains(github.ref, 'release/')}}
 
+env:
+  # Pinned action versions, referenced by the steps below through their YAML anchors.
+  ACTIONS_CHECKOUT_VERSION: &actions_checkout_version actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
 jobs:
   manifest_validation:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: *actions_checkout_version
       - name: Ensure manifest product-config properties are sorted
         id: validate
         run: |

--- a/.github/workflows/openapi-pr.yml
+++ b/.github/workflows/openapi-pr.yml
@@ -34,14 +34,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Find Comment
-        uses: peter-evans/find-comment@v4
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
           body-includes: Redocly previews
       - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/openapi-pr.yml
+++ b/.github/workflows/openapi-pr.yml
@@ -29,19 +29,24 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ !contains(github.ref, 'release/')}}
 
+env:
+  # Pinned action versions, referenced by the steps below through their YAML anchors.
+  ACTIONS_FIND_COMMENT_VERSION: &actions_find_comment_version peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
+  ACTIONS_CREATE_OR_UPDATE_COMMENT_VERSION: &actions_create_or_update_comment_version peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+
 jobs:
   redocly_preview_links:
     runs-on: ubuntu-latest
     steps:
       - name: Find Comment
-        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
+        uses: *actions_find_comment_version
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
           body-includes: Redocly previews
       - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        uses: *actions_create_or_update_comment_version
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -48,8 +48,8 @@ jobs:
     runs-on: ubuntu-latest
     name: OpenAPI Validation
     steps:
-      - uses: actions/checkout@v6
-      - uses: r7kamura/redocly-problem-matchers@v1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: r7kamura/redocly-problem-matchers@3b6f82af579316596ff52f605498423b2a69e483 # v1.2.0
       - name: redocly lint
         run: |-
           npx --yes @redocly/cli@2 lint --config=.redocly.yaml --format=stylish
@@ -58,7 +58,7 @@ jobs:
     name: 'yamllint'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: karancode/yamllint-github-action@master
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: karancode/yamllint-github-action@4052d365f09b8d34eb552c363d1141fd60e2aeb2 # v3.0.0
         with:
           yamllint_file_or_dir: 'docs/api'

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -43,13 +43,19 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ !contains(github.ref, 'release/')}}
 
+env:
+  # Pinned action versions, referenced by the steps below through their YAML anchors.
+  ACTIONS_CHECKOUT_VERSION: &actions_checkout_version actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+  ACTIONS_REDOCLY_PROBLEM_MATCHERS_VERSION: &actions_redocly_problem_matchers_version r7kamura/redocly-problem-matchers@3b6f82af579316596ff52f605498423b2a69e483 # v1.2.0
+  ACTIONS_YAMLLINT_VERSION: &actions_yamllint_version karancode/yamllint-github-action@4052d365f09b8d34eb552c363d1141fd60e2aeb2 # v3.0.0
+
 jobs:
   api_validation:
     runs-on: ubuntu-latest
     name: OpenAPI Validation
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: r7kamura/redocly-problem-matchers@3b6f82af579316596ff52f605498423b2a69e483 # v1.2.0
+      - uses: *actions_checkout_version
+      - uses: *actions_redocly_problem_matchers_version
       - name: redocly lint
         run: |-
           npx --yes @redocly/cli@2 lint --config=.redocly.yaml --format=stylish
@@ -58,7 +64,7 @@ jobs:
     name: 'yamllint'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: karancode/yamllint-github-action@4052d365f09b8d34eb552c363d1141fd60e2aeb2 # v3.0.0
+      - uses: *actions_checkout_version
+      - uses: *actions_yamllint_version
         with:
           yamllint_file_or_dir: 'docs/api'

--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -43,9 +43,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Verify service script installation.
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # build sync gateway since the executable is needed for service installation
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: 1.26.5
       - name: "Build Sync Gateway"

--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -38,14 +38,19 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ !contains(github.ref, 'release/')}}
 
+env:
+  # Pinned action versions, referenced by the steps below through their YAML anchors.
+  ACTIONS_CHECKOUT_VERSION: &actions_checkout_version actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+  ACTIONS_SETUP_GO_VERSION: &actions_setup_go_version actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+
 jobs:
   scripts:
     runs-on: ubuntu-latest
     name: Verify service script installation.
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: *actions_checkout_version
       # build sync gateway since the executable is needed for service installation
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+      - uses: *actions_setup_go_version
         with:
           go-version: 1.26.5
       - name: "Build Sync Gateway"

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -38,9 +38,9 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@master
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
         with:
           ignore_paths: |
             ./build.sh

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -33,14 +33,19 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ !contains(github.ref, 'release/')}}
 
+env:
+  # Pinned action versions, referenced by the steps below through their YAML anchors.
+  ACTIONS_CHECKOUT_VERSION: &actions_checkout_version actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+  ACTIONS_SHELLCHECK_VERSION: &actions_shellcheck_version ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
+
 jobs:
   shellcheck:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: *actions_checkout_version
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
+        uses: *actions_shellcheck_version
         with:
           ignore_paths: |
             ./build.sh


### PR DESCRIPTION
CBG-5675

- Pin actions to SHAs
- bump `actions/checkout` to latest everywhere

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- n/a

<!--
Automated review runs on every non-draft PR raised from this repo (forks are not reviewed automatically).
  - Re-run it, or ask a follow-up, by commenting `@droid <question>`
  - Suppress it with the `droid-skip` label, or `WIP`/`DO NOT MERGE` in the title
-->
