### PR TITLE
CBG-5685: Remove sequence equals method

### DIFF
--- a/db/sequence_id.go
+++ b/db/sequence_id.go
@@ -198,11 +198,6 @@ func (s SequenceID) IsNonZero() bool {
 	return s.Seq > 0
 }
 
-// Equality of sequences, based on seq, triggered by and low hash
-func (s SequenceID) Equals(s2 SequenceID) bool {
-	return s.SafeSequence() == s2.SafeSequence() && s.TriggeredBy == s2.TriggeredBy
-}
-
 // The most significant value is TriggeredBy, unless it's zero, in which case use Seq.
 // The tricky part is that "y" sorts after "y:z" for any nonzero z
 func (s SequenceID) Before(s2 SequenceID) bool {


### PR DESCRIPTION
CBG-5685

Describe your PR here...
- Remove Equals method of sequence ID

## Pre-review checklist
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/1050/

<!--
Automated review runs on every non-draft PR raised from this repo (forks are not reviewed automatically).
  - Re-run it, or ask a follow-up, by commenting `@droid <question>`
  - Suppress it with the `droid-skip` label, or `WIP`/`DO NOT MERGE` in the title
-->
