### PR TITLE
CBG-5705: wait for expected sequences over feed

### DIFF
--- a/db/channel_cache_latelog_test.go
+++ b/db/channel_cache_latelog_test.go
@@ -740,7 +740,7 @@ func TestLateLogsHealthyFeedsNoRollback(t *testing.T) {
 	finalSeq := seq
 
 	// The final late sequence can need one more notify cycle to reach the feeds than WaitForSequenceNotSkipped +
-	// drainBoth() observe (cache commit and feed wakeup are decoupled). Earlier cycles get backstopped by the
+	// drainBoth() observes (cache commit and feed wakeup are decoupled). Earlier cycles get backstopped by the
 	// next writeSeq's drain; the last one has no such backstop, so wait here without requiring a fresh
 	// "caught up" marker.
 	awaitAllSequences := func(feed <-chan *ChangeEntry, seen map[uint64]bool) {
@@ -756,7 +756,11 @@ func TestLateLogsHealthyFeedsNoRollback(t *testing.T) {
 		deadline := time.After(10 * time.Second)
 		for !allSeen() {
 			select {
-			case event := <-feed:
+			case event, ok := <-feed:
+				if !ok {
+					t.Fatal("changes feed closed before all sequences were seen")
+					return
+				}
 				if event != nil {
 					seen[event.Seq.Seq] = true
 				}

--- a/db/channel_cache_latelog_test.go
+++ b/db/channel_cache_latelog_test.go
@@ -739,6 +739,35 @@ func TestLateLogsHealthyFeedsNoRollback(t *testing.T) {
 
 	finalSeq := seq
 
+	// The final late sequence can need one more notify cycle to reach the feeds than WaitForSequenceNotSkipped +
+	// drainBoth() observe (cache commit and feed wakeup are decoupled). Earlier cycles get backstopped by the
+	// next writeSeq's drain; the last one has no such backstop, so wait here without requiring a fresh
+	// "caught up" marker.
+	awaitAllSequences := func(feed <-chan *ChangeEntry, seen map[uint64]bool) {
+		t.Helper()
+		allSeen := func() bool {
+			for s := uint64(1); s <= finalSeq; s++ {
+				if !seen[s] {
+					return false
+				}
+			}
+			return true
+		}
+		deadline := time.After(10 * time.Second)
+		for !allSeen() {
+			select {
+			case event := <-feed:
+				if event != nil {
+					seen[event.Seq.Seq] = true
+				}
+			case <-deadline:
+				return
+			}
+		}
+	}
+	awaitAllSequences(feed1, feed1Seen)
+	awaitAllSequences(feed2, feed2Seen)
+
 	// No data loss: both healthy feeds received every written sequence.
 	for _, feed := range []struct {
 		name string


### PR DESCRIPTION
CBG-5705

Previous fix for waiting for sequence not skipped was not enough. 

## Pre-review checklist
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/

<!--
Automated review runs on every non-draft PR raised from this repo (forks are not reviewed automatically).
  - Re-run it, or ask a follow-up, by commenting `@droid <question>`
  - Suppress it with the `droid-skip` label, or `WIP`/`DO NOT MERGE` in the title
-->
