### PR TITLE
Record assertion messages in devmode so we can print them from a failing TestMain

### DIFF
--- a/base/devmode.go
+++ b/base/devmode.go
@@ -10,11 +10,41 @@ package base
 
 import (
 	"context"
+	"fmt"
+	"slices"
+	"sync"
 )
 
 const (
 	AssertionFailedPrefix = "Assertion failed: "
 )
+
+// assertionFailures collects assertion failure messages in dev mode, so the test harness can report them in detail at the end of a run.
+var assertionFailures = struct {
+	lock sync.Mutex
+	msgs []string
+}{}
+
+// recordAssertionFailure stores an assertion failure message. Safe for concurrent use.
+func recordAssertionFailure(msg string) {
+	assertionFailures.lock.Lock()
+	defer assertionFailures.lock.Unlock()
+	assertionFailures.msgs = append(assertionFailures.msgs, msg)
+}
+
+// AssertionFailures returns a copy of the assertion failure messages recorded so far. Always empty unless compiled with the `cb_sg_devmode` build tag.
+func AssertionFailures() []string {
+	assertionFailures.lock.Lock()
+	defer assertionFailures.lock.Unlock()
+	return slices.Clone(assertionFailures.msgs)
+}
+
+// ClearAssertionFailures discards the recorded assertion failures, for tests that trigger assertions deliberately.
+func ClearAssertionFailures() {
+	assertionFailures.lock.Lock()
+	defer assertionFailures.lock.Unlock()
+	assertionFailures.msgs = nil
+}
 
 // IsDevMode returns true when compiled with the `cb_sg_devmode` build tag
 func IsDevMode() bool {
@@ -22,11 +52,14 @@ func IsDevMode() bool {
 }
 
 // AssertfCtx logs an error message and continues execution, or when compiled with the `cb_sg_devmode` build tag panics for better dev-time visibility.
-// The SG test harness will ensure AssertionFailCount is zero at the end of tests, even without devmode enabled.
+// In dev mode the message is also recorded, and the SG test harness fails the run if any assertion failures were recorded.
 // Note: Callers MUST ensure code is safe to continue executing after the Assert (e.g. by returning an error) and MUST NOT be used like a panic that will halt.
 func AssertfCtx(ctx context.Context, format string, args ...any) {
 
 	SyncGatewayStats.GlobalStats.ResourceUtilization.AssertionFailCount.Add(1)
+	if IsDevMode() {
+		recordAssertionFailure(fmt.Sprintf(AssertionFailedPrefix+format, args...))
+	}
 	assertLogFn(ctx, AssertionFailedPrefix+format, args...)
 }
 

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -945,8 +945,8 @@ func TestBucketPoolMain(ctx context.Context, m *testing.M, bucketReadierFunc TBP
 	teardownFuncs = append(teardownFuncs, func() { GTestBucketPool.Close(ctx) })
 
 	teardownFuncs = append(teardownFuncs, func() {
-		if numAssertionFails := SyncGatewayStats.GlobalStats.ResourceUtilizationStats().AssertionFailCount.Value(); numAssertionFails > 0 {
-			panic(fmt.Sprintf("Test harness failed due to %d assertion failures. Search logs for %q", numAssertionFails, AssertionFailedPrefix))
+		if failures := AssertionFailures(); len(failures) > 0 {
+			panic(fmt.Sprintf("Test harness failed due to %d assertion failures:\n%s", len(failures), strings.Join(failures, "\n")))
 		}
 	})
 	// must be the last teardown function added to the list to correctly detect leaked goroutines

--- a/rest/handler_test.go
+++ b/rest/handler_test.go
@@ -167,11 +167,13 @@ func TestShouldCheckAdminRBAC(t *testing.T) {
 
 			for _, sgcollectable := range []bool{true, false} {
 				t.Run(fmt.Sprintf("sgcollectable=%t", sgcollectable), func(t *testing.T) {
-					// make sure assertion counts are correct
-					require.Equal(t, int64(0), base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().AssertionFailCount.Value())
-					defer func() {
-						base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().AssertionFailCount.Set(0)
-					}()
+					// subtest triggers assertions on purpose, so make sure we're starting clean and don't leave them for the test harness afterwards either
+					if len(base.AssertionFailures()) > 0 {
+						t.Skip("Skipping test - we have other assertion failures present and we can't reliably run this test this without losing those")
+					}
+					require.Empty(t, base.AssertionFailures())
+					defer base.ClearAssertionFailures()
+
 					adminHandler := newHandler(sc, adminPrivs, adminServer, httptest.NewRecorder(), &http.Request{}, handlerOptions{sgcollect: sgcollectable})
 					metricsHandler := newHandler(sc, metricsPrivs, metricsServer, httptest.NewRecorder(), &http.Request{}, handlerOptions{sgcollect: sgcollectable})
 					if requireInterfaceAuth {


### PR DESCRIPTION
Record assertion messages in `devmode` so we can print them from a failing `TestMain`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/1082/

<!--
Automated review runs on every non-draft PR raised from this repo (forks are not reviewed automatically).
  - Re-run it, or ask a follow-up, by commenting `@droid <question>`
  - Suppress it with the `droid-skip` label, or `WIP`/`DO NOT MERGE` in the title
-->
