### PR TITLE
CBG-5683 CI: pin @redocly/cli via npm devDependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
 registries:
   gh-private:
     type: git

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -20,6 +20,8 @@ on:
       - '.redocly.yaml'
       - '.yamllint.yml'
       - '.github/workflows/openapi.yml'
+      - 'package.json'
+      - 'package-lock.json'
     branches:
       - 'master'
       - 'main'
@@ -48,6 +50,7 @@ env:
   ACTIONS_CHECKOUT_VERSION: &actions_checkout_version actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
   ACTIONS_REDOCLY_PROBLEM_MATCHERS_VERSION: &actions_redocly_problem_matchers_version r7kamura/redocly-problem-matchers@3b6f82af579316596ff52f605498423b2a69e483 # v1.2.0
   ACTIONS_YAMLLINT_VERSION: &actions_yamllint_version karancode/yamllint-github-action@4052d365f09b8d34eb552c363d1141fd60e2aeb2 # v3.0.0
+  ACTIONS_SETUP_NODE_VERSION: &actions_checkout_version actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
 
 jobs:
   api_validation:
@@ -55,10 +58,15 @@ jobs:
     name: OpenAPI Validation
     steps:
       - uses: *actions_checkout_version
+      - uses: *actions_setup_node_version
+        with:
+          node-version: '24'
+          cache: 'npm'
+      - run: npm ci
       - uses: *actions_redocly_problem_matchers_version
       - name: redocly lint
         run: |-
-          npx --yes @redocly/cli@2 lint --config=.redocly.yaml --format=stylish
+          npx redocly lint --config=.redocly.yaml --format=stylish
 
   yamllint:
     name: 'yamllint'

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ verbose*.xml
 sync_gateway
 *.pb.gz
 __pycache__
+node_modules/
 tools/cache_perf_tool/cache_perf_tool
 ./cache_perf_tool
 tools/stats-definition-exporter/stats-definition-exporter

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,11 @@ repos:
       - id: redocly-lint
         name: redocly lint
         language: system
-        entry: npx --yes @redocly/cli@2 lint --config=.redocly.yaml --format=stylish
+        # npm ci installs from the lockfile, so no manual setup step and no
+        # stale node_modules after a version bump
+        entry: >-
+          bash -c 'npm ci --no-audit --no-fund --silent &&
+          ./node_modules/.bin/redocly lint --config=.redocly.yaml --format=stylish'
         files: ^(docs/api/|\.redocly\.yaml$)
         pass_filenames: false
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -15,15 +15,19 @@ Changing a REST handler, a query parameter, or a response schema means updating 
 Validates every API root defined in `.redocly.yaml`:
 
 ```sh
-$ npx --yes @redocly/cli@2 lint --config=.redocly.yaml --format=stylish
+$ npm ci
+$ npx redocly lint --config=.redocly.yaml --format=stylish
 ```
+
+Redocly is pinned in `package.json` and `package-lock.json`. `npm ci` installs that exact version.
 
 This is wired into both the `redocly-lint` pre-commit hook (which fires on any change under
 `docs/api/` or to `.redocly.yaml`) and the `openapi` CI workflow, so it usually runs without you
-invoking it directly. `yamllint` also runs over this directory in both places.
+invoking it directly. The hook runs `npm ci` for you, so it needs no setup. `yamllint` also runs
+over this directory in both places.
 
 ## Preview
 
 ```sh
-$ npx --yes @redocly/cli@2 preview-docs --config=.redocly.yaml
+$ npx redocly preview-docs --config=.redocly.yaml
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,28 @@
+{
+  "name": "sync-gateway-openapi-tooling",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sync-gateway-openapi-tooling",
+      "devDependencies": {
+        "@redocly/cli": "2.45.0"
+      }
+    },
+    "node_modules/@redocly/cli": {
+      "version": "2.45.0",
+      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.45.0.tgz",
+      "integrity": "sha512-Z9VtjYEYdUBUvB/rggUJv5WPVMMEA3YM9NprEHD5aGrPeUl8aHIv14wByvL+dhxNkUbZW80AMNOuSXwduDeIsQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "openapi": "bin/cli.js",
+        "redocly": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0 || >=20.19.0 <21.0.0",
+        "npm": ">=10"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "sync-gateway-openapi-tooling",
+  "private": true,
+  "description": "Tooling-only manifest. Pins the OpenAPI linter used by CI and pre-commit.",
+  "devDependencies": {
+    "@redocly/cli": "2.45.0"
+  }
+}


### PR DESCRIPTION
CBG-5683

Pin redocly cli tool w/ npm devDependencies and lockfile
- Tweaks CI and pre-commit hook to utilize
- Enables Dependabot for npm

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- n/a

<!--
Automated review runs on every non-draft PR raised from this repo (forks are not reviewed automatically).
  - Re-run it, or ask a follow-up, by commenting `@droid <question>`
  - Suppress it with the `droid-skip` label, or `WIP`/`DO NOT MERGE` in the title
-->
