### PR TITLE
CBG-5706: Disable MetadataStore fallback when `_default` collection irrecoverably dropped (Fixes TestDropDefaultCollectionDuringMigration flake)

### DIFF
--- a/base/bootstrap.go
+++ b/base/bootstrap.go
@@ -544,7 +544,7 @@ func (cc *CouchbaseCluster) bootstrapFallbackDisabled(bucketName string) bool {
 // gocbcore always-retries KV_COLLECTION_OUTDATED, so without this latch every later bootstrap read
 // burns a full KV deadline rediscovering the same thing - registry reads happen on the cluster-compat
 // poller, on migration arming, and on node deregistration during shutdown. Mirrors
-// MetadataStore.DisableFallbackReadsIfCollectionOutdatedError, which covers the per-database metadata store.
+// MetadataStore.DisableFallbackIfUnrecoverable, which covers the per-database metadata store.
 //
 // Only latches on _default._default: before a bucket opts in, metadataCollections wires the fallback
 // the other way round, and a dropped _system._mobile is not what this guards.

--- a/base/bootstrap.go
+++ b/base/bootstrap.go
@@ -138,7 +138,12 @@ type CouchbaseCluster struct {
 	// database that opted in only at the per-DB level still disables its fallback after migration,
 	// and completing one bucket's migration never disables another bucket's fallback.
 	bucketsBootstrapMigrationComplete SyncMap[string, bool]
-	useGOCBFastFailRetry              bool // When true, readiness checks fail fast instead of using the best-effort retry strategy
+	// bucketsBootstrapFallbackUnavailable records, per bucket, that _default._default was observed
+	// dropped, so bootstrap reads stop consulting it. Distinct from
+	// bucketsBootstrapMigrationComplete - the migration may never have finished, but a dropped
+	// collection is unreadable either way.
+	bucketsBootstrapFallbackUnavailable SyncMap[string, bool]
+	useGOCBFastFailRetry                bool // When true, readiness checks fail fast instead of using the best-effort retry strategy
 }
 
 // bucketBootstrapTarget records where bootstrap docs (registry, dbconfig, cbgt cfg) live for a
@@ -415,7 +420,7 @@ func (cc *CouchbaseCluster) metadataCollections(b *gocb.Bucket) (primary, fallba
 		return b.DefaultCollection(), nil
 	}
 	primary = b.Scope(SystemScope).Collection(SystemCollectionMobile)
-	if cc.bucketBootstrapMigrationComplete(b.Name()) {
+	if cc.bootstrapFallbackDisabled(b.Name()) {
 		return primary, nil
 	}
 	return primary, b.DefaultCollection()
@@ -521,6 +526,50 @@ func (cc *CouchbaseCluster) probeRegistryLocation(b *gocb.Bucket) (target bucket
 	return 0, false, nil
 }
 
+// bootstrapFallbackDisabled reports whether this bucket's bootstrap reads should skip
+// _default._default, for either reason: the bootstrap migration finished, or the collection was
+// dropped.
+func (cc *CouchbaseCluster) bootstrapFallbackDisabled(bucketName string) bool {
+	if cc.bucketBootstrapMigrationComplete(bucketName) {
+		return true
+	}
+	unavailable, _ := cc.bucketsBootstrapFallbackUnavailable.Load(bucketName)
+	return unavailable
+}
+
+// disableBootstrapFallbackIfUnrecoverable stops this bucket's bootstrap reads consulting
+// _default._default once err proves that collection is gone - Couchbase Server rejects any
+// user-created collection whose name starts with "_", so it can never be recreated.
+//
+// gocbcore always-retries KV_COLLECTION_OUTDATED, so without this latch every later bootstrap read
+// burns a full KV deadline rediscovering the same thing - registry reads happen on the cluster-compat
+// poller, on migration arming, and on node deregistration during shutdown. Mirrors
+// MetadataStore.DisableFallbackReadsIfCollectionOutdatedError, which covers the per-database metadata store.
+//
+// Only latches on _default._default: before a bucket opts in, metadataCollections wires the fallback
+// the other way round, and a dropped _system._mobile is not what this guards.
+func (cc *CouchbaseCluster) disableBootstrapFallbackIfUnrecoverable(ctx context.Context, bucketName string, fallback *gocb.Collection, err error) {
+	if fallback == nil {
+		return
+	}
+	cc.disableBootstrapFallbackForCollection(ctx, bucketName, fallback.ScopeName(), fallback.Name(), err)
+}
+
+// disableBootstrapFallbackForCollection is the *gocb.Collection-free half of
+// disableBootstrapFallbackIfUnrecoverable, so the decision can be unit tested without a cluster.
+func (cc *CouchbaseCluster) disableBootstrapFallbackForCollection(ctx context.Context, bucketName, scopeName, collectionName string, err error) {
+	if err == nil || !IsCollectionOutdatedError(err) {
+		return
+	}
+	if scopeName != DefaultScope || collectionName != DefaultCollection {
+		return
+	}
+	if _, loaded := cc.bucketsBootstrapFallbackUnavailable.LoadOrStore(bucketName, true); !loaded {
+		WarnfCtx(ctx, "Bootstrap metadata fallback collection %s.%s on bucket %s is unavailable (%v) - no longer falling back to it. Any bootstrap metadata not already migrated to %s.%s is unrecoverable.",
+			MD(DefaultScope), MD(DefaultCollection), MD(bucketName), err, MD(SystemScope), MD(SystemCollectionMobile))
+	}
+}
+
 // shouldFallback returns true if a primary read returned a not-found-style error and the cluster
 // has a fallback collection configured (i.e. useSystemMetadataCollection is enabled).
 func (cc *CouchbaseCluster) shouldFallback(err error, fallback *gocb.Collection) bool {
@@ -580,6 +629,7 @@ func (cc *CouchbaseCluster) loadConfigWithFallback(ctx context.Context, bucketNa
 			cc.noteBucketFallbackHit(bucketName)
 			return fallback, value, cas, nil
 		}
+		cc.disableBootstrapFallbackIfUnrecoverable(ctx, bucketName, fallback, err)
 	}
 	return primary, value, cas, err
 }
@@ -604,6 +654,7 @@ func (cc *CouchbaseCluster) GetMetadataDocument(ctx context.Context, location, d
 		if err == nil {
 			cc.noteBucketFallbackHit(location)
 		}
+		cc.disableBootstrapFallbackIfUnrecoverable(ctx, location, fallback, err)
 	}
 	SyncGatewayStats.GlobalStats.ResourceUtilizationStats().NumIdleKvOps.Add(1)
 	return cas, err
@@ -628,6 +679,7 @@ func (cc *CouchbaseCluster) InsertMetadataDocument(ctx context.Context, location
 	if fallback != nil {
 		exists, existsErr := cc.configPersistence.keyExists(fallback, key)
 		if existsErr != nil {
+			cc.disableBootstrapFallbackIfUnrecoverable(ctx, location, fallback, existsErr)
 			return 0, existsErr
 		}
 		if exists {
@@ -671,6 +723,7 @@ func (cc *CouchbaseCluster) WriteMetadataDocument(ctx context.Context, location,
 		if err == nil {
 			cc.noteBucketFallbackHit(location)
 		}
+		cc.disableBootstrapFallbackIfUnrecoverable(ctx, location, fallback, err)
 	}
 	return uint64(casOut), err
 }
@@ -694,6 +747,7 @@ func (cc *CouchbaseCluster) TouchMetadataDocument(ctx context.Context, location,
 		if err == nil {
 			cc.noteBucketFallbackHit(location)
 		}
+		cc.disableBootstrapFallbackIfUnrecoverable(ctx, location, fallback, err)
 	}
 	return uint64(casOut), err
 
@@ -717,6 +771,7 @@ func (cc *CouchbaseCluster) DeleteMetadataDocument(ctx context.Context, location
 		if removeErr == nil {
 			cc.noteBucketFallbackHit(location)
 		}
+		cc.disableBootstrapFallbackIfUnrecoverable(ctx, location, fallback, removeErr)
 	}
 	return removeErr
 }
@@ -807,6 +862,7 @@ func (cc *CouchbaseCluster) KeyExists(ctx context.Context, location, docID strin
 	if err == nil && exists {
 		cc.noteBucketFallbackHit(location)
 	}
+	cc.disableBootstrapFallbackIfUnrecoverable(ctx, location, fallback, err)
 	return exists, err
 }
 

--- a/base/bootstrap.go
+++ b/base/bootstrap.go
@@ -454,7 +454,7 @@ func (cc *CouchbaseCluster) SetBucketBootstrapTargetHint(ctx context.Context, bu
 		return err
 	}
 	defer teardown()
-	target, found, err := cc.probeRegistryLocation(b)
+	target, found, err := cc.probeRegistryLocation(ctx, b)
 	if err != nil {
 		return err
 	}
@@ -501,23 +501,28 @@ func (cc *CouchbaseCluster) CachedBootstrapTargets() map[string]string {
 // (target, found): when found, target identifies the collection; when not found, target is
 // undefined and the caller picks based on its own policy (cluster flag or per-DB hint).
 // A "collection not found" probe error on _system._mobile is treated as "not present".
-func (cc *CouchbaseCluster) probeRegistryLocation(b *gocb.Bucket) (target bucketBootstrapTarget, found bool, err error) {
+func (cc *CouchbaseCluster) probeRegistryLocation(ctx context.Context, b *gocb.Bucket) (target bucketBootstrapTarget, found bool, err error) {
 	systemCol := b.Scope(SystemScope).Collection(SystemCollectionMobile)
 	existsInSystem, sysErr := cc.configPersistence.keyExists(systemCol, SGRegistryKey)
 	if sysErr == nil && existsInSystem {
 		return bucketTargetSystemMobile, true, nil
 	}
-	// A bucket marked migration-complete has no legacy registry in _default._default to find — and
-	// _default may have been dropped (system-collection-only deployment / post-migration cleanup).
-	// Skip the _default probe so we never issue a KV op against a missing collection, which would
-	// retry KV_COLLECTION_OUTDATED to the op timeout. ensureBucketBootstrapTargetCached sets this
-	// flag (via the _default-existence check) before any caller reaches this point.
-	if cc.bucketBootstrapMigrationComplete(b.Name()) {
+	// A bucket with the fallback disabled has no legacy registry in _default._default to find — the
+	// migration finished, or the collection was dropped (system-collection-only deployment /
+	// post-migration cleanup). Skip the _default probe so we never issue a KV op against a missing
+	// collection, which would retry KV_COLLECTION_OUTDATED to the op timeout.
+	if cc.bootstrapFallbackDisabled(b.Name()) {
 		return 0, false, nil
 	}
 	defaultCol := b.DefaultCollection()
 	existsInDefault, defErr := cc.configPersistence.keyExists(defaultCol, SGRegistryKey)
 	if defErr != nil {
+		// A dropped _default is latched and treated as "not present", mirroring the _system._mobile
+		// handling above, so later probes skip it instead of paying the KV deadline again.
+		cc.disableBootstrapFallbackIfUnrecoverable(ctx, b.Name(), defaultCol, defErr)
+		if IsCollectionOutdatedError(defErr) {
+			return 0, false, nil
+		}
 		return 0, false, defErr
 	}
 	if existsInDefault {
@@ -1059,6 +1064,7 @@ func (cc *CouchbaseCluster) MigrateBootstrapDocs(ctx context.Context, bucket str
 			if IsDocNotFoundError(err) {
 				continue
 			}
+			cc.disableBootstrapFallbackIfUnrecoverable(ctx, bucket, fallback, err)
 			return fmt.Errorf("read fallback %q during bootstrap migration: %w", docID, err)
 		}
 		fallbackCas := gocb.Cas(cas)
@@ -1076,6 +1082,7 @@ func (cc *CouchbaseCluster) MigrateBootstrapDocs(ctx context.Context, bucket str
 			if IsDocNotFoundError(err) {
 				continue
 			}
+			cc.disableBootstrapFallbackIfUnrecoverable(ctx, bucket, fallback, err)
 			return fmt.Errorf("delete fallback %q during bootstrap migration: %w", docID, err)
 		}
 	}
@@ -1107,7 +1114,7 @@ func (cc *CouchbaseCluster) getBucket(ctx context.Context, bucketName string) (b
 		if err != nil {
 			return nil, nil, err
 		}
-		cc.ensureBucketBootstrapTargetCached(b)
+		cc.ensureBucketBootstrapTargetCached(ctx, b)
 		return b, teardownFn, nil
 	}
 
@@ -1118,7 +1125,7 @@ func (cc *CouchbaseCluster) getBucket(ctx context.Context, bucketName string) (b
 	defer cc.cachedBucketConnections.lock.Unlock()
 	bucket := cc.cachedBucketConnections._get(bucketName)
 	if bucket != nil {
-		cc.ensureBucketBootstrapTargetCached(bucket.bucket)
+		cc.ensureBucketBootstrapTargetCached(ctx, bucket.bucket)
 		return bucket.bucket, teardownFn, nil
 	}
 
@@ -1132,7 +1139,7 @@ func (cc *CouchbaseCluster) getBucket(ctx context.Context, bucketName string) (b
 		bucketCloseFn: bucketCloseFn,
 		refcount:      1,
 	})
-	cc.ensureBucketBootstrapTargetCached(newBucket)
+	cc.ensureBucketBootstrapTargetCached(ctx, newBucket)
 	return newBucket, teardownFn, nil
 }
 
@@ -1150,7 +1157,7 @@ func (cc *CouchbaseCluster) getBucket(ctx context.Context, bucketName string) (b
 // missing collection (which would retry KV_COLLECTION_OUTDATED to the op timeout). Marking complete
 // also makes probeRegistryLocation skip its own _default keyExists for callers that invoke it
 // directly (SetBucketBootstrapTargetHint).
-func (cc *CouchbaseCluster) ensureBucketBootstrapTargetCached(b *gocb.Bucket) {
+func (cc *CouchbaseCluster) ensureBucketBootstrapTargetCached(ctx context.Context, b *gocb.Bucket) {
 	if _, cached := cc.bucketBootstrapTargets.Load(b.Name()); cached {
 		return
 	}
@@ -1161,7 +1168,7 @@ func (cc *CouchbaseCluster) ensureBucketBootstrapTargetCached(b *gocb.Bucket) {
 		cc.SetMigrationComplete(b.Name())
 		return
 	}
-	target, found, err := cc.probeRegistryLocation(b)
+	target, found, err := cc.probeRegistryLocation(ctx, b)
 	if err != nil || !found {
 		return
 	}

--- a/base/bootstrap_test.go
+++ b/base/bootstrap_test.go
@@ -699,3 +699,80 @@ func TestBootstrapDeleteMetadataDocumentFallback(t *testing.T) {
 		require.True(t, IsDocNotFoundError(err), "expected not-found after delete, got %T: %v", err, err)
 	})
 }
+
+// TestBootstrapFallbackDisabledOnDroppedDefaultCollection verifies bootstrap reads stop consulting
+// _default._default once it is seen to have been dropped. Otherwise every registry read pays a full
+// KV deadline - on the cluster-compat poller, on migration arming, and on node deregistration during
+// shutdown.
+//
+// The negative cases matter most: reacting to a merely transient error would permanently skip
+// legitimate unmigrated bootstrap metadata.
+func TestBootstrapFallbackDisabledOnDroppedDefaultCollection(t *testing.T) {
+	testCases := []struct {
+		name        string
+		scope       string
+		collection  string
+		err         error
+		wantDisable bool
+	}{
+		{
+			name:        "collection not found disables fallback",
+			scope:       DefaultScope,
+			collection:  DefaultCollection,
+			err:         gocb.ErrCollectionNotFound,
+			wantDisable: true,
+		},
+		{
+			name:       "timeout from collection outdated only disables fallback",
+			scope:      DefaultScope,
+			collection: DefaultCollection,
+			err: &gocb.TimeoutError{InnerError: gocb.ErrTimeout,
+				RetryReasons: []gocb.RetryReason{gocb.KVCollectionOutdatedRetryReason}},
+			wantDisable: true,
+		},
+		{
+			name:       "timeout with a transient reason alongside must not disable fallback",
+			scope:      DefaultScope,
+			collection: DefaultCollection,
+			err: &gocb.TimeoutError{InnerError: gocb.ErrTimeout,
+				RetryReasons: []gocb.RetryReason{gocb.KVCollectionOutdatedRetryReason, gocb.KVNotMyVBucketRetryReason}},
+			wantDisable: false,
+		},
+		{
+			name:        "doc not found must not disable fallback",
+			scope:       DefaultScope,
+			collection:  DefaultCollection,
+			err:         ErrNotFound,
+			wantDisable: false,
+		},
+		{
+			name:        "no error must not disable fallback",
+			scope:       DefaultScope,
+			collection:  DefaultCollection,
+			err:         nil,
+			wantDisable: false,
+		},
+		{
+			// Before a bucket opts in the fallback is wired the other way round, and a dropped
+			// _system._mobile is not what this guards.
+			name:        "dropped system collection must not disable the default fallback",
+			scope:       SystemScope,
+			collection:  SystemCollectionMobile,
+			err:         gocb.ErrCollectionNotFound,
+			wantDisable: false,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx := TestCtx(t)
+			cc := &CouchbaseCluster{}
+			const bucketName = "bucket1"
+			require.False(t, cc.bootstrapFallbackDisabled(bucketName), "fallback must start in play")
+
+			cc.disableBootstrapFallbackForCollection(ctx, bucketName, testCase.scope, testCase.collection, testCase.err)
+
+			require.Equal(t, testCase.wantDisable, cc.bootstrapFallbackDisabled(bucketName))
+			require.False(t, cc.bootstrapFallbackDisabled("other-bucket"), "latch must be per-bucket")
+		})
+	}
+}

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -3151,7 +3151,7 @@ func TestMetadataStoreUpdateAfterMigrationComplete(t *testing.T) {
 	defer bucket.Close(ctx)
 
 	metaStore := NewMetadataStore(bucket.GetMobileSystemDataStore(), bucket.DefaultDataStore(ctx))
-	metaStore.SetMigrationComplete()
+	metaStore.DisableFallbackReads()
 
 	docID := t.Name()
 	ok, err := metaStore.Fallback().Add(ctx, docID, 0, []byte(`{"counter":99}`))
@@ -3592,7 +3592,7 @@ func TestReadDoesNotGoToFallbackWhenMigrationComplete(t *testing.T) {
 	primaryStore := bucket.GetMobileSystemDataStore()
 
 	metaStore := NewMetadataStore(primaryStore, fallbackStore)
-	metaStore.SetMigrationComplete()
+	metaStore.DisableFallbackReads()
 
 	docID := t.Name()
 	ok, err := metaStore.Fallback().Add(ctx, docID, 0, []byte(`{"some": "data"}`))

--- a/base/dual_metadata_store.go
+++ b/base/dual_metadata_store.go
@@ -58,7 +58,7 @@ func (ms *MetadataStore) Fallback() DataStore {
 // Called whenever the fallback collection stops being worth reading, which happens for three
 // distinct reasons: metadata migration finished (on this node or a peer), _default._default was
 // absent at database open (rest.(*ServerContext)._getOrAddDatabaseFromConfig), or it was observed to
-// have been dropped while the database is online (disableFallbackIfUnrecoverable). In all three cases
+// have been dropped while the database is online (DisableFallbackIfUnrecoverable). In all three cases
 // anything still resident on the fallback is unreachable.
 func (ms *MetadataStore) DisableFallbackReads() {
 	ms.fallbackReadsDisabled.Store(true)
@@ -106,26 +106,19 @@ func (ms *MetadataStore) readFromFallback(ctx context.Context, err error) bool {
 	return false
 }
 
-// disableFallbackIfUnrecoverable permanently disables fallback reads when err proves the fallback
-// collection is gone for good. There is no path back: Couchbase Server rejects any user-created
-// collection whose name starts with "_", so a dropped _default._default cannot be recreated for the
-// life of the bucket. Only a fatal, unrecoverable error trips this - a transient failure must not,
-// or legitimate unmigrated metadata would be skipped for the rest of the process lifetime.
-//
-// Why it matters: gocbcore always-retries KV_COLLECTION_OUTDATED, so one read against a dropped
-// collection burns the whole KV deadline (30s). Left unhandled, every later primary miss pays that
-// again, and sequential readers stall indefinitely - DCP checkpoint loading is one read per vbucket
-// on cbgt's janitor goroutine, which is also the goroutine that services ClosePIndex, so
-// DatabaseContext.Close deadlocks behind it.
-func (ms *MetadataStore) disableFallbackIfUnrecoverable(ctx context.Context, err error) {
-	if err == nil || !IsCollectionOutdatedError(err) {
-		return
+// DisableFallbackIfUnrecoverable permanently disables fallback reads when fallbackErr proves
+// the fallback collection is gone for good, and reports whether it was an unrecoverable error.
+func (ms *MetadataStore) DisableFallbackIfUnrecoverable(ctx context.Context, fallbackErr error) bool {
+	// Collection Outdated on the fallback (`_default._default`) is non-recoverable - since nobody can create underscore-prefixed collections to restore it.
+	if IsCollectionOutdatedError(fallbackErr) {
+		if !ms.fallbackReadsDisabled.Swap(true) {
+			WarnfCtx(ctx, "Metadata fallback collection %s.%s is unavailable (%v) - disabling fallback reads. Any metadata not already migrated to %s.%s is unrecoverable.",
+				MD(ms.fallback.ScopeName()), MD(ms.fallback.CollectionName()), fallbackErr,
+				MD(ms.primary.ScopeName()), MD(ms.primary.CollectionName()))
+		}
+		return true
 	}
-	if !ms.fallbackReadsDisabled.Swap(true) {
-		WarnfCtx(ctx, "Metadata fallback collection %s.%s is unavailable (%v) - disabling fallback reads. Any metadata not already migrated to %s.%s is unrecoverable.",
-			MD(ms.fallback.ScopeName()), MD(ms.fallback.CollectionName()), err,
-			MD(ms.primary.ScopeName()), MD(ms.primary.CollectionName()))
-	}
+	return false
 }
 
 // ---- DataStoreName ----
@@ -162,7 +155,7 @@ func (ms *MetadataStore) Get(ctx context.Context, k string, rv any) (cas uint64,
 	cas, err = ms.primary.Get(ctx, k, rv)
 	if ms.readFromFallback(ctx, err) {
 		_, err = ms.fallback.Get(ctx, k, rv)
-		ms.disableFallbackIfUnrecoverable(ctx, err)
+		ms.DisableFallbackIfUnrecoverable(ctx, err)
 	}
 	return cas, err
 }
@@ -171,7 +164,7 @@ func (ms *MetadataStore) GetRaw(ctx context.Context, k string) (v []byte, cas ui
 	v, cas, err = ms.primary.GetRaw(ctx, k)
 	if ms.readFromFallback(ctx, err) {
 		v, _, err = ms.fallback.GetRaw(ctx, k)
-		ms.disableFallbackIfUnrecoverable(ctx, err)
+		ms.DisableFallbackIfUnrecoverable(ctx, err)
 	}
 	return v, cas, err
 }
@@ -180,7 +173,7 @@ func (ms *MetadataStore) GetExpiry(ctx context.Context, k string) (expiry uint32
 	expiry, err = ms.primary.GetExpiry(ctx, k)
 	if ms.readFromFallback(ctx, err) {
 		expiry, err = ms.fallback.GetExpiry(ctx, k)
-		ms.disableFallbackIfUnrecoverable(ctx, err)
+		ms.DisableFallbackIfUnrecoverable(ctx, err)
 	}
 	return expiry, err
 }
@@ -194,7 +187,7 @@ func (ms *MetadataStore) Exists(ctx context.Context, k string) (exists bool, err
 		return exists, err
 	}
 	exists, err = ms.fallback.Exists(ctx, k)
-	ms.disableFallbackIfUnrecoverable(ctx, err)
+	ms.DisableFallbackIfUnrecoverable(ctx, err)
 	return exists, err
 }
 
@@ -266,7 +259,7 @@ func (ms *MetadataStore) Update(ctx context.Context, k string, exp uint32, callb
 			return false, updateErr, casOut
 		}
 		if err != nil {
-			ms.disableFallbackIfUnrecoverable(ctx, err)
+			ms.DisableFallbackIfUnrecoverable(ctx, err)
 			return false, err, 0
 		}
 
@@ -293,7 +286,7 @@ func (ms *MetadataStore) Update(ctx context.Context, k string, exp uint32, callb
 				//        but it could be two concurrent Deletes that we should at least have one more attempt for
 				return true, nil, 0
 			}
-			ms.disableFallbackIfUnrecoverable(ctx, removeErr)
+			ms.DisableFallbackIfUnrecoverable(ctx, removeErr)
 			return false, removeErr, 0
 		}
 
@@ -350,7 +343,7 @@ func (ms *MetadataStore) Incr(ctx context.Context, k string, amt, def uint64, ex
 		}
 		// any other errors bubble up
 		if !IsCounterNonNumeric(fbIncrErr) {
-			ms.disableFallbackIfUnrecoverable(ctx, fbIncrErr)
+			ms.DisableFallbackIfUnrecoverable(ctx, fbIncrErr)
 			return 0, fbIncrErr
 		}
 
@@ -367,7 +360,7 @@ func (ms *MetadataStore) Incr(ctx context.Context, k string, amt, def uint64, ex
 			continue
 		}
 		if fbErr != nil {
-			ms.disableFallbackIfUnrecoverable(ctx, fbErr)
+			ms.DisableFallbackIfUnrecoverable(ctx, fbErr)
 			return 0, fbErr
 		}
 		var pill SyncSeqMigrationPill
@@ -389,7 +382,7 @@ func (ms *MetadataStore) Incr(ctx context.Context, k string, amt, def uint64, ex
 		// 3. delete fallback pill
 		if delErr := ms.fallback.Delete(ctx, k); delErr != nil && !IsDocNotFoundError(delErr) {
 			WarnfCtx(ctx, "MetadataStore.Incr: failed to clear migrated fallback counter %s: %v", UD(k), delErr)
-			ms.disableFallbackIfUnrecoverable(ctx, delErr)
+			ms.DisableFallbackIfUnrecoverable(ctx, delErr)
 		}
 
 		// 4. retry the caller's Incr on the now migrated primary
@@ -404,7 +397,7 @@ func (ms *MetadataStore) GetXattrs(ctx context.Context, k string, xattrKeys []st
 	xattrs, cas, err = ms.primary.GetXattrs(ctx, k, xattrKeys)
 	if ms.readFromFallback(ctx, err) {
 		xattrs, _, err = ms.fallback.GetXattrs(ctx, k, xattrKeys)
-		ms.disableFallbackIfUnrecoverable(ctx, err)
+		ms.DisableFallbackIfUnrecoverable(ctx, err)
 	}
 	return xattrs, cas, err
 }
@@ -413,7 +406,7 @@ func (ms *MetadataStore) GetWithXattrs(ctx context.Context, k string, xattrKeys 
 	v, xv, cas, err = ms.primary.GetWithXattrs(ctx, k, xattrKeys)
 	if ms.readFromFallback(ctx, err) {
 		v, xv, _, err = ms.fallback.GetWithXattrs(ctx, k, xattrKeys)
-		ms.disableFallbackIfUnrecoverable(ctx, err)
+		ms.DisableFallbackIfUnrecoverable(ctx, err)
 	}
 	return v, xv, cas, err
 }
@@ -489,7 +482,7 @@ func (ms *MetadataStore) WriteUpdateWithXattrs(ctx context.Context, k string, xa
 		// A doc with no/partial xattrs is still a fallback hit — surface what we have to the
 		// callback rather than treat it as not-found.
 		if err != nil && !IsXattrNotFoundError(err) && !errors.Is(err, ErrXattrPartialFound) {
-			ms.disableFallbackIfUnrecoverable(ctx, err)
+			ms.DisableFallbackIfUnrecoverable(ctx, err)
 			return false, err, 0
 		}
 
@@ -520,7 +513,7 @@ func (ms *MetadataStore) WriteUpdateWithXattrs(ctx context.Context, k string, xa
 				//        but it could be two concurrent Tombstones that we should at least have one more attempt for
 				return true, nil, 0
 			}
-			ms.disableFallbackIfUnrecoverable(ctx, tombstoneErr)
+			ms.DisableFallbackIfUnrecoverable(ctx, tombstoneErr)
 			return false, tombstoneErr, 0
 		}
 
@@ -556,7 +549,7 @@ func (ms *MetadataStore) GetSubDocRaw(ctx context.Context, k string, subdocKey s
 	value, casOut, err = ms.primary.GetSubDocRaw(ctx, k, subdocKey)
 	if ms.readFromFallback(ctx, err) {
 		value, _, err = ms.fallback.GetSubDocRaw(ctx, k, subdocKey)
-		ms.disableFallbackIfUnrecoverable(ctx, err)
+		ms.DisableFallbackIfUnrecoverable(ctx, err)
 	}
 	return value, casOut, err
 }

--- a/base/dual_metadata_store.go
+++ b/base/dual_metadata_store.go
@@ -20,9 +20,9 @@ import (
 
 // MetadataStore is a wrapper for a primary and fallback metadata store for read operations during metadata migration
 type MetadataStore struct {
-	primary           DataStore // _system._mobile scope/collection
-	fallback          DataStore // _default._default scope/collection
-	migrationComplete atomic.Bool
+	primary               DataStore // _system._mobile scope/collection
+	fallback              DataStore // _default._default scope/collection
+	fallbackReadsDisabled atomic.Bool
 }
 
 // Compile-time assertion that *MetadataStore implements DataStore.
@@ -52,20 +52,22 @@ func (ms *MetadataStore) Fallback() DataStore {
 	return ms.fallback
 }
 
-// SetMigrationComplete will set migration complete to true to stop reads falling back to fallback datastore.
+// DisableFallbackReads stops reads consulting the fallback datastore, permanently. Writes are
+// unaffected - they always go to primary.
 //
-// The flag really means "the fallback collection is no longer worth reading". A finished migration is
-// one cause; the other two are a _default._default that is absent at database open
-// (rest.(*ServerContext)._getOrAddDatabaseFromConfig) and one observed to have been dropped while the
-// database is online (noteFallbackErr). In every case anything still resident there is unreachable.
-func (ms *MetadataStore) SetMigrationComplete() {
-	ms.migrationComplete.Store(true)
+// Called whenever the fallback collection stops being worth reading, which happens for three
+// distinct reasons: metadata migration finished (on this node or a peer), _default._default was
+// absent at database open (rest.(*ServerContext)._getOrAddDatabaseFromConfig), or it was observed to
+// have been dropped while the database is online (disableFallbackIfUnrecoverable). In all three cases
+// anything still resident on the fallback is unreachable.
+func (ms *MetadataStore) DisableFallbackReads() {
+	ms.fallbackReadsDisabled.Store(true)
 }
 
-// MigrationComplete reports whether reads should skip the fallback datastore. See
-// SetMigrationComplete for the causes - a completed migration is not the only one.
-func (ms *MetadataStore) MigrationComplete() bool {
-	return ms.migrationComplete.Load()
+// FallbackReadsEnabled reports whether reads should still consult the fallback datastore. See
+// DisableFallbackReads for what turns this off - a completed migration is only one of the causes.
+func (ms *MetadataStore) FallbackReadsEnabled() bool {
+	return !ms.fallbackReadsDisabled.Load()
 }
 
 // MetadataStoreMode classifies a database's metadata store for support / observability.
@@ -73,10 +75,10 @@ type MetadataStoreMode string
 
 const (
 	// MetadataStoreModeFallbackActive means the dual store is wrapping primary+fallback and
-	// fallback reads are still in play (migration not yet complete).
+	// fallback reads are still in play.
 	MetadataStoreModeFallbackActive MetadataStoreMode = "fallback_active"
 	// MetadataStoreModeFallbackInactive means the dual store is wrapping primary+fallback but
-	// migration has completed, so reads no longer fall back.
+	// reads no longer fall back - see DisableFallbackReads for the causes.
 	MetadataStoreModeFallbackInactive MetadataStoreMode = "fallback_inactive"
 )
 
@@ -88,45 +90,42 @@ func GetMetadataStoreMode(ds DataStore) MetadataStoreMode {
 	if !ok {
 		return ""
 	}
-	if ms.MigrationComplete() {
-		return MetadataStoreModeFallbackInactive
+	if ms.FallbackReadsEnabled() {
+		return MetadataStoreModeFallbackActive
 	}
-	return MetadataStoreModeFallbackActive
+	return MetadataStoreModeFallbackInactive
 }
 
-// readFromFallback returns true when err indicates the key was not found in primary and metadata migration has
-// not yet complete, meaning the operation should be retried against the fallback DataStore.
+// readFromFallback returns true when err indicates the key was not found in primary and the fallback
+// datastore is still being read, meaning the operation should be retried against it.
 func (ms *MetadataStore) readFromFallback(ctx context.Context, err error) bool {
-	if IsDocNotFoundError(err) && !ms.migrationComplete.Load() {
+	if IsDocNotFoundError(err) && ms.FallbackReadsEnabled() {
 		DebugfCtx(ctx, KeyCRUD, "falling back to fallback datastore for read")
 		return true
 	}
 	return false
 }
 
-// noteFallbackErr stops fallback reads when err shows the fallback collection has been dropped.
-// gocbcore always-retries KV_COLLECTION_OUTDATED, so one read against a dropped collection burns the
-// whole KV deadline (30s) - left unhandled, every later primary miss pays that again. Sequential
-// readers then stall indefinitely: DCP checkpoint loading is one per vbucket on cbgt's janitor
-// goroutine, which is also the goroutine that services ClosePIndex, so DatabaseContext.Close
-// deadlocks behind it.
+// disableFallbackIfUnrecoverable permanently disables fallback reads when err proves the fallback
+// collection is gone for good. There is no path back: Couchbase Server rejects any user-created
+// collection whose name starts with "_", so a dropped _default._default cannot be recreated for the
+// life of the bucket. Only a fatal, unrecoverable error trips this - a transient failure must not,
+// or legitimate unmigrated metadata would be skipped for the rest of the process lifetime.
 //
-// Reuses migrationComplete rather than tracking this separately - see SetMigrationComplete. Any
-// metadata still on the dropped collection is unreachable either way, so for read-routing purposes a
-// dropped fallback and a finished migration are the same thing.
-//
-// One-way: a recreated _default._default has a new collection UID and is empty. Returns err unchanged
-// so callers can wrap in place.
-func (ms *MetadataStore) noteFallbackErr(ctx context.Context, err error) error {
+// Why it matters: gocbcore always-retries KV_COLLECTION_OUTDATED, so one read against a dropped
+// collection burns the whole KV deadline (30s). Left unhandled, every later primary miss pays that
+// again, and sequential readers stall indefinitely - DCP checkpoint loading is one read per vbucket
+// on cbgt's janitor goroutine, which is also the goroutine that services ClosePIndex, so
+// DatabaseContext.Close deadlocks behind it.
+func (ms *MetadataStore) disableFallbackIfUnrecoverable(ctx context.Context, err error) {
 	if err == nil || !IsCollectionOutdatedError(err) {
-		return err
+		return
 	}
-	if !ms.migrationComplete.Swap(true) {
+	if !ms.fallbackReadsDisabled.Swap(true) {
 		WarnfCtx(ctx, "Metadata fallback collection %s.%s is unavailable (%v) - disabling fallback reads. Any metadata not already migrated to %s.%s is unrecoverable.",
 			MD(ms.fallback.ScopeName()), MD(ms.fallback.CollectionName()), err,
 			MD(ms.primary.ScopeName()), MD(ms.primary.CollectionName()))
 	}
-	return err
 }
 
 // ---- DataStoreName ----
@@ -163,7 +162,7 @@ func (ms *MetadataStore) Get(ctx context.Context, k string, rv any) (cas uint64,
 	cas, err = ms.primary.Get(ctx, k, rv)
 	if ms.readFromFallback(ctx, err) {
 		_, err = ms.fallback.Get(ctx, k, rv)
-		err = ms.noteFallbackErr(ctx, err)
+		ms.disableFallbackIfUnrecoverable(ctx, err)
 	}
 	return cas, err
 }
@@ -172,7 +171,7 @@ func (ms *MetadataStore) GetRaw(ctx context.Context, k string) (v []byte, cas ui
 	v, cas, err = ms.primary.GetRaw(ctx, k)
 	if ms.readFromFallback(ctx, err) {
 		v, _, err = ms.fallback.GetRaw(ctx, k)
-		err = ms.noteFallbackErr(ctx, err)
+		ms.disableFallbackIfUnrecoverable(ctx, err)
 	}
 	return v, cas, err
 }
@@ -181,7 +180,7 @@ func (ms *MetadataStore) GetExpiry(ctx context.Context, k string) (expiry uint32
 	expiry, err = ms.primary.GetExpiry(ctx, k)
 	if ms.readFromFallback(ctx, err) {
 		expiry, err = ms.fallback.GetExpiry(ctx, k)
-		err = ms.noteFallbackErr(ctx, err)
+		ms.disableFallbackIfUnrecoverable(ctx, err)
 	}
 	return expiry, err
 }
@@ -191,11 +190,12 @@ func (ms *MetadataStore) Exists(ctx context.Context, k string) (exists bool, err
 	if err != nil && !ms.readFromFallback(ctx, err) {
 		return false, err
 	}
-	if exists || ms.migrationComplete.Load() {
+	if exists || !ms.FallbackReadsEnabled() {
 		return exists, err
 	}
 	exists, err = ms.fallback.Exists(ctx, k)
-	return exists, ms.noteFallbackErr(ctx, err)
+	ms.disableFallbackIfUnrecoverable(ctx, err)
+	return exists, err
 }
 
 // ---- KVStore – write operations (primary only) ----
@@ -253,7 +253,7 @@ func (ms *MetadataStore) Update(ctx context.Context, k string, exp uint32, callb
 		}
 
 		// If we know something exists in Primary, do a direct Update there
-		if primaryExists || ms.migrationComplete.Load() {
+		if primaryExists || !ms.FallbackReadsEnabled() {
 			casOut, updateErr := ms.primary.Update(ctx, k, exp, callback)
 			return false, updateErr, casOut
 		}
@@ -266,7 +266,8 @@ func (ms *MetadataStore) Update(ctx context.Context, k string, exp uint32, callb
 			return false, updateErr, casOut
 		}
 		if err != nil {
-			return false, ms.noteFallbackErr(ctx, err), 0
+			ms.disableFallbackIfUnrecoverable(ctx, err)
+			return false, err, 0
 		}
 
 		newValue, cbExpiry, isDelete, cbErr := callback(fallbackValue)
@@ -292,7 +293,8 @@ func (ms *MetadataStore) Update(ctx context.Context, k string, exp uint32, callb
 				//        but it could be two concurrent Deletes that we should at least have one more attempt for
 				return true, nil, 0
 			}
-			return false, ms.noteFallbackErr(ctx, removeErr), 0
+			ms.disableFallbackIfUnrecoverable(ctx, removeErr)
+			return false, removeErr, 0
 		}
 
 		// Write to primary with CAS=0 to force safe insertion
@@ -321,7 +323,7 @@ func (ms *MetadataStore) Update(ctx context.Context, k string, exp uint32, callb
 func (ms *MetadataStore) Incr(ctx context.Context, k string, amt, def uint64, exp uint32) (casOut uint64, err error) {
 	const maxAttempts = 2
 	for attempt := 0; attempt < maxAttempts; attempt++ {
-		if ms.migrationComplete.Load() {
+		if !ms.FallbackReadsEnabled() {
 			return ms.primary.Incr(ctx, k, amt, def, exp)
 		}
 
@@ -348,7 +350,8 @@ func (ms *MetadataStore) Incr(ctx context.Context, k string, amt, def uint64, ex
 		}
 		// any other errors bubble up
 		if !IsCounterNonNumeric(fbIncrErr) {
-			return 0, ms.noteFallbackErr(ctx, fbIncrErr)
+			ms.disableFallbackIfUnrecoverable(ctx, fbIncrErr)
+			return 0, fbIncrErr
 		}
 
 		// Fallback returned DELTA_BADVAL - we're mid-migration of the seq - the doc has
@@ -364,7 +367,8 @@ func (ms *MetadataStore) Incr(ctx context.Context, k string, amt, def uint64, ex
 			continue
 		}
 		if fbErr != nil {
-			return 0, ms.noteFallbackErr(ctx, fbErr)
+			ms.disableFallbackIfUnrecoverable(ctx, fbErr)
+			return 0, fbErr
 		}
 		var pill SyncSeqMigrationPill
 		if jsonErr := JSONUnmarshal(raw, &pill); jsonErr != nil || !pill.SGMetadataMigrationPill {
@@ -385,7 +389,7 @@ func (ms *MetadataStore) Incr(ctx context.Context, k string, amt, def uint64, ex
 		// 3. delete fallback pill
 		if delErr := ms.fallback.Delete(ctx, k); delErr != nil && !IsDocNotFoundError(delErr) {
 			WarnfCtx(ctx, "MetadataStore.Incr: failed to clear migrated fallback counter %s: %v", UD(k), delErr)
-			ms.noteFallbackErr(ctx, delErr) //nolint:errcheck // already logged; the call is for its latching side effect
+			ms.disableFallbackIfUnrecoverable(ctx, delErr)
 		}
 
 		// 4. retry the caller's Incr on the now migrated primary
@@ -400,7 +404,7 @@ func (ms *MetadataStore) GetXattrs(ctx context.Context, k string, xattrKeys []st
 	xattrs, cas, err = ms.primary.GetXattrs(ctx, k, xattrKeys)
 	if ms.readFromFallback(ctx, err) {
 		xattrs, _, err = ms.fallback.GetXattrs(ctx, k, xattrKeys)
-		err = ms.noteFallbackErr(ctx, err)
+		ms.disableFallbackIfUnrecoverable(ctx, err)
 	}
 	return xattrs, cas, err
 }
@@ -409,7 +413,7 @@ func (ms *MetadataStore) GetWithXattrs(ctx context.Context, k string, xattrKeys 
 	v, xv, cas, err = ms.primary.GetWithXattrs(ctx, k, xattrKeys)
 	if ms.readFromFallback(ctx, err) {
 		v, xv, _, err = ms.fallback.GetWithXattrs(ctx, k, xattrKeys)
-		err = ms.noteFallbackErr(ctx, err)
+		ms.disableFallbackIfUnrecoverable(ctx, err)
 	}
 	return v, xv, cas, err
 }
@@ -458,7 +462,7 @@ func (ms *MetadataStore) DeleteWithXattrs(ctx context.Context, k string, xattrKe
 func (ms *MetadataStore) WriteUpdateWithXattrs(ctx context.Context, k string, xattrKeys []string, exp uint32, previous *sgbucket.BucketDocument, opts *sgbucket.MutateInOptions, callback sgbucket.WriteUpdateWithXattrsFunc) (uint64, error) {
 	// If we're updating with a previous.Cas - we'll be updating on top of a prior fetch from the primary datastore, not the fallback data store.
 	// Or if the fallback is no longer in play (migration complete, or the collection was dropped) - avoid the fallback effort...
-	if (previous != nil && previous.Cas != 0) || ms.migrationComplete.Load() {
+	if (previous != nil && previous.Cas != 0) || !ms.FallbackReadsEnabled() {
 		return ms.primary.WriteUpdateWithXattrs(ctx, k, xattrKeys, exp, previous, opts, callback)
 	}
 
@@ -470,7 +474,7 @@ func (ms *MetadataStore) WriteUpdateWithXattrs(ctx context.Context, k string, xa
 		}
 
 		// If we know something exists in Primary, do a direct WriteUpdateWithXattrs there
-		if primaryExists || ms.migrationComplete.Load() {
+		if primaryExists || !ms.FallbackReadsEnabled() {
 			casOut, updateErr := ms.primary.WriteUpdateWithXattrs(ctx, k, xattrKeys, exp, nil, opts, callback)
 			return false, updateErr, casOut
 		}
@@ -485,7 +489,8 @@ func (ms *MetadataStore) WriteUpdateWithXattrs(ctx context.Context, k string, xa
 		// A doc with no/partial xattrs is still a fallback hit — surface what we have to the
 		// callback rather than treat it as not-found.
 		if err != nil && !IsXattrNotFoundError(err) && !errors.Is(err, ErrXattrPartialFound) {
-			return false, ms.noteFallbackErr(ctx, err), 0
+			ms.disableFallbackIfUnrecoverable(ctx, err)
+			return false, err, 0
 		}
 
 		updatedDoc, cbErr := callback(fallbackBody, fallbackXattrs, 0)
@@ -515,7 +520,8 @@ func (ms *MetadataStore) WriteUpdateWithXattrs(ctx context.Context, k string, xa
 				//        but it could be two concurrent Tombstones that we should at least have one more attempt for
 				return true, nil, 0
 			}
-			return false, ms.noteFallbackErr(ctx, tombstoneErr), 0
+			ms.disableFallbackIfUnrecoverable(ctx, tombstoneErr)
+			return false, tombstoneErr, 0
 		}
 
 		// Write to primary with CAS=0 to force safe insertion.
@@ -550,7 +556,7 @@ func (ms *MetadataStore) GetSubDocRaw(ctx context.Context, k string, subdocKey s
 	value, casOut, err = ms.primary.GetSubDocRaw(ctx, k, subdocKey)
 	if ms.readFromFallback(ctx, err) {
 		value, _, err = ms.fallback.GetSubDocRaw(ctx, k, subdocKey)
-		err = ms.noteFallbackErr(ctx, err)
+		ms.disableFallbackIfUnrecoverable(ctx, err)
 	}
 	return value, casOut, err
 }

--- a/base/dual_metadata_store.go
+++ b/base/dual_metadata_store.go
@@ -53,11 +53,17 @@ func (ms *MetadataStore) Fallback() DataStore {
 }
 
 // SetMigrationComplete will set migration complete to true to stop reads falling back to fallback datastore.
+//
+// The flag really means "the fallback collection is no longer worth reading". A finished migration is
+// one cause; the other two are a _default._default that is absent at database open
+// (rest.(*ServerContext)._getOrAddDatabaseFromConfig) and one observed to have been dropped while the
+// database is online (noteFallbackErr). In every case anything still resident there is unreachable.
 func (ms *MetadataStore) SetMigrationComplete() {
 	ms.migrationComplete.Store(true)
 }
 
-// MigrationComplete reports whether metadata migration has finished.
+// MigrationComplete reports whether reads should skip the fallback datastore. See
+// SetMigrationComplete for the causes - a completed migration is not the only one.
 func (ms *MetadataStore) MigrationComplete() bool {
 	return ms.migrationComplete.Load()
 }
@@ -98,6 +104,31 @@ func (ms *MetadataStore) readFromFallback(ctx context.Context, err error) bool {
 	return false
 }
 
+// noteFallbackErr stops fallback reads when err shows the fallback collection has been dropped.
+// gocbcore always-retries KV_COLLECTION_OUTDATED, so one read against a dropped collection burns the
+// whole KV deadline (30s) - left unhandled, every later primary miss pays that again. Sequential
+// readers then stall indefinitely: DCP checkpoint loading is one per vbucket on cbgt's janitor
+// goroutine, which is also the goroutine that services ClosePIndex, so DatabaseContext.Close
+// deadlocks behind it.
+//
+// Reuses migrationComplete rather than tracking this separately - see SetMigrationComplete. Any
+// metadata still on the dropped collection is unreachable either way, so for read-routing purposes a
+// dropped fallback and a finished migration are the same thing.
+//
+// One-way: a recreated _default._default has a new collection UID and is empty. Returns err unchanged
+// so callers can wrap in place.
+func (ms *MetadataStore) noteFallbackErr(ctx context.Context, err error) error {
+	if err == nil || !IsCollectionOutdatedError(err) {
+		return err
+	}
+	if !ms.migrationComplete.Swap(true) {
+		WarnfCtx(ctx, "Metadata fallback collection %s.%s is unavailable (%v) - disabling fallback reads. Any metadata not already migrated to %s.%s is unrecoverable.",
+			MD(ms.fallback.ScopeName()), MD(ms.fallback.CollectionName()), err,
+			MD(ms.primary.ScopeName()), MD(ms.primary.CollectionName()))
+	}
+	return err
+}
+
 // ---- DataStoreName ----
 
 func (ms *MetadataStore) GetName() string {
@@ -132,6 +163,7 @@ func (ms *MetadataStore) Get(ctx context.Context, k string, rv any) (cas uint64,
 	cas, err = ms.primary.Get(ctx, k, rv)
 	if ms.readFromFallback(ctx, err) {
 		_, err = ms.fallback.Get(ctx, k, rv)
+		err = ms.noteFallbackErr(ctx, err)
 	}
 	return cas, err
 }
@@ -140,6 +172,7 @@ func (ms *MetadataStore) GetRaw(ctx context.Context, k string) (v []byte, cas ui
 	v, cas, err = ms.primary.GetRaw(ctx, k)
 	if ms.readFromFallback(ctx, err) {
 		v, _, err = ms.fallback.GetRaw(ctx, k)
+		err = ms.noteFallbackErr(ctx, err)
 	}
 	return v, cas, err
 }
@@ -148,6 +181,7 @@ func (ms *MetadataStore) GetExpiry(ctx context.Context, k string) (expiry uint32
 	expiry, err = ms.primary.GetExpiry(ctx, k)
 	if ms.readFromFallback(ctx, err) {
 		expiry, err = ms.fallback.GetExpiry(ctx, k)
+		err = ms.noteFallbackErr(ctx, err)
 	}
 	return expiry, err
 }
@@ -160,7 +194,8 @@ func (ms *MetadataStore) Exists(ctx context.Context, k string) (exists bool, err
 	if exists || ms.migrationComplete.Load() {
 		return exists, err
 	}
-	return ms.fallback.Exists(ctx, k)
+	exists, err = ms.fallback.Exists(ctx, k)
+	return exists, ms.noteFallbackErr(ctx, err)
 }
 
 // ---- KVStore – write operations (primary only) ----
@@ -231,7 +266,7 @@ func (ms *MetadataStore) Update(ctx context.Context, k string, exp uint32, callb
 			return false, updateErr, casOut
 		}
 		if err != nil {
-			return false, err, 0
+			return false, ms.noteFallbackErr(ctx, err), 0
 		}
 
 		newValue, cbExpiry, isDelete, cbErr := callback(fallbackValue)
@@ -257,7 +292,7 @@ func (ms *MetadataStore) Update(ctx context.Context, k string, exp uint32, callb
 				//        but it could be two concurrent Deletes that we should at least have one more attempt for
 				return true, nil, 0
 			}
-			return false, removeErr, 0
+			return false, ms.noteFallbackErr(ctx, removeErr), 0
 		}
 
 		// Write to primary with CAS=0 to force safe insertion
@@ -313,7 +348,7 @@ func (ms *MetadataStore) Incr(ctx context.Context, k string, amt, def uint64, ex
 		}
 		// any other errors bubble up
 		if !IsCounterNonNumeric(fbIncrErr) {
-			return 0, fbIncrErr
+			return 0, ms.noteFallbackErr(ctx, fbIncrErr)
 		}
 
 		// Fallback returned DELTA_BADVAL - we're mid-migration of the seq - the doc has
@@ -329,7 +364,7 @@ func (ms *MetadataStore) Incr(ctx context.Context, k string, amt, def uint64, ex
 			continue
 		}
 		if fbErr != nil {
-			return 0, fbErr
+			return 0, ms.noteFallbackErr(ctx, fbErr)
 		}
 		var pill SyncSeqMigrationPill
 		if jsonErr := JSONUnmarshal(raw, &pill); jsonErr != nil || !pill.SGMetadataMigrationPill {
@@ -350,6 +385,7 @@ func (ms *MetadataStore) Incr(ctx context.Context, k string, amt, def uint64, ex
 		// 3. delete fallback pill
 		if delErr := ms.fallback.Delete(ctx, k); delErr != nil && !IsDocNotFoundError(delErr) {
 			WarnfCtx(ctx, "MetadataStore.Incr: failed to clear migrated fallback counter %s: %v", UD(k), delErr)
+			ms.noteFallbackErr(ctx, delErr) //nolint:errcheck // already logged; the call is for its latching side effect
 		}
 
 		// 4. retry the caller's Incr on the now migrated primary
@@ -364,6 +400,7 @@ func (ms *MetadataStore) GetXattrs(ctx context.Context, k string, xattrKeys []st
 	xattrs, cas, err = ms.primary.GetXattrs(ctx, k, xattrKeys)
 	if ms.readFromFallback(ctx, err) {
 		xattrs, _, err = ms.fallback.GetXattrs(ctx, k, xattrKeys)
+		err = ms.noteFallbackErr(ctx, err)
 	}
 	return xattrs, cas, err
 }
@@ -372,6 +409,7 @@ func (ms *MetadataStore) GetWithXattrs(ctx context.Context, k string, xattrKeys 
 	v, xv, cas, err = ms.primary.GetWithXattrs(ctx, k, xattrKeys)
 	if ms.readFromFallback(ctx, err) {
 		v, xv, _, err = ms.fallback.GetWithXattrs(ctx, k, xattrKeys)
+		err = ms.noteFallbackErr(ctx, err)
 	}
 	return v, xv, cas, err
 }
@@ -419,7 +457,7 @@ func (ms *MetadataStore) DeleteWithXattrs(ctx context.Context, k string, xattrKe
 // Callers must not feed a fallback CAS back through previous.Cas — the wrapper's read methods only surface primary CAS, so any non-zero previous.Cas is treated as primary; misuse is documented but not enforced.
 func (ms *MetadataStore) WriteUpdateWithXattrs(ctx context.Context, k string, xattrKeys []string, exp uint32, previous *sgbucket.BucketDocument, opts *sgbucket.MutateInOptions, callback sgbucket.WriteUpdateWithXattrsFunc) (uint64, error) {
 	// If we're updating with a previous.Cas - we'll be updating on top of a prior fetch from the primary datastore, not the fallback data store.
-	// Or if we've tagged MetadataStore with 'migrationComplete' - avoid the fallback effort...
+	// Or if the fallback is no longer in play (migration complete, or the collection was dropped) - avoid the fallback effort...
 	if (previous != nil && previous.Cas != 0) || ms.migrationComplete.Load() {
 		return ms.primary.WriteUpdateWithXattrs(ctx, k, xattrKeys, exp, previous, opts, callback)
 	}
@@ -447,7 +485,7 @@ func (ms *MetadataStore) WriteUpdateWithXattrs(ctx context.Context, k string, xa
 		// A doc with no/partial xattrs is still a fallback hit — surface what we have to the
 		// callback rather than treat it as not-found.
 		if err != nil && !IsXattrNotFoundError(err) && !errors.Is(err, ErrXattrPartialFound) {
-			return false, err, 0
+			return false, ms.noteFallbackErr(ctx, err), 0
 		}
 
 		updatedDoc, cbErr := callback(fallbackBody, fallbackXattrs, 0)
@@ -477,7 +515,7 @@ func (ms *MetadataStore) WriteUpdateWithXattrs(ctx context.Context, k string, xa
 				//        but it could be two concurrent Tombstones that we should at least have one more attempt for
 				return true, nil, 0
 			}
-			return false, tombstoneErr, 0
+			return false, ms.noteFallbackErr(ctx, tombstoneErr), 0
 		}
 
 		// Write to primary with CAS=0 to force safe insertion.
@@ -512,6 +550,7 @@ func (ms *MetadataStore) GetSubDocRaw(ctx context.Context, k string, subdocKey s
 	value, casOut, err = ms.primary.GetSubDocRaw(ctx, k, subdocKey)
 	if ms.readFromFallback(ctx, err) {
 		value, _, err = ms.fallback.GetSubDocRaw(ctx, k, subdocKey)
+		err = ms.noteFallbackErr(ctx, err)
 	}
 	return value, casOut, err
 }

--- a/base/dual_metadata_store_test.go
+++ b/base/dual_metadata_store_test.go
@@ -9,10 +9,14 @@
 package base
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"sync/atomic"
 	"testing"
 
+	"github.com/couchbase/gocb/v2"
 	"github.com/couchbase/sync_gateway/testing/assert"
 	"github.com/couchbase/sync_gateway/testing/require"
 )
@@ -230,4 +234,106 @@ func TestIsCounterNonNumeric(t *testing.T) {
 
 	// Sanity: an unrelated error should NOT be classified as non-numeric.
 	assert.False(t, IsCounterNonNumeric(errors.New("unrelated")))
+}
+
+// getRawErrorDataStore returns a fixed error from every GetRaw and counts how many times it was
+// asked, so tests can prove the wrapper stopped consulting the fallback.
+type getRawErrorDataStore struct {
+	DataStore
+	err   error
+	calls atomic.Int32
+}
+
+func (ds *getRawErrorDataStore) GetRaw(_ context.Context, _ string) ([]byte, uint64, error) {
+	ds.calls.Add(1)
+	return nil, 0, ds.err
+}
+
+// TestMetadataStoreDroppedFallbackDisablesFallbackReads verifies the wrapper stops reading from the
+// fallback once that collection is seen to have been dropped. Otherwise every primary miss pays a
+// full KV timeout, which is what stalls the cbgt janitor goroutine and deadlocks database close.
+//
+// The negative cases matter most: reacting to a merely transient error would permanently skip
+// legitimate unmigrated metadata.
+func TestMetadataStoreDroppedFallbackDisablesFallbackReads(t *testing.T) {
+	testCases := []struct {
+		name        string
+		fallbackErr error
+		wantDisable bool
+	}{
+		{
+			name:        "collection not found disables fallback",
+			fallbackErr: gocb.ErrCollectionNotFound,
+			wantDisable: true,
+		},
+		{
+			name: "timeout from collection outdated only disables fallback",
+			fallbackErr: &gocb.TimeoutError{InnerError: gocb.ErrTimeout,
+				RetryReasons: []gocb.RetryReason{gocb.KVCollectionOutdatedRetryReason}},
+			wantDisable: true,
+		},
+		{
+			name: "timeout with a transient reason alongside must not disable fallback",
+			fallbackErr: &gocb.TimeoutError{InnerError: gocb.ErrTimeout,
+				RetryReasons: []gocb.RetryReason{gocb.KVCollectionOutdatedRetryReason, gocb.KVNotMyVBucketRetryReason}},
+			wantDisable: false,
+		},
+		{
+			name:        "doc not found must not disable fallback",
+			fallbackErr: ErrNotFound,
+			wantDisable: false,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx := TestCtx(t)
+			bucket := GetTestBucket(t)
+			defer bucket.Close(ctx)
+
+			primary, err := bucket.GetNamedDataStore(0)
+			require.NoError(t, err)
+			fallback := &getRawErrorDataStore{DataStore: bucket.DefaultDataStore(ctx), err: testCase.fallbackErr}
+			ms := NewMetadataStore(primary, fallback)
+
+			require.False(t, ms.MigrationComplete(), "fallback must start in play")
+			require.Equal(t, MetadataStoreModeFallbackActive, GetMetadataStoreMode(ms))
+
+			// Primary has no such key, so this read falls through to the erroring fallback.
+			const key = "_sync:m_droppedDB:seq"
+			_, _, err = ms.GetRaw(ctx, key)
+			require.Error(t, err)
+			require.Equal(t, int32(1), fallback.calls.Load(), "first read must consult the fallback")
+
+			if !testCase.wantDisable {
+				assert.False(t, ms.MigrationComplete(), "a transient fallback error must not disable fallback reads")
+				assert.Equal(t, MetadataStoreModeFallbackActive, GetMetadataStoreMode(ms))
+				_, _, err = ms.GetRaw(ctx, key)
+				require.Error(t, err)
+				assert.Equal(t, int32(2), fallback.calls.Load(), "fallback must still be consulted")
+				return
+			}
+
+			assert.ErrorIs(t, err, testCase.fallbackErr, "the fallback error must still reach the caller")
+			// Reusing migrationComplete is deliberate - see MetadataStore.SetMigrationComplete. It
+			// routes reads to primary only, which is what every existing consumer already checks.
+			assert.True(t, ms.MigrationComplete(), "a dropped fallback collection must disable fallback reads")
+			assert.Equal(t, MetadataStoreModeFallbackInactive, GetMetadataStoreMode(ms))
+
+			// Later reads must short-circuit on primary's not-found rather than pay the fallback
+			// again. Distinct keys here on purpose: this mirrors the DCP checkpoint path, which
+			// reads one key per vbucket. A per-key rather than per-store decision would still stall
+			// the cbgt janitor for every remaining vbucket.
+			for vbNo := range 16 {
+				_, _, err = ms.GetRaw(ctx, fmt.Sprintf("_sync:dcp_ck:droppedDB:%d", vbNo))
+				assert.True(t, IsDocNotFoundError(err), "expected primary not-found, got %v", err)
+			}
+			assert.Equal(t, int32(1), fallback.calls.Load(), "fallback must not be consulted once disabled")
+
+			// Exists shares the same gate.
+			exists, err := ms.Exists(ctx, key)
+			assert.NoError(t, err)
+			assert.False(t, exists)
+			assert.Equal(t, int32(1), fallback.calls.Load())
+		})
+	}
 }

--- a/base/dual_metadata_store_test.go
+++ b/base/dual_metadata_store_test.go
@@ -171,7 +171,7 @@ func TestMetadataStoreIncrAfterMigrationCompleteBypassesFallback(t *testing.T) {
 	_, err := ms.Fallback().Incr(ctx, key, 99, 99, 0)
 	require.NoError(t, err)
 
-	ms.SetMigrationComplete()
+	ms.DisableFallbackReads()
 
 	// Wrapper should not consult fallback now; primary doc gets created at the supplied
 	// default value (1) and incremented by amt (0), returning the default value.
@@ -295,7 +295,7 @@ func TestMetadataStoreDroppedFallbackDisablesFallbackReads(t *testing.T) {
 			fallback := &getRawErrorDataStore{DataStore: bucket.DefaultDataStore(ctx), err: testCase.fallbackErr}
 			ms := NewMetadataStore(primary, fallback)
 
-			require.False(t, ms.MigrationComplete(), "fallback must start in play")
+			require.True(t, ms.FallbackReadsEnabled(), "fallback must start in play")
 			require.Equal(t, MetadataStoreModeFallbackActive, GetMetadataStoreMode(ms))
 
 			// Primary has no such key, so this read falls through to the erroring fallback.
@@ -305,7 +305,7 @@ func TestMetadataStoreDroppedFallbackDisablesFallbackReads(t *testing.T) {
 			require.Equal(t, int32(1), fallback.calls.Load(), "first read must consult the fallback")
 
 			if !testCase.wantDisable {
-				assert.False(t, ms.MigrationComplete(), "a transient fallback error must not disable fallback reads")
+				assert.True(t, ms.FallbackReadsEnabled(), "a transient fallback error must not disable fallback reads")
 				assert.Equal(t, MetadataStoreModeFallbackActive, GetMetadataStoreMode(ms))
 				_, _, err = ms.GetRaw(ctx, key)
 				require.Error(t, err)
@@ -314,9 +314,7 @@ func TestMetadataStoreDroppedFallbackDisablesFallbackReads(t *testing.T) {
 			}
 
 			assert.ErrorIs(t, err, testCase.fallbackErr, "the fallback error must still reach the caller")
-			// Reusing migrationComplete is deliberate - see MetadataStore.SetMigrationComplete. It
-			// routes reads to primary only, which is what every existing consumer already checks.
-			assert.True(t, ms.MigrationComplete(), "a dropped fallback collection must disable fallback reads")
+			assert.False(t, ms.FallbackReadsEnabled(), "a dropped fallback collection must disable fallback reads")
 			assert.Equal(t, MetadataStoreModeFallbackInactive, GetMetadataStoreMode(ms))
 
 			// Later reads must short-circuit on primary's not-found rather than pay the fallback

--- a/db/background_mgr_metadata_migration.go
+++ b/db/background_mgr_metadata_migration.go
@@ -254,7 +254,7 @@ func (m *MetadataMigrationManager) Run(ctx context.Context, options MetadataMigr
 			// Completion gates on per-doc move/delete errors and a truncated scan. A failed in-scope move
 			// increments stats.Errors and leaves the doc on the fallback, which the wrapper
 			// would then permanently ignore — so those must clear before we
-			// SetMigrationComplete(). Errors are typically transient (CAS races), so a non-clean
+			// DisableFallbackReads(). Errors are typically transient (CAS races), so a non-clean
 			// pass simply forces a retry; only a persistent failure reaches the maxPasses give-up
 			// below, which never completes.
 			//
@@ -285,7 +285,7 @@ func (m *MetadataMigrationManager) Run(ctx context.Context, options MetadataMigr
 			}
 		}
 
-		ms.SetMigrationComplete()
+		ms.DisableFallbackReads()
 		base.InfofCtx(ctx, base.KeyAll, "[%s] Metadata migration complete after %d pass(es): %d migrated, %d failed, %d out of scope",
 			metadataMigrationLoggingID, m.passes.Load(), m.docsProcessed.Load(), m.docsFailed.Load(), m.docsOutOfScope.Load())
 	} else {

--- a/db/background_mgr_metadata_migration_test.go
+++ b/db/background_mgr_metadata_migration_test.go
@@ -208,7 +208,7 @@ func TestMetadataMigrationManagerMovesUsersAndRoles(t *testing.T) {
 		_, _, getErr = ms.Fallback().GetRaw(ctx, k)
 		assert.True(t, base.IsDocNotFoundError(getErr), "fallback should no longer hold %s", k)
 	}
-	assert.True(t, ms.MigrationComplete(), "clean run must flip MigrationComplete so future reads skip the fallback")
+	assert.False(t, ms.FallbackReadsEnabled(), "clean run must disable fallback reads")
 }
 
 // TestMetadataMigrationCompletesWithCollectionScopedDataInFallback is a regression test for a
@@ -281,7 +281,7 @@ func TestMetadataMigrationCompletesWithCollectionScopedDataInFallback(t *testing
 	// the job it exhausts maxPasses and lands in Error instead.
 	RequireBackgroundManagerState(t, dbCtx.MetadataMigrationManager, BackgroundProcessStateCompleted)
 
-	assert.True(t, ms.MigrationComplete(), "clean run must flip MigrationComplete so future reads skip the fallback")
+	assert.False(t, ms.FallbackReadsEnabled(), "clean run must disable fallback reads")
 
 	rawStatus, err := dbCtx.MetadataMigrationManager.GetStatus(ctx)
 	require.NoError(t, err)
@@ -350,7 +350,7 @@ func TestMetadataMigrationManagerCompletesWithUnknownPrefixLeftInPlace(t *testin
 	// Unknown-prefix docs no longer block completion — the manager reaches the Completed state.
 	RequireBackgroundManagerState(t, dbCtx.MetadataMigrationManager, BackgroundProcessStateCompleted)
 
-	assert.True(t, ms.MigrationComplete(), "MigrationComplete should be flipped — unknown-prefix docs do not block completion")
+	assert.False(t, ms.FallbackReadsEnabled(), "fallback reads should be disabled — unknown-prefix docs do not block completion")
 
 	_, _, err = ms.Fallback().GetRaw(ctx, unknownKey)
 	assert.NoError(t, err, "unrecognised doc should be left in place on the fallback (non-destructive)")
@@ -420,7 +420,7 @@ func TestMetadataMigrationManagerDCPCheckpointGroupIDCollisionCompletesEndToEnd(
 	assert.Zero(t, resp.DocsFailed, "no per-doc errors: the collision is a classification outcome, not a move failure")
 	assert.Equal(t, int64(1), resp.DocsOutOfScope, "own checkpoint is (mis)classified out-of-scope, not unknown-prefix")
 
-	assert.True(t, ms.MigrationComplete(), "out-of-scope docs do not block completion - the run still flips MigrationComplete")
+	assert.False(t, ms.FallbackReadsEnabled(), "out-of-scope docs do not block completion - the run still disables fallback reads")
 
 	_, _, getErr := ms.Fallback().GetRaw(ctx, ownCheckpoint)
 	assert.NoError(t, getErr, "own checkpoint is stranded on the fallback under the known limitation")

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -840,7 +840,7 @@ func initializePrincipalDocsIndex(ctx context.Context, db *DatabaseContext) erro
 	if metadataStore, ok := db.MetadataStore.(*base.MetadataStore); ok {
 		// need to ensure both primary and fallback have index
 		dataStores = append(dataStores, metadataStore.Primary())
-		if !metadataStore.MigrationComplete() {
+		if metadataStore.FallbackReadsEnabled() {
 			dataStores = append(dataStores, metadataStore.Fallback())
 		}
 	} else {

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -97,7 +97,7 @@ func cachingFeedCollections(metadataStore base.DataStore, scopes map[string]Scop
 	collectionNames := base.NewCollectionNameSet()
 	if ms, ok := metadataStore.(*base.MetadataStore); ok {
 		collectionNames.Add(ms.Primary())
-		if !ms.MigrationComplete() {
+		if ms.FallbackReadsEnabled() {
 			collectionNames.Add(ms.Fallback())
 		}
 	} else {

--- a/db/change_listener_dual_metadata_test.go
+++ b/db/change_listener_dual_metadata_test.go
@@ -51,7 +51,7 @@ func TestCachingFeedCollectionsDualMetadataStoreMigrationComplete(t *testing.T) 
 	primary := bucket.GetMobileSystemDataStore() // skips if backing store does not support system collections
 	fallback := bucket.DefaultDataStore(ctx)
 	ms := base.NewMetadataStore(primary, fallback)
-	ms.SetMigrationComplete()
+	ms.DisableFallbackReads()
 
 	got := cachingFeedCollections(ms, nil)
 

--- a/db/database.go
+++ b/db/database.go
@@ -668,12 +668,17 @@ func (context *DatabaseContext) shouldRunMetadataMigration(ctx context.Context) 
 // already-migrated database at construction. When that flag is not set it consults the authoritative,
 // cluster-wide status doc via PerDBMetadataMigrationCompleteFunc — catching the case where a *peer*
 // node completed the migration and this node's local flag is a stale false. When the durable status
-// shows complete, the local flag is converged (SetMigrationComplete) so subsequent callers use the
+// shows complete, the local flag is converged (DisableFallbackReads) so subsequent callers use the
 // fast path and this node's fallback reads stop too. It only converges on a complete status — an
 // in-progress migration returns false, so fallback reads are never disabled mid-migration.
+//
+// Note the fast path is broader than the name: fallback reads are also disabled when
+// _default._default was never there or has been dropped, in which case there is likewise nothing
+// left to migrate. Every caller uses this to decide whether migrating is still worth attempting, so
+// that conflation is intentional.
 func (context *DatabaseContext) MetadataMigrationComplete(ctx context.Context) bool {
 	ms, isDual := context.MetadataStore.(*base.MetadataStore)
-	if isDual && ms.MigrationComplete() {
+	if isDual && !ms.FallbackReadsEnabled() {
 		return true
 	}
 	if context.PerDBMetadataMigrationCompleteFunc == nil {
@@ -681,7 +686,7 @@ func (context *DatabaseContext) MetadataMigrationComplete(ctx context.Context) b
 	}
 	if context.PerDBMetadataMigrationCompleteFunc(ctx) {
 		if isDual {
-			ms.SetMigrationComplete()
+			ms.DisableFallbackReads()
 		}
 		return true
 	}

--- a/db/metadata_migration.go
+++ b/db/metadata_migration.go
@@ -90,7 +90,7 @@ func MigrateMetadata(ctx context.Context, ms *base.MetadataStore, metadataID str
 
 	// Next returns nil for both a clean end-of-stream and a mid-stream abort, so consult Err to tell
 	// them apart. A truncated scan must never look clean, or the orchestrator would
-	// SetMigrationComplete with in-scope docs still on the fallback.
+	// disable fallback reads with in-scope docs still on the fallback.
 	if scanErr := iter.Err(); scanErr != nil {
 		// A dropped fallback collection can never be scanned again - fail the whole migration.
 		if base.IsCollectionOutdatedError(scanErr) {

--- a/db/metadata_migration.go
+++ b/db/metadata_migration.go
@@ -68,6 +68,8 @@ func MigrateMetadata(ctx context.Context, ms *base.MetadataStore, metadataID str
 	}
 	iter, err := rss.Scan(ctx, sgbucket.NewRangeScanForPrefix(base.SyncDocPrefix), sgbucket.ScanOptions{IDsOnly: true})
 	if err != nil {
+		// Result unused: a scan that can't even be opened fails the pass either way.
+		ms.DisableFallbackIfUnrecoverable(ctx, err)
 		return 0, fmt.Errorf("metadata migration scan: %w", err)
 	}
 	defer func() {
@@ -93,7 +95,7 @@ func MigrateMetadata(ctx context.Context, ms *base.MetadataStore, metadataID str
 	// disable fallback reads with in-scope docs still on the fallback.
 	if scanErr := iter.Err(); scanErr != nil {
 		// A dropped fallback collection can never be scanned again - fail the whole migration.
-		if base.IsCollectionOutdatedError(scanErr) {
+		if ms.DisableFallbackIfUnrecoverable(ctx, scanErr) {
 			return int(stats.DocsUnknownPrefix.Load()), fmt.Errorf("metadata migration scan aborted: %w", scanErr)
 		}
 		// Anything else (a partition stream lost to rebalance, a temporary failure) may well
@@ -129,7 +131,7 @@ func migrateSeqCounter(ctx context.Context, ms *base.MetadataStore, seqKey strin
 		if err != nil {
 			// A dropped/recreated fallback collection is terminal - retrying here would
 			// spin on full KV timeouts forever.
-			return !base.IsCollectionOutdatedError(err), err, 0
+			return !ms.DisableFallbackIfUnrecoverable(ctx, err), err, 0
 		}
 		var existing base.SyncSeqMigrationPill
 		if jsonErr := base.JSONUnmarshal(raw, &existing); jsonErr != nil || !existing.SGMetadataMigrationPill {
@@ -147,7 +149,7 @@ func migrateSeqCounter(ctx context.Context, ms *base.MetadataStore, seqKey strin
 				return false, mErr, 0
 			}
 			if _, wErr := ms.Fallback().WriteCas(ctx, seqKey, 0, cas, payload, 0); wErr != nil {
-				return !base.IsCollectionOutdatedError(wErr), wErr, 0
+				return !ms.DisableFallbackIfUnrecoverable(ctx, wErr), wErr, 0
 			}
 			stats.SeqPoisonPillApplied.Add(1)
 		}
@@ -410,7 +412,7 @@ func moveFallbackDoc(ctx context.Context, ms *base.MetadataStore, key string, bi
 		// A dropped/outdated collection is terminal for the whole migration — every remaining key
 		// would incur the same full KV timeout. Abort the pass rather than count this as a
 		// transient per-doc error and grind on.
-		if base.IsCollectionOutdatedError(err) {
+		if ms.DisableFallbackIfUnrecoverable(ctx, err) {
 			return fmt.Errorf("metadata migration: fallback collection unavailable fetching %s: %w", base.UD(key), err)
 		}
 		base.WarnfCtx(ctx, "metadata migration: fallback fetch failed for %s: %v", base.UD(key), err)
@@ -437,7 +439,7 @@ func moveFallbackDoc(ctx context.Context, ms *base.MetadataStore, key string, bi
 		return nil
 	}
 	if delErr := ms.Fallback().Delete(ctx, key); delErr != nil && !base.IsDocNotFoundError(delErr) {
-		if base.IsCollectionOutdatedError(delErr) {
+		if ms.DisableFallbackIfUnrecoverable(ctx, delErr) {
 			return fmt.Errorf("metadata migration: fallback collection unavailable deleting %s: %w", base.UD(key), delErr)
 		}
 		base.WarnfCtx(ctx, "metadata migration: fallback delete failed for %s: %v", base.UD(key), delErr)
@@ -452,7 +454,7 @@ func moveFallbackDoc(ctx context.Context, ms *base.MetadataStore, key string, bi
 // This is used in cases like transient heartbeat documents where it does not make sense to move.
 func deleteFallbackDoc(ctx context.Context, ms *base.MetadataStore, key string, stats *MigrationStats) error {
 	if delErr := ms.Fallback().Delete(ctx, key); delErr != nil && !base.IsDocNotFoundError(delErr) {
-		if base.IsCollectionOutdatedError(delErr) {
+		if ms.DisableFallbackIfUnrecoverable(ctx, delErr) {
 			return fmt.Errorf("metadata migration: fallback collection unavailable deleting %s: %w", base.UD(key), delErr)
 		}
 		base.WarnfCtx(ctx, "metadata migration: fallback delete failed for %s: %v", base.UD(key), delErr)

--- a/db/metadata_migration_test.go
+++ b/db/metadata_migration_test.go
@@ -119,11 +119,15 @@ func TestMigrateMetadataScanError(t *testing.T) {
 			_, err := MigrateMetadata(ctx, msWithScanErr, metadataID, nil, nil, stats)
 			if testCase.wantFatal {
 				require.ErrorIs(t, err, testCase.scanErr, "a dropped collection must fail the migration")
+				require.False(t, msWithScanErr.FallbackReadsEnabled(),
+					"a dropped fallback must stop further fallback reads, so later readers don't each pay a KV deadline")
 				return
 			}
 			require.NoError(t, err, "a transient scan error must not fail the migration outright")
 			require.True(t, stats.ScanAborted.Load(), "a truncated scan must not look like a clean pass")
 			require.Zero(t, stats.DocsMigrated.Load())
+			require.True(t, msWithScanErr.FallbackReadsEnabled(),
+				"a transient error must leave the fallback in play, or unmigrated metadata is skipped for good")
 		})
 	}
 }
@@ -170,6 +174,7 @@ func TestMigrateMetadataCollectionDroppedDuringMoveFailsPass(t *testing.T) {
 	stats := &MigrationStats{}
 	_, err := MigrateMetadata(ctx, msWithFetchErr, metadataID, nil, nil, stats)
 	require.ErrorIs(t, err, gocb.ErrCollectionNotFound, "a dropped fallback collection during a per-doc move must fail the pass")
+	require.False(t, msWithFetchErr.FallbackReadsEnabled(), "a dropped fallback must stop further fallback reads")
 }
 
 // primaryAddErrorDataStore wraps a DataStore so every Add fails with addErr, standing in for the
@@ -203,6 +208,8 @@ func TestMigrateMetadataPrimaryCollectionDroppedFailsPass(t *testing.T) {
 	stats := &MigrationStats{}
 	_, err := MigrateMetadata(ctx, msWithAddErr, metadataID, nil, nil, stats)
 	require.ErrorIs(t, err, gocb.ErrCollectionNotFound, "a dropped primary collection must fail the pass")
+	require.True(t, msWithAddErr.FallbackReadsEnabled(),
+		"a dropped PRIMARY says nothing about the fallback - disabling it here would strand the unmigrated doc below")
 
 	// The doc must be left on the fallback — nothing was written to primary.
 	exists, existsErr := ms.Fallback().Exists(ctx, keys.UserKey("alice"))

--- a/db/query.go
+++ b/db/query.go
@@ -602,7 +602,7 @@ func (context *DatabaseContext) QueryPrincipals(ctx context.Context, startKey st
 	// cannot run a query.
 	metadataStore := context.MetadataStore
 	if ms, ok := metadataStore.(*base.MetadataStore); ok {
-		if !ms.MigrationComplete() {
+		if ms.FallbackReadsEnabled() {
 			queryStatement, params := context.BuildPrincipalsQuery(startKey, 0)
 			return dualMetadataN1QLQuery[PrincipalRow](ctx, ms, QueryPrincipals.name, queryStatement, params, base.RequestPlus, QueryPrincipals.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold, limit)
 		}
@@ -644,7 +644,7 @@ func (context *DatabaseContext) QueryUsers(ctx context.Context, startKey string,
 	// N1QL Query. See QueryPrincipals for the dual-collection wrapper handling.
 	metadataStore := context.MetadataStore
 	if ms, ok := metadataStore.(*base.MetadataStore); ok {
-		if !ms.MigrationComplete() {
+		if ms.FallbackReadsEnabled() {
 			queryStatement, params := context.BuildUsersQuery(startKey, 0)
 			return dualMetadataN1QLQuery[QueryUsersRow](ctx, ms, QueryTypeUsers, queryStatement, params, base.RequestPlus, QueryUsers.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold, limit)
 		}
@@ -694,7 +694,7 @@ func (context *DatabaseContext) QueryRoles(ctx context.Context, startKey string,
 	// N1QL Query. See QueryPrincipals for the dual-collection wrapper handling.
 	metadataStore := context.MetadataStore
 	if ms, ok := metadataStore.(*base.MetadataStore); ok {
-		if !ms.MigrationComplete() {
+		if ms.FallbackReadsEnabled() {
 			queryStatement, params := context.BuildRolesQuery(startKey, 0)
 			return dualMetadataN1QLQuery[PrincipalRow](ctx, ms, QueryRolesExcludeDeleted.name, queryStatement, params, base.RequestPlus, QueryRolesExcludeDeleted.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold, limit)
 		}
@@ -749,7 +749,7 @@ func (context *DatabaseContext) QueryAllRoles(ctx context.Context, startKey stri
 	// N1QL Query. See QueryPrincipals for the dual-collection wrapper handling.
 	metadataStore := context.MetadataStore
 	if ms, ok := metadataStore.(*base.MetadataStore); ok {
-		if !ms.MigrationComplete() {
+		if ms.FallbackReadsEnabled() {
 			return dualMetadataN1QLQuery[PrincipalRow](ctx, ms, queryName, queryStatement, params, base.RequestPlus, QueryRolesExcludeDeleted.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold, limit)
 		}
 		metadataStore = ms.Primary()

--- a/rest/manualbucketpooltest/metadata_migration_no_default_test.go
+++ b/rest/manualbucketpooltest/metadata_migration_no_default_test.go
@@ -470,7 +470,7 @@ func TestDropDefaultCollectionDuringMigration(t *testing.T) {
 	}
 	// even passing this test takes a while to run since it's adversarial in nature
 	// dropping `_default` underneath an unmigrated database will result in at least one KV retry loop
-	// in metadatastore fallback, and on the boostrap to attempt database deregister
+	// in metadatastore fallback, and on the bootstrap to attempt database deregister
 	base.LongRunningTest(t)
 
 	ctx := base.TestCtx(t)

--- a/rest/manualbucketpooltest/metadata_migration_no_default_test.go
+++ b/rest/manualbucketpooltest/metadata_migration_no_default_test.go
@@ -463,10 +463,15 @@ func TestMigrationThenDropDefaultCollectionTwoDatabases(t *testing.T) {
 //
 // CBS only: rosmar does not support dropping the default collection.
 func TestDropDefaultCollectionDuringMigration(t *testing.T) {
+
 	base.TestRequiresCollections(t)
 	if sgtest.UnitTestUrlIsWalrus() {
 		t.Skip("CBS only: rosmar cannot drop _default._default")
 	}
+	// even passing this test takes a while to run since it's adversarial in nature
+	// dropping `_default` underneath an unmigrated database will result in at least one KV retry loop
+	// in metadatastore fallback, and on the boostrap to attempt database deregister
+	base.LongRunningTest(t)
 
 	ctx := base.TestCtx(t)
 	tb := base.GTestBucketPool.CreateTestBucket(t)

--- a/rest/manualbucketpooltest/metadata_migration_no_default_test.go
+++ b/rest/manualbucketpooltest/metadata_migration_no_default_test.go
@@ -13,6 +13,7 @@ package manualbucketpooltest
 import (
 	"fmt"
 	"net/http"
+	"sync"
 	"testing"
 	"time"
 
@@ -481,7 +482,12 @@ func TestDropDefaultCollectionDuringMigration(t *testing.T) {
 		CustomTestBucket: tb.NoCloseClone(),
 		PersistentConfig: true,
 	})
-	defer rt.Close()
+	// Ensure rt.Close() completes within a couple of mins to avoid test hang
+	defer func() {
+		var wg sync.WaitGroup
+		wg.Go(rt.Close)
+		base.WaitWithTimeout(t, &wg, 2*time.Minute)
+	}()
 
 	// 1. Create in legacy mode so all metadata lands in _default._default.
 	dbConfig := rt.NewDbConfig()

--- a/rest/metadatamigrationtest/metadata_migration_test.go
+++ b/rest/metadatamigrationtest/metadata_migration_test.go
@@ -265,7 +265,7 @@ func TestMetadataMigrationGuardHonoursPeerCompletion(t *testing.T) {
 	dbCtx := rt.GetDatabase()
 	ms, ok := dbCtx.MetadataStore.(*base.MetadataStore)
 	require.True(t, ok, "opted-in DB with legacy metadata should have a dual MetadataStore")
-	require.False(t, ms.MigrationComplete(), "precondition: local node must not have marked migration complete")
+	require.True(t, ms.FallbackReadsEnabled(), "precondition: local node must still be reading the fallback")
 
 	// Simulate a peer node completing this DB's migration by stamping the per-DB status entry to
 	// complete directly — this writes only the durable doc, not this node's local flag.
@@ -281,7 +281,7 @@ func TestMetadataMigrationGuardHonoursPeerCompletion(t *testing.T) {
 
 	// The guard reads the authoritative status doc, reports complete, and converges the local flag.
 	require.True(t, dbCtx.MetadataMigrationComplete(ctx), "guard must recognise a peer-completed migration from the status doc")
-	require.True(t, ms.MigrationComplete(), "observing a peer-completed status doc must converge the local migration-complete flag")
+	require.False(t, ms.FallbackReadsEnabled(), "observing a peer-completed status doc must converge the local flag and stop fallback reads")
 }
 
 // TestMetadataMigrationPreservesJSONDatatypeForUserDocs is a regression test for the

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -824,7 +824,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 			base.WarnfCtx(ctx, "db:%s unable to determine whether _default._default exists while resolving metadata fallback: %v — keeping dual-read mode", base.MD(dbName), defaultErr)
 		case !defaultCollectionPresent:
 			metaStore.DisableFallbackReads()
-			base.InfofCtx(ctx, base.KeyConfig, "db:%s _default._default does not exist — marking per-DB MetadataStore wrapper migration-complete (no legacy fallback collection to read from)", base.MD(dbName))
+			base.InfofCtx(ctx, base.KeyConfig, "db:%s _default._default does not exist — disabling fallback reads on the per-DB MetadataStore wrapper (no legacy fallback collection to read from)", base.MD(dbName))
 		case !probeLegacyPerDBMetadata(ctx, fallbackStore, config.MetadataID):
 			if sc.isPerDBMigrationInProgress(ctx, spec.BucketName, config.MetadataID) {
 				base.InfofCtx(ctx, base.KeyConfig, "db:%s no legacy _sync:seq in _default._default but per-DB migration is in_progress on another node — keeping dual-read mode until migration completes", base.MD(dbName))
@@ -835,9 +835,9 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 				// that just finished migrating.
 				primarySeqKey := base.NewMetadataKeys(config.MetadataID).SyncSeqKey()
 				if primaryHasSeq, _ := primaryMetadataStore.Exists(ctx, primarySeqKey); primaryHasSeq {
-					base.InfofCtx(ctx, base.KeyConfig, "db:%s primary metadata present and no legacy data in _default._default — marking per-DB MetadataStore wrapper migration-complete", base.MD(dbName))
+					base.InfofCtx(ctx, base.KeyConfig, "db:%s primary metadata present and no legacy data in _default._default — disabling fallback reads on the per-DB MetadataStore wrapper", base.MD(dbName))
 				} else {
-					base.InfofCtx(ctx, base.KeyConfig, "db:%s no legacy metadata in _default._default — marking per-DB MetadataStore wrapper migration-complete (new-database fast path)", base.MD(dbName))
+					base.InfofCtx(ctx, base.KeyConfig, "db:%s no legacy metadata in _default._default — disabling fallback reads on the per-DB MetadataStore wrapper (new-database fast path)", base.MD(dbName))
 				}
 			}
 		}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -791,7 +791,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	//     and per-DB level (legacy behaviour; simplest RBAC, _default cannot be dropped by customers for this case)
 	//   - _system._mobile (with read-fallback to _default._default) when enabled at either level,
 	//     via base.MetadataStore. For a brand-new database with no legacy metadata in
-	//     _default._default the wrapper is immediately marked MigrationComplete so reads go
+	//     _default._default the wrapper immediately disables fallback reads so they go
 	//     straight to the primary collection — no per-DB migration arming.
 	// defaultCollectionPresent tracks whether _default._default physically exists in the bucket. It
 	// drives two decisions: whether the per-DB MetadataStore wrapper needs _default as a read-fallback,
@@ -816,21 +816,21 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		fallbackStore := bucket.DefaultDataStore(ctx)
 		metaStore := base.NewMetadataStore(primaryMetadataStore, fallbackStore)
 		// It's possible that the legacy _default._default collection has been dropped by a customer,
-		// in which case we can mark the per-DB MetadataStore wrapper as MigrationComplete and skip
+		// in which case we can disable fallback reads on the per-DB MetadataStore wrapper and skip
 		// dual-read mode. If it exists, probe for legacy _sync:seq to determine whether we need to keep
 		// dual-read mode active.
 		switch {
 		case defaultErr != nil:
 			base.WarnfCtx(ctx, "db:%s unable to determine whether _default._default exists while resolving metadata fallback: %v — keeping dual-read mode", base.MD(dbName), defaultErr)
 		case !defaultCollectionPresent:
-			metaStore.SetMigrationComplete()
+			metaStore.DisableFallbackReads()
 			base.InfofCtx(ctx, base.KeyConfig, "db:%s _default._default does not exist — marking per-DB MetadataStore wrapper migration-complete (no legacy fallback collection to read from)", base.MD(dbName))
 		case !probeLegacyPerDBMetadata(ctx, fallbackStore, config.MetadataID):
 			if sc.isPerDBMigrationInProgress(ctx, spec.BucketName, config.MetadataID) {
 				base.InfofCtx(ctx, base.KeyConfig, "db:%s no legacy _sync:seq in _default._default but per-DB migration is in_progress on another node — keeping dual-read mode until migration completes", base.MD(dbName))
 			} else {
-				metaStore.SetMigrationComplete()
-				// Same SetMigrationComplete action covers two distinct cases — log them
+				metaStore.DisableFallbackReads()
+				// Same DisableFallbackReads action covers two distinct cases — log them
 				// separately so operators don't see "new-database fast path" against a DB
 				// that just finished migrating.
 				primarySeqKey := base.NewMetadataKeys(config.MetadataID).SyncSeqKey()
@@ -958,7 +958,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 			// migration is still in flight. Once complete, primary is authoritative; the fallback
 			// (_default._default) may even have been dropped, in which case querying it is wasteful
 			// and noisy (ShouldUseLegacySyncDocsIndex tolerates the error but still fires the query).
-			if !dual.MigrationComplete() {
+			if dual.FallbackReadsEnabled() {
 				fallbackIndexStore = dual.Fallback()
 			} else {
 				migrationComplete = true
@@ -2361,7 +2361,7 @@ func resolveUseSystemMetadataCollection(startup *StartupConfig, db *DbConfig) bo
 
 // probeLegacyPerDBMetadata reports whether this database has metadata in _default._default that
 // the per-DB MetadataStore wrapper would need to read. Used to short-circuit a brand-new database
-// (or one originally created in dual mode) into MigrationComplete state so the wrapper bypasses
+// (or one originally created in dual mode) into fallback-reads-disabled state so the wrapper bypasses
 // fallback from its first read.
 //
 // Probes _sync:seq (or _sync:m_<id>:seq for metadataID-prefixed DBs): the sequence allocator
@@ -2403,7 +2403,7 @@ func defaultCollectionExists(ctx context.Context, bucket base.Bucket) (bool, err
 // race where another node's migration has already moved the _sync:seq counter to primary
 // (causing probeLegacyPerDBMetadata to return false) but has not yet finished migrating all
 // per-DB metadata (users, roles, sessions). Without this check the joining node would
-// incorrectly call SetMigrationComplete, causing reads to skip the fallback and miss
+// incorrectly disable fallback reads, causing reads to skip the fallback and miss
 // not-yet-migrated docs.
 //
 // Returns false (safe to mark complete) when the status doc is absent, the per-DB entry does

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -110,8 +110,8 @@ func TestIsPerDBMigrationInProgress(t *testing.T) {
 			assert.Equal(t, want, got)
 		}
 
-		assert.False(t, nodeBStore.MigrationComplete(),
-			"wrapper must NOT be marked migration-complete while another node is mid-migration")
+		assert.True(t, nodeBStore.FallbackReadsEnabled(),
+			"wrapper must keep reading the fallback while another node is mid-migration")
 	})
 
 	// --- Subtest: per-DB entry is complete → safe to mark complete ---


### PR DESCRIPTION
CBG-5706

Fixes `TestDropDefaultCollectionDuringMigration` flake by ensuring that the fallback metadata store is disabled when we detect that the `_default._default` collection has been irrecoverably dropped.

This case was already handled in the migration job via #8371 but not in the generic `MetadataStore` fallback operations, nor in the bootstrap code - so each failed read would hit a 30s gocb retry without bailing out.

Since nobody can recreate the `_default` collection, and we also know that the fallback data has gone with the collection being dropped, don't even bother attempting to read from the fallback again.

Renamed `migrationComplete` to `fallbackReadsDisabled` since the extra condition that disables the fallback no longer necessarily means the migration is 'complete' - unified the detection/flag setting w/ "DisableFallbackIfUnrecoverable"

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/1075/

<!--
Automated review runs on every non-draft PR raised from this repo (forks are not reviewed automatically).
  - Re-run it, or ask a follow-up, by commenting `@droid <question>`
  - Suppress it with the `droid-skip` label, or `WIP`/`DO NOT MERGE` in the title
-->
