### PR TITLE
Combine e2e test runs into a single directory

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -191,13 +191,11 @@ pipeline {
                                 // but waits up to an hour for batches of PR merges before actually running (via quietPeriod)
                                 build job: 'MainIntegration', quietPeriod: 3600, wait: false
 
-                                echo 'Queueing E2E test runs (rosmar/cbs x dev_e2e/QE) for branch "main" ...'
+                                echo 'Queueing E2E test runs (rosmar/cbs) for branch "main" ...'
                                 script {
                                     def e2eModes = [
-                                        [backingStore: 'rosmar', testDirectory: 'tests/dev_e2e'],
-                                        [backingStore: 'rosmar', testDirectory: 'tests/QE'],
-                                        [backingStore: 'cbs', testDirectory: 'tests/dev_e2e'],
-                                        [backingStore: 'cbs', testDirectory: 'tests/QE'],
+                                        [backingStore: 'rosmar'],
+                                        [backingStore: 'cbs'],
                                     ]
                                     def couchbaseLiteVersion = env.DEFAULT_COUCHBASE_LITE_VERSION
                                     def couchbaseServerVersion = env.DEFAULT_COUCHBASE_SERVER_VERSION
@@ -205,7 +203,6 @@ pipeline {
                                         build job: 'Couchbase Lite E2E', wait: false, parameters: [
                                             string(name: 'SG_COMMIT', value: env.SG_COMMIT),
                                             string(name: 'BACKING_STORE', value: mode.backingStore),
-                                            string(name: 'TEST_DIRECTORY', value: mode.testDirectory),
                                             string(name: 'COUCHBASE_LITE_VERSION', value: couchbaseLiteVersion),
                                             string(name: 'COUCHBASE_SERVER_VERSION', value: couchbaseServerVersion),
                                         ]

--- a/integration-test/e2e/Jenkinsfile
+++ b/integration-test/e2e/Jenkinsfile
@@ -7,7 +7,6 @@ def e2eDetails(slackUtils) {
         SG_COMMIT: slackUtils.refLink(params.SG_COMMIT),
         Commit: slackUtils.gitCommitLink(),
         BACKING_STORE: params.BACKING_STORE,
-        TEST_DIRECTORY: params.TEST_DIRECTORY,
         COUCHBASE_LITE_VERSION: params.COUCHBASE_LITE_VERSION,
         COUCHBASE_SERVER_VERSION: params.COUCHBASE_SERVER_VERSION,
     ]
@@ -23,11 +22,6 @@ pipeline {
             name: 'BACKING_STORE',
             choices: ['rosmar', 'cbs'],
             description: 'Backing store to use'
-        )
-        choice(
-            name: 'TEST_DIRECTORY',
-            choices: ['tests/dev_e2e', 'tests/QE'],
-            description: 'Directory for tests'
         )
         string(
             name: 'COUCHBASE_LITE_TESTS_COMMIT',

--- a/integration-test/e2e/run_e2e_tests.sh
+++ b/integration-test/e2e/run_e2e_tests.sh
@@ -11,14 +11,13 @@
 set -eux -o pipefail
 
 # Resolve the script and repository directories
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-REPO_DIR="$( dirname "$( dirname "${SCRIPT_DIR}" )" )"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}")"  && pwd)"
+REPO_DIR="$( dirname "$( dirname "${SCRIPT_DIR}")")"
 
 # Check for required environment variables
 : "${BACKING_STORE:?BACKING_STORE must be set}"
 : "${COUCHBASE_LITE_TESTS_COMMIT:?COUCHBASE_LITE_TESTS_COMMIT must be set}"
 : "${COUCHBASE_LITE_VERSION:?COUCHBASE_LITE_VERSION must be set}"
-: "${TEST_DIRECTORY:?TEST_DIRECTORY must be set}"
 
 # Validate BACKING_STORE
 if [[ "$BACKING_STORE" != "rosmar" && "$BACKING_STORE" != "cbs" ]]; then
@@ -38,6 +37,10 @@ fi
 export GIT_CONFIG_GLOBAL="${SCRIPT_DIR}/.gitconfig.e2e"
 export GOPRIVATE="github.com/couchbaselabs/go-fleecedelta"
 git config --global url.git@github.com:couchbaselabs/go-fleecedelta.insteadOf https://github.com/couchbaselabs/go-fleecedelta
+git config --global filter.lfs.required true
+git config --global filter.lfs.clean "git-lfs clean -- %f"
+git config --global filter.lfs.smudge "git-lfs smudge -- %f"
+git config --global filter.lfs.process "git-lfs filter-process"
 
 # Clean up any existing clone to make local re-runs idempotent
 rm -rf couchbase-lite-tests
@@ -62,4 +65,4 @@ uv run -- ./environment/local/start_local.py "${START_LOCAL_ARGS[@]}"
 
 TOPOLOGY_CONFIG="$(cat environment/local/topology_config)"
 # shellcheck disable=SC2086
-uv run pytest --config "${TOPOLOGY_CONFIG}" --junitxml="${TEST_DIRECTORY}/junit_report.xml" -o junit_logging=all -o junit_log_passing_tests=false "./${TEST_DIRECTORY}" ${PYTEST_EXTRA_ARGS:-}
+uv run pytest --config "${TOPOLOGY_CONFIG}" --junitxml="tests/junit_report.xml" -o junit_logging=all -o junit_log_passing_tests=false "./tests" ${PYTEST_EXTRA_ARGS:-}


### PR DESCRIPTION
Combine e2e test runs into a single directory

This drops the complexity of the e2e tests because there is no separation of test runs. This is only possible after https://github.com/couchbaselabs/couchbase-lite-tests/commit/5afda7df166626f5b719868bfce34cc2fc3d5038

## Pre-review checklist

Tested by running `integration-test/e2e/run_e2e_tests.sh` locally. I added additional code for git lfs which is necessary for me to run locally but not if the system /etc/gitconfig is lfs-enabled.