### PR TITLE
CBG-5105 fix TestOfflineDatabaseStartup flake

### DIFF
--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -905,7 +905,8 @@ func TestOfflineDatabaseStartup(t *testing.T) {
 
 	// ensure doc1 is imported now we're online
 	rt.WaitForChanges(3, "/{{.keyspace}}/_changes", "", true)
-	assert.Equal(t, int64(1), rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value())
+	// the import stat is incremented by the import feed goroutine after the write that makes doc1 visible in _changes, so wait for it
+	base.RequireWaitForStat(t, rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value, 1)
 }
 
 func TestCompactIntervalFromConfig(t *testing.T) {


### PR DESCRIPTION
CBG-5105 fix TestOfflineDatabaseStartup flake

The test waited for doc1 to appear in _changes, then asserted ImportCount == 1. Those are two different goroutines: the caching feed adds the doc to the channel cache as soon as it sees the import's write, while the import goroutine only increments the stat after that write returns. The changes feed could reach 3 before the increment, failing with expected 1, actual 0. 