### PR TITLE
[4.1.2 Backport] CBG-5743: passing invalid collections to /db/_resync?action=start will cause resync to be stuck in running

### DIFF
--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -137,6 +137,11 @@ type LeakyBucketConfig struct {
 	// tests to trigger CAS retry handling by modifying the underlying document in a UpdateCallback implementation.
 	UpdateCallback func(key string)
 
+	// PreUpdateCallback is invoked before Update calls into the underlying dataStore. If it returns an error,
+	// Update returns that error immediately without ever calling into the underlying dataStore - allows tests
+	// to simulate a write that fails before it reaches the server.
+	PreUpdateCallback func(key string) error
+
 	// GetRawCallback issues a callback prior to running GetRaw. Allows tests to issue a doc mutation or deletion prior
 	// to GetRaw being ran.
 	GetRawCallback       func(key string) error
@@ -265,6 +270,18 @@ func (b *LeakyBucket) setUpdateCallback(fn func(string)) {
 	b.configLock.Lock()
 	defer b.configLock.Unlock()
 	b._config.UpdateCallback = fn
+}
+
+func (b *LeakyBucket) getPreUpdateCallback() func(string) error {
+	b.configLock.RLock()
+	defer b.configLock.RUnlock()
+	return b._config.PreUpdateCallback
+}
+
+func (b *LeakyBucket) setPreUpdateCallback(fn func(string) error) {
+	b.configLock.Lock()
+	defer b.configLock.Unlock()
+	b._config.PreUpdateCallback = fn
 }
 
 func (b *LeakyBucket) getPostUpdateCallback() func(string) {

--- a/base/leaky_datastore.go
+++ b/base/leaky_datastore.go
@@ -162,6 +162,12 @@ func (lds *LeakyDataStore) WriteCas(ctx context.Context, k string, exp uint32, c
 	return lds.dataStore.WriteCas(ctx, k, exp, cas, v, opt)
 }
 func (lds *LeakyDataStore) Update(ctx context.Context, k string, exp uint32, callback sgbucket.UpdateFunc) (casOut uint64, err error) {
+	if preUpdateCb := lds.bucket.getPreUpdateCallback(); preUpdateCb != nil {
+		if err := preUpdateCb(k); err != nil {
+			return 0, err
+		}
+	}
+
 	updateCb := lds.bucket.getUpdateCallback()
 	forceTimeoutKeys := lds.bucket.getForceTimeoutErrorOnUpdateKeys()
 
@@ -368,6 +374,10 @@ func (lds *LeakyDataStore) SetPostUpdateCallback(callback func(key string)) {
 
 func (lds *LeakyDataStore) SetUpdateCallback(callback func(key string)) {
 	lds.bucket.setUpdateCallback(callback)
+}
+
+func (lds *LeakyDataStore) SetPreUpdateCallback(callback func(key string) error) {
+	lds.bucket.setPreUpdateCallback(callback)
 }
 
 func (lds *LeakyDataStore) SetWriteCasCallback(callback func(key string) (uint64, error)) {

--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -285,8 +285,15 @@ func (b *BackgroundManager[O]) start(ctx context.Context, options O, processClus
 		b.setStartTime(previousStatus.StartTime)
 	}
 
+	// Capture the terminator markStart just created rather than reading the mutable b.terminator field later on -
+	// a subsequent Start() call can reassign b.terminator once this one returns, and this goroutine tree must keep
+	//operating on the instance created for THIS run, not whatever b.terminator happens to be by the time it runs.
+	//terminator := b.terminator
+
 	initMode, err := b.Process.Init(ctx, options, processClusterStatus)
 	if err != nil {
+		b.SetError(err)
+		b.updateTerminalStatus(ctx)
 		return err
 	}
 
@@ -334,16 +341,7 @@ func (b *BackgroundManager[O]) start(ctx context.Context, options O, processClus
 
 		// Once our background process run has completed we should update the completed status and delete the heartbeat
 		// doc
-		if b.mode() != backgroundManagerModeLocal {
-			err := b.UpdateStatusClusterAware(ctx)
-			if err != nil {
-				base.WarnfCtx(ctx, "Failed to update background manager status: %v", err)
-			}
-
-			// Delete the heartbeat doc to allow another process to run
-			// Note: We can ignore the error, worst case is the user has to wait until the heartbeat doc expires
-			_ = b.clusterAwareOptions.metadataStore.Delete(ctx, b.clusterAwareOptions.HeartbeatDocID())
-		}
+		b.updateTerminalStatus(ctx)
 	}()
 
 	if b.mode() != backgroundManagerModeLocal {
@@ -359,6 +357,10 @@ func (b *BackgroundManager[O]) start(ctx context.Context, options O, processClus
 		}
 		if err != nil {
 			base.ErrorfCtx(ctx, "Failed to update background manager status: %v", err)
+			// Process.Run's goroutine is already launched by this point, so without this the caller would
+			// get an error back while the process keeps running in the background unbeknownst to them.
+			// SetError both marks the state as Error and terminates the already-running process.
+			b.SetError(err)
 			return err
 		}
 	}
@@ -433,6 +435,20 @@ func (b *BackgroundManager[O]) markStart(ctx context.Context, previousStatus Bac
 
 	b.setRunState(BackgroundProcessStateRunning)
 	return nil
+}
+
+// updateTerminalStatus persists the current (terminal) status and removes the heartbeat doc to allow a subsequent run.
+func (b *BackgroundManager[O]) updateTerminalStatus(ctx context.Context) {
+	if b.mode() != backgroundManagerModeLocal {
+		err := b.UpdateStatusClusterAware(ctx)
+		if err != nil {
+			base.WarnfCtx(ctx, "Failed to update background manager status: %v", err)
+		}
+
+		// Delete the heartbeat doc to allow another process to run
+		// Note: We can ignore the error, worst case is the user has to wait until the heartbeat doc expires
+		_ = b.clusterAwareOptions.metadataStore.Delete(ctx, b.clusterAwareOptions.HeartbeatDocID())
+	}
 }
 
 // getClusterStatusState gets the current background process state of the cluster.

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"iter"
 	"maps"
+	"net/http"
 	"slices"
 	"sort"
 	"strings"
@@ -145,7 +146,7 @@ func (r *ResyncManagerDCP) Init(ctx context.Context, options ResyncOptions, clus
 		var err error
 		collections, err = r.db.collections(options.Collections)
 		if err != nil {
-			return backgroundManagerInitReset, err
+			return backgroundManagerInitReset, base.HTTPErrorf(http.StatusBadRequest, "%w", err)
 		}
 	} else {
 		collections = slices.Collect(maps.Values(r.db.CollectionByID))

--- a/db/background_mgr_test.go
+++ b/db/background_mgr_test.go
@@ -11,6 +11,7 @@ package db
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -1475,4 +1476,65 @@ func TestBackgroundManagerMultiNodePollingAvoidsOverwrite(t *testing.T) {
 	var status BackgroundManagerStatus
 	require.NoError(t, base.JSONUnmarshal(rawStatus, &status))
 	assert.Equal(t, BackgroundProcessStateCompleted, status.State, "expected the bucket status to remain completed and NOT be overwritten")
+}
+
+// TestBackgroundManagerStartReturnsErrorWhileProcessKeepsRunning reproduces the case where Init succeeds and
+// Process.Run is launched in its own goroutine, but the subsequent persist of the initial cluster status fails.
+// Start() returns that error to the caller, even though Run is already executing in the background.
+func TestBackgroundManagerStartReturnsErrorWhileProcessKeepsRunning(t *testing.T) {
+
+	t.Skip("This test will pass after the fix in CBG-5660")
+
+	testBucket := base.GetTestBucket(t)
+	ctx := context.Background()
+	defer testBucket.Close(ctx)
+
+	metaKeys := base.NewMetadataKeys("test-start-persist-fail")
+	processSuffix := "multi-persist-fail"
+	// Same key start()'s final updateMultiNodeClusterAwareStatus call will write to.
+	statusDocID := metaKeys.BackgroundProcessStatusPrefix(processSuffix)
+
+	// The first Update call for statusDocID fails outright, so start() sees an error and returns it, exactly
+	// like a transient bucket blip would. Every call after that behaves normally, so the manager can be reused
+	// as-is for the recovery Start() below without needing a different key or a fresh metadataStore.
+	var updateCount atomic.Int32
+	leakyBucket := base.NewLeakyBucket(testBucket, base.LeakyBucketConfig{
+		PreUpdateCallback: func(key string) error {
+			if key == statusDocID && updateCount.Add(1) == 1 {
+				return errors.New("simulated write failure")
+			}
+			return nil
+		},
+	})
+	leakyMetadataStore := leakyBucket.DefaultDataStore(ctx)
+
+	process := &MockProcess{}
+	mgr := &BackgroundManager[map[string]any]{
+		name: "persist-fail-mgr",
+		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
+			metadataStore: leakyMetadataStore,
+			metaKeys:      metaKeys,
+			processSuffix: processSuffix,
+			multiNode:     true,
+		},
+		Process: process,
+	}
+
+	// Start() reports failure to the caller...
+	err := mgr.Start(ctx, map[string]any{})
+	require.Error(t, err)
+
+	// ...but Process.Run was already launched before that failure occurred, so the manager should not be left
+	// reporting Running forever - it should reflect the failure as an Error state, same as the Process.Run-error
+	// path does via SetError.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.NotEqual(c, BackgroundProcessStateRunning, mgr.GetRunState())
+		assert.Equal(c, BackgroundProcessStateError, mgr.GetRunState())
+	}, 5*time.Second, 100*time.Millisecond)
+
+	require.NoError(t, mgr.Start(ctx, map[string]any{}))
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, BackgroundProcessStateRunning, mgr.GetRunState())
+	}, 5*time.Second, 100*time.Millisecond)
+	require.NoError(t, mgr.Stop(ctx))
 }

--- a/docs/api/paths/admin/db-_resync.yaml
+++ b/docs/api/paths/admin/db-_resync.yaml
@@ -87,6 +87,8 @@ post:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/Resync-status
+    '400':
+      $ref: ../../components/responses.yaml#/request-problem
     '403':
       $ref: ../../components/responses.yaml#/Unauthorized-database
     '503':

--- a/rest/adminapitest/resync_test.go
+++ b/rest/adminapitest/resync_test.go
@@ -606,3 +606,40 @@ function sync(doc, oldDoc){
 	log.Printf("rt2 stats - resync num processed: %v", rt2.GetDatabase().DbStats.Database().ResyncNumProcessed.Value())
 
 }
+
+// TestResyncInvalidCollections verifies behavior when _resync is started with collection names not present in the
+// database config: the start fails with 400, GET /_resync is not left reporting a running state, and a subsequent
+// valid start succeeds and completes.
+func TestResyncInvalidCollections(t *testing.T) {
+	rt := rest.NewRestTester(t, nil)
+	defer rt.Close()
+
+	rt.TakeDbOffline()
+
+	invalidBody := `{"scopes": {"_default": ["nonexistent_collection"]}}`
+
+	// First start with invalid collection: Init() fails synchronously, returns 400
+	resp := rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_resync?action=start", invalidBody)
+	rest.RequireStatus(t, resp, http.StatusBadRequest)
+	assert.Contains(t, resp.BodyString(), "nonexistent_collection")
+
+	// Status should not be left reporting a running state after Init() fails synchronously.
+	resp = rt.SendAdminRequest(http.MethodGet, "/{{.db}}/_resync", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	var status db.ResyncManagerResponseDCP
+	require.NoError(t, base.JSONUnmarshal(resp.BodyBytes(), &status))
+	require.Equal(t, db.BackgroundProcessStateError, status.State)
+
+	// Second start with invalid collection: still fails request validation and returns 400.
+	resp = rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_resync?action=start", invalidBody)
+	rest.RequireStatus(t, resp, http.StatusBadRequest)
+
+	// Starting with valid collections should succeed after the failed start resets the db/background-manager state.
+	resp = rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_resync?action=start", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+
+	resp = rt.SendAdminRequest(http.MethodGet, "/{{.db}}/_resync", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	require.NoError(t, base.JSONUnmarshal(resp.BodyBytes(), &status))
+	_ = rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
+}

--- a/rest/api.go
+++ b/rest/api.go
@@ -465,6 +465,7 @@ func (h *handler) handlePostResync() error {
 				Reset:               reset,
 			})
 			if err != nil {
+				atomic.CompareAndSwapUint32(&h.db.State, db.DBResyncing, db.DBOffline)
 				return err
 			}
 
@@ -504,6 +505,7 @@ func (h *handler) handlePostResync() error {
 		if err != nil {
 			return err
 		}
+
 		h.writeRawJSON(status)
 
 		base.Audit(h.ctx(), base.AuditIDDatabaseResyncStop, nil)


### PR DESCRIPTION
CBG-5743

Unclean cherry pick of #8454 (CBG-5496) to 4.1.2

Stacked on #8660 (CBG-5752), which sits on #8635 (CBG-5744).

Changes from main commit:
- `db/background_mgr_test.go` — `TestBackgroundManagerStartReturnsErrorWhileProcessKeepsRunning` is typed against `MockProcessOptions`, added by CBG-5653 (#8490) which is not on 4.1.2. Applied in full against `BackgroundManager[map[string]any]`, matching the rest of the file on this branch; no assertions changed. The test keeps upstream's `t.Skip` for CBG-5660.

🤖 Opened with the `sync-gateway-backport` skill in [Claude Code](https://claude.com/claude-code)
