### PR TITLE
Revert bad Jenkins Go version from mod file logic (#8570)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,15 +34,33 @@ pipeline {
                 stage('Go Modules') {
                     steps {
                         script {
-                            // go fetches the toolchain named in go.mod on demand
-                            env.GOTOOLS = sh(
+                            // bootstrap a go version from go.mod. This requires a new enough version of go to run golang.org/dl/go$ver
+                            env.GO_VERSION = 'go' + sh(
                               returnStdout: true,
-                              script: 'go env GOPATH'
+                              script: '''
+                                go list -m -f '{{.GoVersion}}'
+                              '''
                             ).trim()
                             sh '''
                               set -eux
 
+                              echo "Sync Gateway go.mod version is $GO_VERSION"
+                              go install "golang.org/dl/$GO_VERSION@latest"
+                              ~/go/bin/$GO_VERSION download
+                            '''
+                            env.GOROOT = sh(
+                              returnStdout: true,
+                              script: '~/go/bin/$GO_VERSION env GOROOT'
+                            ).trim()
+                            env.GOTOOLS = sh(
+                              returnStdout: true,
+                              script: '~/go/bin/$GO_VERSION env GOPATH'
+                            ).trim()
+                            env.PATH = "${env.GOROOT}/bin:${env.PATH}"
+                            sh '''
+                              which go
                               go version
+                              go env
                             '''
                             sshagent(credentials: ['CB_SG_Robot_Github_SSH_Key']) {
                                 sh '''

--- a/jenkins-integration-build.sh
+++ b/jenkins-integration-build.sh
@@ -54,8 +54,12 @@ export GOPRIVATE=github.com/couchbaselabs/go-fleecedelta
 SG_COMMIT_HASH=$(git rev-parse HEAD)
 echo "Sync Gateway git commit hash: $SG_COMMIT_HASH"
 
-# go fetches the toolchain named in go.mod on demand
-go version
+GO_VERSION=go$(go list -m -f '{{.GoVersion}}')
+echo "Sync Gateway go.mod version is ${GO_VERSION}"
+go install "golang.org/dl/${GO_VERSION}@latest"
+~/go/bin/"${GO_VERSION}" download
+GOROOT=$(~/go/bin/"${GO_VERSION}" env GOROOT)
+PATH=${GOROOT}/bin:$PATH
 
 echo "Downloading tool dependencies..."
 go install gotest.tools/gotestsum@latest


### PR DESCRIPTION
I think I broke this in #8570 because I didn't understand that `GOTOOLCHAIN=auto` will allow upgrades from the given mod file version.

Reverted to old implementation - which was already doing `go.mod` file version checks. My bad!

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/

<!--
Automated review runs on every non-draft PR raised from this repo (forks are not reviewed automatically).
  - Re-run it, or ask a follow-up, by commenting `@droid <question>`
  - Suppress it with the `droid-skip` label, or `WIP`/`DO NOT MERGE` in the title
-->
