### PR TITLE
[4.0.8 Backport] CBG-5741: wire channel cache compact_low_watermark_pct correctly

### DIFF
--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -177,8 +177,8 @@ func TestConfigValidationDeltaSync(t *testing.T) {
 }
 
 func TestConfigValidationCache(t *testing.T) {
-	jsonConfig := `{"databases": {"db": {"cache": {"rev_cache": {"size": 0}, "channel_cache": {"max_number": 100, "compact_high_watermark_pct": 95, "compact_low_watermark_pct": 25}}}}}`
 	ctx := base.TestCtx(t)
+	jsonConfig := `{"databases": {"db": {"cache": {"rev_cache": {"size": 0}, "channel_cache": {"max_number": 100, "compact_high_watermark_pct": 95, "compact_low_watermark_pct": 25, "max_num_pending": 5, "max_wait_pending": 100, "max_wait_skipped": 200, "max_length": 300, "min_length": 10, "expiry_seconds": 30}}}}}`
 	buf := bytes.NewBufferString(jsonConfig)
 	config, err := readLegacyServerConfig(ctx, buf)
 	assert.NoError(t, err)
@@ -221,6 +221,31 @@ func TestConfigValidationCache(t *testing.T) {
 	} else {
 		// CE disallowed - should be nil
 		assert.Nil(t, config.Databases["db"].CacheConfig.ChannelCacheConfig.LowWatermarkPercent)
+	}
+
+	// check the validated config is wired through to the cache options the database is built with
+	sc := NewServerContext(ctx, &StartupConfig{}, false)
+	defer sc.Close(ctx)
+
+	opts, err := dbcOptionsFromConfig(ctx, sc, config.Databases["db"], "db")
+	require.NoError(t, err)
+
+	assert.Equal(t, 5, opts.CacheOptions.CachePendingSeqMaxNum)
+	assert.Equal(t, 100*time.Millisecond, opts.CacheOptions.CachePendingSeqMaxWait)
+	assert.Equal(t, 200*time.Millisecond, opts.CacheOptions.CacheSkippedSeqMaxWait)
+	assert.Equal(t, 300, opts.CacheOptions.ChannelCacheMaxLength)
+	assert.Equal(t, 10, opts.CacheOptions.ChannelCacheMinLength)
+	assert.Equal(t, 30*time.Second, opts.CacheOptions.ChannelCacheAge)
+
+	if base.IsEnterpriseEdition() {
+		assert.Equal(t, 100, opts.CacheOptions.MaxNumChannels)
+		assert.Equal(t, 95, opts.CacheOptions.CompactHighWatermarkPercent)
+		assert.Equal(t, 25, opts.CacheOptions.CompactLowWatermarkPercent)
+	} else {
+		// CE disallowed - should fall back to defaults
+		assert.Equal(t, db.DefaultChannelCacheMaxNumber, opts.CacheOptions.MaxNumChannels)
+		assert.Equal(t, db.DefaultCompactHighWatermarkPercent, opts.CacheOptions.CompactHighWatermarkPercent)
+		assert.Equal(t, db.DefaultCompactLowWatermarkPercent, opts.CacheOptions.CompactLowWatermarkPercent)
 	}
 }
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1206,11 +1206,11 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 			if config.CacheConfig.ChannelCacheConfig.MaxNumber != nil {
 				cacheOptions.MaxNumChannels = *config.CacheConfig.ChannelCacheConfig.MaxNumber
 			}
-			if config.CacheConfig.ChannelCacheConfig.HighWatermarkPercent != nil && *config.CacheConfig.ChannelCacheConfig.HighWatermarkPercent > 0 {
-				cacheOptions.CompactHighWatermarkPercent = *config.CacheConfig.ChannelCacheConfig.HighWatermarkPercent
+			if hwm := config.CacheConfig.ChannelCacheConfig.HighWatermarkPercent; hwm != nil && *hwm > 0 {
+				cacheOptions.CompactHighWatermarkPercent = *hwm
 			}
-			if config.CacheConfig.ChannelCacheConfig.HighWatermarkPercent != nil && *config.CacheConfig.ChannelCacheConfig.HighWatermarkPercent > 0 {
-				cacheOptions.CompactLowWatermarkPercent = *config.CacheConfig.ChannelCacheConfig.HighWatermarkPercent
+			if lwm := config.CacheConfig.ChannelCacheConfig.LowWatermarkPercent; lwm != nil && *lwm > 0 {
+				cacheOptions.CompactLowWatermarkPercent = *lwm
 			}
 		}
 


### PR DESCRIPTION
CBG-5741

Unclean cherry pick of #8616 to 4.0.8
Changes from main commit:
- `rest/config_test.go` — conflict on the two lines at the top of `TestConfigValidationCache`; 4.0.8 declares `jsonConfig` before `ctx`, main declares them the other way round. Resolved by taking the main side, so the resulting code is identical to upstream.

🤖 Opened with the `sync-gateway-backport` skill in [Claude Code](https://claude.com/claude-code)
