### PR TITLE
Improve gotestsum output for assertion failures

### DIFF
--- a/base/devmode.go
+++ b/base/devmode.go
@@ -19,31 +19,52 @@ const (
 	AssertionFailedPrefix = "Assertion failed: "
 )
 
-// assertionFailures collects assertion failure messages in dev mode, so the test harness can report them in detail at the end of a run.
-var assertionFailures = struct {
-	lock sync.Mutex
-	msgs []string
-}{}
-
-// recordAssertionFailure stores an assertion failure message. Safe for concurrent use.
-func recordAssertionFailure(msg string) {
-	assertionFailures.lock.Lock()
-	defer assertionFailures.lock.Unlock()
-	assertionFailures.msgs = append(assertionFailures.msgs, msg)
+// assertionFailure is a single recorded assertion failure, and the name of the test that was running when it happened, when known.
+type assertionFailure struct {
+	testName string
+	msg      string
 }
 
-// AssertionFailures returns a copy of the assertion failure messages recorded so far. Always empty unless compiled with the `cb_sg_devmode` build tag.
-func AssertionFailures() []string {
+// assertionFailures collects assertion failures in dev mode, so the test harness can report them in detail at the end of a run.
+var assertionFailures = struct {
+	lock     sync.Mutex
+	failures []assertionFailure
+}{}
+
+// recordAssertionFailure stores an assertion failure message, along with the name of the test in ctx, if there is one. Safe for concurrent use.
+func recordAssertionFailure(ctx context.Context, msg string) {
+	failure := assertionFailure{testName: getLogCtx(ctx).TestName, msg: msg}
 	assertionFailures.lock.Lock()
 	defer assertionFailures.lock.Unlock()
-	return slices.Clone(assertionFailures.msgs)
+	assertionFailures.failures = append(assertionFailures.failures, failure)
+}
+
+// getAssertionFailures returns a copy of the assertion failures recorded so far.
+func getAssertionFailures() []assertionFailure {
+	assertionFailures.lock.Lock()
+	defer assertionFailures.lock.Unlock()
+	return slices.Clone(assertionFailures.failures)
+}
+
+// AssertionFailures returns the assertion failure messages recorded so far, prefixed with the test that recorded them where known. Always empty unless compiled with the `cb_sg_devmode` build tag.
+func AssertionFailures() []string {
+	failures := getAssertionFailures()
+	msgs := make([]string, 0, len(failures))
+	for _, failure := range failures {
+		if failure.testName == "" {
+			msgs = append(msgs, failure.msg)
+			continue
+		}
+		msgs = append(msgs, failure.testName+": "+failure.msg)
+	}
+	return msgs
 }
 
 // ClearAssertionFailures discards the recorded assertion failures, for tests that trigger assertions deliberately.
 func ClearAssertionFailures() {
 	assertionFailures.lock.Lock()
 	defer assertionFailures.lock.Unlock()
-	assertionFailures.msgs = nil
+	assertionFailures.failures = nil
 }
 
 // IsDevMode returns true when compiled with the `cb_sg_devmode` build tag
@@ -58,7 +79,7 @@ func AssertfCtx(ctx context.Context, format string, args ...any) {
 
 	SyncGatewayStats.GlobalStats.ResourceUtilization.AssertionFailCount.Add(1)
 	if IsDevMode() {
-		recordAssertionFailure(fmt.Sprintf(AssertionFailedPrefix+format, args...))
+		recordAssertionFailure(ctx, fmt.Sprintf(AssertionFailedPrefix+format, args...))
 	}
 	assertLogFn(ctx, AssertionFailedPrefix+format, args...)
 }

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -12,10 +12,13 @@ package base
 
 import (
 	"context"
+	"flag"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/url"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -944,10 +947,9 @@ func TestBucketPoolMain(ctx context.Context, m *testing.M, bucketReadierFunc TBP
 	GTestBucketPool = NewTestBucketPoolWithOptions(ctx, bucketReadierFunc, bucketInitFunc, options)
 	teardownFuncs = append(teardownFuncs, func() { GTestBucketPool.Close(ctx) })
 
+	hadAssertionFailures := false
 	teardownFuncs = append(teardownFuncs, func() {
-		if failures := AssertionFailures(); len(failures) > 0 {
-			panic(fmt.Sprintf("Test harness failed due to %d assertion failures:\n%s", len(failures), strings.Join(failures, "\n")))
-		}
+		hadAssertionFailures = reportAssertionFailures()
 	})
 	// must be the last teardown function added to the list to correctly detect leaked goroutines
 	if dumpGoroutines {
@@ -964,7 +966,76 @@ func TestBucketPoolMain(ctx context.Context, m *testing.M, bucketReadierFunc TBP
 		fn()
 	}
 
+	if hadAssertionFailures && status == 0 {
+		status = 1
+	}
+
 	os.Exit(status)
+}
+
+// reportAssertionFailures writes any assertion failures recorded during the test run to stdout, and returns true if there were any.
+//
+// Each test that recorded a failure is reported as a synthetic failing test, rather than as plain output from TestMain, so that
+// the messages are attributed to a named test in `go test -json` output. Without this, gotestsum output formats that only print
+// output for failing tests (as CI uses) show that the package failed without ever showing why.
+func reportAssertionFailures() bool {
+	failures := getAssertionFailures()
+	if len(failures) == 0 {
+		return false
+	}
+
+	// Group by the reported (sanitized) name rather than the raw test name, so that test names that sanitize to the same
+	// thing are reported as a single synthetic test instead of two blocks sharing a name.
+	msgsByTest := make(map[string][]string, len(failures))
+	for _, failure := range failures {
+		name := assertionFailureTestName(failure.testName)
+		msgsByTest[name] = append(msgsByTest[name], failure.msg)
+	}
+	for _, testName := range slices.Sorted(maps.Keys(msgsByTest)) {
+		emitSyntheticTestFailure(testName, msgsByTest[testName])
+	}
+	return true
+}
+
+// assertionFailureTestName returns the name to report assertion failures from the given test under. The test that recorded the
+// failure has already finished (and may well have passed), so the failures are reported under a distinct synthetic name.
+func assertionFailureTestName(testName string) string {
+	name := "TestAssertionFailures"
+	if testName == "" {
+		return name
+	}
+	// test2json treats a `/` as a subtest separator, and gotestsum can't handle a subtest of a test it never saw run.
+	return name + "_" + strings.Map(func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			return r
+		}
+		return '_'
+	}, testName)
+}
+
+// emitSyntheticTestFailure writes `go test` framing for a failing test that was never actually run, to attach msgs to a named
+// test in the test output. When the test binary is being run by `go test -json`, framing lines have to be prefixed with a
+// marker byte to distinguish them from ordinary test output (see cmd/internal/test2json).
+func emitSyntheticTestFailure(testName string, msgs []string) {
+	marker := ""
+	if runningUnderTest2JSON() {
+		marker = "\x16"
+	}
+	// Build the whole block up front and write it once: leaked goroutines may still be logging to stdout during teardown,
+	// and a partial write landing mid-line would leave a marker off the start of a line, losing the test attribution.
+	var buf strings.Builder
+	fmt.Fprintf(&buf, "%s=== RUN   %s\n", marker, testName)
+	for _, msg := range msgs {
+		fmt.Fprintf(&buf, "    %s\n", msg)
+	}
+	fmt.Fprintf(&buf, "%s--- FAIL: %s (0.00s)\n", marker, testName)
+	_, _ = os.Stdout.WriteString(buf.String())
+}
+
+// runningUnderTest2JSON returns true if this test binary's output is being converted into JSON events by `go test -json`.
+func runningUnderTest2JSON() bool {
+	f := flag.Lookup("test.v")
+	return f != nil && f.Value.String() == "test2json"
 }
 
 // TestBucketPoolNoIndexes runs a TestMain for packages that do not require creation of indexes

--- a/jenkins-integration-build.sh
+++ b/jenkins-integration-build.sh
@@ -147,7 +147,7 @@ else
 fi
 
 set +e -x # Output all executed shell commands
-gotestsum --junitfile=integration.xml --junitfile-project-name integration --junitfile-testcase-classname relative --format standard-verbose -- "${GO_TEST_FLAGS[@]}" -coverprofile=coverage_int.out -coverpkg=github.com/couchbase/sync_gateway/... "github.com/couchbase/sync_gateway/${TARGET_PACKAGE}" 2>&1 | stdbuf -oL tee "${INT_LOG_FILE_NAME}.out" | stdbuf -oL grep -a -E '(--- (FAIL|PASS|SKIP):|github.com/couchbase/sync_gateway(/.+)?\t|TEST: |panic: )'
+gotestsum --junitfile=integration.xml --junitfile-project-name integration --junitfile-testcase-classname relative --format standard-verbose -- "${GO_TEST_FLAGS[@]}" -coverprofile=coverage_int.out -coverpkg=github.com/couchbase/sync_gateway/... "github.com/couchbase/sync_gateway/${TARGET_PACKAGE}" 2>&1 | stdbuf -oL tee "${INT_LOG_FILE_NAME}.out" | stdbuf -oL grep -a -E '(--- (FAIL|PASS|SKIP):|github.com/couchbase/sync_gateway(/.+)?\t|TEST: |panic: |Assertion failed: )'
 if [ "${PIPESTATUS[0]}" -ne "0" ]; then # If test exit code is not 0 (failed)
     echo "Go test failed! Parsing logs to find cause..."
     TEST_FAILED=true


### PR DESCRIPTION
The harness panic from TestMain is package-level output, which the CI gotestsum format (pkgname-and-test-fails, --hide-summary=output) never prints - so a run failed with no visible reason.

Tag each recorded assertion failure with the test from its ctx, and report them as synthetic failing tests so the messages are attributed to a test name in `go test -json` output. Also match the messages in the Jenkins integration log filter.

Example, like an:

```
// TestDemoAssertionSwallowedByRecover mimics the real-world case: SG code hits an // AssertfCtx, devmode panics, and something up the stack recovers - so the test // itself passes and nothing points at the assertion. func TestDemoAssertionSwallowedByRecover(t *testing.T) {
	t.Run("import feed", func(t *testing.T) {
		ctx := TestCtx(t)
		func() {
			defer func() { _ = recover() }() // pretend: HTTP handler / DCP worker recovery
			AssertfCtx(ctx, "VBucketCAS: No CAS found for vbucket %d", 512)
		}()
	})
}

// TestDemoAssertionWithNoTestInCtx covers an assertion from a background task whose // ctx never descended from TestCtx, so there is no test name to attribute it to. func TestDemoAssertionWithNoTestInCtx(t *testing.T) {
	func() {
		defer func() { _ = recover() }()
		AssertfCtx(context.Background(), "failed to marshal audit fields: %v", "unsupported type")
	}()
}
```

Output now shows `Assertion failed` in this output, which is the github actions output:

```
gotestsum --format pkgname-and-test-fails --hide-summary=skipped --hide-summary=output --jsonfile test.json -- -tags cb_sg_devmode -shuffle=on -timeout=30m -count=1 "./base/" -run TestDemo
=== RUN   TestAssertionFailures
    Assertion failed: failed to marshal audit fields: unsupported type
--- FAIL: TestAssertionFailures (0.00s)
=== RUN   TestAssertionFailures_TestDemoAssertionSwallowedByRecover_import_feed
    Assertion failed: VBucketCAS: No CAS found for vbucket 512
--- FAIL: TestAssertionFailures_TestDemoAssertionSwallowedByRecover_import_feed (0.00s)
✖  base (9ms) (-test.shuffle 1787252037115337340)
```
