### PR TITLE
WIP: CBG-5729: don't track cluster updates on the manager teardown waitgroup

### DIFF
--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -402,8 +402,10 @@ type sgReplicateManager struct {
 	activeReplicators          map[string]*ActiveReplicator  // currently assigned replications
 	activeReplicatorsLock      sync.RWMutex                  // Mutex for activeReplications
 	clusterUpdateTerminator    chan struct{}                 // Terminator for cluster update retry
+	clusterUpdateGate          sync.RWMutex                  // Read-held for the duration of a cluster update, so Stop can drain them by taking the write side
+	clusterUpdateClosed        bool                          // Guarded by clusterUpdateGate - once set by Stop, no further cluster updates run
 	clusterSubscribeTerminator chan struct{}                 // Terminator for cluster change monitoring
-	closeWg                    sync.WaitGroup                // Teardown waitgroup for subscribe and retry goroutines
+	closeWg                    sync.WaitGroup                // Teardown waitgroup for goroutines this manager owns (startup, subscribe, heartbeat)
 	dbContext                  *DatabaseContext              // reference to the parent DatabaseContext
 	CheckpointInterval         time.Duration                 // The value to be used for time-based checkpoints
 	SupportedBLIPSubprotocols  []string                      // Optional specification to force the subprotocol of the active replicator.
@@ -835,6 +837,13 @@ func (m *sgReplicateManager) Stop() {
 	}
 	close(m.clusterUpdateTerminator)
 
+	// Drain in-flight cluster updates and refuse any starting later.  Must come after RemoveNode above,
+	// which is itself a cluster update - closing any earlier would silently skip it.  Taking the write side
+	// waits for in-flight updates, and blocks new ones from acquiring the read side while it waits.
+	m.clusterUpdateGate.Lock()
+	m.clusterUpdateClosed = true
+	m.clusterUpdateGate.Unlock()
+
 	m.closeWg.Wait()
 }
 
@@ -1000,8 +1009,15 @@ func (m *sgReplicateManager) loadSGRCluster() (sgrCluster *SGRCluster, cas uint6
 
 // updateCluster manages CAS retry for SGRCluster updates.
 func (m *sgReplicateManager) updateCluster(callback ClusterUpdateFunc) error {
-	m.closeWg.Add(1)
-	defer m.closeWg.Done()
+	// Read-held for the whole update so Stop's write-side acquisition drains it.  closeWg cannot be used
+	// here: updateCluster runs on the caller's goroutine, so its Add can race Stop's Wait, which is a
+	// WaitGroup misuse panic rather than a wait.
+	m.clusterUpdateGate.RLock()
+	defer m.clusterUpdateGate.RUnlock()
+	if m.clusterUpdateClosed {
+		base.DebugfCtx(m.loggingCtx, base.KeyReplicate, "manager stopped, not updating cluster config")
+		return nil
+	}
 	for i := 1; i <= maxSGRClusterCasRetries; i++ {
 		select {
 		case <-m.clusterUpdateTerminator:

--- a/db/sg_replicate_cfg_test.go
+++ b/db/sg_replicate_cfg_test.go
@@ -1089,3 +1089,119 @@ func TestStartReplicationsRacesStopTeardownDuringStart(t *testing.T) {
 	// Close would otherwise stop it a second time, panicking on the already-closed terminators.
 	testDB.SGReplicateMgr = nil
 }
+
+// TestSGReplicateManagerStopDoesNotPanicOnConcurrentClusterUpdate asserts that a cluster config write racing
+// Stop() does not panic.  updateCluster used to register itself on closeWg, the same waitgroup Stop waits on -
+// but it runs on the caller's goroutine, so a call arriving once Stop was already inside closeWg.Wait with the
+// counter at zero was a WaitGroup misuse panic, not a wait.  In production that is any request that writes the
+// cluster config during a database close or config reload: PUT /{db}/_replication/{id},
+// PUT /{db}/_replicationStatus/{id}, DELETE /{db}/_replication/{id}.
+//
+// The window is small, so this loops.  Before the fix it panicked on the first attempt.
+func TestSGReplicateManagerStopDoesNotPanicOnConcurrentClusterUpdate(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelWarn, base.KeyCluster)
+
+	testDB, ctx := setupTestDB(t)
+	defer testDB.Close(ctx)
+
+	const attempts = 200
+	for i := range attempts {
+		// A distinct cfg prefix and node per attempt, so attempts do not interfere.
+		cfgSG, err := base.NewCfgSG(ctx, testDB.MetadataStore, fmt.Sprintf("p%d", i), false)
+		require.NoError(t, err)
+		mgr, err := NewSGReplicateManager(ctx, testDB.DatabaseContext, cfgSG)
+		require.NoError(t, err)
+		require.NoError(t, mgr.StartLocalNode(fmt.Sprintf("n%d", i), nil))
+		// Registers a goroutine on closeWg, so Stop's Wait blocks and there is a waiter to misuse.
+		require.NoError(t, mgr.SubscribeCfgChanges(ctx))
+
+		var recovered atomic.Value
+		catch := func(fn func()) {
+			defer func() {
+				if r := recover(); r != nil {
+					recovered.CompareAndSwap(nil, fmt.Sprint(r))
+				}
+			}()
+			fn()
+		}
+
+		var hammer sync.WaitGroup
+		stopHammer := make(chan struct{})
+		for range 4 {
+			hammer.Go(func() {
+				catch(func() {
+					for {
+						select {
+						case <-stopHammer:
+							return
+						default:
+						}
+						_ = mgr.updateCluster(func(*SGRCluster) (bool, error) { return true, nil })
+					}
+				})
+			})
+		}
+		catch(mgr.Stop)
+		close(stopHammer)
+		base.WaitWithTimeout(t, &hammer, time.Minute)
+
+		if r := recovered.Load(); r != nil {
+			t.Fatalf("attempt %d: cluster config write concurrent with Stop() panicked: %v", i, r)
+		}
+	}
+}
+
+// TestSGReplicateManagerStopDrainsClusterUpdates asserts the guarantee that makes the fix safe: no cluster
+// update runs past Stop.  Stop blocks until an in-flight update finishes, and an update starting afterwards is
+// refused rather than run against a torn-down manager.
+func TestSGReplicateManagerStopDrainsClusterUpdates(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCluster)
+
+	testDB, ctx := setupTestDB(t)
+	defer testDB.Close(ctx)
+
+	cfgSG, err := base.NewCfgSG(ctx, testDB.MetadataStore, "", false)
+	require.NoError(t, err)
+	mgr, err := NewSGReplicateManager(ctx, testDB.DatabaseContext, cfgSG)
+	require.NoError(t, err)
+	require.NoError(t, mgr.StartLocalNode("localNode", nil))
+
+	// An update parks inside its callback, so it is in flight for as long as the test wants.
+	inUpdate := make(chan struct{})
+	release := make(chan struct{})
+	var updateWg sync.WaitGroup
+	updateWg.Go(func() {
+		assert.NoError(t, mgr.updateCluster(func(*SGRCluster) (bool, error) {
+			inUpdate <- struct{}{}
+			<-release
+			return true, nil // cancel, so there is no CAS write to retry
+		}))
+	})
+	base.RequireChanRecv(t, inUpdate)
+
+	stopDone := make(chan struct{})
+	var stopWg sync.WaitGroup
+	stopWg.Go(func() {
+		mgr.Stop()
+		close(stopDone)
+	})
+
+	// Stop must not complete while the update is still in flight.
+	select {
+	case <-stopDone:
+		require.Fail(t, "Stop returned while a cluster update was still in flight")
+	case <-time.After(500 * time.Millisecond):
+	}
+
+	close(release)
+	base.WaitWithTimeout(t, &updateWg, time.Minute)
+	base.WaitWithTimeout(t, &stopWg, time.Minute)
+
+	// An update starting after Stop is refused outright, so it cannot touch a torn-down manager.
+	ran := false
+	require.NoError(t, mgr.updateCluster(func(*SGRCluster) (bool, error) {
+		ran = true
+		return true, nil
+	}))
+	require.False(t, ran, "cluster update ran after Stop returned")
+}


### PR DESCRIPTION
CBG-5729: don't track cluster updates on the manager teardown waitgroup

Stacked on #8608 (CBG-5694 / CBG-5736).

`updateCluster` registered itself on `closeWg`, the waitgroup `Stop` waits on. But it runs on the *caller's* goroutine — a REST handler, or the heartbeat listener — so calls arrive at times the manager does not control. A `sync.WaitGroup` cannot accept an `Add` that races its own `Wait`, so a cluster update starting once `Stop` was already inside `closeWg.Wait` with the counter at zero panicked the process:

```
panic: sync: WaitGroup is reused before previous Wait has returned
sync.(*WaitGroup).Wait(...)
db.(*sgReplicateManager).Stop(...)
```

In production that is any request writing the cluster config during a database close or config reload: `PUT /{db}/_replication/{id}`, `PUT /{db}/_replicationStatus/{id}`, `DELETE /{db}/_replication/{id}`.

### Approach

In-flight cluster updates get their own waitgroup, with registration serialised against its `Wait` by `clusterUpdateLock` and refused once `Stop` has set `clusterUpdateClosed`. `Add` can no longer race `Wait`.

This also **strengthens** the drain rather than weakening it. Previously an update that arrived before the `Wait` was waited for, while one arriving during it panicked instead — best-effort with a crash as its failure mode. Now in-flight updates are always drained, and an update starting after `Stop` is refused rather than run against a torn-down manager.

Simply dropping the `closeWg` registration also fixes the panic and is a smaller diff, but it lets an in-flight cluster update outlive `Stop`. `TestSGReplicateManagerStopDrainsClusterUpdates` fails that way, which is why it is not the approach taken here.

`closeClusterUpdates` runs *after* `Stop`'s own `RemoveNode`, which is itself a cluster update — closing any earlier would silently skip removing the local node from the cfg.

`closeWg` now tracks only the goroutines the manager owns (startup, subscribe, heartbeat), and its comment says so. The previous "subscribe and retry goroutines" is what licensed the misuse, since `updateCluster`'s retry loop is not a goroutine.

### Tests

- `TestSGReplicateManagerStopDoesNotPanicOnConcurrentClusterUpdate` — the ticket's reproducer. Panics on attempt 0 without the fix.
- `TestSGReplicateManagerStopDrainsClusterUpdates` — asserts `Stop` blocks on an in-flight update and refuses one started afterwards. Fails under the simpler plain-removal fix.

Both verified against the unfixed code, and run under CE and EE with `-race`.

### Not addressed here

Two adjacent bugs in the same area, deliberately out of scope:

- **CBG-5735** — `_stopOnlineProcesses` nils `SGReplicateMgr` while an in-flight REST request still holds the outgoing `DatabaseContext`, so `updateCluster` panics on a **nil receiver**. Different panic on the same line; needs the request gate, not this waitgroup.
- The narrow window where a replication started just after `Stop`'s teardown loop is never stopped (spun off from CBG-5736).

## Pre-review checklist
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] (pending)
