### PR TITLE
CI/Lint: Disable new failing redocly spec-ref-siblings lint rule

### DIFF
--- a/.redocly.yaml
+++ b/.redocly.yaml
@@ -80,6 +80,7 @@ rules:
   no-identical-paths: off     # /{db} != /{targetdb}
   no-path-trailing-slash: off # Some endpoints require a trailing slash
   security-defined: off       # TODO: Denote public and authenticated API endpoints with https://redocly.com/docs/cli/rules/security-defined
+  spec-ref-siblings: off      # TODO: CBG-5686 - remove sibling properties defined alongside $ref and re-enable this rule
   custom-rules/typecheck-defaults: error
   custom-rules/check-additional-properties-names: error
   custom-rules/check-properties-sorted: error


### PR DESCRIPTION
Created a CBG to fix but for now disabling the linter

<!--
Automated review runs on every non-draft PR raised from this repo (forks are not reviewed automatically).
  - Re-run it, or ask a follow-up, by commenting `@droid <question>`
  - Suppress it with the `droid-skip` label, or `WIP`/`DO NOT MERGE` in the title
-->
