### PR TITLE
[4.0.8 Backport] CBG-5416: do not mark error in async init manager if stopping

### DIFF
--- a/db/background_mgr_async_index_init.go
+++ b/db/background_mgr_async_index_init.go
@@ -38,12 +38,11 @@ func (a *AsyncIndexInitManager) Run(ctx context.Context, options map[string]inte
 	a.lock.Lock()
 	doneChan := a._doneChan
 	a.lock.Unlock()
-	select {
-	case err := <-doneChan:
-		return err
-	case <-terminator.Done():
+	err := <-doneChan
+	if terminator.IsClosed() {
 		return nil
 	}
+	return err
 }
 
 type CollectionIndexStatus string


### PR DESCRIPTION
CBG-5416

Clean cherry pick of #8305 to 4.0.8

🤖 Opened with the `sync-gateway-backport` skill in [Claude Code](https://claude.com/claude-code)
