### PR TITLE
CBG-5701: replace WaitForCondition with testify helpers in ISGR

### DIFF
--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -749,11 +749,11 @@ func TestReplicationStatusActions(t *testing.T) {
 
 		// Verify replication has restarted from zero. Since docs have already been replicated,
 		// expect no docs read, two docs checked.
-		statError := rt1.WaitForCondition(func() bool {
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			status := rt1.GetReplicationStatus(replicationID)
-			return status.DocsCheckedPull == 2 && status.DocsRead == 0
-		})
-		assert.NoError(t, statError)
+			assert.Equal(c, int64(2), status.DocsCheckedPull)
+			assert.Equal(c, int64(0), status.DocsRead)
+		}, 10*time.Second, 100*time.Millisecond)
 	})
 }
 
@@ -1085,31 +1085,20 @@ func TestReplicationConcurrentPush(t *testing.T) {
 		changesResults.RequireDocIDs(t, []string{docAllChannels1, docAllChannels2})
 
 		// wait for both replications to have pushed, and total pushed to equal 2
-		assert.NoError(t, activeRT.WaitForCondition(func() bool {
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			abcStatus := activeRT.GetReplicationStatus("rep_ABC")
-			if abcStatus.DocsCheckedPush != 2 {
-				t.Logf("abcStatus.DocsCheckedPush not 2, is %v", abcStatus.DocsCheckedPush)
-				t.Logf("abcStatus=%+v", abcStatus)
-				return false
-			}
+			assert.Equal(c, int64(2), abcStatus.DocsCheckedPush, "abcStatus=%+v", abcStatus)
 			defStatus := activeRT.GetReplicationStatus("rep_DEF")
-			if defStatus.DocsCheckedPush != 2 {
-				t.Logf("defStatus.DocsCheckedPush not 2, is %v", defStatus.DocsCheckedPush)
-				t.Logf("defStatus=%+v", defStatus)
-				return false
-			}
+			assert.Equal(c, int64(2), defStatus.DocsCheckedPush, "defStatus=%+v", defStatus)
 
 			// DocsWritten is incremented on a successful write, but ALSO in the race scenario where the remote responds
 			// to the changes message to say it needs the rev, but then receives the rev from another source. This means that
 			// in this test, DocsWritten can be any value between 0 and 2 for each replication, but should be at least 2
 			// for both replications
 			totalDocsWritten := abcStatus.DocsWritten + defStatus.DocsWritten
-			if totalDocsWritten < 2 || totalDocsWritten > 4 {
-				t.Logf("Total docs written is not between 2 and 4, is abc=%v, def=%v", abcStatus.DocsWritten, defStatus.DocsWritten)
-				return false
-			}
-			return true
-		}))
+			assert.GreaterOrEqual(c, totalDocsWritten, int64(2))
+			assert.LessOrEqual(c, totalDocsWritten, int64(4))
+		}, 10*time.Second, 100*time.Millisecond)
 
 		// Validate doc contents
 		docAll1Body := remoteRT.GetDocBody(docAllChannels1)
@@ -1770,14 +1759,13 @@ func TestReplicationHeartbeatRemoval(t *testing.T) {
 		assert.NoError(t, activeRT2Mgr.RemoveNode(activeRTUUID))
 
 		// Wait for nodes to add themselves back to cluster
-		err := activeRT.WaitForCondition(func() bool {
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			clusterDef, err := activeRTMgr.GetSGRCluster()
-			if err != nil {
-				return false
+			if !assert.NoError(c, err) {
+				return
 			}
-			return len(clusterDef.Nodes) == 2
-		})
-		assert.NoError(t, err, "Nodes did not re-register after removal")
+			assert.Len(c, clusterDef.Nodes, 2)
+		}, 10*time.Second, 100*time.Millisecond, "Nodes did not re-register after removal")
 
 		// Wait and validate replications are rebalanced
 		activeRT.WaitForAssignedReplications(1)
@@ -6440,15 +6428,16 @@ func TestLocalWinsConflictResolution(t *testing.T) {
 				rest.RequireStatus(t, response, http.StatusOK)
 
 				// Wait for expected property value on remote to determine replication complete
-				waitErr := remoteRT.WaitForCondition(func() bool {
-					var remoteDoc db.Body
+				require.EventuallyWithT(t, func(c *assert.CollectT) {
+					var remoteDoc struct {
+						Prop string `json:"prop"`
+					}
 					rawResponse := remoteRT.SendAdminRequest("GET", "/{{.keyspace}}/"+docID, "")
-					require.NoError(t, base.JSONUnmarshal(rawResponse.Body.Bytes(), &remoteDoc))
-					prop, ok := remoteDoc["prop"].(string)
-					t.Logf("-- Waiting for property: %v, got property: %v", test.expectedResult.propertyValue, prop)
-					return ok && prop == test.expectedResult.propertyValue
-				})
-				require.NoError(t, waitErr)
+					if !assert.NoError(c, base.JSONUnmarshal(rawResponse.Body.Bytes(), &remoteDoc)) {
+						return
+					}
+					assert.Equal(c, test.expectedResult.propertyValue, remoteDoc.Prop)
+				}, 10*time.Second, 100*time.Millisecond)
 
 				localDoc := activeRT.GetDocBody(docID)
 				localRevID := localDoc.ExtractRev()
@@ -7230,8 +7219,7 @@ func TestReplicatorCheckpointOnStop(t *testing.T) {
 		// Check checkpoint document was wrote to bucket with correct status
 		// _sync:local:checkpoint/sgr2cp:push:TestReplicatorCheckpointOnStop
 		expectedCheckpointName := base.SyncDocPrefix + "local:checkpoint/" + db.PushCheckpointID(replicationID)
-		lastSeq, err := activeRT.WaitForCheckpointLastSequence(expectedCheckpointName)
-		require.NoError(t, err)
+		lastSeq := activeRT.WaitForCheckpointLastSequence(expectedCheckpointName)
 		assert.Equal(t, seq, lastSeq)
 
 		err = activeRT.GetDatabase().SGReplicateMgr.DeleteReplication(replicationID)

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1289,8 +1289,7 @@ func RequireStatus(t testing.TB, response *TestResponse, expectedStatus int) {
 		response.Req.Method, response.Req.URL, response.Body)
 }
 
-func AssertStatus(t testing.TB, response *TestResponse, expectedStatus int) bool {
-	t.Helper()
+func AssertStatus(t assert.TestingT, response *TestResponse, expectedStatus int) bool {
 	return assert.Equalf(t, expectedStatus, response.Code,
 		"Response status %d %q (expected %d %q)\nfor %s <%s> : %s",
 		response.Code, http.StatusText(response.Code),

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -971,16 +971,6 @@ func WaitForConditionWithOptions(ctx context.Context, successFunc func() bool, m
 	return nil
 }
 
-func (rt *RestTester) WaitForConditionShouldRetry(conditionFunc func() (shouldRetry bool, err error, value any), maxNumAttempts, timeToSleepMs int) error {
-	sleeper := base.CreateSleeperFunc(maxNumAttempts, timeToSleepMs)
-	err, _ := base.RetryLoop(rt.Context(), "Wait for condition options", conditionFunc, sleeper)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func (rt *RestTester) SendAdminRequest(method, resource, body string) *TestResponse {
 	request := Request(method, rt.mustTemplateResource(resource), body)
 

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -308,44 +308,40 @@ func (rt *RestTester) WaitForTombstoneRevIDOnly(docID string, deleteVersion DocV
 	rt.WaitForTombstone(docID, deleteVersion)
 }
 
-func (rt *RestTester) WaitForCheckpointLastSequence(expectedName string) (string, error) {
+func (rt *RestTester) WaitForCheckpointLastSequence(expectedName string) string {
+	rt.TB().Helper()
 	var lastSeq string
-	successFunc := func() bool {
+	require.EventuallyWithT(rt.TB(), func(c *assert.CollectT) {
 		val, _, err := rt.GetSingleDataStore().GetRaw(rt.Context(), expectedName)
-		if err != nil {
-			rt.TB().Logf("Error getting checkpoint: %v - will retry", err)
-			return false
+		if !assert.NoError(c, err) {
+			return
 		}
 		var config struct { // db.replicationCheckpoint
 			LastSeq string `json:"last_sequence"`
 		}
-		err = json.Unmarshal(val, &config)
-		if err != nil {
-			rt.TB().Logf("Error unmarshalling checkpoint: %v - will retry", err)
-			return false
+		if !assert.NoError(c, json.Unmarshal(val, &config)) {
+			return
 		}
 		lastSeq = config.LastSeq
-		return lastSeq != ""
-	}
-	return lastSeq, rt.WaitForCondition(successFunc)
+		assert.NotEqual(c, "", lastSeq)
+	}, 10*time.Second, 100*time.Millisecond)
+	return lastSeq
 }
 
 func (rt *RestTester) WaitForActiveReplicatorInitialization(count int) {
 	rt.TB().Helper()
-	successFunc := func() bool {
+	require.EventuallyWithT(rt.TB(), func(c *assert.CollectT) {
 		ar := rt.GetDatabase().SGReplicateMgr.GetNumberActiveReplicators()
-		return ar == count
-	}
-	require.NoError(rt.TB(), rt.WaitForCondition(successFunc), "mismatch on number of active replicators")
+		assert.Equal(c, count, ar)
+	}, 10*time.Second, 100*time.Millisecond, "mismatch on number of active replicators")
 }
 
 func (rt *RestTester) WaitForPullBlipSenderInitialisation(name string) {
 	rt.TB().Helper()
-	successFunc := func() bool {
+	require.EventuallyWithT(rt.TB(), func(c *assert.CollectT) {
 		bs := rt.GetDatabase().SGReplicateMgr.GetActiveReplicator(name).Pull.GetBlipSender()
-		return bs != nil
-	}
-	require.NoError(rt.TB(), rt.WaitForCondition(successFunc), "blip sender on active replicator not initialized")
+		assert.NotNil(c, bs)
+	}, 10*time.Second, 100*time.Millisecond, "blip sender on active replicator not initialized")
 }
 
 // CreateReplication creates a replication via the REST API with the specified ID, remoteURL, direction and channel filter
@@ -387,11 +383,10 @@ func (rt *RestTester) CreateReplicationForDB(dbName string, replicationID string
 
 func (rt *RestTester) WaitForAssignedReplications(count int) {
 	rt.TB().Helper()
-	successFunc := func() bool {
+	require.EventuallyWithT(rt.TB(), func(c *assert.CollectT) {
 		replicationStatuses := rt.GetReplicationStatuses("?localOnly=true")
-		return len(replicationStatuses) == count
-	}
-	require.NoError(rt.TB(), rt.WaitForCondition(successFunc))
+		assert.Len(c, replicationStatuses, count)
+	}, 10*time.Second, 100*time.Millisecond)
 }
 
 func (rt *RestTester) GetActiveReplicatorCount() int {
@@ -402,22 +397,17 @@ func (rt *RestTester) GetActiveReplicatorCount() int {
 
 func (rt *RestTester) WaitForActiveReplicatorCount(expCount int) {
 	rt.TB().Helper()
-	var count int
-	successFunc := func() bool {
-		count = rt.GetActiveReplicatorCount()
-		return count == expCount
-	}
-	require.NoError(rt.TB(), rt.WaitForCondition(successFunc), "Mismatch in active replicator count, expected count %d actual %d", expCount, count)
+	require.EventuallyWithT(rt.TB(), func(c *assert.CollectT) {
+		assert.Equal(c, expCount, rt.GetActiveReplicatorCount())
+	}, 10*time.Second, 100*time.Millisecond, "Mismatch in active replicator count")
 }
 
 func (rt *RestTester) WaitForReplicationStatusForDB(dbName string, replicationID string, targetStatus string) {
 	rt.TB().Helper()
-	var status db.ReplicationStatus
-	successFunc := func() bool {
-		status = rt.GetReplicationStatusForDB(dbName, replicationID)
-		return status.Status == targetStatus
-	}
-	require.NoError(rt.TB(), rt.WaitForCondition(successFunc), "Expected status: %s, actual status: %s", targetStatus, status.Status)
+	require.EventuallyWithT(rt.TB(), func(c *assert.CollectT) {
+		status := rt.GetReplicationStatusForDB(dbName, replicationID)
+		assert.Equal(c, targetStatus, status.Status)
+	}, 10*time.Second, 100*time.Millisecond, "Expected status: %s", targetStatus)
 }
 
 func (rt *RestTester) WaitForReplicationStatus(replicationID string, targetStatus string) {

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -311,15 +311,16 @@ func (rt *RestTester) WaitForTombstoneRevIDOnly(docID string, deleteVersion DocV
 func (rt *RestTester) WaitForCheckpointLastSequence(expectedName string) string {
 	rt.TB().Helper()
 	var lastSeq string
+	ds := rt.GetSingleDataStore()
 	require.EventuallyWithT(rt.TB(), func(c *assert.CollectT) {
-		val, _, err := rt.GetSingleDataStore().GetRaw(rt.Context(), expectedName)
+		val, _, err := ds.GetRaw(rt.Context(), expectedName)
 		if !assert.NoError(c, err) {
 			return
 		}
 		var config struct { // db.replicationCheckpoint
 			LastSeq string `json:"last_sequence"`
 		}
-		if !assert.NoError(c, json.Unmarshal(val, &config)) {
+		if !assert.NoError(c, base.JSONUnmarshal(val, &config), "Could not unmarshal %s", string(val)) {
 			return
 		}
 		lastSeq = config.LastSeq
@@ -330,16 +331,22 @@ func (rt *RestTester) WaitForCheckpointLastSequence(expectedName string) string 
 
 func (rt *RestTester) WaitForActiveReplicatorInitialization(count int) {
 	rt.TB().Helper()
+	database := rt.GetDatabase()
 	require.EventuallyWithT(rt.TB(), func(c *assert.CollectT) {
-		ar := rt.GetDatabase().SGReplicateMgr.GetNumberActiveReplicators()
+		ar := database.SGReplicateMgr.GetNumberActiveReplicators()
 		assert.Equal(c, count, ar)
 	}, 10*time.Second, 100*time.Millisecond, "mismatch on number of active replicators")
 }
 
 func (rt *RestTester) WaitForPullBlipSenderInitialisation(name string) {
 	rt.TB().Helper()
+	database := rt.GetDatabase()
 	require.EventuallyWithT(rt.TB(), func(c *assert.CollectT) {
-		bs := rt.GetDatabase().SGReplicateMgr.GetActiveReplicator(name).Pull.GetBlipSender()
+		replicator := database.SGReplicateMgr.GetActiveReplicator(name)
+		if !assert.NotNil(c, replicator, "replicator %s does not exist", replicator) {
+			return
+		}
+		bs := replicator.Pull.GetBlipSender()
 		assert.NotNil(c, bs)
 	}, 10*time.Second, 100*time.Millisecond, "blip sender on active replicator not initialized")
 }
@@ -384,7 +391,14 @@ func (rt *RestTester) CreateReplicationForDB(dbName string, replicationID string
 func (rt *RestTester) WaitForAssignedReplications(count int) {
 	rt.TB().Helper()
 	require.EventuallyWithT(rt.TB(), func(c *assert.CollectT) {
-		replicationStatuses := rt.GetReplicationStatuses("?localOnly=true")
+		rawResponse := rt.SendAdminRequest("GET", "/{{.db}}/_replicationStatus/?localOnly=true", "")
+		if !AssertStatus(c, rawResponse, http.StatusOK) {
+			return
+		}
+		var replicationStatuses []db.ReplicationStatus
+		if !assert.NoError(c, base.JSONUnmarshal(rawResponse.Body.Bytes(), &replicationStatuses)) {
+			return
+		}
 		assert.Len(c, replicationStatuses, count)
 	}, 10*time.Second, 100*time.Millisecond)
 }
@@ -405,7 +419,10 @@ func (rt *RestTester) WaitForActiveReplicatorCount(expCount int) {
 func (rt *RestTester) WaitForReplicationStatusForDB(dbName string, replicationID string, targetStatus string) {
 	rt.TB().Helper()
 	require.EventuallyWithT(rt.TB(), func(c *assert.CollectT) {
-		status := rt.GetReplicationStatusForDB(dbName, replicationID)
+		rawResponse := rt.SendAdminRequest("GET", "/"+dbName+"/_replicationStatus/"+replicationID, "")
+		RequireStatus(rt.TB(), rawResponse, 200)
+		var status db.ReplicationStatus
+		require.NoError(rt.TB(), base.JSONUnmarshal(rawResponse.Body.Bytes(), &status))
 		assert.Equal(c, targetStatus, status.Status)
 	}, 10*time.Second, 100*time.Millisecond, "Expected status: %s", targetStatus)
 }
@@ -484,12 +501,12 @@ func waitForBackgroundManagerState[T backgroundManagerResponse](rt *RestTester, 
 	var response T
 	require.EventuallyWithT(rt.TB(), func(c *assert.CollectT) {
 		resp := rt.SendAdminRequest("GET", url, "")
-		// Use c (not rt.TB()) for all assertions so that failures are recorded on the
-		// CollectT and not on the real testing.T. EventuallyWithT runs the condition in a
-		// goroutine; calling rt.TB().Errorf/FailNow from that goroutine after the test
-		// has completed causes a "Fail in goroutine after TestXxx has completed" panic.
-		require.Equal(c, http.StatusOK, resp.Code)
-		require.NoError(c, base.JSONUnmarshal(resp.BodyBytes(), &response))
+		if !assert.Equal(c, http.StatusOK, resp.Code) {
+			return
+		}
+		if !assert.NoError(c, base.JSONUnmarshal(resp.BodyBytes(), &response)) {
+			return
+		}
 		assert.Equal(c, state, response.GetState())
 	}, timeout, pollInterval, "waiting for %s to reach state %q", url, state)
 	return response


### PR DESCRIPTION
CBG-5701: replace WaitForCondition with testify helpers in ISGR

Provide better error reporting on failures.

## Pre-review checklist
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/1035/

<!--
Automated review runs on every non-draft PR raised from this repo (forks are not reviewed automatically).
  - Re-run it, or ask a follow-up, by commenting `@droid <question>`
  - Suppress it with the `droid-skip` label, or `WIP`/`DO NOT MERGE` in the title
-->
