### PR TITLE
CBG-5472 Fix flaky TestSyncInfoUpgradeGate

### DIFF
--- a/rest/cluster_compat_test.go
+++ b/rest/cluster_compat_test.go
@@ -1532,10 +1532,15 @@ func TestClusterCompatRefreshIntervalUnclamped(t *testing.T) {
 // TestSyncInfoUpgradeGate tests syncInfo write gate during a rolling upgrade.
 // With a 4.0 peer present, writes must stay legacy JSON and once all peers reach 4.1+, writes flip to V1.
 func TestSyncInfoUpgradeGate(t *testing.T) {
-	rt := NewRestTesterPersistentConfig(t)
+	rt := NewRestTesterPersistentConfigNoDB(t)
 	defer rt.Close()
 
+	// Pre-mark syncInfo as migrated so attachment migration doesn't start and race with this
+	// test's own syncInfo writes below.
 	ctx := base.TestCtx(t)
+	require.NoError(t, base.SetSyncInfoMetaVersion(ctx, rt.GetTestBucket().GetSingleDataStore(), db.MetaVersionValue, nil))
+	RequireStatus(t, rt.CreateDatabase("db", rt.NewDbConfig()), http.StatusCreated)
+
 	bucketName := rt.Bucket().GetName()
 	ccm := rt.ServerContext().ClusterCompat
 	require.NotNil(t, ccm)

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -433,6 +433,12 @@ func (rt *RestTester) Bucket() base.Bucket {
 	return rt.TestBucket.Bucket
 }
 
+// GetTestBucket returns the underlying TestBucket, initializing it first if necessary.
+func (rt *RestTester) GetTestBucket() *base.TestBucket {
+	rt.Bucket()
+	return rt.TestBucket
+}
+
 // MetadataStore returns the datastore for the database on the RestTester
 func (rt *RestTester) MetadataStore() base.DataStore {
 	return rt.GetDatabase().MetadataStore


### PR DESCRIPTION
## Summary
- The attachment migration background manager starts automatically as soon as a database comes online, whenever its collection's syncInfo doc has no migrated MetaDataVersion yet.
- On completion, it writes syncInfo itself, tagged with whatever ClusterCompatVersion it resolves at that moment (self-only, since the fake peer isn't registered yet at that point in the test).
- That write races with the test's own syncInfo writes and can land after them, silently overwriting the test's legacy-JSON assertion with the migration manager's stale V1-tagged write.
- Fix: mark syncInfo as already-migrated before creating the database, so the manager finds nothing to do and never starts, removing the race entirely.

Reproduced on original code: 8/15000 runs failed; 0/15000 failed after the fix (both verified with identical run parameters, `-race` enabled).

```
--- FAIL: TestSyncInfoUpgradeGate (0.02s)
    cluster_compat_test.go:1563:
        	Error Trace:	rest/cluster_compat_test.go:1563
        	Error:      	Not equal:
        	            	expected: 0x7b
        	            	actual  : 0x1
        	Test:       	TestSyncInfoUpgradeGate
        	Messages:   	during mixed-version cluster, syncInfo write must be legacy JSON
```

## Test plan
- [x] `go test ./rest/ -run TestSyncInfoUpgradeGate -count=15000 -race`: 0 failures on the fix, reproduced on original code without the fix (8/15000 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)