### PR TITLE
Fix GSI test failures from close-signalled channel waits

### DIFF
--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -1080,47 +1080,52 @@ const (
 )
 
 // RequireChanSend performs a blocking send on a channel with a TestChanTimeout timeout. Fails the test if the send cannot complete in time.
-func RequireChanSend[T any](t testing.TB, ch chan<- T, val T) {
+// msgAndArgs is an optional Printf-style description of what is being waited on, included in the failure message.
+func RequireChanSend[T any](t testing.TB, ch chan<- T, val T, msgAndArgs ...any) {
 	t.Helper()
-	RequireChanSendWithTimeout(t, ch, val, TestChanTimeout)
+	RequireChanSendWithTimeout(t, ch, val, TestChanTimeout, msgAndArgs...)
 }
 
 // RequireChanSendWithTimeout performs a blocking send on a channel with a timeout. Fails the test if the send cannot complete in time.
-func RequireChanSendWithTimeout[T any](t testing.TB, ch chan<- T, val T, timeout time.Duration) {
+func RequireChanSendWithTimeout[T any](t testing.TB, ch chan<- T, val T, timeout time.Duration, msgAndArgs ...any) {
 	t.Helper()
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
 	select {
 	case ch <- val:
 	case <-timer.C:
-		require.FailNow(t, fmt.Sprintf("timed out after %v waiting for channel send", timeout))
+		require.FailNow(t, fmt.Sprintf("timed out after %v waiting for channel send", timeout), msgAndArgs...)
 	}
 }
 
-// RequireChanRecv reads from a channel with a TestChanTimeout timeout. Fails the test if no value arrives in time.
-func RequireChanRecv[T any](t testing.TB, ch <-chan T) T {
+// RequireChanRecv reads from a channel with a TestChanTimeout timeout. Fails the test if no value arrives in time,
+// or if the channel is closed without a value being sent - use RequireChanClosed for channels that signal by closing.
+// msgAndArgs is an optional Printf-style description of what is being waited on, included in the failure message.
+func RequireChanRecv[T any](t testing.TB, ch <-chan T, msgAndArgs ...any) T {
 	t.Helper()
-	return RequireChanRecvWithTimeout(t, ch, TestChanTimeout)
+	return RequireChanRecvWithTimeout(t, ch, TestChanTimeout, msgAndArgs...)
 }
 
 // RequireChanRecvWithTimeout reads from a channel with a timeout. Fails the test if no value arrives in time.
-func RequireChanRecvWithTimeout[T any](t testing.TB, ch <-chan T, timeout time.Duration) T {
+func RequireChanRecvWithTimeout[T any](t testing.TB, ch <-chan T, timeout time.Duration, msgAndArgs ...any) T {
 	t.Helper()
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
 	select {
 	case val, ok := <-ch:
-		require.True(t, ok, "channel closed without sending a value")
+		if !ok {
+			require.FailNow(t, "channel closed without sending a value", msgAndArgs...)
+		}
 		return val
 	case <-timer.C:
-		require.FailNow(t, fmt.Sprintf("timed out after %v waiting for channel read", timeout))
+		require.FailNow(t, fmt.Sprintf("timed out after %v waiting for channel read", timeout), msgAndArgs...)
 		return *new(T) // unreachable
 	}
 }
 
 // RequireChanClosedWithTimeout waits for channel to be closed. Will drain the channel if required.
 // Fails the test if the channel is not closed in time.
-func RequireChanClosedWithTimeout[T any](t testing.TB, ch <-chan T, timeout time.Duration) {
+func RequireChanClosedWithTimeout[T any](t testing.TB, ch <-chan T, timeout time.Duration, msgAndArgs ...any) {
 	t.Helper()
 	for {
 		select {
@@ -1131,16 +1136,17 @@ func RequireChanClosedWithTimeout[T any](t testing.TB, ch <-chan T, timeout time
 			}
 			return
 		case <-time.After(timeout):
-			require.FailNow(t, fmt.Sprintf("timed out after %v waiting for channel send", timeout))
+			require.FailNow(t, fmt.Sprintf("timed out after %v waiting for channel close", timeout), msgAndArgs...)
 		}
 	}
 }
 
 // RequireChanClosed waits for channel to be closed. Will drain the channel if required.
 // Fails the test if the channel is not closed in TestChanTimeout.
-func RequireChanClosed[T any](t testing.TB, ch <-chan T) {
+// msgAndArgs is an optional Printf-style description of what is being waited on, included in the failure message.
+func RequireChanClosed[T any](t testing.TB, ch <-chan T, msgAndArgs ...any) {
 	t.Helper()
-	RequireChanClosedWithTimeout(t, ch, TestChanTimeout)
+	RequireChanClosedWithTimeout(t, ch, TestChanTimeout, msgAndArgs...)
 }
 
 // RequireDocsVisibleToRangeScan blocks until every docID is returned by a KV range scan of

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -1141,6 +1141,27 @@ func RequireChanClosedWithTimeout[T any](t testing.TB, ch <-chan T, timeout time
 	}
 }
 
+// RequireNoErrorOnChanCloseWithTimeout waits for an error channel to be closed, failing the test if a non-nil
+// error is sent before the close, or if the channel isn't closed within the timeout.  Use this for channels that
+// report success by closing without a send, and failure by sending an error before closing.
+// msgAndArgs is an optional Printf-style description of what is being waited on, included in the failure message.
+func RequireNoErrorOnChanCloseWithTimeout(t testing.TB, ch <-chan error, timeout time.Duration, msgAndArgs ...any) {
+	t.Helper()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	for {
+		select {
+		case err, ok := <-ch:
+			if !ok {
+				return
+			}
+			require.NoError(t, err, msgAndArgs...)
+		case <-timer.C:
+			require.FailNow(t, fmt.Sprintf("timed out after %v waiting for channel close", timeout), msgAndArgs...)
+		}
+	}
+}
+
 // RequireChanClosed waits for channel to be closed. Will drain the channel if required.
 // Fails the test if the channel is not closed in TestChanTimeout.
 // msgAndArgs is an optional Printf-style description of what is being waited on, included in the failure message.

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -1205,7 +1205,7 @@ func TestMultipleBucketWithBadDbConfigScenario1(t *testing.T) {
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		databaseNames := rt3.ServerContext().AllDatabaseNames()
 		assert.Empty(c, databaseNames)
-	}, 10*time.Second, 100*time.Millisecond)
+	}, rest.ConfigPollingWaitTimeout, 100*time.Millisecond)
 
 	// assert a request to the db fails with correct error message
 	resp := rt3.SendAdminRequest(http.MethodGet, "/db1/_config", "")
@@ -1273,7 +1273,7 @@ func TestMultipleBucketWithBadDbConfigScenario2(t *testing.T) {
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		validDatabase := rt3.ServerContext().AllDatabases()
 		assert.Len(c, validDatabase, 1)
-	}, 10*time.Second, 100*time.Millisecond)
+	}, rest.ConfigPollingWaitTimeout, 100*time.Millisecond)
 }
 
 // TestMultipleBucketWithBadDbConfigScenario3:
@@ -1401,7 +1401,7 @@ func TestConfigPollingRemoveDatabase(t *testing.T) {
 			require.EventuallyWithT(t, func(c *assert.CollectT) {
 				_, err := rt.ServerContext().GetActiveDatabase(dbName)
 				assert.ErrorIs(c, err, base.ErrNotFound)
-			}, 10*time.Second, 100*time.Millisecond)
+			}, rest.ConfigPollingWaitTimeout, 100*time.Millisecond)
 
 			// assert that a request to the database fails with correct error message
 			resp = rt.SendAdminRequest(http.MethodGet, "/db1/_config", "")

--- a/rest/database_init_manager_test.go
+++ b/rest/database_init_manager_test.go
@@ -50,16 +50,12 @@ func TestDatabaseInitManager(t *testing.T) {
 	// Drop indexes
 	base.DropAllBucketIndexes(t, tb)
 
-	// Async index creation
+	// Async index creation.  The worker closes doneChan without sending on success, and only sends a value to
+	// report an error, so a successful init is a wait for close and a failed one is a wait for a send.
 	doneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true, false)
 	require.NoError(t, err)
 
-	select {
-	case err := <-doneChan:
-		require.NoError(t, err)
-	case <-time.After(30 * time.Second):
-		require.Fail(t, "InitializeDatabase didn't complete in 10s")
-	}
+	base.RequireChanClosedWithTimeout(t, doneChan, base.TestIndexInitTimeout, "initial init done chan")
 
 }
 
@@ -108,7 +104,7 @@ func TestDatabaseInitPostMigrationExcludesDefault(t *testing.T) {
 	// migrationComplete=true models a system-metadata database that has finished migrating off _default.
 	doneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true, true)
 	require.NoError(t, err)
-	require.NoError(t, base.RequireChanRecv(t, doneChan))
+	base.RequireChanClosedWithTimeout(t, doneChan, base.TestIndexInitTimeout, "post-migration init done chan")
 
 	seenLock.Lock()
 	defer seenLock.Unlock()
@@ -480,8 +476,8 @@ func TestDatabaseInitConfigChangeSameCollections(t *testing.T) {
 		log.Printf("Collection complete callback invoked for %s %s", dbName, scName)
 		currentCount := atomic.LoadInt64(&collectionCount)
 		if currentCount == 0 {
-			base.RequireChanSend(t, singleCollectionInitChannel, nil)      // notify the test that indexes have been created for this collection
-			require.NoError(t, base.RequireChanRecv(t, testSignalChannel)) // wait for the test to unblock before proceeding to the next collection
+			base.RequireChanSend(t, singleCollectionInitChannel, nil, "singleCollectionInit-%s", scName)                       // notify the test that indexes have been created for this collection
+			base.RequireChanClosedWithTimeout(t, testSignalChannel, base.TestIndexInitTimeout, "testSignalChannel-%s", scName) // wait for the test to unblock before proceeding to the next collection
 		}
 		atomic.AddInt64(&collectionCount, 1)
 	}
@@ -496,7 +492,7 @@ func TestDatabaseInitConfigChangeSameCollections(t *testing.T) {
 	require.NoError(t, err)
 
 	// Wait for first collection to be initialized
-	require.NoError(t, base.RequireChanRecv(t, singleCollectionInitChannel))
+	require.NoError(t, base.RequireChanRecv(t, singleCollectionInitChannel, "first collection init"))
 
 	// Make a duplicate call to initialize database, should reuse the existing agent
 	duplicateDoneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true, false)
@@ -506,8 +502,8 @@ func TestDatabaseInitConfigChangeSameCollections(t *testing.T) {
 	close(testSignalChannel)
 
 	// Wait for notification on both done channels
-	require.NoError(t, base.RequireChanRecv(t, doneChan))
-	require.NoError(t, base.RequireChanRecv(t, duplicateDoneChan))
+	base.RequireChanClosedWithTimeout(t, doneChan, base.TestIndexInitTimeout, "first init done chan")
+	base.RequireChanClosedWithTimeout(t, duplicateDoneChan, base.TestIndexInitTimeout, "duplicate init done chan")
 
 	// Verify initialization was only run for two collections
 	totalCount := atomic.LoadInt64(&collectionCount)
@@ -518,7 +514,7 @@ func TestDatabaseInitConfigChangeSameCollections(t *testing.T) {
 	// Rerun init, should start a new worker for the database and re-verify init for each collection
 	rerunDoneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true, false)
 	require.NoError(t, err)
-	require.NoError(t, base.RequireChanRecv(t, rerunDoneChan))
+	base.RequireChanClosedWithTimeout(t, rerunDoneChan, base.TestIndexInitTimeout, "repeated init done chan")
 	totalCount = atomic.LoadInt64(&collectionCount)
 	require.Equal(t, expectedCollectionCount*2, totalCount)
 }
@@ -571,8 +567,8 @@ func TestDatabaseInitConfigChangeDifferentCollections(t *testing.T) {
 		log.Printf("Collection complete callback invoked for %s %s", dbName, scName)
 		currentCount := atomic.LoadInt64(&collectionCount)
 		if currentCount == 0 {
-			base.RequireChanSend(t, firstCollectionInitChannel, nil)       // notify the test that indexes have been created for this collection
-			require.NoError(t, base.RequireChanRecv(t, testSignalChannel)) // wait for the test to unblock before proceeding to the next collection
+			base.RequireChanSend(t, firstCollectionInitChannel, nil, "firstCollectionInit-%s", scName)                         // notify the test that indexes have been created for this collection
+			base.RequireChanClosedWithTimeout(t, testSignalChannel, base.TestIndexInitTimeout, "testSignalChannel-%s", scName) // wait for the test to unblock before proceeding to the next collection
 		}
 		atomic.AddInt64(&collectionCount, 1)
 	}
@@ -587,7 +583,7 @@ func TestDatabaseInitConfigChangeDifferentCollections(t *testing.T) {
 	require.NoError(t, err)
 
 	// Wait for first collection to be initialized
-	require.NoError(t, base.RequireChanRecv(t, firstCollectionInitChannel))
+	require.NoError(t, base.RequireChanRecv(t, firstCollectionInitChannel, "first collection init"))
 
 	// Make a call to initialize database for the same db name, different collections
 	modifiedDbConfig := makeDbConfig(tb.GetName(), dbName, collection1and3ScopesConfig)
@@ -600,11 +596,11 @@ func TestDatabaseInitConfigChangeDifferentCollections(t *testing.T) {
 	close(testSignalChannel)
 
 	// Unblock second collection for original invocation
-	cancelErr := base.RequireChanRecv(t, doneChan)
+	cancelErr := base.RequireChanRecv(t, doneChan, "first init cancellation")
 	require.Error(t, cancelErr, "expected first init to be cancelled")
 
 	// Wait for notification on new done channel
-	require.NoError(t, base.RequireChanRecv(t, modifiedDoneChan))
+	base.RequireChanClosedWithTimeout(t, modifiedDoneChan, base.TestIndexInitTimeout, "modified init done chan")
 
 	// Verify initialization was run for four collections (one prior to cancellation, three for subsequent init)
 	totalCount := atomic.LoadInt64(&collectionCount)
@@ -668,13 +664,13 @@ func TestDatabaseInitConcurrentDatabasesDifferentBuckets(t *testing.T) {
 		log.Printf("Collection complete callback invoked for %s %s", dbName, scName)
 		currentCount := atomic.LoadInt64(&collectionCount)
 		if currentCount == 0 {
-			base.RequireChanSend(t, firstCollectionInitChannel, nil)       // notify the test that indexes have been created for this collection
-			require.NoError(t, base.RequireChanRecv(t, testSignalChannel)) // wait for the test to unblock before proceeding to the next collection
+			base.RequireChanSend(t, firstCollectionInitChannel, nil, "firstCollectionInit-%s", scName)                         // notify the test that indexes have been created for this collection
+			base.RequireChanClosedWithTimeout(t, testSignalChannel, base.TestIndexInitTimeout, "testSignalChannel-%s", scName) // wait for the test to unblock before proceeding to the next collection
 		}
 		atomic.AddInt64(&collectionCount, 1)
 	}
 	initMgr.testDatabaseCompleteCallback = func(dbName string) {
-		base.RequireChanSend(t, databaseCompleteChannel, nil)
+		base.RequireChanSend(t, databaseCompleteChannel, nil, "database init complete for %s", dbName)
 	}
 
 	db1Name := "db1Name"
@@ -702,12 +698,12 @@ func TestDatabaseInitConcurrentDatabasesDifferentBuckets(t *testing.T) {
 	close(testSignalChannel)
 
 	// Wait for notification on both done channels
-	require.NoError(t, base.RequireChanRecvWithTimeout(t, doneChan1, base.TestIndexInitTimeout))
-	require.NoError(t, base.RequireChanRecvWithTimeout(t, doneChan2, base.TestIndexInitTimeout))
+	base.RequireChanClosedWithTimeout(t, doneChan1, base.TestIndexInitTimeout, "db1 init done chan")
+	base.RequireChanClosedWithTimeout(t, doneChan2, base.TestIndexInitTimeout, "db2 init done chan")
 
 	// Wait for db completion notifications for both databases
-	require.NoError(t, base.RequireChanRecv(t, databaseCompleteChannel))
-	require.NoError(t, base.RequireChanRecv(t, databaseCompleteChannel))
+	require.NoError(t, base.RequireChanRecv(t, databaseCompleteChannel, "database 1 init complete"))
+	require.NoError(t, base.RequireChanRecv(t, databaseCompleteChannel, "database 2 init complete"))
 
 	// Verify initialization was run for 8 collections (four for db1, four for db2)
 	// _mobile, _default, collection1, collection2
@@ -770,7 +766,7 @@ func TestDatabaseInitTeardownTiming(t *testing.T) {
 			log.Printf("invoking InitializeDatabase again during teardown")
 			doneChan2, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true, false)
 			require.NoError(t, err)
-			require.NoError(t, base.RequireChanRecv(t, doneChan2))
+			base.RequireChanClosedWithTimeout(t, doneChan2, base.TestIndexInitTimeout, "init done chan for re-invocation during teardown")
 		}
 	}
 
@@ -778,7 +774,7 @@ func TestDatabaseInitTeardownTiming(t *testing.T) {
 	doneChan1, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true, false)
 	require.NoError(t, err)
 
-	require.NoError(t, base.RequireChanRecv(t, doneChan1))
+	base.RequireChanClosedWithTimeout(t, doneChan1, base.TestIndexInitTimeout, "initial init done chan")
 	wg.Wait()
 
 	// Verify initialization was run for 8 collections, since it runs on 4 collections twice

--- a/rest/database_init_manager_test.go
+++ b/rest/database_init_manager_test.go
@@ -55,7 +55,7 @@ func TestDatabaseInitManager(t *testing.T) {
 	doneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true, false)
 	require.NoError(t, err)
 
-	base.RequireChanClosedWithTimeout(t, doneChan, base.TestIndexInitTimeout, "initial init done chan")
+	base.RequireNoErrorOnChanCloseWithTimeout(t, doneChan, base.TestIndexInitTimeout, "initial init done chan")
 
 }
 
@@ -104,7 +104,7 @@ func TestDatabaseInitPostMigrationExcludesDefault(t *testing.T) {
 	// migrationComplete=true models a system-metadata database that has finished migrating off _default.
 	doneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true, true)
 	require.NoError(t, err)
-	base.RequireChanClosedWithTimeout(t, doneChan, base.TestIndexInitTimeout, "post-migration init done chan")
+	base.RequireNoErrorOnChanCloseWithTimeout(t, doneChan, base.TestIndexInitTimeout, "post-migration init done chan")
 
 	seenLock.Lock()
 	defer seenLock.Unlock()
@@ -502,8 +502,8 @@ func TestDatabaseInitConfigChangeSameCollections(t *testing.T) {
 	close(testSignalChannel)
 
 	// Wait for notification on both done channels
-	base.RequireChanClosedWithTimeout(t, doneChan, base.TestIndexInitTimeout, "first init done chan")
-	base.RequireChanClosedWithTimeout(t, duplicateDoneChan, base.TestIndexInitTimeout, "duplicate init done chan")
+	base.RequireNoErrorOnChanCloseWithTimeout(t, doneChan, base.TestIndexInitTimeout, "first init done chan")
+	base.RequireNoErrorOnChanCloseWithTimeout(t, duplicateDoneChan, base.TestIndexInitTimeout, "duplicate init done chan")
 
 	// Verify initialization was only run for two collections
 	totalCount := atomic.LoadInt64(&collectionCount)
@@ -514,7 +514,7 @@ func TestDatabaseInitConfigChangeSameCollections(t *testing.T) {
 	// Rerun init, should start a new worker for the database and re-verify init for each collection
 	rerunDoneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true, false)
 	require.NoError(t, err)
-	base.RequireChanClosedWithTimeout(t, rerunDoneChan, base.TestIndexInitTimeout, "repeated init done chan")
+	base.RequireNoErrorOnChanCloseWithTimeout(t, rerunDoneChan, base.TestIndexInitTimeout, "repeated init done chan")
 	totalCount = atomic.LoadInt64(&collectionCount)
 	require.Equal(t, expectedCollectionCount*2, totalCount)
 }
@@ -600,7 +600,7 @@ func TestDatabaseInitConfigChangeDifferentCollections(t *testing.T) {
 	require.Error(t, cancelErr, "expected first init to be cancelled")
 
 	// Wait for notification on new done channel
-	base.RequireChanClosedWithTimeout(t, modifiedDoneChan, base.TestIndexInitTimeout, "modified init done chan")
+	base.RequireNoErrorOnChanCloseWithTimeout(t, modifiedDoneChan, base.TestIndexInitTimeout, "modified init done chan")
 
 	// Verify initialization was run for four collections (one prior to cancellation, three for subsequent init)
 	totalCount := atomic.LoadInt64(&collectionCount)
@@ -698,8 +698,8 @@ func TestDatabaseInitConcurrentDatabasesDifferentBuckets(t *testing.T) {
 	close(testSignalChannel)
 
 	// Wait for notification on both done channels
-	base.RequireChanClosedWithTimeout(t, doneChan1, base.TestIndexInitTimeout, "db1 init done chan")
-	base.RequireChanClosedWithTimeout(t, doneChan2, base.TestIndexInitTimeout, "db2 init done chan")
+	base.RequireNoErrorOnChanCloseWithTimeout(t, doneChan1, base.TestIndexInitTimeout, "db1 init done chan")
+	base.RequireNoErrorOnChanCloseWithTimeout(t, doneChan2, base.TestIndexInitTimeout, "db2 init done chan")
 
 	// Wait for db completion notifications for both databases
 	require.NoError(t, base.RequireChanRecv(t, databaseCompleteChannel, "database 1 init complete"))
@@ -766,7 +766,7 @@ func TestDatabaseInitTeardownTiming(t *testing.T) {
 			log.Printf("invoking InitializeDatabase again during teardown")
 			doneChan2, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true, false)
 			require.NoError(t, err)
-			base.RequireChanClosedWithTimeout(t, doneChan2, base.TestIndexInitTimeout, "init done chan for re-invocation during teardown")
+			base.RequireNoErrorOnChanCloseWithTimeout(t, doneChan2, base.TestIndexInitTimeout, "init done chan for re-invocation during teardown")
 		}
 	}
 
@@ -774,7 +774,7 @@ func TestDatabaseInitTeardownTiming(t *testing.T) {
 	doneChan1, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true, false)
 	require.NoError(t, err)
 
-	base.RequireChanClosedWithTimeout(t, doneChan1, base.TestIndexInitTimeout, "initial init done chan")
+	base.RequireNoErrorOnChanCloseWithTimeout(t, doneChan1, base.TestIndexInitTimeout, "initial init done chan")
 	wg.Wait()
 
 	// Verify initialization was run for 8 collections, since it runs on 4 collections twice

--- a/rest/indextest/index_test.go
+++ b/rest/indextest/index_test.go
@@ -132,7 +132,7 @@ func TestAsyncInitializeIndexes(t *testing.T) {
 			log.Printf("closing initStarted")
 			close(initStarted)
 		}
-		require.NoError(t, base.RequireChanRecv(t, unblockInit))
+		base.RequireChanClosedWithTimeout(t, unblockInit, base.TestIndexInitTimeout, "waiting for test to unblock initialization")
 	}
 	sc.DatabaseInitManager.SetTestCallbacks(collectionCompleteCallback, nil)
 
@@ -156,7 +156,7 @@ func TestAsyncInitializeIndexes(t *testing.T) {
 	resp.RequireStatus(http.StatusCreated)
 
 	// Wait for init to start before interacting with the db
-	require.NoError(t, base.RequireChanRecv(t, initStarted))
+	base.RequireChanClosedWithTimeout(t, initStarted, base.TestIndexInitTimeout, "waiting for initialization to start")
 	log.Printf("initialization started")
 
 	// Get config values before taking db offline
@@ -263,7 +263,7 @@ func TestAsyncInitWithResync(t *testing.T) {
 			log.Printf("closing initStarted")
 			close(initStarted)
 		}
-		require.NoError(t, base.RequireChanRecv(t, unblockInit))
+		base.RequireChanClosedWithTimeout(t, unblockInit, base.TestIndexInitTimeout, "waiting for test to unblock initialization")
 	}
 	sc.DatabaseInitManager.SetTestCallbacks(collectionCompleteCallback, nil)
 	// Recreate the database with offline=true and a modified sync function
@@ -278,7 +278,7 @@ func TestAsyncInitWithResync(t *testing.T) {
 	resp.RequireStatus(http.StatusCreated)
 
 	// Wait for init to start before calling resync
-	require.NoError(t, base.RequireChanRecv(t, initStarted))
+	base.RequireChanClosedWithTimeout(t, initStarted, base.TestIndexInitTimeout, "waiting for initialization to start")
 	log.Printf("initialization started")
 
 	// Start resync
@@ -350,7 +350,7 @@ func TestAsyncOnlineOffline(t *testing.T) {
 			log.Printf("closing initStarted")
 			close(initStarted)
 		}
-		require.NoError(t, base.RequireChanRecv(t, unblockInit))
+		base.RequireChanClosedWithTimeout(t, unblockInit, base.TestIndexInitTimeout, "waiting for test to unblock initialization")
 	}
 	sc.DatabaseInitManager.SetTestCallbacks(collectionCompleteCallback, nil)
 
@@ -376,7 +376,7 @@ func TestAsyncOnlineOffline(t *testing.T) {
 	resp.RequireStatus(http.StatusCreated)
 
 	// Wait for init to start before interacting with the db, validate db state is offline
-	require.NoError(t, base.RequireChanRecv(t, initStarted))
+	base.RequireChanClosedWithTimeout(t, initStarted, base.TestIndexInitTimeout, "waiting for initialization to start")
 	log.Printf("initialization started")
 	waitAndRequireDBState(t, sc, dbName, db.DBOffline)
 	verifyInitializationActive(t, sc, dbName, true)
@@ -471,7 +471,7 @@ func TestAsyncCreateThenDelete(t *testing.T) {
 			log.Printf("closing initStarted")
 			close(initStarted)
 		}
-		require.NoError(t, base.RequireChanRecv(t, unblockInit))
+		base.RequireChanClosedWithTimeout(t, unblockInit, base.TestIndexInitTimeout, "waiting for test to unblock initialization")
 	}
 	firstDatabaseComplete := make(chan error)
 	databaseCompleteCount := int64(0)
@@ -510,7 +510,7 @@ func TestAsyncCreateThenDelete(t *testing.T) {
 	resp.RequireStatus(http.StatusCreated)
 
 	// Wait for init to start before interacting with the db, validate db state is offline
-	require.NoError(t, base.RequireChanRecv(t, initStarted))
+	base.RequireChanClosedWithTimeout(t, initStarted, base.TestIndexInitTimeout, "waiting for initialization to start")
 	waitAndRequireDBState(t, sc, dbName, db.DBOffline)
 
 	// Take the database online while async init is still in progress, verify state goes to Starting
@@ -528,7 +528,7 @@ func TestAsyncCreateThenDelete(t *testing.T) {
 
 	close(unblockInit)
 
-	require.NoError(t, base.RequireChanRecv(t, firstDatabaseComplete))
+	base.RequireChanClosedWithTimeout(t, firstDatabaseComplete, base.TestIndexInitTimeout, "waiting for database complete callback")
 
 	// Verify only one collection was initialized asynchronously (in-progress when database was deleted)
 	totalCount := atomic.LoadInt64(&collectionCount)
@@ -621,7 +621,7 @@ func TestAsyncInitConfigUpdates(t *testing.T) {
 			log.Printf("closing initStarted")
 			close(initStarted)
 		}
-		require.NoError(t, base.RequireChanRecv(t, unblockInit))
+		base.RequireChanClosedWithTimeout(t, unblockInit, base.TestIndexInitTimeout, "waiting for test to unblock initialization")
 	}
 	sc.DatabaseInitManager.SetTestCallbacks(collectionCompleteCallback, nil)
 
@@ -645,7 +645,7 @@ func TestAsyncInitConfigUpdates(t *testing.T) {
 	resp.RequireStatus(http.StatusCreated)
 
 	// Wait for init to start before interacting with the db, validate db state is offline
-	require.NoError(t, base.RequireChanRecv(t, initStarted))
+	base.RequireChanClosedWithTimeout(t, initStarted, base.TestIndexInitTimeout, "waiting for initialization to start")
 	log.Printf("initialization started")
 	waitAndRequireDBState(t, sc, dbName, db.DBOffline)
 
@@ -738,7 +738,7 @@ func TestAsyncInitRemoteConfigUpdates(t *testing.T) {
 			log.Printf("closing initStarted")
 			close(initStarted)
 		}
-		require.NoError(t, base.RequireChanRecv(t, unblockInit))
+		base.RequireChanClosedWithTimeout(t, unblockInit, base.TestIndexInitTimeout, "waiting for test to unblock initialization")
 	}
 	sc.DatabaseInitManager.SetTestCallbacks(collectionCompleteCallback, nil)
 
@@ -774,7 +774,7 @@ func TestAsyncInitRemoteConfigUpdates(t *testing.T) {
 	require.NoError(t, err)
 
 	// Wait for init to start before interacting with the db, validate db state is offline
-	require.NoError(t, base.RequireChanRecv(t, initStarted))
+	base.RequireChanClosedWithTimeout(t, initStarted, base.TestIndexInitTimeout, "waiting for initialization to start")
 	log.Printf("initialization started")
 	waitAndRequireDBState(t, sc, dbName, db.DBOffline)
 

--- a/rest/manualbucketpooltest/database_init_manager_test.go
+++ b/rest/manualbucketpooltest/database_init_manager_test.go
@@ -122,8 +122,8 @@ func TestDatabaseInitConcurrentDatabasesSameBucket(t *testing.T) {
 
 	// Wait for notification on both done channels.  Each one covers all the remaining collections for that database,
 	// so these waits are gated on real index creation and use TestIndexInitTimeout.
-	base.RequireChanClosedWithTimeout(t, doneChan1, base.TestIndexInitTimeout, "db1 InitializeDatabase done chan")
-	base.RequireChanClosedWithTimeout(t, doneChan2, base.TestIndexInitTimeout, "db2 InitializeDatabase done chan")
+	base.RequireNoErrorOnChanCloseWithTimeout(t, doneChan1, base.TestIndexInitTimeout, "db1 InitializeDatabase done chan")
+	base.RequireNoErrorOnChanCloseWithTimeout(t, doneChan2, base.TestIndexInitTimeout, "db2 InitializeDatabase done chan")
 
 	// Verify initialization/checks were run 7 times total: 3 for db1 and 4 for db2.
 	// The distinct collections are _mobile, _default, collection1, collection2, and

--- a/rest/manualbucketpooltest/database_init_manager_test.go
+++ b/rest/manualbucketpooltest/database_init_manager_test.go
@@ -89,8 +89,8 @@ func TestDatabaseInitConcurrentDatabasesSameBucket(t *testing.T) {
 		}
 		log.Printf("Collection complete callback invoked for %s %s", dbName, scName)
 		if atomic.CompareAndSwapInt64(&collectionCount, 0, 1) {
-			base.RequireChanSend(t, firstCollectionInitChannel, nil)       // notify the test that indexes have been created for this collection
-			require.NoError(t, base.RequireChanRecv(t, testSignalChannel)) // wait for the test to unblock before proceeding to the next collection
+			base.RequireChanSend(t, firstCollectionInitChannel, nil, "firstCollectionInit-%s", scName)                         // notify the test that indexes have been created for this collection
+			base.RequireChanClosedWithTimeout(t, testSignalChannel, base.TestIndexInitTimeout, "testSignalChannel-%s", scName) // wait for the test to unblock before proceeding to the next collection
 			return
 		}
 		atomic.AddInt64(&collectionCount, 1)
@@ -111,7 +111,7 @@ func TestDatabaseInitConcurrentDatabasesSameBucket(t *testing.T) {
 	require.NoError(t, err)
 
 	// Wait for first collection to be initialized
-	require.NoError(t, base.RequireChanRecvWithTimeout(t, firstCollectionInitChannel, base.TestIndexInitTimeout))
+	require.NoError(t, base.RequireChanRecvWithTimeout(t, firstCollectionInitChannel, base.TestIndexInitTimeout, "first collection init"))
 
 	// Start second async index creation for db2 while first is still running
 	doneChan2, err := initMgr.InitializeDatabase(ctx, sc.Config, db2Config.ToDatabaseConfig(), testUseLegacySyncDocsIndex, true, false)
@@ -122,8 +122,8 @@ func TestDatabaseInitConcurrentDatabasesSameBucket(t *testing.T) {
 
 	// Wait for notification on both done channels.  Each one covers all the remaining collections for that database,
 	// so these waits are gated on real index creation and use TestIndexInitTimeout.
-	require.NoError(t, base.RequireChanRecvWithTimeout(t, doneChan1, base.TestIndexInitTimeout))
-	require.NoError(t, base.RequireChanRecvWithTimeout(t, doneChan2, base.TestIndexInitTimeout))
+	base.RequireChanClosedWithTimeout(t, doneChan1, base.TestIndexInitTimeout, "db1 InitializeDatabase done chan")
+	base.RequireChanClosedWithTimeout(t, doneChan2, base.TestIndexInitTimeout, "db2 InitializeDatabase done chan")
 
 	// Verify initialization/checks were run 7 times total: 3 for db1 and 4 for db2.
 	// The distinct collections are _mobile, _default, collection1, collection2, and

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1097,6 +1097,12 @@ func (rt *RestTester) WaitForDatabaseState(dbName string, targetState string) {
 	}, 10*time.Second, 100*time.Millisecond)
 }
 
+// ConfigPollingWaitTimeout is the timeout to use for waits that depend on the config polling loop picking up a
+// change made directly in the bucket. A poll that reads the config registry before such a change and the database
+// config document after it spends defaultConfigRetryTimeout in getConfigVersionWithRetry before rolling the
+// registry back, so these waits must tolerate more than that to avoid being flaky.
+const ConfigPollingWaitTimeout = defaultConfigRetryTimeout + 10*time.Second
+
 // WaitForDatabase waits for the named database to become active on the server context (e.g. after config polling picks up a valid config), and returns its database context. Fails the test harness if this does not happen within the timeout.
 func (rt *RestTester) WaitForDatabase(dbName string) *db.DatabaseContext {
 	rt.TB().Helper()
@@ -1105,7 +1111,7 @@ func (rt *RestTester) WaitForDatabase(dbName string) *db.DatabaseContext {
 		var err error
 		dbCtx, err = rt.ServerContext().GetActiveDatabase(dbName)
 		assert.NoError(c, err)
-	}, 10*time.Second, 100*time.Millisecond)
+	}, ConfigPollingWaitTimeout, 100*time.Millisecond)
 	return dbCtx
 }
 
@@ -1115,7 +1121,7 @@ func (rt *RestTester) WaitForInvalidDatabases(dbNames ...string) {
 	require.EventuallyWithT(rt.TB(), func(c *assert.CollectT) {
 		invalidDatabases := rt.ServerContext().AllInvalidDatabaseNames(rt.TB())
 		assert.ElementsMatch(c, dbNames, invalidDatabases)
-	}, 10*time.Second, 100*time.Millisecond)
+	}, ConfigPollingWaitTimeout, 100*time.Millisecond)
 }
 
 // WaitForBucketMetadataMigrationComplete polls the bucket-wide metadata migration status doc until


### PR DESCRIPTION
Fix GSI test failures from close-signalled channel waits

Regression from e2c0e8f208c3c717279b7466f83a8c9174b0a035 which changed WaitForChannel to RequireChanRecv
- DatabaseInitWorker closes doneChan without sending on success and sends error followed by close on failure. Distinguish between both for tests.
- Chan helpers take optional msgAndArgs, restoring the descriptive text the old WaitForChannel calls carried; closed-without-value now FailNow so those args render.

## Integration tests
- [x] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/1096/
