### PR TITLE
Reenable test on 8.1.0 affected by MB-73113

### DIFF
--- a/rest/manualbucketpooltest/metadata_migration_no_default_test.go
+++ b/rest/manualbucketpooltest/metadata_migration_no_default_test.go
@@ -326,10 +326,9 @@ func TestFreshDeploymentWithDroppedDefaultCollectionTwoDatabases(t *testing.T) {
 func TestMigrationThenDropDefaultCollectionTwoDatabases(t *testing.T) {
 	base.TestRequiresCollections(t)
 
-	// TODO MB-73113: Couchbase Server 8.0.0+ never finishes a deferred index build on a collection once _default._default
-	// has been dropped, so db2 below never comes online. The 8.x minimums here are placeholders no build will reach, which
-	// skips all of 8.0.x and 8.1.x. Replace them with the real fixed versions once MB-73113 ships in an 8.x build.
-	base.RequireServerVersionForTest(t, "7.6.0", "8.0.99", "8.1.99")
+	// MB-73113: a deferred index build never finishes on any collection once _default._default has been dropped.
+	// Fixed in 8.1.0@2674. There is no 8.0.x backport yet, so the 8.0 minimum stays at a build no release will reach.
+	base.RequireServerVersionForTest(t, "7.6.0", "8.0.99", "8.1.0@2674")
 
 	ctx := base.TestCtx(t)
 


### PR DESCRIPTION
## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
`TestMigrationThenDropDefaultCollectionTwoDatabases`:
- [x] 7.6.7 (should pass) https://jenkins.sgwdev.com/job/SyncGatewayIntegration/1061/
```
--- PASS: TestMigrationThenDropDefaultCollectionTwoDatabases (24.81s)
```
- [x] 8.0.2 (should skip) https://jenkins.sgwdev.com/job/SyncGatewayIntegration/1068/
```
=== RUN   TestMigrationThenDropDefaultCollectionTwoDatabases
    util_testing.go:333: Test requires Couchbase Server [7.6.0 8.0.99 8.1.0@2674], but running against 8.0.2@5503
--- SKIP: TestMigrationThenDropDefaultCollectionTwoDatabases (0.00s)
```
- [x] 8.1.0-2638 (should skip) https://jenkins.sgwdev.com/job/SyncGatewayIntegration/1069/
```
=== RUN   TestMigrationThenDropDefaultCollectionTwoDatabases
    util_testing.go:333: Test requires Couchbase Server [7.6.0 8.0.99 8.1.0@2674], but running against 8.1.0@2638
--- SKIP: TestMigrationThenDropDefaultCollectionTwoDatabases (0.00s)
```
- [x] 8.1.0-2687 (should pass) https://jenkins.sgwdev.com/job/SyncGatewayIntegration/1070/
```
--- PASS: TestMigrationThenDropDefaultCollectionTwoDatabases (24.93s)
```

<!--
Automated review runs on every non-draft PR raised from this repo (forks are not reviewed automatically).
  - Re-run it, or ask a follow-up, by commenting `@droid <question>`
  - Suppress it with the `droid-skip` label, or `WIP`/`DO NOT MERGE` in the title
-->
