### PR TITLE
CBG-5715: document whole-number fields as integer rather than number

### DIFF
--- a/docs/api/components/parameters.yaml
+++ b/docs/api/components/parameters.yaml
@@ -197,7 +197,7 @@ limit-result-rows:
   in: query
   required: false
   schema:
-    type: number
+    type: integer
   description: This limits the number of result rows returned. Using a value of `0` has the same effect as the value `1`.
 log-level:
   name: logLevel

--- a/docs/api/components/parameters.yaml
+++ b/docs/api/components/parameters.yaml
@@ -198,7 +198,7 @@ limit-result-rows:
   required: false
   schema:
     type: integer
-  description: This limits the number of result rows returned. Using a value of `0` has the same effect as the value `1`.
+  description: This limits the number of result rows returned. Using a value of `0` means no limit (equivalent to omitting `limit`).
 log-level:
   name: logLevel
   in: query

--- a/docs/api/components/responses.yaml
+++ b/docs/api/components/responses.yaml
@@ -157,9 +157,9 @@ all-docs:
                       type: string
             uniqueItems: true
           total_rows:
-            type: number
+            type: integer
           update_seq:
-            type: number
+            type: integer
         required:
           - rows
           - total_rows

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1614,7 +1614,7 @@ Database:
         The maximum depth a document's revision tree can grow to.
       type: integer
       default: 50
-      minimum: 0
+      minimum: 1
     roles:
       additionalProperties:
         x-additionalPropertiesName: rolename

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -586,7 +586,9 @@ Changes-feed:
         properties:
           seq:
             description: The change sequence number.
-            type: integer
+            oneOf:
+              - type: integer
+              - type: string
           id:
             description: The document ID the change happened on.
             type: string

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -418,7 +418,7 @@ User-session-information:
           type: object
           additionalProperties:
             x-additionalPropertiesName: channelName
-            type: number
+            type: integer
             minimum: 1
             description: The sequence number the user was granted access.
             title: sequence number
@@ -460,7 +460,7 @@ OIDC-callback:
       type: string
     expires_in:
       description: The time until the id_token expires (TTL).
-      type: number
+      type: integer
   title: OpenID Connect callback properties
 OIDC-token:
   description: Properties expected back from an OpenID Connect provider after successful authentication
@@ -533,7 +533,7 @@ Document:
       properties:
         start:
           description: Prefix number for the latest revision.
-          type: number
+          type: integer
         ids:
           description: 'Array of valid Revision Tree IDs, in reverse order (latest first).'
           type: array
@@ -586,7 +586,7 @@ Changes-feed:
         properties:
           seq:
             description: The change sequence number.
-            type: number
+            type: integer
           id:
             description: The document ID the change happened on.
             type: string
@@ -1035,7 +1035,7 @@ Database:
       default: The database name
     bucket_op_timeout_ms:
       description: 'This is the amount of milliseconds should pass before a bucket operation times out. An error will be returned if the bucket operation times out saying: `operation timed out`.'
-      type: number
+      type: integer
     cacertpath:
       description: The root CA cert path for X.509 bucket authentication.
       type: string
@@ -1084,11 +1084,11 @@ Database:
               default: 50000
             max_wait_pending:
               description: The maximum time (in milliseconds) for waiting for a pending sequence before skipping it.
-              type: number
+              type: integer
               default: 5000
             max_wait_skipped:
               description: The maximum amount of time (in milliseconds) to wait for a skipped sequence before abandoning it.
-              type: number
+              type: integer
               default: 3600000
             min_length:
               description: The minimum number of entries to maintain in the cache per channel.
@@ -1150,7 +1150,7 @@ Database:
             **Deprecated, please use the database setting `cache.channel_cache.max_length` instead**
 
             The maximum number of entries maintained in cache per channel.
-          type: number
+          type: integer
           deprecated: true
         channel_cache_min_length:
           description: |-
@@ -1178,14 +1178,14 @@ Database:
             **Deprecated, please use the database setting `cache.channel_cache.max_wait_pending` instead**
 
             The maximum time (in milliseconds) for waiting for a pending sequence before skipping it.
-          type: number
+          type: integer
           deprecated: true
         max_wait_skipped:
           description: |-
             **Deprecated, please use the database setting `cache.channel_cache.max_wait_skipped` instead**
 
             The maximum time (in milliseconds) for waiting for pending sequences before skipping.
-          type: number
+          type: integer
           deprecated: true
     certpath:
       description: The cert path (public key) for X.509 bucket auth.
@@ -1235,7 +1235,7 @@ Database:
             The number of seconds deltas for old revisions are available for.
 
             This defaults to 24 hours (in seconds).
-          type: number
+          type: integer
           default: 86400
     disable_password_auth:
       description: Whether to disable username/password authentication and only allow OIDC and guest access.
@@ -1308,7 +1308,7 @@ Database:
         Partitions are distributed among all Sync Gateway nodes participating in import processing (`import_docs=true`), and each process a subset of the server's vbuckets.
 
         Each partition is processed by an independent function that runs simultaneously to others, so `import_partitions` can be used to tune concurrency based on the number of Sync Gateway nodes, and the number of cores per node.
-      type: number
+      type: integer
       default: 16
       minimum: 1
       maximum: 1024
@@ -1319,11 +1319,11 @@ Database:
           $ref: '#/NumIndexPartitions'
         num_replicas:
           description: This is the number of Global Secondary Indexes (GSI) to use for core indexes.
-          type: number
+          type: integer
           default: 1
     javascript_timeout_secs:
       description: The maximum number of seconds the sync, import filter, and custom conflict resolver JavaScript functions are allowed to run for before timing out. Set to 0 to allow the JS functions to run uncapped.
-      type: number
+      type: integer
       default: 60
     keypath:
       description: The key path (private key) for X.509 bucket auth
@@ -1465,7 +1465,7 @@ Database:
               description: List of enabled audit events for this database.
               type: array
               items:
-                type: number
+                type: integer
               example: [1234, 5678]
         console:
           description: Console logging configuration.
@@ -1593,7 +1593,7 @@ Database:
                 type: string
     old_rev_expiry_seconds:
       description: The number of seconds before old revisions are removed from the Couchbase Server bucket.
-      type: number
+      type: integer
       default: 300
     password:
       description: The password for authenticating to the server.
@@ -1610,7 +1610,7 @@ Database:
     revs_limit:
       description: |-
         The maximum depth a document's revision tree can grow to.
-      type: number
+      type: integer
       default: 50
       minimum: 0
     roles:
@@ -1672,7 +1672,7 @@ Database:
       default: 300
     slow_query_warning_threshold:
       description: 'The amount of milliseconds a N1QL query should run before logging a warning. '
-      type: number
+      type: integer
       default: 500
     store_legacy_revtree_data:
       description: |-
@@ -1703,7 +1703,7 @@ Database:
               type: boolean
         dcp_read_buffer:
           description: Set the dcp feed to use a different read buffer size.
-          type: number
+          type: integer
         force_api_forbidden_errors:
           description: Force REST API errors to return forbidden
           type: boolean
@@ -1712,7 +1712,7 @@ Database:
           type: boolean
         kv_buffer:
           description: Set the kv pool to use a different buffer size.
-          type: number
+          type: integer
         oidc_test_provider:
           type: object
           properties:
@@ -1754,19 +1754,19 @@ Database:
           properties:
             access_and_role_grants_per_doc:
               description: The number of access and role grants per document to be used as a threshold for grant count warnings.
-              type: number
+              type: integer
             channel_name_size:
               description: The number of channel name characters to be used as a threshold for channel name warnings.
-              type: number
+              type: integer
             channels_per_doc:
               description: The number of channels per document to be used as a threshold for the channel count warnings.
-              type: number
+              type: integer
             channels_per_user:
               description: The number of channels per user to be used as a threshold for channel count warnings.
-              type: number
+              type: integer
             xattr_size_bytes:
               description: The number of bytes to be used as a threshold for xattr size limit warnings.
-              type: number
+              type: integer
     use_views:
       description: Force the use of views instead of GSI.
       type: boolean
@@ -1820,7 +1820,7 @@ Database:
       description: |-
         **Deprecated, please use the database setting `index.num_replicas` instead**
       deprecated: true
-      type: number
+      type: integer
       default: 1
     pool:
       description: This field is unsupported and ignored.
@@ -1832,7 +1832,7 @@ Database:
         **Deprecated, please use the database setting `cache.rev_cache.size` instead**
 
         The maximum number of revisions to store in the revision cache.
-      type: number
+      type: integer
       deprecated: true
     suspendable:
       description: This option has no effect.
@@ -1996,7 +1996,7 @@ Event-config:
       type: string
     timeout:
       description: The amount of time (in seconds) to attempt connect to the webhook before giving up.
-      type: number
+      type: integer
   title: Event-config
 Resync-status:
   description: The status of a resync operation
@@ -2246,7 +2246,7 @@ Startup-config:
           default: 90s
         max_connections:
           description: Max of incoming HTTP connections to accept
-          type: number
+          type: integer
           default: 0
         metrics_interface:
           description: |-
@@ -2421,7 +2421,7 @@ Startup-config:
         - $ref: '#/Logging-config'
     max_file_descriptors:
       description: Max of open file descriptors (RLIMIT_NOFILE)
-      type: number
+      type: integer
       default: 5000
       minimum: 0
       readOnly: true
@@ -2825,7 +2825,7 @@ Audit-logging-config:
       description: List of enabled global audit events.
       type: array
       items:
-        type: number
+        type: integer
       example: [1234, 5678]
       readOnly: true
 Console-logging-keys-level:
@@ -3000,7 +3000,7 @@ Status:
         properties:
           seq:
             description: The latest sequence number in the database.
-            type: number
+            type: integer
             minimum: 0
           server_uuid:
             description: The server unique identifier.
@@ -3087,7 +3087,8 @@ Status:
             (cgroupv2 `memory.max` or cgroupv1 `memory.limit_in_bytes`). Only present when
             running inside a cgroup with a memory limit configured.
           type: integer
-          format: uint64
+          format: int64
+          minimum: 0
           example: 2147483648
     node_uid:
       description: |-
@@ -3312,7 +3313,7 @@ NumIndexPartitions:
     The number of partitions to use for the large indexes created by Sync Gateway. It is not recommended to set this unless you require additional horizontal scalability for individual indexes and have appropriately scaled your Query nodes to handle the increased query parallelism. If set, the recommended number is 8 and does not need to be directly related to the number of your Query nodes. Ensure documentation is read to understand the performance tradeoffs and instructions for migration if you have previously run with only one partition. See [/{db}/_index_init](#operation/post_db-_index_init) for more information.
 
     If not specified or 1, all indexes will be non partitioned.
-  type: number
+  type: integer
   default: 1
   title: Number of Index Partitions
 IndexSettings:

--- a/docs/api/paths/admin/db-.yaml
+++ b/docs/api/paths/admin/db-.yaml
@@ -50,11 +50,11 @@ get:
                 type: boolean
               purge_seq:
                 description: Unused field.
-                type: number
+                type: integer
                 default: 0
               disk_format_version:
                 description: Unused field.
-                type: number
+                type: integer
                 default: 0
               state:
                 description: The current state of the database.

--- a/docs/api/paths/admin/keyspace-docid-attach.yaml
+++ b/docs/api/paths/admin/keyspace-docid-attach.yaml
@@ -53,7 +53,7 @@ get:
       headers:
         Content-Length:
           schema:
-            type: number
+            type: integer
           description: Length of the attachment in bytes
         Etag:
           schema:
@@ -135,7 +135,7 @@ head:
         Content-Length:
           schema:
             description: Length of the attachment in bytes
-            type: number
+            type: integer
         Etag:
           schema:
             type: string

--- a/docs/api/paths/diagnostic/keyspace-sync.yaml
+++ b/docs/api/paths/diagnostic/keyspace-sync.yaml
@@ -86,7 +86,7 @@ post:
                       - type: string
                         example: foo
                         description: A string value to be used as the user XATTR.
-                      - type: integer
+                      - type: number
                         example: 100
                         description: A number value to be used as the user XATTR.
                       - type: boolean
@@ -163,7 +163,7 @@ post:
                     example: channel1
               expiry:
                 description: The document expiry (TTL in seconds) as determined by the sync function.
-                type: number
+                type: integer
                 example: 300
               exception:
                 $ref: ../../components/schemas.yaml#/DiagnosticFunctionException

--- a/docs/api/paths/public/db-.yaml
+++ b/docs/api/paths/public/db-.yaml
@@ -45,11 +45,11 @@ get:
                 type: boolean
               purge_seq:
                 description: Unused field.
-                type: number
+                type: integer
                 default: 0
               disk_format_version:
                 description: Unused field.
-                type: number
+                type: integer
                 default: 0
               state:
                 description: The current state of the database.

--- a/docs/api/paths/public/keyspace-docid-attach.yaml
+++ b/docs/api/paths/public/keyspace-docid-attach.yaml
@@ -48,7 +48,7 @@ get:
       headers:
         Content-Length:
           schema:
-            type: number
+            type: integer
           description: Length of the attachment in bytes
         Etag:
           schema:
@@ -122,7 +122,7 @@ head:
         Content-Length:
           schema:
             description: Length of the attachment in bytes
-            type: number
+            type: integer
         Etag:
           schema:
             type: string


### PR DESCRIPTION
CBG-5715

Split out of #8589 — stack 4/9, based on #8651.

Sequence numbers, counters, byte/millisecond/second sizes, timeouts and thresholds are all whole numbers in Go, but were declared `type: number`, which documents them as accepting fractional values. Retype the 45 affected schemas to `integer`, leaving the genuinely fractional ones (`compact_interval_days`, the CPU utilization percentages, which carry `format: float`) as `number`.

Two related type fixes:
- `Status.runtime.cgroup_memory_limit_bytes` used `format: uint64`, which is not an OpenAPI format. Use the standard `int64` plus `minimum: 0`, matching its sibling `go_memlimit_bytes`. (Raised by @factory-droid on #8589.)
- The `_sync` diagnostic endpoint's user xattr value accepts any JSON number, not just integers, so widen that `oneOf` branch to `number`.

Every one of the 45 was traced to its Go declaration: `uint32` (`bucket_op_timeout_ms`, `old_rev_expiry_seconds`, `slow_query_warning_threshold`, all five `warning_thresholds`, `rev_max_age_seconds`, `rev_cache_size`, `NumIndexPartitions`), `uint16` (`import_partitions`), `uint`/`uint64` (`max_connections`, `max_file_descriptors`, `update_seq`, `purge_seq`, `disk_format_version`, `_revisions.start`, `Status.seq`), `int` (`total_rows`, `dcp_read_buffer`, `kv_buffer`, `expires_in`), `[]uint` (`enabled_events`).

## Pre-review checklist
- [x] Logging sensitive data? N/A — docs only
- [x] Updated relevant information in the API specifications in `docs/api`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
