### PR TITLE
CBG-5746: reject requests once the server context is closing

### DIFF
--- a/rest/handler.go
+++ b/rest/handler.go
@@ -223,7 +223,9 @@ func newHandler(server *ServerContext, privs handlerPrivs, serverType serverType
 func (h *handler) ctx() context.Context {
 	if h.rqCtx == nil {
 		serverAddr, err := h.getServerAddr()
-		if err != nil {
+		// the http server can be removed while a request is in flight if the server context is
+		// closing, so only assert if the server context is still running
+		if err != nil && h.server.serverCtx.Err() == nil {
 			base.AssertfCtx(h.rq.Context(), "Error getting server address: %v", err)
 		}
 		ctx := base.RequestLogCtx(h.rq.Context(), base.RequestData{

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -449,6 +449,13 @@ func createDiagnosticRouter(sc *ServerContext) *mux.Router {
 // for URLs that don't match a route.
 func wrapRouter(sc *ServerContext, privs handlerPrivs, serverType serverType, router *mux.Router) http.Handler {
 	return http.HandlerFunc(func(response http.ResponseWriter, rq *http.Request) {
+		// Reject requests once shutdown has started. Shutdown only happens in tests
+		if sc.serverCtx.Err() != nil {
+			response.Header().Set("Content-Type", "application/json")
+			response.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = response.Write([]byte(`{"error":"Service Unavailable","reason":"Sync Gateway is shutting down"}`))
+			return
+		}
 		FixQuotedSlashes(rq)
 		var match mux.RouteMatch
 		if router.Match(rq, &match) {


### PR DESCRIPTION
CBG-5746: reject requests once the server context is closing

ServerContext.Close stops the HTTP servers before tearing down databases, but listeners it does not own (test HTTP servers) keep delivering requests.

To avoid a panic, have wrapRouter now returns a 503 once serverCtx is cancelled.

This fixes an
intermittent rest/replicatortest package failure like: `Error getting server address: server type "public" not found running in server context`. This is typically, but not always, in ISGR tests.

The ordering that lets this happen, and a repro:

```
	rt := NewRestTester(t, nil)
	srv := httptest.NewServer(rt.TestPublicHandler())
	// closed after rt.Close, as userDBURL's t.Cleanup(srv.Close) is
	defer srv.Close()

	rt.Close()

	// before: "server type \"public\" not found running in server
	// context" assertion, connection closed, client sees EOF
	// after:  503 Service Unavailable
	resp, err := srv.Client().Get(srv.URL + "/db/")
```

This occurs when node1 -> node2 ISGR connection.
1. node2 RestTester.Close
2. node1 goes into reconnect loop
3. node2 is in a state of partial shutdown where it could be handling request

It is possible that we could or should reorder the tests, but this panic almost always occurs in teardown and I don't think we should have to worry about exact ordering. This would be the style of idioms to change and it's not totally obvious to me how to fix this https://github.com/couchbase/sync_gateway/blob/fdc23320ca4c49222d5daaa06c5d6db2fdd557c6/rest/utilities_testing_isgr.go#L242-L244

