### PR TITLE
CBG-5734: fix test flake in TestReplicationRebalancePull/Push

### DIFF
--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -824,6 +824,13 @@ func TestReplicationRebalancePull(t *testing.T) {
 		docDEF1Body := activeRT.GetDocBody(docDEF1)
 		assert.Equal(t, "remoteRT", docDEF1Body["source"])
 
+		// Make the rebalance deterministic - activeRT is running both replications, so wait for the first
+		// document pulled by each to reach the status document and the checkpoint.
+		replicationIDs := []string{"rep_ABC", "rep_DEF"}
+		for _, replicationID := range replicationIDs {
+			requirePersistedReplicationProgress(activeRT, replicationID, db.ActiveReplicatorTypePull, 1)
+		}
+
 		// Add another node to the active cluster
 		activeRT2 := addActiveRT(t, activeRT.GetDatabase().Name, activeRT.TestBucket)
 		defer activeRT2.Close()
@@ -854,27 +861,15 @@ func TestReplicationRebalancePull(t *testing.T) {
 		docDEF2Body2 := activeRT2.GetDocBody(docDEF2)
 		assert.Equal(t, "remoteRT", docDEF2Body2["source"])
 
-		// Validate replication stats across rebalance, on both active nodes
-		rest.WaitAndAssertCondition(t, func() bool {
-			actual := activeRT.GetReplicationStatus("rep_ABC").DocsRead
-			t.Logf("activeRT rep_ABC DocsRead: %d", actual)
-			return actual == 2
-		})
-		rest.WaitAndAssertCondition(t, func() bool {
-			actual := activeRT.GetReplicationStatus("rep_DEF").DocsRead
-			t.Logf("activeRT rep_DEF DocsRead: %d", actual)
-			return actual == 2
-		})
-		rest.WaitAndAssertCondition(t, func() bool {
-			actual := activeRT2.GetReplicationStatus("rep_ABC").DocsRead
-			t.Logf("activeRT2 rep_ABC DocsRead: %d", actual)
-			return actual == 2
-		})
-		rest.WaitAndAssertCondition(t, func() bool {
-			actual := activeRT2.GetReplicationStatus("rep_DEF").DocsRead
-			t.Logf("activeRT2 rep_DEF DocsRead: %d", actual)
-			return actual == 2
-		})
+		// Each replication inherited the document it pulled before the rebalance and read the one it
+		// pulled after. The node running a replication reports live stats, the other reads the status
+		// document it persists.
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			for _, replicationID := range replicationIDs {
+				assert.Equal(c, int64(2), activeRT.GetReplicationStatus(replicationID).DocsRead, "%s: DocsRead on activeRT after rebalance", replicationID)
+				assert.Equal(c, int64(2), activeRT2.GetReplicationStatus(replicationID).DocsRead, "%s: DocsRead on activeRT2 after rebalance", replicationID)
+			}
+		}, 20*time.Second, 100*time.Millisecond)
 
 		// explicitly stop the SGReplicateMgrs on the active nodes, to prevent a node rebalance during test teardown.
 		activeRT.GetDatabase().SGReplicateMgr.Stop()
@@ -930,6 +925,15 @@ func TestReplicationRebalancePush(t *testing.T) {
 		docDEF1Body := remoteRT.GetDocBody(docDEF1)
 		assert.Equal(t, "activeRT", docDEF1Body["source"])
 
+		// Make the rebalance deterministic - activeRT is running both replications, so wait for the first
+		// document pushed by each to reach the status document and the checkpoint. Without the checkpoint,
+		// that document is pushed again after the move: the passive already has it, so DocsWritten doesn't
+		// move, but DocsCheckedPush does.
+		replicationIDs := []string{"rep_ABC", "rep_DEF"}
+		for _, replicationID := range replicationIDs {
+			requirePersistedReplicationProgress(activeRT, replicationID, db.ActiveReplicatorTypePush, 1)
+		}
+
 		// Add another node to the active cluster
 		activeRT2 := addActiveRT(t, activeRT.GetDatabase().Name, activeRT.TestBucket)
 		defer activeRT2.Close()
@@ -954,35 +958,15 @@ func TestReplicationRebalancePush(t *testing.T) {
 		docDEF2Body := remoteRT.GetDocBody(docDEF2)
 		assert.Equal(t, "activeRT", docDEF2Body["source"])
 
-		// Validate replication stats across rebalance, on both active nodes
-		// Checking DocsCheckedPush here, as DocsWritten isn't necessarily going to be 2, due to a
-		// potential for race updating status during replication rebalance:
-		//     1. active node 1 writes document 1 to passive
-		//     2. replication is rebalanced prior to checkpoint being persisted
-		//     3. active node 2 is assigned replication, starts from zero (since checkpoint wasn't persisted)
-		//     4. active node 2 attempts to write document 1, passive already has it.  DocsCheckedPush is incremented, but not DocsWritten
-		// Note that we can't wait for checkpoint persistence prior to rebalance, as the node initiating the rebalance
-		// isn't necessarily the one running the replication.
-		rest.WaitAndAssertCondition(t, func() bool {
-			actual := activeRT.GetReplicationStatus("rep_ABC").DocsCheckedPush
-			t.Logf("activeRT rep_ABC DocsCheckedPush: %d", actual)
-			return actual == 2
-		})
-		rest.WaitAndAssertCondition(t, func() bool {
-			actual := activeRT.GetReplicationStatus("rep_DEF").DocsCheckedPush
-			t.Logf("activeRT rep_DEF DocsCheckedPush: %d", actual)
-			return actual == 2
-		})
-		rest.WaitAndAssertCondition(t, func() bool {
-			actual := activeRT2.GetReplicationStatus("rep_ABC").DocsCheckedPush
-			t.Logf("activeRT2 rep_ABC DocsCheckedPush: %d", actual)
-			return actual == 2
-		})
-		rest.WaitAndAssertCondition(t, func() bool {
-			actual := activeRT2.GetReplicationStatus("rep_DEF").DocsCheckedPush
-			t.Logf("activeRT2 rep_DEF DocsCheckedPush: %d", actual)
-			return actual == 2
-		})
+		// Each replication inherited the document it pushed before the rebalance and checked the one it
+		// pushed after, never re-checking the first. DocsCheckedPush rather than DocsWritten, so that a
+		// regression re-checking an already-replicated document fails here rather than passing silently.
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			for _, replicationID := range replicationIDs {
+				assert.Equal(c, int64(2), activeRT.GetReplicationStatus(replicationID).DocsCheckedPush, "%s: DocsCheckedPush on activeRT after rebalance", replicationID)
+				assert.Equal(c, int64(2), activeRT2.GetReplicationStatus(replicationID).DocsCheckedPush, "%s: DocsCheckedPush on activeRT2 after rebalance", replicationID)
+			}
+		}, 20*time.Second, 100*time.Millisecond)
 
 		// explicitly stop the SGReplicateMgrs on the active nodes, to prevent a node rebalance during test teardown.
 		activeRT.GetDatabase().SGReplicateMgr.Stop()

--- a/rest/replicatortest/replicator_test_helper.go
+++ b/rest/replicatortest/replicator_test_helper.go
@@ -17,6 +17,7 @@ import (
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbase/sync_gateway/rest"
 	"github.com/couchbase/sync_gateway/testing/assert"
+	"github.com/couchbase/sync_gateway/testing/require"
 )
 
 // Helper functions for SGR testing
@@ -28,6 +29,36 @@ func reduceTestCheckpointInterval(interval time.Duration) func() {
 		db.DefaultCheckpointInterval = previousInterval
 	}
 
+}
+
+// requirePersistedReplicationProgress waits for the status document and the checkpoint of a
+// replication to reflect expectedDocs documents processed. A node picking up a reassigned replication
+// inherits its stats from the status document and resumes from the checkpoint, and the two are written
+// on independent tickers - so waiting for both before a rebalance makes the stats reported after it
+// deterministic. A checkpoint is only written once a sequence has been processed, so its presence also
+// means an already-replicated document won't be processed again.
+func requirePersistedReplicationProgress(rt *rest.RestTester, replicationID string, direction db.ActiveReplicatorDirection, expectedDocs int64) {
+	rt.TB().Helper()
+	var checkpointID, statName string
+	var persistedDocs func(*db.ReplicationStatus) int64
+	switch direction {
+	case db.ActiveReplicatorTypePush:
+		checkpointID, statName = db.PushCheckpointID(replicationID), "DocsCheckedPush"
+		persistedDocs = func(status *db.ReplicationStatus) int64 { return status.DocsCheckedPush }
+	case db.ActiveReplicatorTypePull:
+		checkpointID, statName = db.PullCheckpointID(replicationID), "DocsRead"
+		persistedDocs = func(status *db.ReplicationStatus) int64 { return status.DocsRead }
+	default:
+		require.FailNow(rt.TB(), "unsupported replication direction "+string(direction))
+	}
+	require.EventuallyWithT(rt.TB(), func(c *assert.CollectT) {
+		status, err := db.LoadReplicationStatus(rt.Context(), rt.GetDatabase(), replicationID)
+		if !assert.NoError(c, err) {
+			return
+		}
+		assert.Equal(c, expectedDocs, persistedDocs(status), "%s: %s in persisted replication status document", replicationID, statName)
+	}, 20*time.Second, 10*time.Millisecond)
+	rt.WaitForCheckpointLastSequence(db.RealSpecialDocID(db.DocTypeLocal, db.CheckpointDocIDPrefix+checkpointID))
 }
 
 // AddActiveRT returns a new RestTester backed by a no-close clone of TestBucket


### PR DESCRIPTION
CBG-5734: fix test flake in TestReplicationRebalancePull/Push

The exact DocsRead/DocsCheckedPush == 2 waits raced with the replication status and checkpoint persistence around a node rebalance. Assert what holds regardless of what was persisted before the move: each replication counted its own post-rebalance document, and both active nodes agree on the count per replication.

I could repro this more easily with changing sequence batching timeout here https://github.com/couchbase/sync_gateway/pull/8611 which changes how fast the nodes come online.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/1076/

<!--
Automated review runs on every non-draft PR raised from this repo (forks are not reviewed automatically).
  - Re-run it, or ask a follow-up, by commenting `@droid <question>`
  - Suppress it with the `droid-skip` label, or `WIP`/`DO NOT MERGE` in the title
-->
