### PR TITLE
[4.1.2 Backport] CBG-5594: fix BackgroundManager.Stop transition

### DIFF
--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -44,7 +44,21 @@ const (
 var errBackgroundManagerStatusAlreadyStopping = base.HTTPErrorf(http.StatusServiceUnavailable, "Process currently stopping. Wait until stopped to retry")
 
 // errBackgroundManagerStatusNotRunning is returned when the bucket status is not running but the local status is.
-var errBackgroundManagerStatusNotRunning = errors.New("status in bucket is not running, but local status is, avoiding overwriting local status to bucket")
+type errBackgroundManagerStatusNotRunning struct {
+	state   BackgroundProcessState
+	message string
+}
+
+func (e errBackgroundManagerStatusNotRunning) Error() string {
+	return e.message
+}
+
+func newErrBackgroundManagerStatusNotRunning(state BackgroundProcessState, message string) errBackgroundManagerStatusNotRunning {
+	return errBackgroundManagerStatusNotRunning{
+		state:   state,
+		message: message,
+	}
+}
 
 // errBackgroundManagerProcessAlreadyRunning is returned when an action to Start a process occurs but it is already running.
 var errBackgroundManagerProcessAlreadyRunning = base.HTTPErrorf(http.StatusServiceUnavailable, "Process already running")
@@ -202,7 +216,9 @@ func (b *BackgroundManager[O]) Join(ctx context.Context) error {
 	if err != nil {
 		if base.IsDocNotFoundError(err) {
 			b.callUpdateDatabaseState(ctx, false)
-			return errBackgroundManagerStatusNotRunning
+			// The status document does not exist, meaning the background process is not running yet on the cluster.
+			// We report BackgroundProcessStateCompleted as the state since it is currently not running.
+			return newErrBackgroundManagerStatusNotRunning(BackgroundProcessStateCompleted, fmt.Sprintf("failed to join background process %q: no cluster status document found in bucket", b.name))
 		}
 		return fmt.Errorf("failed to read status doc for background process %q: %w", b.name, err)
 	}
@@ -307,7 +323,7 @@ func (b *BackgroundManager[O]) start(ctx context.Context, options O, processClus
 				case <-ticker.C:
 					err := b.UpdateSingleNodeClusterAwareStatus(ctx)
 					if err != nil {
-						base.WarnfCtx(ctx, "Failed to update background manager status: %v", err)
+						base.WarnfCtx(ctx, "Failed to update background manager status in periodic polling: %v, will retry", err)
 					}
 				case <-terminator.Done():
 					ticker.Stop()
@@ -334,7 +350,7 @@ func (b *BackgroundManager[O]) start(ctx context.Context, options O, processClus
 		b.statusLock.Lock()
 		if b.status.State == BackgroundProcessStateStopping {
 			b.status.State = BackgroundProcessStateStopped
-		} else if b.status.State != BackgroundProcessStateError {
+		} else if b.status.State == BackgroundProcessStateRunning {
 			b.status.State = BackgroundProcessStateCompleted
 		}
 		b.statusLock.Unlock()
@@ -356,7 +372,7 @@ func (b *BackgroundManager[O]) start(ctx context.Context, options O, processClus
 			err = b.UpdateSingleNodeClusterAwareStatus(ctx)
 		}
 		if err != nil {
-			base.ErrorfCtx(ctx, "Failed to update background manager status: %v", err)
+			base.ErrorfCtx(ctx, "Failed to update background manager status on start: %v", err)
 			// Process.Run's goroutine is already launched by this point, so without this the caller would
 			// get an error back while the process keeps running in the background unbeknownst to them.
 			// SetError both marks the state as Error and terminates the already-running process.
@@ -442,7 +458,9 @@ func (b *BackgroundManager[O]) updateTerminalStatus(ctx context.Context) {
 	if b.mode() != backgroundManagerModeLocal {
 		err := b.UpdateStatusClusterAware(ctx)
 		if err != nil {
-			base.WarnfCtx(ctx, "Failed to update background manager status: %v", err)
+			if _, ok := errors.AsType[errBackgroundManagerStatusNotRunning](err); !ok {
+				base.WarnfCtx(ctx, "Failed to update terminal background manager status after finishing process: %v", err)
+			}
 		}
 
 		// Delete the heartbeat doc to allow another process to run
@@ -782,8 +800,9 @@ func (b *BackgroundManager[O]) updateMultiNodeClusterAwareStatus(ctx context.Con
 			if err := base.JSONUnmarshal(current, &output); err != nil {
 				return nil, nil, false, fmt.Errorf("Could not unmarshal doc(%q) within updateClusterAwareStatus: %w", docID, err)
 			}
-			// If the local status is running, but another node stopped or errored, do not serialize status and report
-			// not running so that caller can terminate the background manager on this node
+			// If the local status is running, but another node stopped or errored, adopt that state locally so
+			// that we transition properly when our process terminates, and report not running so that caller can
+			// terminate the background manager on this node.
 			if mode == backgroundManagerStatusUpdate {
 				if status, ok := output["status"]; ok {
 					bucketState, err := unmarshalBackgroundProcessState(status)
@@ -791,7 +810,7 @@ func (b *BackgroundManager[O]) updateMultiNodeClusterAwareStatus(ctx context.Con
 						return nil, nil, false, err
 					}
 					if slices.Contains([]BackgroundProcessState{BackgroundProcessStateCompleted, BackgroundProcessStateStopping, BackgroundProcessStateStopped, BackgroundProcessStateError}, bucketState) && b.GetRunState() == BackgroundProcessStateRunning {
-						return nil, nil, false, errBackgroundManagerStatusNotRunning
+						return nil, nil, false, newErrBackgroundManagerStatusNotRunning(bucketState, fmt.Sprintf("canceling update: another node already transitioned background process %q to terminal state %q", b.name, bucketState))
 					}
 				}
 			}
@@ -864,14 +883,13 @@ func (b *BackgroundManager[O]) startPollingMultiNodeStatus(ctx context.Context, 
 	for {
 		select {
 		case <-ticker.C:
-			err := b.updateMultiNodeClusterAwareStatus(ctx, backgroundManagerStatusUpdate)
-			if err != nil {
-				if errors.Is(err, errBackgroundManagerStatusNotRunning) {
-					b.terminator.Close()
+			if err := b.updateMultiNodeClusterAwareStatus(ctx, backgroundManagerStatusUpdate); err != nil {
+				if stateErr, ok := errors.AsType[errBackgroundManagerStatusNotRunning](err); ok {
+					b.compareAndSwapRunState(BackgroundProcessStateRunning, stateErr.state)
+					terminator.Close()
 					return
-				} else {
-					base.DebugfCtx(ctx, base.KeyAll, "Failed to update multi node cluster aware status: %v, will retry", err)
 				}
+				base.DebugfCtx(ctx, base.KeyAll, "Failed to update multi node cluster aware status: %v, will retry", err)
 			}
 		case <-terminator.Done():
 			ticker.Stop()
@@ -890,7 +908,9 @@ func (b *BackgroundManager[O]) stopProcess(ctx context.Context) {
 	if b.mode() == backgroundManagerModeMultiNode {
 		err := b.UpdateStatusClusterAware(ctx)
 		if err != nil {
-			base.WarnfCtx(ctx, "Failed to update cluster status to stopping: %v", err)
+			if _, ok := errors.AsType[errBackgroundManagerStatusNotRunning](err); !ok {
+				base.WarnfCtx(ctx, "Failed to update cluster status to stopping: %v", err)
+			}
 		}
 	}
 

--- a/db/background_mgr_test.go
+++ b/db/background_mgr_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/testing/sgtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -578,7 +579,8 @@ func TestBackgroundManagerJoinNoDoc(t *testing.T) {
 		terminator: base.NewSafeTerminator(),
 	}
 
-	require.ErrorIs(t, mgr.Join(ctx), errBackgroundManagerStatusNotRunning)
+	var statusErr errBackgroundManagerStatusNotRunning
+	require.ErrorAs(t, mgr.Join(ctx), &statusErr)
 }
 
 // TestBackgroundManagerJoinSingleNodeError verifies that Join returns an error for single-node managers
@@ -830,7 +832,8 @@ func TestBackgroundManagerJoinCallsUpdateDatabaseStateWhenNotRunning(t *testing.
 
 	// No status doc exists → Join must return errBackgroundManagerStatusNotRunning.
 	err := mgr.Join(ctx)
-	require.ErrorIs(t, err, errBackgroundManagerStatusNotRunning)
+	var statusErr errBackgroundManagerStatusNotRunning
+	require.ErrorAs(t, err, &statusErr)
 
 	mu.Lock()
 	calls := make([]bool, len(dbStateCalls))
@@ -1113,7 +1116,8 @@ func TestUpdateDatabaseStateJoinOverwritesRunningState(t *testing.T) {
 
 	// B's Join will see no cluster status doc → errBackgroundManagerStatusNotRunning → callUpdateDatabaseState(false).
 	err := mgrB.Join(ctx)
-	require.ErrorIs(t, err, errBackgroundManagerStatusNotRunning)
+	var statusErr errBackgroundManagerStatusNotRunning
+	require.ErrorAs(t, err, &statusErr)
 
 	// B wrote false to the shared state doc, even though A is still running.
 	// A's next UpdateStatusClusterAware call must restore true.
@@ -1396,17 +1400,122 @@ func TestBackgroundManagerJoinPreservesPreviousStatus(t *testing.T) {
 	require.NoError(t, mgr2.Stop(ctx))
 }
 
-func TestBackgroundManagerMultiNodePollingAvoidsOverwrite(t *testing.T) {
+// TestBackgroundManagerMultiNodePollingConverges verifies that when another node moves the shared
+// cluster status to a terminal state, a still-running node that only observes this via polling
+// converges to that same state - without overwriting it.
+func TestBackgroundManagerMultiNodePollingConverges(t *testing.T) {
+	t.Skip("CBG-5660: test can flake until all the modes of background manager stopping are addressed")
+	tests := []struct {
+		name          string
+		externalState BackgroundProcessState
+	}{
+		{name: "Completed", externalState: BackgroundProcessStateCompleted},
+		{name: "Error", externalState: BackgroundProcessStateError},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			testBucket := base.GetTestBucket(t)
+			ctx := base.TestCtx(t)
+			defer testBucket.Close(ctx)
+
+			metadataStore := testBucket.DefaultDataStore(ctx)
+			metaKeys := base.NewMetadataKeys("test-polling-converge")
+
+			clusterOpts := &ClusterAwareBackgroundManagerOptions{
+				metadataStore: metadataStore,
+				metaKeys:      metaKeys,
+				processSuffix: "polling-converge",
+				multiNode:     true,
+			}
+
+			process1 := &MockProcess{}
+			mgr1 := &BackgroundManager[map[string]any]{
+				name:                "mgr1",
+				Process:             process1,
+				clusterAwareOptions: clusterOpts,
+				terminator:          base.NewSafeTerminator(),
+			}
+			process2 := &MockProcess{}
+			mgr2 := &BackgroundManager[map[string]any]{
+				name:                "mgr2",
+				Process:             process2,
+				clusterAwareOptions: clusterOpts,
+				terminator:          base.NewSafeTerminator(),
+			}
+
+			// Start both managers. Both should run.
+			require.NoError(t, mgr1.Start(ctx, map[string]any{}))
+			defer func() { _ = mgr1.Stop(ctx) }()
+
+			require.NoError(t, mgr2.Start(ctx, map[string]any{}))
+			defer func() { _ = mgr2.Stop(ctx) }()
+
+			RequireBackgroundManagerState(t, mgr1, BackgroundProcessStateRunning)
+			RequireBackgroundManagerState(t, mgr2, BackgroundProcessStateRunning)
+
+			// Simulate another node reaching a terminal state by manually writing it to the shared
+			// cluster status document.
+			docID := clusterOpts.StatusDocID()
+			_, err := metadataStore.Update(ctx, docID, 0, func(current []byte) ([]byte, *uint32, bool, error) {
+				var output map[string]json.RawMessage
+				if current != nil {
+					_ = base.JSONUnmarshal(current, &output)
+				} else {
+					output = make(map[string]json.RawMessage)
+				}
+
+				status := BackgroundManagerStatus{
+					State:     test.externalState,
+					StartTime: time.Now(),
+				}
+				statusBytes, err := base.JSONMarshal(status)
+				if err != nil {
+					return nil, nil, false, err
+				}
+				output["status"] = statusBytes
+				output["meta"] = json.RawMessage("null")
+
+				outputBytes, err := base.JSONMarshal(output)
+				if err != nil {
+					return nil, nil, false, err
+				}
+				return outputBytes, nil, false, nil
+			})
+			require.NoError(t, err)
+
+			// Wait for mgr2's polling loop to detect the terminal status and close its terminator.
+			require.Eventually(t, func() bool {
+				return mgr2.terminator.IsClosed()
+			}, 10*time.Second, 100*time.Millisecond, "expected mgr2 terminator to be closed after polling detects "+string(test.externalState)+" status")
+
+			assert.Equal(t, test.externalState, mgr2.GetRunState(), "mgr2 should adopt the real external state")
+
+			// Verify that the status in the bucket remains as set externally and is not overwritten by mgr2.
+			rawStatus, err := mgr2.GetStatus(ctx)
+			require.NoError(t, err)
+			var status BackgroundManagerStatus
+			require.NoError(t, base.JSONUnmarshal(rawStatus, &status))
+			assert.Equal(t, test.externalState, status.State, "expected the bucket status to remain "+string(test.externalState)+" and NOT be overwritten")
+		})
+	}
+}
+
+// TestBackgroundManagerMultiNodeStopConvergesToStopped verifies that stopping a multi-node process
+// via one manager brings every manager - including ones that only observe the stop by polling the
+// shared cluster status - to Stopped, both locally and in the persisted cluster status.
+func TestBackgroundManagerMultiNodeStopConvergesToStopped(t *testing.T) {
+	t.Skip("CBG-5660: test can flake until all the modes of background manager stopping are addressed")
 	testBucket := base.GetTestBucket(t)
 	ctx := base.TestCtx(t)
 	defer testBucket.Close(ctx)
 	metadataStore := testBucket.DefaultDataStore(ctx)
-	metaKeys := base.NewMetadataKeys("test-polling-overwrite")
+	metaKeys := base.NewMetadataKeys("test-multi-node-stop")
 
-	clusterOpts := &ClusterAwareBackgroundManagerOptions{
+	options := &ClusterAwareBackgroundManagerOptions{
 		metadataStore: metadataStore,
 		metaKeys:      metaKeys,
-		processSuffix: "polling-overwrite",
+		processSuffix: "multi-node-stop",
 		multiNode:     true,
 	}
 
@@ -1414,7 +1523,7 @@ func TestBackgroundManagerMultiNodePollingAvoidsOverwrite(t *testing.T) {
 	mgr1 := &BackgroundManager[map[string]any]{
 		name:                "mgr1",
 		Process:             process1,
-		clusterAwareOptions: clusterOpts,
+		clusterAwareOptions: options,
 		terminator:          base.NewSafeTerminator(),
 	}
 
@@ -1422,7 +1531,7 @@ func TestBackgroundManagerMultiNodePollingAvoidsOverwrite(t *testing.T) {
 	mgr2 := &BackgroundManager[map[string]any]{
 		name:                "mgr2",
 		Process:             process2,
-		clusterAwareOptions: clusterOpts,
+		clusterAwareOptions: options,
 		terminator:          base.NewSafeTerminator(),
 	}
 
@@ -1433,49 +1542,26 @@ func TestBackgroundManagerMultiNodePollingAvoidsOverwrite(t *testing.T) {
 	require.NoError(t, mgr2.Start(ctx, nil))
 	defer func() { _ = mgr2.Stop(ctx) }()
 
-	RequireBackgroundManagerState(t, mgr1, BackgroundProcessStateRunning)
-	RequireBackgroundManagerState(t, mgr2, BackgroundProcessStateRunning)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, BackgroundProcessStateRunning, mgr1.GetRunState())
+		assert.Equal(c, BackgroundProcessStateRunning, mgr2.GetRunState())
+	}, 5*time.Second, 100*time.Millisecond)
 
-	// Simulate mgr1 completing successfully by manually writing a completed status to the cluster status document.
-	docID := clusterOpts.StatusDocID()
-	_, err := metadataStore.Update(ctx, docID, 0, func(current []byte) ([]byte, *uint32, bool, error) {
-		var output map[string]json.RawMessage
-		if current != nil {
-			_ = base.JSONUnmarshal(current, &output)
-		} else {
-			output = make(map[string]json.RawMessage)
-		}
+	// Only mgr1 receives Stop(); mgr2 only learns about it via status polling.
+	require.NoError(t, mgr1.Stop(ctx))
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, BackgroundProcessStateStopped, mgr1.GetRunState())
+		assert.Equal(c, BackgroundProcessStateStopped, mgr2.GetRunState())
+	}, 10*time.Second, 100*time.Millisecond)
 
-		status := BackgroundManagerStatus{
-			State:     BackgroundProcessStateCompleted,
-			StartTime: time.Now(),
-		}
-		statusBytes, err := base.JSONMarshal(status)
-		if err != nil {
-			return nil, nil, false, err
-		}
-		output["status"] = statusBytes
-		output["meta"] = json.RawMessage("null")
-
-		outputBytes, err := base.JSONMarshal(output)
-		if err != nil {
-			return nil, nil, false, err
-		}
-		return outputBytes, nil, false, nil
-	})
+	// RequireBackgroundManagerState reads the shared cluster doc via GetStatus, and with two
+	// managers able to write it, an Eventually-style wait could observe a transient correct value
+	// before it's overwritten and pass regardless. GetRunState has no such race, and once both
+	// managers are terminal their status pollers have stopped writing, so a single cluster read
+	// afterwards is stable.
+	clusterState, err := mgr1.getClusterStatusState(ctx)
 	require.NoError(t, err)
-
-	// Wait for mgr2's polling loop to detect the completed status and close its terminator.
-	require.Eventually(t, func() bool {
-		return mgr2.terminator.IsClosed()
-	}, 10*time.Second, 100*time.Millisecond, "expected mgr2 terminator to be closed after polling detects completed status")
-
-	// Verify that the status in the bucket remains completed and is not overwritten by mgr2.
-	rawStatus, err := mgr2.GetStatus(ctx)
-	require.NoError(t, err)
-	var status BackgroundManagerStatus
-	require.NoError(t, base.JSONUnmarshal(rawStatus, &status))
-	assert.Equal(t, BackgroundProcessStateCompleted, status.State, "expected the bucket status to remain completed and NOT be overwritten")
+	assert.Equal(t, BackgroundProcessStateStopped, clusterState)
 }
 
 // TestBackgroundManagerStartReturnsErrorWhileProcessKeepsRunning reproduces the case where Init succeeds and
@@ -1537,4 +1623,94 @@ func TestBackgroundManagerStartReturnsErrorWhileProcessKeepsRunning(t *testing.T
 		assert.Equal(c, BackgroundProcessStateRunning, mgr.GetRunState())
 	}, 5*time.Second, 100*time.Millisecond)
 	require.NoError(t, mgr.Stop(ctx))
+}
+
+// TestBackgroundManagerConcurrentStopStartRace stress-tests starting, stopping, and updating status
+// concurrently across multiple goroutines to verify there are no deadlocks, panics, or race conditions.
+func TestBackgroundManagerConcurrentStopStartRace(t *testing.T) {
+	testBucket := base.GetTestBucket(t)
+	ctx := base.TestCtx(t)
+	defer testBucket.Close(ctx)
+
+	metadataStore := testBucket.DefaultDataStore(ctx)
+	metaKeys := base.NewMetadataKeys("test-stop-start-race")
+
+	clusterOpts := &ClusterAwareBackgroundManagerOptions{
+		metadataStore: metadataStore,
+		metaKeys:      metaKeys,
+		processSuffix: "stop-start-race",
+		multiNode:     true,
+	}
+
+	process := &MockProcess{}
+	mgr := &BackgroundManager[map[string]any]{
+		name:                "race-mgr",
+		Process:             process,
+		clusterAwareOptions: clusterOpts,
+		terminator:          base.NewSafeTerminator(),
+	}
+
+	// Depending on how the goroutines below interleave, the manager can be left running or mid-stop when
+	// they finish, which would leave its goroutines using the bucket after it has been closed. Registered
+	// after the testBucket.Close defer above, so it runs before the bucket is closed.
+	defer func() {
+		terminalStates := []BackgroundProcessState{BackgroundProcessStateStopped, BackgroundProcessStateCompleted, BackgroundProcessStateError}
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			// Stop is a no-op if the process is already stopped or stopping.
+			assert.NoError(c, mgr.Stop(ctx))
+			assert.Contains(c, terminalStates, mgr.GetRunState())
+			// Also wait for the persisted status, which the process goroutine writes after transitioning
+			// to a terminal state, to ensure it is done with the bucket.
+			rawStatus, err := mgr.GetStatus(ctx)
+			if !assert.NoError(c, err) {
+				return
+			}
+			var status BackgroundManagerStatus
+			if !assert.NoError(c, base.JSONUnmarshal(rawStatus, &status)) {
+				return
+			}
+			assert.Contains(c, terminalStates, status.State, "BackgroundManager did not reach a terminal state: %s", string(rawStatus))
+		}, sgtest.GetBackgroundManagerStatusTransitionTimeout(t), 10*time.Millisecond)
+	}()
+
+	numGoroutines := 10
+	iterations := 20
+
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines * 3)
+
+	// Worker group 1: Concurrently start
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				_ = mgr.Start(ctx, map[string]any{})
+				time.Sleep(1 * time.Millisecond)
+			}
+		}()
+	}
+
+	// Worker group 2: Concurrently stop
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				_ = mgr.Stop(ctx)
+				time.Sleep(1 * time.Millisecond)
+			}
+		}()
+	}
+
+	// Worker group 3: Concurrently update status
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				_ = mgr.UpdateStatusClusterAware(ctx)
+				time.Sleep(1 * time.Millisecond)
+			}
+		}()
+	}
+
+	wg.Wait()
 }


### PR DESCRIPTION
CBG-5594

Unclean cherry pick of #8468 (CBG-5521) to 4.1.2

Stacked on #8631 (CBG-5743), which sits on #8660 (CBG-5752) and #8635 (CBG-5744).

Changes from main commit:
- `db/background_mgr_test.go` — upstream's new tests are typed against `MockProcessOptions`, added by CBG-5653 (#8490) which is not on 4.1.2. Applied against `BackgroundManager[map[string]any]` in six places, matching the rest of the file on this branch; no assertions changed. `db/background_mgr.go` is identical to upstream.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/1105/ (fails in TestDatabaseInitDefaultCollectionForMetadataStoreMode, unrelated to this PR)

🤖 Opened with the `sync-gateway-backport` skill in [Claude Code](https://claude.com/claude-code)
