### PR TITLE
CBG-5715: use minLength/maxLength for string length constraints

### DIFF
--- a/docs/api/components/parameters.yaml
+++ b/docs/api/components/parameters.yaml
@@ -331,8 +331,8 @@ replicationid:
   required: true
   schema:
     type: string
-    minimum: 1
-    maximum: 160
+    minLength: 1
+    maxLength: 160
   description: What replication to target based on its replication ID.
 replicator2:
   name: replicator2

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -892,7 +892,7 @@ Replication:
 
         When the replication ID is specified in the URL, this must be set to the same replication ID if specifying it at all.
       type: string
-      maximum: 160
+      maxLength: 160
     run_as:
       description: This is used if you want to specify a user to run the replication as. This means that the replication will only be able to replicate what the user  access to what the user has access to.
       type: string
@@ -1777,7 +1777,7 @@ Database:
 
         This is an Enterprise Edition feature only.
       type: string
-      maximum: 15
+      maxLength: 15
     username:
       description: The username for authenticating to the server.
       type: string


### PR DESCRIPTION
CBG-5715

Split out of #8589 — stack 1/9, based on `main`.

`minimum`/`maximum` only apply to numeric schemas, so the length limits declared on these string schemas were silently ignored by validators and not rendered in the docs.

- `replicationid` path parameter: 1-160 characters
- `Replication.replication_id`: max 160 characters
- `Database.user_xattr_key`: max 15 characters

Because `maximum` on a string is inert while `maxLength` actually binds, both values were checked against the code rather than carried over on trust:

- `db/sg_replicate_cfg.go:190` — `if len(rc.ID) > 160`, with a comment explaining the 160 (checkpoint-key prefix headroom). Note the adjacent error string says "less than 160" while the check admits exactly 160; `maxLength: 160` matches the check.
- `rest/config.go:1145` — `if len(*dbConfig.UserXattrKey) > 15`.

## Pre-review checklist
- [x] Logging sensitive data? N/A — docs only
- [x] Updated relevant information in the API specifications in `docs/api`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
