### PR TITLE
CBG-5720: fix flaky TestAttachmentCompactionAPI

### DIFF
--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -571,7 +571,7 @@ func TestAttachmentDifferentVBUUIDsBetweenPhases(t *testing.T) {
 // CreateLegacyAttachmentDoc writes a doc with pre-4.0 attachment metadata in its _sync xattr, plus
 // the v1 attachment body doc it references, and returns the attachment doc ID.
 //
-// This document will under go an import which will generate a new mutation.
+// This helper performs a db.Put followed by a direct _sync xattr update, producing multiple KV mutations.
 func CreateLegacyAttachmentDoc(t *testing.T, ctx context.Context, db *DatabaseCollectionWithUser, docID string, body []byte, attID string, attBody []byte) string {
 
 	attDigest := Sha1DigestKey(attBody)

--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -568,6 +568,10 @@ func TestAttachmentDifferentVBUUIDsBetweenPhases(t *testing.T) {
 	require.Equal(t, "_sync:dcp_ck::sg:att_compaction:TestAttachmentDifferentVBUUIDsBetweenPhases_sweep", dcpClient.GetMetadataKeyPrefix())
 }
 
+// CreateLegacyAttachmentDoc writes a doc with pre-4.0 attachment metadata in its _sync xattr, plus
+// the v1 attachment body doc it references, and returns the attachment doc ID.
+//
+// This document will under go an import which will generate a new mutation.
 func CreateLegacyAttachmentDoc(t *testing.T, ctx context.Context, db *DatabaseCollectionWithUser, docID string, body []byte, attID string, attBody []byte) string {
 
 	attDigest := Sha1DigestKey(attBody)

--- a/rest/attachmentcompactiontest/attachment_compaction_api_test.go
+++ b/rest/attachmentcompactiontest/attachment_compaction_api_test.go
@@ -28,6 +28,9 @@ import (
 func TestAttachmentCompactionAPI(t *testing.T) {
 	// attachment compaction has to run on default collection, we can't run on multiple scopes right now for SG_TEST_USE_DEFAULT_COLLECTION = false
 	rt := rest.NewRestTesterDefaultCollection(t, &rest.RestTesterConfig{
+		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+			AutoImport: false, // CreateLegacyAttachmentDoc docs would be imported, marking their attachments twice
+		}},
 		LeakyBucketConfig: &base.LeakyBucketConfig{},
 	})
 	defer rt.Close()
@@ -125,9 +128,15 @@ func TestAttachmentCompactionPersistence(t *testing.T) {
 
 	// Attachment Compaction only runs on _default._default
 	rt1 := rest.NewRestTesterDefaultCollection(t, &rest.RestTesterConfig{
+		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+			AutoImport: false, // CreateLegacyAttachmentDoc docs would be imported, marking their attachments twice
+		}},
 		CustomTestBucket: noCloseTB,
 	})
 	rt2 := rest.NewRestTesterDefaultCollection(t, &rest.RestTesterConfig{
+		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+			AutoImport: false, // CreateLegacyAttachmentDoc docs would be imported, marking their attachments twice
+		}},
 		CustomTestBucket: tb.LeakyBucketClone(base.LeakyBucketConfig{}),
 	})
 	defer rt2.Close()
@@ -261,6 +270,9 @@ func TestAttachmentCompactionDryRun(t *testing.T) {
 func TestAttachmentCompactionReset(t *testing.T) {
 	// Attachment Compaction only runs on _default._default
 	rt := rest.NewRestTesterDefaultCollection(t, &rest.RestTesterConfig{
+		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+			AutoImport: false, // CreateLegacyAttachmentDoc docs would be imported, marking their attachments twice
+		}},
 		LeakyBucketConfig: &base.LeakyBucketConfig{},
 	})
 	defer rt.Close()
@@ -312,7 +324,11 @@ func TestAttachmentCompactionInvalidDocs(t *testing.T) {
 	ctx := base.TestCtx(t)
 
 	// attachment compaction has to run on default collection, we can't run on multiple scopes right now for SG_TEST_USE_DEFAULT_COLLECTION = false
-	rt := rest.NewRestTesterDefaultCollection(t, nil)
+	rt := rest.NewRestTesterDefaultCollection(t, &rest.RestTesterConfig{
+		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+			AutoImport: false, // CreateLegacyAttachmentDoc docs would be imported, marking their attachments twice
+		}},
+	})
 	defer rt.Close()
 
 	// Avoid racing the automatic startup migration against the mark phase below.
@@ -396,6 +412,9 @@ func TestAttachmentCompactionStartTimeAndStats(t *testing.T) {
 func TestAttachmentCompactionAbort(t *testing.T) {
 	// Attachment Compaction only runs on _default._default
 	rt := rest.NewRestTesterDefaultCollection(t, &rest.RestTesterConfig{
+		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+			AutoImport: false, // CreateLegacyAttachmentDoc docs would be imported, marking their attachments twice
+		}},
 		LeakyBucketConfig: &base.LeakyBucketConfig{},
 	})
 	defer rt.Close()

--- a/rest/utilities_testing_attachment.go
+++ b/rest/utilities_testing_attachment.go
@@ -35,9 +35,9 @@ func (rt *RestTester) WaitForAttachmentCompactionStatus(expectedState db.Backgro
 // CreateLegacyAttachmentDoc writes a doc with pre-4.0 attachment metadata in its _sync xattr, plus
 // the v1 attachment body doc it references, and returns the attachment doc ID.
 //
-// This doc will be imported, moving the attachment metadata to _globalSync. Tests must disable
-// auto-import (DbConfig.AutoImport = false), or DCP may deliver both mutations and attachment
-// compaction marks the same attachment twice.
+// If auto-import is enabled, this doc may be imported, moving the attachment metadata to _globalSync.
+// Tests that rely on stable legacy metadata should disable auto-import (DbConfig.AutoImport = false),
+// otherwise DCP may deliver both mutations and attachment compaction can mark the same attachment twice.
 func CreateLegacyAttachmentDoc(t *testing.T, ctx context.Context, collection *db.DatabaseCollectionWithUser, docID string, body []byte, attID string, attBody []byte) string {
 	attDigest := db.Sha1DigestKey(attBody)
 

--- a/rest/utilities_testing_attachment.go
+++ b/rest/utilities_testing_attachment.go
@@ -32,6 +32,12 @@ func (rt *RestTester) WaitForAttachmentCompactionStatus(expectedState db.Backgro
 	return response
 }
 
+// CreateLegacyAttachmentDoc writes a doc with pre-4.0 attachment metadata in its _sync xattr, plus
+// the v1 attachment body doc it references, and returns the attachment doc ID.
+//
+// This doc will be imported, moving the attachment metadata to _globalSync. Tests must disable
+// auto-import (DbConfig.AutoImport = false), or DCP may deliver both mutations and attachment
+// compaction marks the same attachment twice.
 func CreateLegacyAttachmentDoc(t *testing.T, ctx context.Context, collection *db.DatabaseCollectionWithUser, docID string, body []byte, attID string, attBody []byte) string {
 	attDigest := db.Sha1DigestKey(attBody)
 

--- a/rest/x509_test.go
+++ b/rest/x509_test.go
@@ -101,7 +101,13 @@ func TestAttachmentCompactionRun(t *testing.T) {
 	tb, _, _, _ := setupX509Tests(t, true)
 	defer tb.Close(ctx)
 
-	rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb, useTLSServer: true})
+	rt := NewRestTester(t, &RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+			AutoImport: false, // CreateLegacyAttachmentDoc docs would be imported, marking their attachments twice
+		}},
+		CustomTestBucket: tb,
+		useTLSServer:     true,
+	})
 	defer rt.Close()
 
 	collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()


### PR DESCRIPTION
CBG-5720: turn off import in tests using CreateLegacyAttachmentDoc

These docs get imported, moving attachment metadata to _globalSync. DCP can deliver both that mutation and the pre-migration one, so the compaction mark phase counts the same attachment twice.

I can't really think of a way to write this attachment easily without causing an import, and it doesn't seem worthwhile.

## Pre-review checklist
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/1049/

<!--
Automated review runs on every non-draft PR raised from this repo (forks are not reviewed automatically).
  - Re-run it, or ask a follow-up, by commenting `@droid <question>`
  - Suppress it with the `droid-skip` label, or `WIP`/`DO NOT MERGE` in the title
-->
