### PR TITLE
CBG-4156/CBG-4996 disable sequence batching in flaky tests

### DIFF
--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1527,6 +1527,8 @@ func TestAssignSequenceReleaseLoop(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges, base.KeyCRUD, base.KeyDCP)
 
+	defer SuspendSequenceBatching()()
+
 	// import disabled
 	db, ctx := SetupTestDBWithOptions(t, DatabaseContextOptions{})
 	defer db.Close(ctx)

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1795,6 +1795,8 @@ func TestAllDocsOnly(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
+	defer SuspendSequenceBatching()()
+
 	// Lower the log max length so no more than 50 items will be kept.
 	cacheOptions := DefaultCacheOptions()
 	cacheOptions.ChannelCacheMaxLength = 50
@@ -1906,6 +1908,8 @@ func TestAllDocsOnly(t *testing.T) {
 // Unit test for bug #673
 func TestUpdatePrincipal(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges)
+
+	defer SuspendSequenceBatching()()
 
 	// use default collection based on use of GetPrincipalForTest
 	db, ctx := setupTestDBDefaultCollection(t)
@@ -2072,6 +2076,8 @@ func TestRepeatedConflict(t *testing.T) {
 }
 
 func TestConflicts(t *testing.T) {
+
+	defer SuspendSequenceBatching()()
 
 	db, ctx := setupTestDBAllowConflicts(t)
 	defer db.Close(ctx)
@@ -2838,6 +2844,8 @@ func TestRecentSequenceHandlingForDeduplication(t *testing.T) {
 }
 
 func TestRecentSequenceHistory(t *testing.T) {
+
+	defer SuspendSequenceBatching()()
 
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)

--- a/db/sequence_allocator.go
+++ b/db/sequence_allocator.go
@@ -77,9 +77,19 @@ func newSequenceAllocator(ctx context.Context, datastore base.DataStore, dbStats
 	s.sequenceBatchSize = idleBatchSize
 	s.releaseSequenceWait = defaultReleaseSequenceWait
 
+	// Allow the release wait to be shortened under cb_sg_devmode, to make sequence gaps deterministic for testing.
+	testReleaseSequenceWait, err := GetTestReleaseSequenceWait()
+	if err != nil {
+		return nil, err
+	}
+	if testReleaseSequenceWait > 0 {
+		base.InfofCtx(ctx, base.KeyCRUD, "Using test override for release sequence wait: %v", testReleaseSequenceWait)
+		s.releaseSequenceWait = testReleaseSequenceWait
+	}
+
 	// The reserveNotify channel manages communication between the releaseSequenceMonitor goroutine and _reserveSequenceRange invocations.
 	s.reserveNotify = make(chan struct{}, 1)
-	_, err := s.lastSequence(ctx) // just reads latest sequence from bucket
+	_, err = s.lastSequence(ctx) // just reads latest sequence from bucket
 	if err != nil {
 		return nil, err
 	}

--- a/db/sequence_release_devmode_off.go
+++ b/db/sequence_release_devmode_off.go
@@ -1,0 +1,21 @@
+// Copyright 2026-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+//go:build !cb_sg_devmode
+
+package db
+
+import (
+	"time"
+)
+
+// GetTestReleaseSequenceWait returns an override for the time the sequence allocator waits after a reserve before
+// releasing unused sequences.  If cb_sg_devmode build flag is not set, do not use.
+func GetTestReleaseSequenceWait() (time.Duration, error) {
+	return 0, nil
+}

--- a/db/sequence_release_devmode_on.go
+++ b/db/sequence_release_devmode_on.go
@@ -1,0 +1,40 @@
+// Copyright 2026-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+//go:build cb_sg_devmode
+
+package db
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+// GetTestReleaseSequenceWait returns an override for the time the sequence allocator waits after a reserve before
+// releasing unused sequences, used for testing purposes to simulate a slow node that leaves gaps in the sequence
+// numbering.  Returns 0 when unset, in which case defaultReleaseSequenceWait is used.
+//
+// Setting this to a very small value (e.g. SG_TEST_RELEASE_SEQUENCE_WAIT=1ns) makes any test that depends on
+// densely allocated sequences fail deterministically, instead of intermittently on a loaded CI machine.  Tests
+// asserting on exact sequence values should call SuspendSequenceBatching to pin the batch size to 1.
+func GetTestReleaseSequenceWait() (time.Duration, error) {
+	waitEnvVar := "SG_TEST_RELEASE_SEQUENCE_WAIT"
+	w := os.Getenv(waitEnvVar)
+	if w == "" {
+		return 0, nil
+	}
+	wait, err := time.ParseDuration(w)
+	if err != nil {
+		return 0, fmt.Errorf("setting %s=%s is not a valid time: %w", waitEnvVar, w, err)
+	}
+	if wait < 0 {
+		return 0, fmt.Errorf("setting %s=%s must not be negative", waitEnvVar, w)
+	}
+	return wait, nil
+}

--- a/db/sequence_release_devmode_on.go
+++ b/db/sequence_release_devmode_on.go
@@ -31,7 +31,7 @@ func GetTestReleaseSequenceWait() (time.Duration, error) {
 	}
 	wait, err := time.ParseDuration(w)
 	if err != nil {
-		return 0, fmt.Errorf("setting %s=%s is not a valid time: %w", waitEnvVar, w, err)
+		return 0, fmt.Errorf("setting %s=%s is not a valid duration (for example 1500ms or 1s): %w", waitEnvVar, w, err)
 	}
 	if wait < 0 {
 		return 0, fmt.Errorf("setting %s=%s must not be negative", waitEnvVar, w)

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -125,6 +125,27 @@ Read via `os.Getenv` by test code, so they work with plain `go test`. Defined in
 | `SG_TEST_TLS_SKIP_VERIFY` | Skip TLS certificate verification | `true` |
 | `SG_TEST_USE_AUTH_HANDLER` | Use an auth handler | unset |
 
+### Fault injection
+
+These require the `cb_sg_devmode` build tag; without it they are compiled out and ignored.
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `SG_TEST_CACHING_FEED_DELAY` | Delay applied to each DCP event in the caching feed, to simulate a slow feed | unset |
+| `SG_TEST_RELEASE_SEQUENCE_WAIT` | How long the sequence allocator waits after reserving before releasing unused sequences | `1500ms` |
+
+Lowering `SG_TEST_RELEASE_SEQUENCE_WAIT` makes the allocator release the unused tail of every
+sequence batch immediately, so sequence numbering develops the gaps that otherwise only appear on a
+loaded machine:
+
+```sh
+SG_TEST_RELEASE_SEQUENCE_WAIT=1ns go test -tags cb_sg_devmode ./rest/... ./db/...
+```
+
+Any test that asserts exact sequence numbers then fails deterministically rather than
+intermittently in CI. The fix for such a test is `defer db.SuspendSequenceBatching()()`, which pins
+the allocation batch size to 1 so there is never an unused sequence to release.
+
 ### Diagnostics
 
 | Variable | Purpose | Default |

--- a/rest/access_test.go
+++ b/rest/access_test.go
@@ -71,6 +71,8 @@ func TestStarAccess(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyChanges)
 
+	defer db.SuspendSequenceBatching()()
+
 	var allDocsResult allDocsResponse
 
 	// Create some docs:

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3862,6 +3862,8 @@ func TestFetchBackupRevisionByCVThroughAPI(t *testing.T) {
 }
 
 func TestDocumentChannelHistoryCompact(t *testing.T) {
+	defer db.SuspendSequenceBatching()()
+
 	rt := NewRestTester(t, &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
 	defer rt.Close()
 

--- a/rest/blip_channel_filter_test.go
+++ b/rest/blip_channel_filter_test.go
@@ -23,6 +23,8 @@ func TestChannelFilterRemovalFromChannel(t *testing.T) {
 	base.LongRunningTest(t)
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyChanges, base.KeyCache, base.KeyCRUD, base.KeyHTTP)
+	defer db.SuspendSequenceBatching()()
+
 	btcRunner := NewBlipTesterClientRunner(t)
 	btcRunner.Run(func(t *testing.T) {
 		for _, sendDocWithChannelRemoval := range []bool{true, false} {

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -1750,6 +1750,8 @@ func updateTestDoc(rt *rest.RestTester, docid string, revid string, body string)
 func TestChangesIncludeDocs(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
+	defer db.SuspendSequenceBatching()()
+
 	rtConfig := rest.RestTesterConfig{SyncFn: `function(doc) {channel(doc.channels)}`}
 	rt := rest.NewRestTester(t, &rtConfig)
 	testDB := rt.GetDatabase()
@@ -2059,6 +2061,8 @@ func TestChangesViewBackfillFromPartialQueryOnly(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)
 
+	defer db.SuspendSequenceBatching()()
+
 	rtConfig := rest.RestTesterConfig{SyncFn: `function(doc, oldDoc){channel(doc.channels);}`}
 	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
@@ -2120,6 +2124,8 @@ func TestChangesViewBackfillFromPartialQueryOnly(t *testing.T) {
 func TestChangesViewBackfillNoOverlap(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)
+
+	defer db.SuspendSequenceBatching()()
 
 	rtConfig := rest.RestTesterConfig{SyncFn: `function(doc, oldDoc){channel(doc.channels);}`}
 	rt := rest.NewRestTester(t, &rtConfig)
@@ -2245,6 +2251,8 @@ func TestChangesViewBackfill(t *testing.T) {
 func TestChangesViewBackfillStarChannel(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)
+
+	defer db.SuspendSequenceBatching()()
 
 	rtConfig := rest.RestTesterConfig{SyncFn: `function(doc, oldDoc){channel(doc.channels);}`}
 	rt := rest.NewRestTester(t, &rtConfig)

--- a/rest/diagnostic_api_test.go
+++ b/rest/diagnostic_api_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbase/sync_gateway/testing/require"
 )
 
@@ -173,6 +174,8 @@ func (g docGrant) request(rt *RestTester) {
 }
 
 func TestGetAllChannelsByUser(t *testing.T) {
+	defer db.SuspendSequenceBatching()()
+
 	tests := []struct {
 		name          string
 		adminChannels []string
@@ -655,6 +658,8 @@ func TestGetAllChannelsByUser(t *testing.T) {
 }
 
 func TestGetAllChannelsByUserWithSingleNamedCollection(t *testing.T) {
+	defer db.SuspendSequenceBatching()()
+
 	ctx := base.TestCtx(t)
 	base.TestRequiresCollections(t)
 
@@ -726,6 +731,8 @@ func TestGetAllChannelsByUserWithSingleNamedCollection(t *testing.T) {
 
 func TestGetAllChannelsByUserWithMultiCollections(t *testing.T) {
 	base.TestRequiresCollections(t)
+
+	defer db.SuspendSequenceBatching()()
 
 	rt := NewRestTesterMultipleCollections(t, &RestTesterConfig{PersistentConfig: true}, 2)
 	defer rt.Close()
@@ -828,6 +835,8 @@ func TestGetAllChannelsByUserDeletedRole(t *testing.T) {
 	if base.TestsUseNamedCollections() {
 		t.Skip("Only works with default collection until CBG-4003 is fixed")
 	}
+	defer db.SuspendSequenceBatching()()
+
 	rt := NewRestTesterPersistentConfig(t)
 	defer rt.Close()
 
@@ -860,6 +869,8 @@ func TestGetAllChannelsByUserDeletedRole(t *testing.T) {
 }
 
 func TestGetAllChannelsByUserNonexistentAndDeletedUser(t *testing.T) {
+
+	defer db.SuspendSequenceBatching()()
 
 	rt := NewRestTesterPersistentConfig(t)
 	defer rt.Close()

--- a/rest/diagnostic_doc_api_test.go
+++ b/rest/diagnostic_doc_api_test.go
@@ -27,6 +27,8 @@ import (
 )
 
 func TestGetAlldocChannels(t *testing.T) {
+	defer db.SuspendSequenceBatching()()
+
 	rt := NewRestTester(t, &RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`})
 	defer rt.Close()
 
@@ -65,6 +67,8 @@ func TestGetAlldocChannels(t *testing.T) {
 }
 
 func TestGetUserDocAccessSpan(t *testing.T) {
+	defer db.SuspendSequenceBatching()()
+
 	tests := []struct {
 		name          string
 		adminChannels []string
@@ -511,6 +515,8 @@ func TestGetUserDocAccessSpan(t *testing.T) {
 }
 
 func TestGetUserDocAccessSpanWithSingleNamedCollection(t *testing.T) {
+	defer db.SuspendSequenceBatching()()
+
 	ctx := base.TestCtx(t)
 	base.TestRequiresCollections(t)
 
@@ -565,6 +571,8 @@ func TestGetUserDocAccessSpanWithSingleNamedCollection(t *testing.T) {
 func TestGetUserDocAccessSpanWithMultiCollections(t *testing.T) {
 	base.TestRequiresCollections(t)
 
+	defer db.SuspendSequenceBatching()()
+
 	rt := NewRestTesterMultipleCollections(t, &RestTesterConfig{PersistentConfig: true, SyncFn: `function(doc) {channel(doc.channel);}`}, 2)
 	defer rt.Close()
 
@@ -606,6 +614,8 @@ func TestGetUserDocAccessSpanWithMultiCollections(t *testing.T) {
 }
 
 func TestGetUserDocAccessSpanDeletedRole(t *testing.T) {
+	defer db.SuspendSequenceBatching()()
+
 	rt := NewRestTester(t, &RestTesterConfig{
 		SyncFn: `function(doc) {channel(doc.channel); access(doc.user, doc.channel); role(doc.user, doc.role);}`,
 	})
@@ -646,6 +656,8 @@ func TestGetUserDocAccessSpanDeletedRole(t *testing.T) {
 
 // put doc in multiple channels, remove from some channels, assert response gets right sequences for each channels
 func TestGetUserDocAccessMultiChannel(t *testing.T) {
+	defer db.SuspendSequenceBatching()()
+
 	rt := NewRestTester(t, &RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`})
 	defer rt.Close()
 	userGrant := userGrant{
@@ -680,6 +692,8 @@ func TestGetUserDocAccessMultiChannel(t *testing.T) {
 
 // give user access to chanA through admin API and role, remove admin API assignment, and assert access span is admin assignment to 0
 func TestGetUserDocAccessContinuousRoleAdminAPI(t *testing.T) {
+	defer db.SuspendSequenceBatching()()
+
 	rt := NewRestTester(t, &RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`})
 	defer rt.Close()
 
@@ -717,6 +731,8 @@ func TestGetUserDocAccessContinuousRoleAdminAPI(t *testing.T) {
 
 // give user access to chanA through admin API and sync fn, remove admin API assignment, and assert access span is admin assignment to 0
 func TestGetUserDocAccessContinuousSyncFnAdminAPI(t *testing.T) {
+	defer db.SuspendSequenceBatching()()
+
 	rt := NewRestTester(t, &RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel); access(doc.user, doc.channel);}`})
 	defer rt.Close()
 
@@ -771,6 +787,8 @@ func TestGetUserDocAccessDynamicGrantOnChanRemoval(t *testing.T) {
 
 // give role access to chanA through sync fn, remove doc from channel and keep role assignment
 func TestGetUserDocAccessDynamicRoleChanRemoval(t *testing.T) {
+	defer db.SuspendSequenceBatching()()
+
 	rt := NewRestTester(t, &RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel); access(doc.user, doc.dynamicChan);}`})
 	defer rt.Close()
 
@@ -800,6 +818,8 @@ func TestGetUserDocAccessDynamicRoleChanRemoval(t *testing.T) {
 
 // give role access to chanA through sync fn, remove channel from role and keep doc in chan
 func TestGetUserDocAccessDynamicRoleChanRemoval2(t *testing.T) {
+	defer db.SuspendSequenceBatching()()
+
 	rt := NewRestTester(t, &RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel); access(doc.user, doc.dynamicChan);}`})
 	defer rt.Close()
 
@@ -831,6 +851,8 @@ func TestGetUserDocAccessDynamicRoleChanRemoval2(t *testing.T) {
 
 // multiple doc ids
 func TestGetUserDocAccessMultiDoc(t *testing.T) {
+	defer db.SuspendSequenceBatching()()
+
 	rt := NewRestTester(t, &RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel); access(doc.dynamicChan, doc.user);}`})
 	defer rt.Close()
 
@@ -902,6 +924,8 @@ func TestGetUserDocAccessNoDocID(t *testing.T) {
 
 // duplicate doc ids
 func TestGetUserDocAccessDuplicates(t *testing.T) {
+	defer db.SuspendSequenceBatching()()
+
 	rt := NewRestTester(t, &RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel); access(doc.dynamicChan, doc.user);}`})
 	defer rt.Close()
 


### PR DESCRIPTION
CBG-4156/CBG-4996 disable sequence batching in tests

If a test asserts on sequence number, make sure to suspend sequence batching to have deterministic numbers.

Created SG_TEST_RELEASE_SEQUENCE_WAIT environment variable to more easily be able to find the tests that flake.

Fixes CBG-4516 TestGetAllChannelsByUser and TestChannelFilterRemovalFromChannel

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/1074/

<!--
Automated review runs on every non-draft PR raised from this repo (forks are not reviewed automatically).
  - Re-run it, or ask a follow-up, by commenting `@droid <question>`
  - Suppress it with the `droid-skip` label, or `WIP`/`DO NOT MERGE` in the title
-->
