### PR TITLE
CBG-5724: upgrade to go 1.26.6 / create 4.0.8 builds

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/couchbase/sync_gateway
 
-go 1.26.5
+go 1.26.6
 
 require (
 	dario.cat/mergo v1.0.2

--- a/manifest/4.0/4.0.7.xml
+++ b/manifest/4.0/4.0.7.xml
@@ -18,13 +18,13 @@ licenses/APL2.txt.
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="0ae8f452cece1e1f48f99e370a103b55bfea2dbe">
-        <annotation name="VERSION" value="4.0.8" keep="true"/>
+        <annotation name="VERSION" value="4.0.7" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>
 
 
     <!-- Sync Gateway -->
-    <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="release/4.0.8"/>
+    <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="57e671010afbfc2732968822865fb7e6b4fc0685"/>
 
 </manifest>

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -858,11 +858,11 @@
             "trigger_blackduck": true
         },
         "manifest/4.0.xml": {
-            "go_version": "1.25.11",
+            "go_version": "1.25.13",
             "interval": 120,
             "production": true,
-            "release": "4.0.7",
-            "release_name": "Couchbase Sync Gateway 4.0.7",
+            "release": "4.0.8",
+            "release_name": "Couchbase Sync Gateway 4.0.8",
             "start_build": 1,
             "trigger_blackduck": true
         },
@@ -976,8 +976,18 @@
             "start_build": 5,
             "trigger_blackduck": true
         },
+        "manifest/4.0/4.0.7.xml": {
+            "do-build": false,
+            "go_version": "1.25.11",
+            "interval": 1440,
+            "production": true,
+            "release": "4.0.7",
+            "release_name": "Couchbase Sync Gateway 4.0.7",
+            "start_build": 3,
+            "trigger_blackduck": true
+        },
         "manifest/4.1.xml": {
-            "go_version": "1.26.5",
+            "go_version": "1.26.6",
             "interval": 120,
             "production": true,
             "release": "4.1.2",
@@ -1016,7 +1026,7 @@
             "trigger_blackduck": true
         },
         "manifest/default.xml": {
-            "go_version": "1.26.5",
+            "go_version": "1.26.6",
             "interval": 30,
             "production": true,
             "release": "4.2.0",


### PR DESCRIPTION
CBG-5724

- Upgrade to go 1.26.6
- Create 4.0.8 builds

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- n/a

<!--
Automated review runs on every non-draft PR raised from this repo (forks are not reviewed automatically).
  - Re-run it, or ask a follow-up, by commenting `@droid <question>`
  - Suppress it with the `droid-skip` label, or `WIP`/`DO NOT MERGE` in the title
-->
