### PR TITLE
CBG-5695 fix TestObtainUserChannelsForDeletedRoleCasFail flake

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -16,6 +16,7 @@ import (
 	"maps"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -2826,17 +2827,19 @@ func TestInvalidateRoles(t *testing.T) {
 	err = auth.Save(user)
 	assert.NoError(t, err)
 
-	enableRetry := false
+	userDocID := auth.DocIDForUser("user")
+	var enableRetry atomic.Bool
 	leakyDataStore.SetUpdateCallback(func(key string) {
-		if enableRetry {
-			enableRetry = false
-			err = auth.InvalidateRoles("user", 5)
-			assert.NoError(t, err)
+		if key != userDocID {
+			return
+		}
+		if enableRetry.CompareAndSwap(true, false) {
+			assert.NoError(t, auth.InvalidateRoles("user", 5))
 		}
 	})
 
 	// Invalidate roles at invalSeq but cause cas retry by setting to 5
-	enableRetry = true
+	enableRetry.Store(true)
 	err = auth.InvalidateRoles("user", 10)
 	assert.NoError(t, err)
 

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -549,16 +550,16 @@ func TestUserAndRoleResponseContentType(t *testing.T) {
 
 func TestObtainUserChannelsForDeletedRoleCasFail(t *testing.T) {
 	testCases := []struct {
-		Name      string
-		RunBefore bool
+		Name             string
+		triggerOnUserDoc bool
 	}{
 		{
-			"Delete On GetUser",
-			true,
+			Name:             "Delete On GetUser",
+			triggerOnUserDoc: true,
 		},
 		{
-			"Delete On inheritedChannels",
-			false,
+			Name:             "Delete On inheritedChannels",
+			triggerOnUserDoc: false,
 		},
 	}
 
@@ -602,26 +603,25 @@ func TestObtainUserChannelsForDeletedRoleCasFail(t *testing.T) {
 			leakyDataStore, ok := base.AsLeakyDataStore(tbDatastore)
 			require.True(t, ok)
 
-			triggerCallback := false
+			triggerDocID := rt.GetDatabase().MetadataKeys.RoleKey("role")
+			if testCase.triggerOnUserDoc {
+				triggerDocID = rt.GetDatabase().MetadataKeys.UserKey("user")
+			}
+			var triggerCallback atomic.Bool
 			leakyDataStore.SetUpdateCallback(func(key string) {
-				if triggerCallback {
-					triggerCallback = false
-					resp = rt.SendAdminRequest("DELETE", "/db/_role/role", ``)
-					RequireStatus(t, resp, http.StatusOK)
+				if key != triggerDocID {
+					return
+				}
+				if triggerCallback.CompareAndSwap(true, false) {
+					deleteResp := rt.SendAdminRequest("DELETE", "/db/_role/role", ``)
+					RequireStatus(t, deleteResp, http.StatusOK)
 				}
 			})
-
-			if testCase.RunBefore {
-				triggerCallback = true
-			}
+			triggerCallback.Store(true)
 
 			authenticator := rt.GetDatabase().Authenticator(base.TestCtx(t))
 			user, err := authenticator.GetUser("user")
 			assert.NoError(t, err)
-
-			if !testCase.RunBefore {
-				triggerCallback = true
-			}
 
 			chs, err := user.InheritedCollectionChannels(s, c)
 			assert.NoError(t, err)
@@ -629,7 +629,7 @@ func TestObtainUserChannelsForDeletedRoleCasFail(t *testing.T) {
 			assert.Equal(t, []string{"!"}, chs.AllKeys())
 
 			// Ensure callback ran
-			assert.False(t, triggerCallback)
+			assert.False(t, triggerCallback.Load())
 		})
 
 	}


### PR DESCRIPTION
CBG-5695 fix TestObtainUserChannelsForDeletedRoleCasFail flake

The leaky bucket update callback fires for every update in the bucket, which might not be the right document, or not fired during the getPrincipal CAS update.

Also fix another test which followed same pattern.