### PR TITLE
CBG-5715: fix fields documented as string that are not strings

### DIFF
--- a/docs/api/components/parameters.yaml
+++ b/docs/api/components/parameters.yaml
@@ -170,7 +170,7 @@ include_doc:
   in: query
   required: false
   schema:
-    type: string
+    type: boolean
   description: Include the body associated with the document.
 include_docs:
   name: include_docs
@@ -242,7 +242,7 @@ offline:
   in: query
   required: false
   schema:
-    type: string
+    type: boolean
   description: 'If true, the OpenID Connect provider is requested to confirm with the user the permissions requested and refresh the OIDC token. To do this, access_type=offline and prompt=consent is set on the redirection link.'
 oidc-code:
   name: code

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1277,7 +1277,7 @@ Database:
           description: The maximum amount of concurrent event handling independent functions that can be running at the same time.
           type: integer
         wait_for_process:
-          description: The maximum amount of time (in milliseconds) to wait when the even queue is full.
+          description: The maximum amount of time (in milliseconds) to wait when the event queue is full.
           type: string
     guest:
       $ref: '#/User'
@@ -2174,18 +2174,24 @@ Compact-status:
 
         This is the amount of documents that have been purged so far.
       type: integer
+      format: int64
+      minimum: 0
     marked_attachments:
       description: |-
         **Applicable to attachment compaction only**
 
         This is the number of references there are to legacy attachments.
       type: integer
+      format: int64
+      minimum: 0
     purged_attachments:
       description: |-
         **Applicable to attachment compaction only**
 
         This is the amount of attachments that have been purged so far.
       type: integer
+      format: int64
+      minimum: 0
     compact_id:
       description: |-
         **Applicable to attachment compaction only**

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -473,7 +473,8 @@ OIDC-token:
     refresh_token:
       type: string
     expires_in:
-      type: string
+      type: integer
+      minimum: 0
     id_token:
       type: string
   title: OIDC-token
@@ -1274,7 +1275,7 @@ Database:
                       default: false
         max_processes:
           description: The maximum amount of concurrent event handling independent functions that can be running at the same time.
-          type: string
+          type: integer
         wait_for_process:
           description: The maximum amount of time (in milliseconds) to wait when the even queue is full.
           type: string
@@ -2172,19 +2173,19 @@ Compact-status:
         **Applicable to tombstone compaction only**
 
         This is the amount of documents that have been purged so far.
-      type: string
+      type: integer
     marked_attachments:
       description: |-
         **Applicable to attachment compaction only**
 
         This is the number of references there are to legacy attachments.
-      type: string
+      type: integer
     purged_attachments:
       description: |-
         **Applicable to attachment compaction only**
 
         This is the amount of attachments that have been purged so far.
-      type: string
+      type: integer
     compact_id:
       description: |-
         **Applicable to attachment compaction only**

--- a/docs/api/paths/admin/keyspace-_changes.yaml
+++ b/docs/api/paths/admin/keyspace-_changes.yaml
@@ -163,7 +163,7 @@ post:
               description: Maximum number of changes to return.
               type: integer
             since:
-              description: Starts the results from the change immediately after the given sequence ID. Sequence IDs should be considered opaque; they come from the last_seq property of a prior response.
+              description: Starts the results from the change immediately after the given sequence ID. Sequence IDs should be considered opaque; they come from the last_seq property of a prior response. Accepts either a string or, for a simple sequence, a number.
               oneOf:
                 - type: string
                 - type: integer

--- a/docs/api/paths/admin/keyspace-_changes.yaml
+++ b/docs/api/paths/admin/keyspace-_changes.yaml
@@ -176,9 +176,6 @@ post:
             include_docs:
               description: Include the body associated with each document.
               type: boolean
-            revocations:
-              description: 'If true, revocation messages will be sent on the changes feed.'
-              type: string
             filter:
               description: Set a filter to either filter by channels or document IDs.
               type: string

--- a/docs/api/paths/public/keyspace-_changes.yaml
+++ b/docs/api/paths/public/keyspace-_changes.yaml
@@ -108,7 +108,7 @@ get:
           websocket: Stream changes over a WebSocket connection.
     - name: request_plus
       in: query
-      description: 'When true, ensures all valid documents written prior to the request being issued are included in the response.  This is only applicable for non-continuous feeds.'
+      description: When true, ensures all valid documents written prior to the request being issued are included in the response.  This is only applicable for non-continuous feeds.
       schema:
         type: boolean
         default: false
@@ -150,7 +150,7 @@ post:
               description: Maximum number of changes to return.
               type: integer
             since:
-              description: Starts the results from the change immediately after the given sequence ID. Sequence IDs should be considered opaque; they come from the last_seq property of a prior response.
+              description: Starts the results from the change immediately after the given sequence ID. Sequence IDs should be considered opaque; they come from the last_seq property of a prior response. Accepts either a string or, for a simple sequence, a number.
               oneOf:
                 - type: string
                 - type: integer

--- a/docs/api/paths/public/keyspace-_changes.yaml
+++ b/docs/api/paths/public/keyspace-_changes.yaml
@@ -163,9 +163,6 @@ post:
             include_docs:
               description: Include the body associated with each document.
               type: boolean
-            revocations:
-              description: 'If true, revocation messages will be sent on the changes feed.'
-              type: string
             filter:
               description: Set a filter to either filter by channels or document IDs.
               type: string


### PR DESCRIPTION
CBG-5715

Split out of #8589 — stack 6/9, based on #8653.

Each of these is documented as `string` but is unmarshalled into a bool or an integer, so the documented request bodies would be rejected and the documented response types don't match what is emitted:

- `include_doc` and `offline` query params are read with `getBoolQuery` (`rest/admin_api.go:1632`, `rest/oidc_api.go:118`)
- `_changes` POST body (per `readChangesOptionsFromJSON`, `rest/changes_api.go:599`): `limit` is `int`, `heartbeat`/`timeout` are `*uint64`, `active_only`/`include_docs` are `bool`, and `doc_ids` is a real `[]string` here — unlike the query parameter, which is a serialized string
- `event_handlers.max_processes` is a `uint` (`rest/config.go:218`)
- `OIDC-token.expires_in` is an `int` TTL (`rest/oidc_api.go:67`)
- `Compact-status.docs_purged`, `marked_attachments` and `purged_attachments` are `int64` counters

`revocations` is also dropped from the `_changes` POST body. Neither `readChangesOptionsFromJSON` nor `updateChangesOptionsFromQuery` reads it, so a POST cannot set it at all — not via the body and not via the query string. It is only honoured on GET (`rest/changes_api.go:190`). @bbrks spotted this on #8589 and suspected an oversight in the handler; removing the property documents current behaviour, and the handler gap is worth its own ticket if `revocations` should work on POST.

`wait_for_process` is left as a string: it really is parsed as a duration string, not a number (`rest/config.go:219`).

Covers the three @factory-droid comments on #8589 about the POST `/_changes` request bodies and `OIDC-token.expires_in`.

## Pre-review checklist
- [x] Logging sensitive data? N/A — docs only
- [x] Updated relevant information in the API specifications in `docs/api`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
