### PR TITLE
[4.0.8 Backport] CBG-5410: don't respond with Set-Cookie for one_time session

### DIFF
--- a/auth/session.go
+++ b/auth/session.go
@@ -58,7 +58,8 @@ func (auth *Authenticator) AuthenticateCookie(rq *http.Request, response http.Re
 	// SessionTimeElapsed and tenPercentOfTtl use Nanoseconds for more precision when converting to int
 	sessionTimeElapsed := int((time.Now().Add(duration).Sub(session.Expiration)).Nanoseconds())
 	tenPercentOfTtl := int(duration.Nanoseconds()) / 10
-	if sessionTimeElapsed > tenPercentOfTtl {
+	// One-time sessions must not refresh the cookie — they will be deleted on this request.
+	if sessionTimeElapsed > tenPercentOfTtl && (session.OneTime == nil || !*session.OneTime) {
 		session.Expiration = time.Now().Add(duration)
 		if err = auth.datastore.Set(auth.DocIDForSession(session.ID), base.DurationToCbsExpiry(duration), nil, session); err != nil {
 			return nil, err

--- a/auth/session_test.go
+++ b/auth/session_test.go
@@ -367,6 +367,90 @@ func TestUserDeleteAllSessions(t *testing.T) {
 	require.EqualError(t, err, "401 Session no longer valid for user")
 }
 
+// TestAuthenticateCookieOneTimeSession verifies one-time session behaviour in AuthenticateCookie:
+//   - The session is consumed on first use and rejected on the second.
+//   - No Set-Cookie header is ever written, including when the normal TTL-refresh branch would
+//     fire for a regular session (sessionTimeElapsed > 10% of TTL).
+func TestAuthenticateCookieOneTimeSession(t *testing.T) {
+	ctx := base.TestCtx(t)
+	testBucket := base.GetTestBucket(t)
+	defer testBucket.Close(ctx)
+	dataStore := testBucket.GetSingleDataStore()
+	a := NewTestAuthenticator(t, dataStore, nil, DefaultAuthenticatorOptions(ctx))
+
+	const username = "Alice"
+	user, err := a.NewUser(username, "password", base.Set{})
+	require.NoError(t, err)
+	require.NoError(t, a.Save(user))
+
+	t.Run("one-time session authenticates once then is deleted", func(t *testing.T) {
+		session, err := a.CreateSession(ctx, user, 2*time.Hour, true)
+		require.NoError(t, err)
+
+		req, err := http.NewRequest(http.MethodGet, "", nil)
+		require.NoError(t, err)
+		req.AddCookie(a.MakeSessionCookie(session, false, false, http.SameSiteDefaultMode))
+
+		authedUser, err := a.AuthenticateCookie(req, httptest.NewRecorder())
+		require.NoError(t, err)
+		require.NotNil(t, authedUser)
+		assert.Equal(t, username, authedUser.Name())
+
+		_, err = a.AuthenticateCookie(req, httptest.NewRecorder())
+		require.Error(t, err)
+		assert.Equal(t, http.StatusUnauthorized, err.(*base.HTTPError).Status)
+	})
+
+	t.Run("one-time session does not set cookie even when TTL refresh would trigger", func(t *testing.T) {
+		// Expiration=now+2h with Ttl=24h means sessionTimeElapsed≈22h > tenPercentOfTtl≈2.4h,
+		// so a regular session would call http.SetCookie here — a one-time session must not.
+		oneTime := true
+		sessionID, err := base.GenerateRandomSecret()
+		require.NoError(t, err)
+		session := &LoginSession{
+			ID:          sessionID,
+			Username:    username,
+			Expiration:  time.Now().Add(2 * time.Hour),
+			Ttl:         24 * time.Hour,
+			SessionUUID: user.GetSessionUUID(),
+			OneTime:     &oneTime,
+		}
+		require.NoError(t, dataStore.Set(a.DocIDForSession(sessionID), base.DurationToCbsExpiry(24*time.Hour), nil, session))
+
+		req, err := http.NewRequest(http.MethodGet, "", nil)
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: a.SessionCookieName, Value: sessionID})
+		recorder := httptest.NewRecorder()
+		authedUser, err := a.AuthenticateCookie(req, recorder)
+		require.NoError(t, err)
+		require.NotNil(t, authedUser)
+		assert.Empty(t, recorder.Header().Get("Set-Cookie"), "one-time session must not set a cookie even when TTL refresh would trigger")
+	})
+
+	t.Run("regular session refreshes cookie when TTL threshold met", func(t *testing.T) {
+		// Same setup without OneTime — the refresh branch should fire and Set-Cookie should be present.
+		sessionID, err := base.GenerateRandomSecret()
+		require.NoError(t, err)
+		session := &LoginSession{
+			ID:          sessionID,
+			Username:    username,
+			Expiration:  time.Now().Add(2 * time.Hour),
+			Ttl:         24 * time.Hour,
+			SessionUUID: user.GetSessionUUID(),
+		}
+		require.NoError(t, dataStore.Set(a.DocIDForSession(sessionID), base.DurationToCbsExpiry(24*time.Hour), nil, session))
+
+		req, err := http.NewRequest(http.MethodGet, "", nil)
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: a.SessionCookieName, Value: sessionID})
+		recorder := httptest.NewRecorder()
+		authedUser, err := a.AuthenticateCookie(req, recorder)
+		require.NoError(t, err)
+		require.NotNil(t, authedUser)
+		assert.NotEmpty(t, recorder.Header().Get("Set-Cookie"), "regular session should refresh cookie when TTL threshold is met")
+	})
+}
+
 func TestCreateOneTimeSession(t *testing.T) {
 	ctx := base.TestCtx(t)
 	testBucket := base.GetTestBucket(t)

--- a/docs/api/paths/public/db-_session.yaml
+++ b/docs/api/paths/public/db-_session.yaml
@@ -26,7 +26,7 @@ post:
     If `Origin` header is passed to this endpoint, the `Origin` header must match both the `cors.login_origin` and `cors.origin` configuration options.
   parameters:
     - name: one_time
-      description: Sets the session to only be valid for a single authentication. This session will expire in 5 minutes if not used.
+      description: Sets the session to only be valid for a single authentication. This session will expire in 5 minutes if not used. If this is set the session cookie is only returned in the response body, and not the header.
       in: query
       schema:
         type: boolean

--- a/docs/api/paths/public/db-_session.yaml
+++ b/docs/api/paths/public/db-_session.yaml
@@ -26,7 +26,7 @@ post:
     If `Origin` header is passed to this endpoint, the `Origin` header must match both the `cors.login_origin` and `cors.origin` configuration options.
   parameters:
     - name: one_time
-      description: Sets the session to only be valid for a single authentication. This session will expire in 5 minutes if not used. If this is set the session cookie is only returned in the response body, and not the header.
+      description: Sets the session to only be valid for a single authentication. This session will expire in 5 minutes if not used. When set, the server does not return a `Set-Cookie` header; the one-time session ID is returned in the JSON body as `one_time_session_id`.
       in: query
       schema:
         type: boolean

--- a/rest/blip_sync_test.go
+++ b/rest/blip_sync_test.go
@@ -117,6 +117,7 @@ func TestOneTimeSessionBlipSyncAuthentication(t *testing.T) {
 		secWebSocketProtocolHeader: blipSessionIDPrefix + sessionResp.SessionID,
 	})
 	RequireStatus(t, resp, http.StatusUpgradeRequired)
+	assert.Empty(t, resp.Header().Get("Set-Cookie"), "one-time session auth must not set a session cookie")
 
 	// one time token is expired
 	resp = rt.SendRequestWithHeaders(http.MethodGet, "/{{.db}}/_blipsync", "", map[string]string{

--- a/rest/session_api.go
+++ b/rest/session_api.go
@@ -150,9 +150,11 @@ func (h *handler) makeSessionWithTTL(user auth.User, expiry time.Duration, oneTi
 	if err != nil {
 		return "", err
 	}
-	cookie := auth.MakeSessionCookie(session, h.db.Options.SecureCookieOverride, h.db.Options.SessionCookieHttpOnly, h.db.SameSiteCookieMode)
-	base.AddDbPathToCookie(h.rq, cookie)
-	http.SetCookie(h.response, cookie)
+	if !oneTime {
+		cookie := auth.MakeSessionCookie(session, h.db.Options.SecureCookieOverride, h.db.Options.SessionCookieHttpOnly, h.db.SameSiteCookieMode)
+		base.AddDbPathToCookie(h.rq, cookie)
+		http.SetCookie(h.response, cookie)
+	}
 	return session.ID, nil
 }
 

--- a/rest/session_test.go
+++ b/rest/session_test.go
@@ -753,6 +753,49 @@ func TestSessionExpirationDateTimeFormat(t *testing.T) {
 	assert.True(t, expires.Sub(time.Now()).Hours() <= 24, "Couldn't validate session expiration")
 }
 
+// TestSessionCreationCookieBehavior verifies that POST /_session sets a cookie for regular sessions
+// and does not set a cookie for one-time sessions (whose ID is delivered via the JSON body instead).
+func TestSessionCreationCookieBehavior(t *testing.T) {
+	rt := NewRestTesterPersistentConfig(t)
+	defer rt.Close()
+
+	username := "alice"
+	rt.CreateUser(username, []string{"*"})
+
+	dbName := rt.GetDatabase().Name
+
+	t.Run("regular session sets cookie", func(t *testing.T) {
+		resp := rt.SendUserRequest(http.MethodPost, "/{{.db}}/_session", "", username)
+		RequireStatus(t, resp, http.StatusOK)
+
+		cookie, err := http.ParseSetCookie(resp.Header().Get("Set-Cookie"))
+		require.NoError(t, err)
+		assert.Equal(t, auth.DefaultCookieName, cookie.Name)
+		assert.NotEmpty(t, cookie.Value)
+		assert.Equal(t, "/"+dbName, cookie.Path)
+		assert.True(t, cookie.Expires.After(time.Now()), "cookie expiration should be in the future")
+
+		var body struct {
+			OneTimeSessionID string `json:"one_time_session_id"`
+		}
+		require.NoError(t, base.JSONUnmarshal(resp.BodyBytes(), &body))
+		assert.Empty(t, body.OneTimeSessionID, "regular session response must not include one_time_session_id")
+	})
+
+	t.Run("one-time session sets no cookie", func(t *testing.T) {
+		resp := rt.SendUserRequest(http.MethodPost, "/{{.db}}/_session?one_time=true", "", username)
+		RequireStatus(t, resp, http.StatusOK)
+
+		assert.Empty(t, resp.Header().Get("Set-Cookie"), "one-time session creation must not set a cookie")
+
+		var body struct {
+			OneTimeSessionID string `json:"one_time_session_id"`
+		}
+		require.NoError(t, base.JSONUnmarshal(resp.BodyBytes(), &body))
+		assert.NotEmpty(t, body.OneTimeSessionID, "one-time session response must include one_time_session_id")
+	})
+}
+
 func TestOneTimeSessionWithCookie(t *testing.T) {
 	rt := NewRestTesterPersistentConfig(t)
 	defer rt.Close()
@@ -762,9 +805,16 @@ func TestOneTimeSessionWithCookie(t *testing.T) {
 
 	resp := rt.SendUserRequest(http.MethodPost, "/{{.db}}/_session?one_time=true", "", username)
 	RequireStatus(t, resp, http.StatusOK)
+	assert.Empty(t, resp.Header().Get("Set-Cookie"), "one-time session creation must not set a cookie")
+
+	var sessionResp struct {
+		SessionID string `json:"one_time_session_id"`
+	}
+	require.NoError(t, base.JSONUnmarshal(resp.BodyBytes(), &sessionResp))
+	require.NotEmpty(t, sessionResp.SessionID)
 
 	headers := map[string]string{
-		"Cookie": resp.Header().Get("Set-Cookie"),
+		"Cookie": auth.DefaultCookieName + "=" + sessionResp.SessionID,
 	}
 
 	resp = rt.SendRequestWithHeaders(http.MethodGet, "/{{.db}}/", "", headers)


### PR DESCRIPTION
CBG-5410

Unclean cherry pick of #8315 to 4.0.8
Changes from main commit:
- `auth/session_test.go` — dropped the `ctx` argument from the two new `dataStore.Set` calls; `DataStore.Set` does not take a context on 4.0.8

🤖 Opened with the `sync-gateway-backport` skill in [Claude Code](https://claude.com/claude-code)
