### PR TITLE
CBG-5749: allow tests against go 1.27

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
       - name: golangci-lint
         uses: *actions_golangci_lint_version
         with:
-          version: v2.12.2
+          version: v2.13.1
           args: --config=.golangci-strict.yml
 
   test:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
         # Cache per checkout: a shared cache serves results from other clones of this module,
         # which report findings against that clone's file paths.
         entry: sh -c 'export GOLANGCI_LINT_CACHE="$(git rev-parse --absolute-git-dir)/golangci-lint-cache";
-               exec go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
+               exec go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.13.1
                run --config=.golangci-strict.yml --fix=false'
         types: [go]
         pass_filenames: false

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -48,14 +48,14 @@ func TestReadServerConfig(t *testing.T) {
 	tests := []struct {
 		name        string
 		config      string
-		errStdlib   string
-		errJSONIter string
+		errStdlib   []string
+		errJSONIter []string
 	}{
 		{
 			name:        "nil",
 			config:      ``,
-			errStdlib:   "EOF",
-			errJSONIter: "EOF",
+			errStdlib:   []string{"EOF"},
+			errJSONIter: []string{"EOF"},
 		},
 		{
 			name:   "valid empty",
@@ -68,20 +68,25 @@ func TestReadServerConfig(t *testing.T) {
 		{
 			name:        "unknown field",
 			config:      `{"invalid": true}`,
-			errStdlib:   `json: unknown field "invalid": unrecognized JSON field`,
-			errJSONIter: `found unknown field: invalid`,
+			errStdlib:   []string{`json: unknown field "invalid": unrecognized JSON field`},
+			errJSONIter: []string{`found unknown field: invalid`},
 		},
 		{
-			name:        "incorrect type",
-			config:      `{"logging": true}`,
-			errStdlib:   `json: cannot unmarshal bool into Go struct field LegacyServerConfig.Logging of type base.LegacyLoggingConfig`,
-			errJSONIter: `expect { or n, but found t`,
+			name:   "incorrect type",
+			config: `{"logging": true}`,
+			errStdlib: []string{
+				// go < 1.27
+				`json: cannot unmarshal bool into Go struct field LegacyServerConfig.Logging of type base.LegacyLoggingConfig`,
+				// go >= 1.27
+				`json: cannot unmarshal bool into Go struct field .logging of type base.LegacyLoggingConfig`,
+			},
+			errJSONIter: []string{`expect { or n, but found t`},
 		},
 		{
 			name:        "invalid JSON",
 			config:      `{true}`,
-			errStdlib:   `invalid character 't' looking for beginning of object key string`,
-			errJSONIter: `expects " or n, but found t`,
+			errStdlib:   []string{`invalid character 't' looking for beginning of object key string`},
+			errJSONIter: []string{`expects " or n, but found t`},
 		},
 		{
 			name:   "sync fn backquotes",
@@ -95,19 +100,28 @@ func TestReadServerConfig(t *testing.T) {
 			_, err := readLegacyServerConfig(base.TestCtx(t), buf)
 
 			// stdlib/CE specific error checking
-			expectedErr := test.errStdlib
+			expectedErrs := test.errStdlib
 			if !base.UseStdlibJSON && base.IsEnterpriseEdition() {
 				// jsoniter specific error checking
-				expectedErr = test.errJSONIter
+				expectedErrs = test.errJSONIter
 			}
 
 			// If we expected no error, make sure we didn't get one
-			if expectedErr == "" {
+			if len(expectedErrs) == 0 {
 				require.NoError(tt, err, "unexpected error for test config")
 			} else {
-				// Otherwise - check the error we got matches what we expected
-				require.NotNil(tt, err)
-				assert.Contains(tt, err.Error(), expectedErr)
+				// Otherwise - check the error we got matches one of the messages we expected
+				require.Error(tt, err)
+				// reduce the error to the expected message it contains (jsoniter appends context to its errors), so a
+				// mismatch reports the full set of expected errors
+				actualErr := err.Error()
+				for _, expectedErr := range expectedErrs {
+					if strings.Contains(actualErr, expectedErr) {
+						actualErr = expectedErr
+						break
+					}
+				}
+				require.Contains(tt, expectedErrs, actualErr)
 			}
 		})
 	}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -2023,24 +2023,21 @@ func (sc *ServerContext) initializeNoX509HttpClient(ctx context.Context) (*http.
 	httpTransport := &http.Transport{
 		ForceAttemptHTTP2: true,
 
-		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-			return httpDialer.DialContext(ctx, network, addr)
-		},
+		DialContext: httpDialer.DialContext,
 		DialTLSContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-			tcpConn, err := httpDialer.DialContext(ctx, network, addr)
-			if err != nil {
-				return nil, err
-			}
-
-			// Update tlsConfig.ServerName based on addr
-			tlsConfig := baseTlsConfig.Clone()
+			// Update tlsConfig.ServerName based on addr, before dialing, to avoid leaking the connection on error
 			host, _, err := net.SplitHostPort(addr)
 			if err != nil {
 				return nil, err
 			}
+			tlsConfig := baseTlsConfig.Clone()
 			tlsConfig.ServerName = host
-			tlsConn := tls.Client(tcpConn, tlsConfig)
-			return tlsConn, nil
+
+			tcpConn, err := httpDialer.DialContext(ctx, network, addr)
+			if err != nil {
+				return nil, err
+			}
+			return tls.Client(tcpConn, tlsConfig), nil
 		},
 		MaxIdleConns:        base.DefaultHttpMaxIdleConns,
 		MaxIdleConnsPerHost: base.DefaultHttpMaxIdleConnsPerHost,

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -2023,11 +2023,11 @@ func (sc *ServerContext) initializeNoX509HttpClient(ctx context.Context) (*http.
 	httpTransport := &http.Transport{
 		ForceAttemptHTTP2: true,
 
-		Dial: func(network, addr string) (net.Conn, error) {
-			return httpDialer.Dial(network, addr)
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return httpDialer.DialContext(ctx, network, addr)
 		},
-		DialTLS: func(network, addr string) (net.Conn, error) {
-			tcpConn, err := httpDialer.Dial(network, addr)
+		DialTLSContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			tcpConn, err := httpDialer.DialContext(ctx, network, addr)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
CBG-5749: allow tests against go 1.27

- TestReadServerConfig asserts on an exact string from encoding/json which changes with go 1.27

Linting:

- test with golangci-lint v2.13.1
  - Replace deprecated http.Transport Dial/DialTLS with DialContext/ DialTLSContext in initializeNoX509HttpClient.

I'm not planning to do an update yet, but I don't want anyone else to investigate these issues.