### PR TITLE
CBG-5715: add x-enumDescriptions to enums that only listed values

### DIFF
--- a/docs/api/components/parameters.yaml
+++ b/docs/api/components/parameters.yaml
@@ -51,6 +51,9 @@ compact-type:
     enum:
       - attachment
       - tombstone
+    x-enumDescriptions:
+      attachment: Clean up legacy (pre-3.0) attachments.
+      tombstone: Purge the JSON bodies of old, non-current revisions.
   description: |-
     This is the type of compaction to use. The type must be either:
     * `attachment` for cleaning up legacy (pre-3.0) attachments

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1435,7 +1435,7 @@ Database:
                     description: >
                       The domain of the role for which audit logging is disabled.
                     enum: [cbs, sgw]
-                    x-enumDescription:
+                    x-enumDescriptions:
                       cbs: Couchbase Server RBAC
                       sgw: Sync Gateway Role
                     type: string
@@ -1453,7 +1453,7 @@ Database:
                       The domain of the user for which audit logging is disabled.
                     type: string
                     enum: [cbs, sgw]
-                    x-enumDescription:
+                    x-enumDescriptions:
                       cbs: Couchbase Server User
                       sgw: Sync Gateway User
                   name:
@@ -1742,6 +1742,11 @@ Database:
             - "Lax"
             - "None"
             - "Strict"
+          x-enumDescriptions:
+            Default: Omit the SameSite attribute entirely.
+            Lax: Blocked on cross-site requests, but allowed when a user navigates to the site directly.
+            None: Allowed on all requests, including cross-site. Requires the cookie to be marked `Secure`.
+            Strict: Only sent on same-site requests.
         sgr_tls_skip_verify:
           description: Enable self-signed certificates for SG-replicate testing.
           type: boolean
@@ -1891,7 +1896,7 @@ Database-audit:
             description: >
               The domain of the role for which audit logging is disabled.
             enum: [cbs, sgw]
-            x-enumDescription:
+            x-enumDescriptions:
               cbs: Couchbase Server User
               sgw: Sync Gateway User
             type: string
@@ -1908,7 +1913,7 @@ Database-audit:
             description: >
               The domain of the role for which audit logging is disabled.
             enum: [cbs, sgw]
-            x-enumDescription:
+            x-enumDescriptions:
               cbs: Couchbase Server RBAC
               sgw: Sync Gateway Role
             type: string
@@ -1938,7 +1943,7 @@ Database-audit-verbose:
             description: >
               The domain of the role for which audit logging is disabled.
             enum: [cbs, sgw]
-            x-enumDescription:
+            x-enumDescriptions:
               cbs: Couchbase Server User
               sgw: Sync Gateway User
             type: string
@@ -1955,7 +1960,7 @@ Database-audit-verbose:
             description: >
               The domain of the role for which audit logging is disabled.
             enum: [cbs, sgw]
-            x-enumDescription:
+            x-enumDescriptions:
               cbs: Couchbase Server RBAC
               sgw: Sync Gateway Role
             type: string
@@ -2013,6 +2018,12 @@ Resync-status:
         - stopping
         - stopped
         - error
+      x-enumDescriptions:
+        running: Currently running.
+        completed: Finished successfully.
+        stopping: In the process of stopping.
+        stopped: Stopped before completion.
+        error: Failed with an error.
     start_time:
       description: The ISO-8601 date and time the resync operation was started.
       type: string
@@ -2055,6 +2066,12 @@ Attachment-Migration-status:
         - stopping
         - stopped
         - error
+      x-enumDescriptions:
+        running: Currently running.
+        completed: Finished successfully.
+        stopping: In the process of stopping.
+        stopped: Stopped before completion.
+        error: Failed with an error.
     start_time:
       description: The ISO-8601 date and time the attachment migration operation was started.
       type: string
@@ -2093,6 +2110,12 @@ Metadata-Migration-status:
         - stopping
         - stopped
         - error
+      x-enumDescriptions:
+        running: Currently running.
+        completed: Finished successfully.
+        stopping: In the process of stopping.
+        stopped: Stopped before completion.
+        error: Failed with an error.
     start_time:
       description: The ISO-8601 date and time the metadata migration operation was started.
       type: string
@@ -2531,6 +2554,11 @@ Logging-config:
         - partial
         - full
         - unset
+      x-enumDescriptions:
+        none: No redaction; logs may contain sensitive data.
+        partial: Redacts sensitive data from logs. Default.
+        full: Not implemented separately; behaves the same as `partial`.
+        unset: Not explicitly configured; behaves the same as `partial`.
       readOnly: true
     console:
       $ref: '#/Console-logging-config'

--- a/docs/api/paths/admin/_profile-profilename.yaml
+++ b/docs/api/paths/admin/_profile-profilename.yaml
@@ -18,6 +18,12 @@ parameters:
         - threadcreate
         - mutex
         - goroutine
+      x-enumDescriptions:
+        heap: A snapshot of memory usage, useful for spotting memory leaks.
+        block: Where the server is waiting on locks or channels.
+        threadcreate: Where new OS threads were created.
+        mutex: Where goroutines are contending for the same lock.
+        goroutine: A snapshot of everything the server is currently doing.
 post:
   summary: Create point-in-time profile
   description: |-

--- a/docs/api/paths/admin/_sgcollect_info.yaml
+++ b/docs/api/paths/admin/_sgcollect_info.yaml
@@ -54,6 +54,9 @@ post:
               enum:
                 - partial
                 - none
+              x-enumDescriptions:
+                partial: Redacts sensitive data from the collected logs.
+                none: No redaction; collected logs may contain sensitive data. Default.
             redact_salt:
               description: The salt to use for the log redactions.
               type: string

--- a/docs/api/paths/admin/_sgcollect_info.yaml
+++ b/docs/api/paths/admin/_sgcollect_info.yaml
@@ -50,7 +50,7 @@ post:
             redact_level:
               description: The redaction level to use for redacting the collected logs.
               type: string
-              default: partial
+              default: none
               enum:
                 - partial
                 - none

--- a/docs/api/paths/admin/db-_replicationStatus-replicationid.yaml
+++ b/docs/api/paths/admin/db-_replicationStatus-replicationid.yaml
@@ -63,6 +63,10 @@ put:
           - start
           - stop
           - reset
+        x-enumDescriptions:
+          start: Start a stopped replication.
+          stop: Stop an active replication.
+          reset: Reset replication checkpoints. The replication must be stopped first.
   responses:
     '200':
       description: Successfully changed target state of replicator

--- a/docs/api/paths/admin/keyspace-_changes.yaml
+++ b/docs/api/paths/admin/keyspace-_changes.yaml
@@ -66,7 +66,7 @@ get:
           _doc_ids: Filter by document ID, using the `doc_ids` parameter. Requires `feed=normal`.
     - name: channels
       in: query
-      description: 'A comma-separated list of channel names to filter the response to only the channels specified. To use this option, the `filter` query option must be set to `sync_gateway/bychannels`.'
+      description: 'A comma-separated list of channel names to filter the response to only the channels specified. To use this option, the `filter` query option must be set to `sync_gateway/bychannel`.'
       schema:
         type: string
     - name: doc_ids
@@ -183,7 +183,7 @@ post:
               description: Set a filter to either filter by channels or document IDs.
               type: string
             channels:
-              description: 'A comma-separated list of channel names to filter the response to only the channels specified. To use this option, the `filter` query option must be set to `sync_gateway/bychannels`.'
+              description: 'A comma-separated list of channel names to filter the response to only the channels specified. To use this option, the `filter` query option must be set to `sync_gateway/bychannel`.'
               type: string
             doc_ids:
               description: 'An array of document IDs to filter the documents in the response to only the documents specified. To use this option, the `filter` query option must be set to `_doc_ids` and the `feed` parameter must be `normal`.'

--- a/docs/api/paths/admin/keyspace-_changes.yaml
+++ b/docs/api/paths/admin/keyspace-_changes.yaml
@@ -38,6 +38,9 @@ get:
         enum:
           - main_only
           - all_docs
+        x-enumDescriptions:
+          main_only: Return only the current winning revision.
+          all_docs: Return all leaf revisions, including conflicts and deleted conflicts.
     - name: active_only
       in: query
       description: Set true to exclude deleted documents and notifications for documents the user no longer has access to from the changes feed.
@@ -58,6 +61,9 @@ get:
         enum:
           - sync_gateway/bychannel
           - _doc_ids
+        x-enumDescriptions:
+          sync_gateway/bychannel: Filter by channel, using the `channels` parameter.
+          _doc_ids: Filter by document ID, using the `doc_ids` parameter. Requires `feed=normal`.
     - name: channels
       in: query
       description: 'A comma-separated list of channel names to filter the response to only the channels specified. To use this option, the `filter` query option must be set to `sync_gateway/bychannels`.'
@@ -100,6 +106,11 @@ get:
           - longpoll
           - continuous
           - websocket
+        x-enumDescriptions:
+          normal: Return all current changes at once, then close the connection.
+          longpoll: As `normal`, but if there are no changes yet, waits for the next change (or the heartbeat/timeout) before sending its single response.
+          continuous: Stream each change as it happens, over a single long-lived connection.
+          websocket: Stream changes over a WebSocket connection.
 
     - name: request_plus
       in: query

--- a/docs/api/paths/public/keyspace-_changes.yaml
+++ b/docs/api/paths/public/keyspace-_changes.yaml
@@ -61,7 +61,7 @@ get:
           _doc_ids: Filter by document ID, using the `doc_ids` parameter. Requires `feed=normal`.
     - name: channels
       in: query
-      description: 'A comma-separated list of channel names to filter the response to only the channels specified. To use this option, the `filter` query option must be set to `sync_gateway/bychannels`.'
+      description: 'A comma-separated list of channel names to filter the response to only the channels specified. To use this option, the `filter` query option must be set to `sync_gateway/bychannel`.'
       schema:
         type: string
     - name: doc_ids
@@ -170,7 +170,7 @@ post:
               description: Set a filter to either filter by channels or document IDs.
               type: string
             channels:
-              description: 'A comma-separated list of channel names to filter the response to only the channels specified. To use this option, the `filter` query option must be set to `sync_gateway/bychannels`.'
+              description: 'A comma-separated list of channel names to filter the response to only the channels specified. To use this option, the `filter` query option must be set to `sync_gateway/bychannel`.'
               type: string
             doc_ids:
               description: 'An array of document IDs to filter the documents in the response to only the documents specified. To use this option, the `filter` query option must be set to `_doc_ids` and the `feed` parameter must be `normal`.'

--- a/docs/api/paths/public/keyspace-_changes.yaml
+++ b/docs/api/paths/public/keyspace-_changes.yaml
@@ -33,6 +33,9 @@ get:
         enum:
           - main_only
           - all_docs
+        x-enumDescriptions:
+          main_only: Return only the current winning revision.
+          all_docs: Return all leaf revisions, including conflicts and deleted conflicts.
     - name: active_only
       in: query
       description: Set true to exclude deleted documents and notifications for documents the user no longer has access to from the changes feed.
@@ -53,6 +56,9 @@ get:
         enum:
           - sync_gateway/bychannel
           - _doc_ids
+        x-enumDescriptions:
+          sync_gateway/bychannel: Filter by channel, using the `channels` parameter.
+          _doc_ids: Filter by document ID, using the `doc_ids` parameter. Requires `feed=normal`.
     - name: channels
       in: query
       description: 'A comma-separated list of channel names to filter the response to only the channels specified. To use this option, the `filter` query option must be set to `sync_gateway/bychannels`.'
@@ -95,6 +101,11 @@ get:
           - longpoll
           - continuous
           - websocket
+        x-enumDescriptions:
+          normal: Return all current changes at once, then close the connection.
+          longpoll: As `normal`, but if there are no changes yet, waits for the next change (or the heartbeat/timeout) before sending its single response.
+          continuous: Stream each change as it happens, over a single long-lived connection.
+          websocket: Stream changes over a WebSocket connection.
     - name: request_plus
       in: query
       description: 'When true, ensures all valid documents written prior to the request being issued are included in the response.  This is only applicable for non-continuous feeds.'


### PR DESCRIPTION
CBG-5715

Split out of #8589 — stack 5/9, based on #8652.

These enums rendered as a bare list of allowed values, leaving the reader to guess what each one does. Document each value using the same `x-enumDescriptions` extension already used elsewhere in the specs:

- `_compact?type`, `_profile/{name}`, `_sgcollect_info` redact_level
- `_replicationStatus/{id}` action
- `_changes` style, filter and feed (public and admin)
- resync, attachment migration and metadata migration status
- logging redaction_level, unsupported session_cookie_samesite

Also fixes six pre-existing uses of the singular `x-enumDescription` on the audit logging `domain` fields. Redocly only recognises the plural form, so those cbs/sgw descriptions were being silently dropped.

`Compact-status.phase` is deliberately left out: its enum is currently attached to the wrong property, which is the next PR in the stack.

Both of @bbrks' description comments on #8589 are incorporated here:
- `_sgcollect_info` redaction: `none` is the default, not `partial` (`tools/sgcollect.py:150` — `--log-redaction-level` `default="none"`).
- `longpoll` is one-shot: `changes_api.go:346` sets `options.Wait = true` and calls the same `sendSimpleChanges` path as `normal`, so it sends a single response.

Other factual claims verified: redaction `full` and `unset` both fall through `SetRedaction` to `RedactUserData = true`, i.e. they behave as `partial`; `same_site_cookie: Default` omits the attribute (`auth/session.go:192`); `reset` requires a stopped replication (`db/sg_replicate_cfg.go:444`).

## Pre-review checklist
- [x] Logging sensitive data? N/A — docs only
- [x] Updated relevant information in the API specifications in `docs/api`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
