### PR TITLE
CBG-5715: type serialized JSON array query parameters as strings

### DIFF
--- a/docs/api/components/parameters.yaml
+++ b/docs/api/components/parameters.yaml
@@ -276,7 +276,7 @@ open_revs:
   schema:
     type: string
   example: '["1-abc","2-def"]'
-  description: 'Option to fetch specified revisions of the document. The value can be `all` to fetch all leaf revisions, or a serialized JSON array of revision numbers (i.e. `open_revs=["rev1", "rev2"]`). Only leaf revision bodies that haven''t been pruned are guaranteed to be returned. If this option is specified the response will be in multipart format. Use the `Accept: application/json` request header to get the result as a JSON object.'
+  description: 'Option to fetch specified revisions of the document. The value can be `all` to fetch all leaf revisions, or a serialized JSON array of revision IDs (i.e. `open_revs=["1-abc", "2-def"]`). Only leaf revision bodies that haven''t been pruned are guaranteed to be returned. If this option is specified the response will be in multipart format. Use the `Accept: application/json` request header to get the result as a JSON object.'
 pprof-seconds:
   name: seconds
   in: query

--- a/docs/api/components/parameters.yaml
+++ b/docs/api/components/parameters.yaml
@@ -38,10 +38,9 @@ atts_since:
   in: query
   required: false
   schema:
-    type: array
-    items:
-      type: string
-  description: Include attachments only since specified revisions. Excludes the attachments for the specified revisions. Only gets used if `attachments=true`.
+    type: string
+  example: '["1-abc","2-def"]'
+  description: 'A serialized JSON array of revision IDs. Include attachments only since the specified revisions, excluding the attachments for the specified revisions. Only gets used if `attachments=true`.'
 compact-type:
   name: type
   in: query
@@ -190,10 +189,9 @@ keys:
   in: query
   required: false
   schema:
-    type: array
-    items:
-      type: string
-  description: An array of document ID strings to filter by.
+    type: string
+  example: '["doc1","doc2"]'
+  description: A serialized JSON array of document ID strings to filter by.
 limit-result-rows:
   name: limit
   in: query
@@ -276,10 +274,9 @@ open_revs:
   in: query
   required: false
   schema:
-    type: array
-    items:
-      type: string
-  description: 'Option to fetch specified revisions of the document. The value can be all to fetch all leaf revisions or an array of revision numbers (i.e. open_revs=["rev1", "rev2"]). Only leaf revision bodies that haven''t been pruned are guaranteed to be returned. If this option is specified the response will be in multipart format. Use the `Accept: application/json` request header to get the result as a JSON object.'
+    type: string
+  example: '["1-abc","2-def"]'
+  description: 'Option to fetch specified revisions of the document. The value can be `all` to fetch all leaf revisions, or a serialized JSON array of revision numbers (i.e. `open_revs=["rev1", "rev2"]`). Only leaf revision bodies that haven''t been pruned are guaranteed to be returned. If this option is specified the response will be in multipart format. Use the `Accept: application/json` request header to get the result as a JSON object.'
 pprof-seconds:
   name: seconds
   in: query
@@ -354,10 +351,9 @@ revs_from:
   in: query
   required: false
   schema:
-    type: array
-    items:
-      type: string
-  description: 'Trim the revision history to stop at the first revision in the provided list. If no match is found, the revisions will be trimmed to the `revs_limit`.'
+    type: string
+  example: '["1-abc"]'
+  description: 'Trim the revision history to stop at the first revision in the provided serialized JSON array of revision IDs. If no match is found, the revisions will be trimmed to the `revs_limit`.'
 revs_limit:
   name: revs_limit
   in: query

--- a/docs/api/paths/admin/keyspace-_changes.yaml
+++ b/docs/api/paths/admin/keyspace-_changes.yaml
@@ -65,11 +65,16 @@ get:
         type: string
     - name: doc_ids
       in: query
-      description: 'A valid JSON array of document IDs to filter the documents in the response to only the documents specified. To use this option, the `filter` query option must be set to `_doc_ids` and the `feed` parameter must be `normal`. Also accepts a comma separated list of document IDs instead.'
+      description: 'A JSON array of document IDs, serialized to a string, to filter the documents in the response to only the documents specified. To use this option, the `filter` query option must be set to `_doc_ids` and the `feed` parameter must be `normal`. Also accepts a comma-separated list of document IDs instead.'
       schema:
-        type: array
-        items:
-          type: string
+        type: string
+      examples:
+        jsonArray:
+          summary: Serialized JSON array
+          value: '["doc1","doc2"]'
+        commaSeparated:
+          summary: Comma-separated list
+          value: 'doc1,doc2'
     - name: heartbeat
       in: query
       description: The interval (in milliseconds) to send an empty line (CRLF) in the response. This is to help prevent gateways from deciding the socket is idle and therefore closing it. This is only applicable to `feed=longpoll` or `feed=continuous`. This will override any timeouts to keep the feed alive indefinitely. Setting to 0 results in no heartbeat. The maximum heartbeat can be set in the server replication configuration. If heartbeat is non zero, it must be at least 25000 milliseconds.

--- a/docs/api/paths/admin/keyspace-_changes.yaml
+++ b/docs/api/paths/admin/keyspace-_changes.yaml
@@ -153,6 +153,9 @@ post:
               type: integer
             since:
               description: Starts the results from the change immediately after the given sequence ID. Sequence IDs should be considered opaque; they come from the last_seq property of a prior response.
+              oneOf:
+                - type: string
+                - type: integer
             style:
               description: Controls whether to return the current winning revision (`main_only`) or all the leaf revision including conflicts and deleted former conflicts (`all_docs`).
               type: string

--- a/docs/api/paths/admin/keyspace-_changes.yaml
+++ b/docs/api/paths/admin/keyspace-_changes.yaml
@@ -150,16 +150,18 @@ post:
           properties:
             limit:
               description: Maximum number of changes to return.
-              type: string
+              type: integer
+            since:
+              description: Starts the results from the change immediately after the given sequence ID. Sequence IDs should be considered opaque; they come from the last_seq property of a prior response.
             style:
               description: Controls whether to return the current winning revision (`main_only`) or all the leaf revision including conflicts and deleted former conflicts (`all_docs`).
               type: string
             active_only:
               description: Set true to exclude deleted documents and notifications for documents the user no longer has access to from the changes feed.
-              type: string
+              type: boolean
             include_docs:
               description: Include the body associated with each document.
-              type: string
+              type: boolean
             revocations:
               description: 'If true, revocation messages will be sent on the changes feed.'
               type: string
@@ -176,10 +178,10 @@ post:
                 type: string
             heartbeat:
               description: The interval (in milliseconds) to send an empty line (CRLF) in the response. This is to help prevent gateways from deciding the socket is idle and therefore closing it. This is only applicable to `feed=longpoll` or `feed=continuous`. This will override any timeouts to keep the feed alive indefinitely. Setting to 0 results in no heartbeat. The maximum heartbeat can be set in the server replication configuration.
-              type: string
+              type: integer
             timeout:
               description: 'This is the maximum period (in milliseconds) to wait for a change before the response is sent, even if there are no results. This is only applicable for `feed=longpoll` or `feed=continuous` changes feeds. Setting to 0 results in no timeout.'
-              type: string
+              type: integer
             feed:
               description: 'The type of changes feed to use. '
               type: string

--- a/docs/api/paths/admin/keyspace-_changes.yaml
+++ b/docs/api/paths/admin/keyspace-_changes.yaml
@@ -170,8 +170,10 @@ post:
               description: 'A comma-separated list of channel names to filter the response to only the channels specified. To use this option, the `filter` query option must be set to `sync_gateway/bychannels`.'
               type: string
             doc_ids:
-              description: 'A valid JSON array of document IDs to filter the documents in the response to only the documents specified. To use this option, the `filter` query option must be set to `_doc_ids` and the `feed` parameter must be `normal`.'
-              type: string
+              description: 'An array of document IDs to filter the documents in the response to only the documents specified. To use this option, the `filter` query option must be set to `_doc_ids` and the `feed` parameter must be `normal`.'
+              type: array
+              items:
+                type: string
             heartbeat:
               description: The interval (in milliseconds) to send an empty line (CRLF) in the response. This is to help prevent gateways from deciding the socket is idle and therefore closing it. This is only applicable to `feed=longpoll` or `feed=continuous`. This will override any timeouts to keep the feed alive indefinitely. Setting to 0 results in no heartbeat. The maximum heartbeat can be set in the server replication configuration.
               type: string

--- a/docs/api/paths/public/keyspace-_changes.yaml
+++ b/docs/api/paths/public/keyspace-_changes.yaml
@@ -60,11 +60,16 @@ get:
         type: string
     - name: doc_ids
       in: query
-      description: 'A valid JSON array of document IDs to filter the documents in the response to only the documents specified. To use this option, the `filter` query option must be set to `_doc_ids` and the `feed` parameter must be `normal`. Also accepts a comma separated list of document IDs instead.'
+      description: 'A JSON array of document IDs, serialized to a string, to filter the documents in the response to only the documents specified. To use this option, the `filter` query option must be set to `_doc_ids` and the `feed` parameter must be `normal`. Also accepts a comma-separated list of document IDs instead.'
       schema:
-        type: array
-        items:
-          type: string
+        type: string
+      examples:
+        jsonArray:
+          summary: Serialized JSON array
+          value: '["doc1","doc2"]'
+        commaSeparated:
+          summary: Comma-separated list
+          value: 'doc1,doc2'
     - name: heartbeat
       in: query
       description: The interval (in milliseconds) to send an empty line (CRLF) in the response. This is to help prevent gateways from deciding the socket is idle and therefore closing it. This is only applicable to `feed=longpoll` or `feed=continuous`. This will override any timeouts to keep the feed alive indefinitely. Setting to 0 results in no heartbeat. The maximum heartbeat can be set in the server replication configuration. If heartbeat is non zero, it must be at least 25000 milliseconds.

--- a/docs/api/paths/public/keyspace-_changes.yaml
+++ b/docs/api/paths/public/keyspace-_changes.yaml
@@ -140,6 +140,9 @@ post:
               type: integer
             since:
               description: Starts the results from the change immediately after the given sequence ID. Sequence IDs should be considered opaque; they come from the last_seq property of a prior response.
+              oneOf:
+                - type: string
+                - type: integer
             style:
               description: Controls whether to return the current winning revision (`main_only`) or all the leaf revision including conflicts and deleted former conflicts (`all_docs`).
               type: string

--- a/docs/api/paths/public/keyspace-_changes.yaml
+++ b/docs/api/paths/public/keyspace-_changes.yaml
@@ -95,6 +95,12 @@ get:
           - longpoll
           - continuous
           - websocket
+    - name: request_plus
+      in: query
+      description: 'When true, ensures all valid documents written prior to the request being issued are included in the response.  This is only applicable for non-continuous feeds.'
+      schema:
+        type: boolean
+        default: false
     - name: version_type
       in: query
       description: 'The preferred type of document versioning to use for the changes feed.'
@@ -131,13 +137,15 @@ post:
           properties:
             limit:
               description: Maximum number of changes to return.
-              type: string
+              type: integer
+            since:
+              description: Starts the results from the change immediately after the given sequence ID. Sequence IDs should be considered opaque; they come from the last_seq property of a prior response.
             style:
               description: Controls whether to return the current winning revision (`main_only`) or all the leaf revision including conflicts and deleted former conflicts (`all_docs`).
               type: string
             active_only:
               description: Set true to exclude deleted documents and notifications for documents the user no longer has access to from the changes feed.
-              type: string
+              type: boolean
             include_docs:
               description: Include the body associated with each document.
               type: boolean
@@ -157,13 +165,27 @@ post:
                 type: string
             heartbeat:
               description: The interval (in milliseconds) to send an empty line (CRLF) in the response. This is to help prevent gateways from deciding the socket is idle and therefore closing it. This is only applicable to `feed=longpoll` or `feed=continuous`. This will override any timeouts to keep the feed alive indefinitely. Setting to 0 results in no heartbeat. The maximum heartbeat can be set in the server replication configuration.
-              type: string
+              type: integer
             timeout:
               description: 'This is the maximum period (in milliseconds) to wait for a change before the response is sent, even if there are no results. This is only applicable for `feed=longpoll` or `feed=continuous` changes feeds. Setting to 0 results in no timeout.'
-              type: string
+              type: integer
             feed:
               description: 'The type of changes feed to use. '
               type: string
+            request_plus:
+              description: 'When true, ensures all valid documents written prior to the request being issued are included in the response.  This is only applicable for non-continuous feeds.'
+              type: boolean
+              default: false
+            version_type:
+              description: The preferred type of document versioning to use for the changes feed.
+              type: string
+              default: rev
+              enum:
+                - rev
+                - cv
+              x-enumDescriptions:
+                rev: 'Revision Tree IDs. For example: 1-293a80ce8f4874724732f27d35b3959a13cd96e0'
+                cv: 'Current Version. For example: 1854e4e557cc0000@zTWkmBiYZgNQo7BHVZrB/Q'
   responses:
     '200':
       $ref: ../../components/responses.yaml#/changes-feed

--- a/docs/api/paths/public/keyspace-_changes.yaml
+++ b/docs/api/paths/public/keyspace-_changes.yaml
@@ -151,8 +151,10 @@ post:
               description: 'A comma-separated list of channel names to filter the response to only the channels specified. To use this option, the `filter` query option must be set to `sync_gateway/bychannels`.'
               type: string
             doc_ids:
-              description: 'A valid JSON array of document IDs to filter the documents in the response to only the documents specified. To use this option, the `filter` query option must be set to `_doc_ids` and the `feed` parameter must be `normal`.'
-              type: string
+              description: 'An array of document IDs to filter the documents in the response to only the documents specified. To use this option, the `filter` query option must be set to `_doc_ids` and the `feed` parameter must be `normal`.'
+              type: array
+              items:
+                type: string
             heartbeat:
               description: The interval (in milliseconds) to send an empty line (CRLF) in the response. This is to help prevent gateways from deciding the socket is idle and therefore closing it. This is only applicable to `feed=longpoll` or `feed=continuous`. This will override any timeouts to keep the feed alive indefinitely. Setting to 0 results in no heartbeat. The maximum heartbeat can be set in the server replication configuration.
               type: string


### PR DESCRIPTION
CBG-5715

Split out of #8589 — stack 2/9, based on #8649.

`atts_since`, `keys`, `open_revs`, `revs_from` and `_changes?doc_ids` are all read as a single query string containing a serialized JSON array — not an OpenAPI `array`, which renders and validates as repeated/comma-separated query values.

Retype them as `string` and add examples showing the expected encoding. `doc_ids` also accepts a comma-separated list, so it gets both examples.

Evidence:
- `rest/doc_api.go:54,57` — `getJSONStringArrayQuery("revs_from")` / `("atts_since")`
- `rest/bulk_api.go:92` — `getJSONStringArrayQuery("keys")`; `rest/view_api.go:107` JSON-unmarshals `keys` for views
- `rest/doc_api.go:31,145` — `open_revs` is `all` or a JSON array string
- `rest/changes_api.go:213-228` — GET `doc_ids` tries `JSONUnmarshal` first, then falls back to `strings.Split(",")`

## Pre-review checklist
- [x] Logging sensitive data? N/A — docs only
- [x] Updated relevant information in the API specifications in `docs/api`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
