### PR TITLE
CBG-5700 replace WaitForCondition with RequireWaitForStat

### DIFF
--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -568,23 +568,6 @@ func TestAttachmentDifferentVBUUIDsBetweenPhases(t *testing.T) {
 	require.Equal(t, "_sync:dcp_ck::sg:att_compaction:TestAttachmentDifferentVBUUIDsBetweenPhases_sweep", dcpClient.GetMetadataKeyPrefix())
 }
 
-func WaitForConditionWithOptions(t testing.TB, successFunc func() bool, maxNumAttempts, timeToSleepMs int) error {
-	waitForSuccess := func() (shouldRetry bool, err error, value any) {
-		if successFunc() {
-			return false, nil, nil
-		}
-		return true, nil, nil
-	}
-
-	sleeper := base.CreateSleeperFunc(maxNumAttempts, timeToSleepMs)
-	err, _ := base.RetryLoop(base.TestCtx(t), "Wait for condition options", waitForSuccess, sleeper)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func CreateLegacyAttachmentDoc(t *testing.T, ctx context.Context, db *DatabaseCollectionWithUser, docID string, body []byte, attID string, attBody []byte) string {
 
 	attDigest := Sha1DigestKey(attBody)

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -749,10 +749,7 @@ func TestResyncUsingDCPStream(t *testing.T) {
 				rt.CreateTestDoc(fmt.Sprintf("doc%d", i))
 			}
 
-			err := rt.WaitForCondition(func() bool {
-				return int(rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value()) == testCase.docsCreated
-			})
-			assert.NoError(t, err)
+			base.RequireWaitForStat(t, rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value, int64(testCase.docsCreated))
 			rt.GetDatabase().DbStats.Database().SyncFunctionCount.Set(0)
 
 			response := rt.SendAdminRequest("POST", "/db/_resync?action=start", "")

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -235,10 +235,7 @@ func TestSingleCollectionDCP(t *testing.T) {
 	require.True(t, ok)
 
 	// ensure the doc is picked up by the import DCP feed and actually gets imported
-	err = rt.WaitForCondition(func() bool {
-		return rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value() == 1
-	})
-	require.NoError(t, err)
+	base.RequireWaitForStat(t, rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value, 1)
 
 	rt.WaitForDoc(docID)
 }
@@ -263,10 +260,7 @@ func TestMultiCollectionDCP(t *testing.T) {
 	}
 
 	// ensure the docs are picked up by the import DCP feed and actually gets imported
-	err := rt.WaitForCondition(func() bool {
-		return rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value() == numCollections
-	})
-	require.NoError(t, err)
+	base.RequireWaitForStat(t, rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value, int64(numCollections))
 
 	rt.WaitForPendingChanges()
 

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -64,10 +64,7 @@ func TestImportFeed(t *testing.T) {
 	assert.NoError(t, err, "Error writing SDK doc")
 
 	// Wait for import
-	err = rt.WaitForCondition(func() bool {
-		return rt.GetDatabase().DbStats.SharedBucketImportStats.ImportCount.Value() == 1
-	})
-	require.NoError(t, err)
+	base.RequireWaitForStat(t, rt.GetDatabase().DbStats.SharedBucketImportStats.ImportCount.Value, 1)
 
 	xattrs, _, err := dataStore.GetXattrs(rt.Context(), mobileKey, []string{base.MouXattrName, base.VirtualXattrRevSeqNo})
 	require.NoError(t, err)

--- a/rest/importuserxattrtest/import_test.go
+++ b/rest/importuserxattrtest/import_test.go
@@ -59,10 +59,7 @@ func TestUserXattrAutoImport(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Wait for doc to be imported
-	err = rt.WaitForCondition(func() bool {
-		return rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value() == 1
-	})
-	assert.NoError(t, err)
+	base.RequireWaitForStat(t, rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value, 1)
 
 	// Ensure sync function has ran twice (once for PUT and once for xattr addition)
 	assert.Equal(t, int64(2), rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
@@ -80,10 +77,7 @@ func TestUserXattrAutoImport(t *testing.T) {
 	_, err = dataStore.UpdateXattrs(ctx, docKey, 0, cas, map[string][]byte{xattrKey: base.MustJSONMarshal(t, channelName)}, nil)
 	require.NoError(t, err)
 
-	err = rt.WaitForCondition(func() bool {
-		return rt.GetDatabase().DbStats.Database().Crc32MatchCount.Value() == 1
-	})
-	assert.NoError(t, err)
+	base.RequireWaitForStat(t, rt.GetDatabase().DbStats.Database().Crc32MatchCount.Value, 1)
 
 	xattrs, _, err = dataStore.GetXattrs(ctx, docKey, []string{base.SyncXattrName})
 	assert.NoError(t, err)
@@ -100,10 +94,7 @@ func TestUserXattrAutoImport(t *testing.T) {
 	err = dataStore.Set(ctx, docKey, 0, nil, map[string]any{})
 	assert.NoError(t, err)
 
-	err = rt.WaitForCondition(func() bool {
-		return rt.GetDatabase().DbStats.Database().Crc32MatchCount.Value() == 2
-	})
-	assert.NoError(t, err)
+	base.RequireWaitForStat(t, rt.GetDatabase().DbStats.Database().Crc32MatchCount.Value, 2)
 
 	var syncData3 db.SyncData
 	xattrs, _, err = dataStore.GetXattrs(ctx, docKey, []string{base.SyncXattrName})
@@ -121,10 +112,7 @@ func TestUserXattrAutoImport(t *testing.T) {
 	err = dataStore.Set(ctx, docKey, 0, nil, updateVal)
 	assert.NoError(t, err)
 
-	err = rt.WaitForCondition(func() bool {
-		return rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value() == 2
-	})
-	assert.NoError(t, err)
+	base.RequireWaitForStat(t, rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value, 2)
 
 	assert.Equal(t, int64(3), rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
 
@@ -172,10 +160,7 @@ func TestUserXattrOnDemandImportGET(t *testing.T) {
 	rest.RequireStatus(t, resp, http.StatusOK)
 
 	// Wait for import
-	err = rt.WaitForCondition(func() bool {
-		return rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value() == 1
-	})
-	assert.NoError(t, err)
+	base.RequireWaitForStat(t, rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value, 1)
 
 	// Ensure sync function has been ran on import
 	assert.Equal(t, int64(1), rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
@@ -192,10 +177,7 @@ func TestUserXattrOnDemandImportGET(t *testing.T) {
 	rest.RequireStatus(t, resp, http.StatusOK)
 
 	// Wait for import
-	err = rt.WaitForCondition(func() bool {
-		return rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value() == 2
-	})
-	assert.NoError(t, err)
+	base.RequireWaitForStat(t, rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value, 2)
 
 	// Ensure sync function has ran on import
 	assert.Equal(t, int64(2), rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
@@ -268,10 +250,7 @@ func TestUserXattrOnDemandImportWrite(t *testing.T) {
 	rest.RequireStatus(t, resp, http.StatusConflict)
 
 	// Wait for import
-	err = rt.WaitForCondition(func() bool {
-		return rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value() == 1
-	})
-	assert.NoError(t, err)
+	base.RequireWaitForStat(t, rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value, 1)
 
 	// Ensure sync function has ran on import
 	assert.Equal(t, int64(2), rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
@@ -287,10 +266,7 @@ func TestUserXattrOnDemandImportWrite(t *testing.T) {
 	rest.RequireStatus(t, resp, http.StatusConflict)
 
 	// Wait for import
-	err = rt.WaitForCondition(func() bool {
-		return rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value() == 2
-	})
-	assert.NoError(t, err)
+	base.RequireWaitForStat(t, rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value, 2)
 
 	// Ensure sync function has ran on import
 	assert.Equal(t, int64(3), rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value())

--- a/rest/importuserxattrtest/rawdoc_test.go
+++ b/rest/importuserxattrtest/rawdoc_test.go
@@ -49,10 +49,7 @@ func TestUserXattrsRawGet(t *testing.T) {
 		nil)
 	require.NoError(t, err)
 
-	err = rt.WaitForCondition(func() bool {
-		return rt.GetDatabase().DbStats.SharedBucketImportStats.ImportCount.Value() == 1
-	})
-	require.NoError(t, err)
+	base.RequireWaitForStat(t, rt.GetDatabase().DbStats.SharedBucketImportStats.ImportCount.Value, 1)
 
 	resp = rt.SendAdminRequest("GET", "/{{.keyspace}}/_raw/"+docKey, "")
 	rest.RequireStatus(t, resp, http.StatusOK)

--- a/rest/importuserxattrtest/revid_import_test.go
+++ b/rest/importuserxattrtest/revid_import_test.go
@@ -9,7 +9,6 @@
 package importuserxattrtest
 
 import (
-	"log"
 	"maps"
 	"net/http"
 	"testing"
@@ -70,10 +69,7 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 	require.NoError(t, err)
 
 	// Wait for import
-	err = rt.WaitForCondition(func() bool {
-		return rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value() == 1
-	})
-	assert.NoError(t, err)
+	base.RequireWaitForStat(t, rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value, 1)
 
 	// Ensure import worked and sequence incremented but that sequence did not
 	var syncData2 db.SyncData
@@ -94,11 +90,7 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 	err = rt.GetSingleDataStore().Set(ctx, docKey, 0, nil, []byte(`{"update": "update"}`))
 	assert.NoError(t, err)
 
-	err = rt.WaitForCondition(func() bool {
-		log.Printf("Import count is: %v", rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value())
-		return rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value() == 2
-	})
-	assert.NoError(t, err)
+	base.RequireWaitForStat(t, rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value, 2)
 
 	var syncData3 db.SyncData
 	xattrs, _, err = dataStore.GetXattrs(rt.Context(), docKey, []string{base.SyncXattrName})

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -6523,10 +6523,7 @@ func TestSendChangesToNoConflictPreHydrogenTarget(t *testing.T) {
 	response := rt1.SendAdminRequest("PUT", "/{{.keyspace}}/doc1", "{}")
 	rest.RequireStatus(t, response, http.StatusCreated)
 
-	err = rt2.WaitForCondition(func() bool {
-		return base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().ErrorCount.Value() == errorCountBefore+1
-	})
-	assert.NoError(t, err)
+	base.RequireWaitForStat(t, base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().ErrorCount.Value, errorCountBefore+1)
 
 	assert.Equal(t, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
 	assert.Equal(t, db.PreHydrogenTargetAllowConflictsError.Error(), ar.GetStatus(ctx1).ErrorMessage)

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -1145,10 +1145,7 @@ func TestRemovingUserXattr(t *testing.T) {
 
 			// Trigger import
 			testCase.importTrigger(t, rt, docKey)
-			err = rt.WaitForCondition(func() bool {
-				return rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value() == 1
-			})
-			assert.NoError(t, err)
+			base.RequireWaitForStat(t, rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value, 1)
 
 			// Get sync data for doc and ensure user xattr has been used correctly to set channel
 			xattrs, cas, err := dataStore.GetXattrs(rt.Context(), docKey, []string{base.SyncXattrName})
@@ -1166,10 +1163,7 @@ func TestRemovingUserXattr(t *testing.T) {
 
 			// Trigger import
 			testCase.importTrigger(t, rt, docKey)
-			err = rt.WaitForCondition(func() bool {
-				return rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value() == 2
-			})
-			assert.NoError(t, err)
+			base.RequireWaitForStat(t, rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value, 2)
 
 			// Ensure old channel set with user xattr has been removed
 			xattrs, _, err = dataStore.GetXattrs(rt.Context(), docKey, []string{base.SyncXattrName})


### PR DESCRIPTION
CBG-5700 replace WaitForCondition with RequireWaitForStat

Remove `WaitForCondition` retry loops for a testify retry loop. In the future, I think we could have stat loops take a `SgwStat` so they could also report the stat name on error in addition to the value.

