### PR TITLE
Isolate `golangci-lint` pre-commit caches

### DIFF
--- a/.golangci-strict.yml
+++ b/.golangci-strict.yml
@@ -107,9 +107,11 @@ linters:
         path: rest/debug.go
       # The logging implementation itself, the standalone CLIs under tools/, and tests (which print
       # diagnostics and generate data) write to stdout by design.
+      # tools/ is matched unanchored: reported paths can gain a prefix when golangci-lint
+      # replays cached results from another checkout of this module.
       - linters:
           - forbidigo
-        path: (base/logging\.go|base/redactor\.go|^tools/|_test.*\.go)
+        path: (base/logging\.go|base/redactor\.go|(^|/)tools/|_test.*\.go)
       - text: "ST1000:" # at least one file in a package should have a package comment
         linters:
           - staticcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -63,9 +63,11 @@ linters:
         text: fieldalignment # detect Go structs that would take less memory if their fields were sorted
       # The logging implementation itself, the standalone CLIs under tools/, and tests (which print
       # diagnostics and generate data) write to stdout by design.
+      # tools/ is matched unanchored: reported paths can gain a prefix when golangci-lint
+      # replays cached results from another checkout of this module.
       - linters:
           - forbidigo
-        path: (base/logging\.go|base/redactor\.go|^tools/|_test.*\.go)
+        path: (base/logging\.go|base/redactor\.go|(^|/)tools/|_test.*\.go)
       - text:  "missing cases in switch"
         linters:
           - exhaustive

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,8 +26,11 @@ repos:
         name: golangci-lint
         language: system
         # version must match .github/workflows/ci.yml golangci job
-        entry: go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
-        args: [run, --config=.golangci-strict.yml, --fix=false]
+        # Cache per checkout: a shared cache serves results from other clones of this module,
+        # which report findings against that clone's file paths.
+        entry: sh -c 'export GOLANGCI_LINT_CACHE="$(git rev-parse --absolute-git-dir)/golangci-lint-cache";
+               exec go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
+               run --config=.golangci-strict.yml --fix=false'
         types: [go]
         pass_filenames: false
 


### PR DESCRIPTION
Isolate `golangci-lint` caches for SG when cloned in different locations - avoids unwanted cache reuse between multiple checkouts that could result in editing the wrong files if results are misinterpreted.

This made me chase my tail for a good 30 mins before I realised the linter was failing because it was reading a bad cached version from another directory.