### PR TITLE
CBG-5715: attach the compaction phase enum to phase, not dry_run

### DIFF
--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -2206,14 +2206,18 @@ Compact-status:
 
         For failed processes, this indicates the phase at which a compact_id restart will commence (where relevant).
       type: string
-    dry_run:
-      description: |
-        **Applicable to attachment compaction only**
-      type: string
       enum:
         - mark
         - sweep
         - cleanup
+      x-enumDescriptions:
+        mark: Scanning documents to find attachments still in use.
+        sweep: Deleting attachments that are no longer used.
+        cleanup: Finishing up and clearing temporary compaction data.
+    dry_run:
+      description: |
+        **Applicable to attachment compaction only**
+      type: boolean
   required:
     - status
     - start_time


### PR DESCRIPTION
CBG-5715

Split out of #8589 — stack 7/9, based on #8654.

The `mark`/`sweep`/`cleanup` enum was indented one property too far down, so it constrained `dry_run` (a `bool` in Go, previously also documented as a string) while `phase` — the field that actually carries those values — was documented as an unconstrained string.

Move the enum onto `phase`, document each value, and correct `dry_run` to boolean.

Evidence: `db/background_mgr_attachment_compaction.go:42` — `_phase string // current phase: "mark", "sweep", "cleanup", or "" when idle`, and `:327` — `DryRun bool json:"dry_run,omitempty"`.

## Pre-review checklist
- [x] Logging sensitive data? N/A — docs only
- [x] Updated relevant information in the API specifications in `docs/api`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
