### PR TITLE
CBG-5681: Derive CI Go version from go.mod only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ env:
   ACTIONS_CHECKOUT_VERSION: &actions_checkout_version actions/checkout@v6
   ACTIONS_SETUP_GO_VERSION: &actions_setup_go_version actions/setup-go@v6
   ACTIONS_RUFF_VERSION: &actions_ruff_version astral-sh/ruff-action@v4.0.0
-  GO_VERSION: &go_version 1.26.5
+  GO_MOD_FILE: &go_mod_file go.mod
   GOTESTSUM_VERSION: 1.13.0
   GO_TEST_ANNOTATIONS_VERSION: &go_test_annotations_version guyarb/golang-test-annotations@v0.9.0
 
@@ -46,7 +46,7 @@ jobs:
       - uses: *actions_checkout_version
       - uses: *actions_setup_go_version
         with:
-          go-version: *go_version
+          go-version-file: *go_mod_file
       - name: go-build
         run: go build "./..."
 
@@ -57,7 +57,7 @@ jobs:
       - uses: *actions_checkout_version
       - uses: *actions_setup_go_version
         with:
-          go-version: *go_version
+          go-version-file: *go_mod_file
       - run: go install github.com/google/addlicense@latest
       - run: addlicense -check -f licenses/addlicense.tmpl .
 
@@ -68,7 +68,7 @@ jobs:
       - uses: *actions_checkout_version
       - uses: *actions_setup_go_version
         with:
-          go-version: *go_version
+          go-version-file: *go_mod_file
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
@@ -95,7 +95,7 @@ jobs:
       - uses: *actions_checkout_version
       - uses: *actions_setup_go_version
         with:
-          go-version: *go_version
+          go-version-file: *go_mod_file
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@v${{ env.GOTESTSUM_VERSION }}
       - name: Build
@@ -133,7 +133,7 @@ jobs:
       - uses: *actions_checkout_version
       - uses: *actions_setup_go_version
         with:
-          go-version: *go_version
+          go-version-file: *go_mod_file
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@v${{ env.GOTESTSUM_VERSION }}
       - name: Run Tests
@@ -170,7 +170,7 @@ jobs:
       - uses: *actions_checkout_version
       - uses: *actions_setup_go_version
         with:
-          go-version: *go_version
+          go-version-file: *go_mod_file
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@v${{ env.GOTESTSUM_VERSION }}
       - name: Run Tests
@@ -205,7 +205,7 @@ jobs:
       - uses: *actions_checkout_version
       - uses: *actions_setup_go_version
         with:
-          go-version: *go_version
+          go-version-file: *go_mod_file
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@v${{ env.GOTESTSUM_VERSION }}
       - name: Run Tests
@@ -243,7 +243,7 @@ jobs:
       - uses: *actions_checkout_version
       - uses: *actions_setup_go_version
         with:
-          go-version: *go_version
+          go-version-file: *go_mod_file
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@v${{ env.GOTESTSUM_VERSION }}
       - name: Run Tests
@@ -309,7 +309,7 @@ jobs:
       - uses: *actions_checkout_version
       - uses: *actions_setup_go_version
         with:
-          go-version: *go_version
+          go-version-file: *go_mod_file
       - name: Build
         run: go build -v "./tools/stats-definition-exporter"
       - name: Install gotestsum
@@ -345,7 +345,7 @@ jobs:
       - uses: *actions_checkout_version
       - uses: *actions_setup_go_version
         with:
-          go-version: *go_version
+          go-version-file: *go_mod_file
       - name: Build
         run: go build "./tools/cache_perf_tool"
   govulncheck:
@@ -356,5 +356,7 @@ jobs:
         # tag for repo at v1 is not updated
         uses: golang/govulncheck-action@31f7c5463448f83528bd771c2d978d940080c9fd
         with:
-           go-version-input: *go_version
-           go-package: ./...
+          # blank this or the action's 'stable' default overrides the file
+          go-version-input: ''
+          go-version-file: *go_mod_file
+          go-package: ./...

--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -47,7 +47,7 @@ jobs:
       # build sync gateway since the executable is needed for service installation
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.26.5
+          go-version-file: go.mod
       - name: "Build Sync Gateway"
         run: mkdir -p ./bin && go build -o ./bin ./...
       - name: "Run test scripts"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,33 +34,15 @@ pipeline {
                 stage('Go Modules') {
                     steps {
                         script {
-                            // bootstrap a go version from go.mod. This requires a new enough version of go to run golang.org/dl/go$ver
-                            env.GO_VERSION = 'go' + sh(
+                            // go fetches the toolchain named in go.mod on demand
+                            env.GOTOOLS = sh(
                               returnStdout: true,
-                              script: '''
-                                go list -m -f '{{.GoVersion}}'
-                              '''
+                              script: 'go env GOPATH'
                             ).trim()
                             sh '''
                               set -eux
 
-                              echo "Sync Gateway go.mod version is $GO_VERSION"
-                              go install "golang.org/dl/$GO_VERSION@latest"
-                              ~/go/bin/$GO_VERSION download
-                            '''
-                            env.GOROOT = sh(
-                              returnStdout: true,
-                              script: '~/go/bin/$GO_VERSION env GOROOT'
-                            ).trim()
-                            env.GOTOOLS = sh(
-                              returnStdout: true,
-                              script: '~/go/bin/$GO_VERSION env GOPATH'
-                            ).trim()
-                            env.PATH = "${env.GOROOT}/bin:${env.PATH}"
-                            sh '''
-                              which go
                               go version
-                              go env
                             '''
                             sshagent(credentials: ['CB_SG_Robot_Github_SSH_Key']) {
                                 sh '''

--- a/jenkins-integration-build.sh
+++ b/jenkins-integration-build.sh
@@ -54,12 +54,8 @@ export GOPRIVATE=github.com/couchbaselabs/go-fleecedelta
 SG_COMMIT_HASH=$(git rev-parse HEAD)
 echo "Sync Gateway git commit hash: $SG_COMMIT_HASH"
 
-GO_VERSION=go$(go list -m -f '{{.GoVersion}}')
-echo "Sync Gateway go.mod version is ${GO_VERSION}"
-go install "golang.org/dl/${GO_VERSION}@latest"
-~/go/bin/"${GO_VERSION}" download
-GOROOT=$(~/go/bin/"${GO_VERSION}" env GOROOT)
-PATH=${GOROOT}/bin:$PATH
+# go fetches the toolchain named in go.mod on demand
+go version
 
 echo "Downloading tool dependencies..."
 go install gotest.tools/gotestsum@latest


### PR DESCRIPTION
CBG-5681

Make `go.mod` the source of truth for Go version for CI/local dev.
- `product-config.json` still defines Go version for each officially built product version.
- Assumes a base install of Go 1.21 or newer to be able to use the toolchain directive in this way.

This will only really be properly tested post-merge so I'm prepared to do required follow-ups if needed.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/1032/

<!--
Automated review runs on every non-draft PR raised from this repo (forks are not reviewed automatically).
  - Re-run it, or ask a follow-up, by commenting `@droid <question>`
  - Suppress it with the `droid-skip` label, or `WIP`/`DO NOT MERGE` in the title
-->
