### PR TITLE
fix TestLateLogsHealthyFeedsNoRollback flake

### DIFF
--- a/db/channel_cache_latelog_test.go
+++ b/db/channel_cache_latelog_test.go
@@ -710,6 +710,7 @@ func TestLateLogsHealthyFeedsNoRollback(t *testing.T) {
 
 	writeSeq := func(seq uint64) {
 		WriteDirect(t, collection, []string{"ABC"}, seq)
+		require.NoError(t, db.WaitForSequenceNotSkipped(ctx, seq))
 		drainBoth()
 	}
 


### PR DESCRIPTION
Flake with race with sequence not appearing over feed before draining changes feed

## Pre-review checklist
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/

<!--
Automated review runs on every non-draft PR raised from this repo (forks are not reviewed automatically).
  - Re-run it, or ask a follow-up, by commenting `@droid <question>`
  - Suppress it with the `droid-skip` label, or `WIP`/`DO NOT MERGE` in the title
-->
