### PR TITLE
CBG-5506 Fix flaky TestActiveReplicatorPushPullNewDocLegacyRevAndAllowUpdateAfter

### DIFF
--- a/rest/replicatortest/replicator_test_legacy_rev_test.go
+++ b/rest/replicatortest/replicator_test_legacy_rev_test.go
@@ -556,7 +556,9 @@ func TestActiveReplicatorPushPullNewDocLegacyRevAndAllowUpdateAfter(t *testing.T
 
 		// assert no conflicts on either side
 		assert.Equal(t, int64(0), replicationStats.PushConflictCount.Value())
-		assert.Equal(t, int64(2), replicationStats.PulledCount.Value())
+		// PulledCount is incremented in a defer after the pulled rev is written, so WaitForVersion above (which
+		// polls the doc via a separate GET) can observe the write slightly before the stat updates. Poll here too.
+		base.RequireWaitForStat(t, replicationStats.PulledCount.Value, 2)
 	})
 }
 


### PR DESCRIPTION
CBG-5506 Fix flaky TestActiveReplicatorPushPullNewDocLegacyRevAndAllowUpdateAfter

PulledCount is incremented after WaitForVersion can observe the write, causing a rare race.

previous fixes for similar tests:

https://github.com/couchbase/sync_gateway/commit/857a719bc4cde4f9c6ca51e81e71a50ebef7063d
https://github.com/couchbase/sync_gateway/commit/2627047b58000296994a9c8b066082b45193fc19
https://github.com/couchbase/sync_gateway/commit/a12549671398f0786e435aea175f9f98c10dbfc5

