### PR TITLE
CBG-5715: rename doc_write_conflicts to doc_write_conflict

### DIFF
--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -960,7 +960,7 @@ Replication-status:
     doc_write_failures:
       description: The number of documents that have failed to be wrote (pushed) to the target database. There will be no attempt to try to push these docs again.
       type: integer
-    doc_write_conflicts:
+    doc_write_conflict:
       description: The number of documents that had a conflict.
       type: integer
     rejected_by_remote:


### PR DESCRIPTION
CBG-5715

Split out of #8589 — stack 3/9, based on #8650.

The field is serialized from `ReplicationStatus.DocWriteConflict`, whose JSON tag is `doc_write_conflict` (`db/sg_replicate_cfg.go:1405`), so the spec documented a property name that never appears in a response.

## Pre-review checklist
- [x] Logging sensitive data? N/A — docs only
- [x] Updated relevant information in the API specifications in `docs/api`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
