### PR TITLE
Don't send notifications on PR builds

### DIFF
--- a/integration-test/slackUtils.groovy
+++ b/integration-test/slackUtils.groovy
@@ -85,15 +85,24 @@ def slackUserIdForBuild() {
     return slackUserId
 }
 
-// Sends a failure-style Slack notification: always to #syncgatewaybot; additionally either DMs
-// the user who manually triggered the build (if known) or posts to #syncgatewaybot-alerts (if
-// triggered by a pipeline rather than a person).
+// Returns true if this build is for a pull request, which Jenkins signals by setting CHANGE_ID.
+def isPRBuild() {
+    return env.CHANGE_ID as boolean
+}
+
+// Sends a failure-style Slack notification to #syncgatewaybot, always, as the record of every
+// failure, plus at most one of:
+//  1. a DM to whoever manually triggered the build, so the person waiting on it hears first - only if
+//     slackUserIdForBuild() can identify them, or
+//  2. #syncgatewaybot-alerts, to escalate failures from automated builds that aren't against a PR -
+//     main-branch and downstream job runs nobody is watching. A PR build never lands here, since its
+//     failures are already reported on the PR itself.
 def slackSendFailure(String title, String status, String link, Map details = [:]) {
     def message = slackMessage(title, status, link, details)
     def dmTarget = slackUserIdForBuild()
     if (dmTarget) {
         slackSend(channel: dmTarget, color: 'danger', message: message)
-    } else {
+    } else if (!isPRBuild()) {
         slackSend(channel: 'syncgatewaybot-alerts', color: 'danger', message: message)
     }
     slackSend(channel: 'syncgatewaybot', color: 'danger', message: message)


### PR DESCRIPTION
Don't send notifications on PR builds

Send email to:

- syncgatewaybot, always
Either:
- calling user (if known)
- syncgatewaybot-alerts (if not a PR build)
