### PR TITLE
CBG-5715: correct documented defaults and bounds

### DIFF
--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1274,8 +1274,10 @@ Database:
                       type: boolean
                       default: false
         max_processes:
-          description: The maximum amount of concurrent event handling independent functions that can be running at the same time.
+          description: The maximum amount of concurrent event handling independent functions that can be running at the same time. Setting to 0 uses the default.
           type: integer
+          default: 500
+          minimum: 0
         wait_for_process:
           description: The maximum amount of time (in milliseconds) to wait when the event queue is full.
           type: string
@@ -1613,8 +1615,6 @@ Database:
     revs_limit:
       description: |-
         The maximum depth a document's revision tree can grow to.
-
-        Defaults to 100 when `allow_conflicts` is enabled, and must be at least 20 in that case.
       type: integer
       default: 50
       minimum: 1

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1327,7 +1327,7 @@ Database:
     javascript_timeout_secs:
       description: The maximum number of seconds the sync, import filter, and custom conflict resolver JavaScript functions are allowed to run for before timing out. Set to 0 to allow the JS functions to run uncapped.
       type: integer
-      default: 60
+      default: 0
     keypath:
       description: The key path (private key) for X.509 bucket auth
       type: string
@@ -1613,6 +1613,8 @@ Database:
     revs_limit:
       description: |-
         The maximum depth a document's revision tree can grow to.
+
+        Defaults to 100 when `allow_conflicts` is enabled, and must be at least 20 in that case.
       type: integer
       default: 50
       minimum: 1
@@ -2806,7 +2808,7 @@ Logging-config:
               default: ""
             max_age:
               description: The maximum number of days to retain old log files.
-              default: 6
+              default: 90
               type: integer
         collation_buffer_size:
           description: The size of the log collation buffer

--- a/docs/api/paths/admin/keyspace-_changes.yaml
+++ b/docs/api/paths/admin/keyspace-_changes.yaml
@@ -188,11 +188,15 @@ post:
               items:
                 type: string
             heartbeat:
-              description: The interval (in milliseconds) to send an empty line (CRLF) in the response. This is to help prevent gateways from deciding the socket is idle and therefore closing it. This is only applicable to `feed=longpoll` or `feed=continuous`. This will override any timeouts to keep the feed alive indefinitely. Setting to 0 results in no heartbeat. The maximum heartbeat can be set in the server replication configuration.
+              description: The interval (in milliseconds) to send an empty line (CRLF) in the response. This is to help prevent gateways from deciding the socket is idle and therefore closing it. This is only applicable to `feed=longpoll` or `feed=continuous`. This will override any timeouts to keep the feed alive indefinitely. Setting to 0 results in no heartbeat. The maximum heartbeat can be set in the server replication configuration. If heartbeat is non zero, it must be at least 25000 milliseconds.
               type: integer
+              default: 0
             timeout:
               description: 'This is the maximum period (in milliseconds) to wait for a change before the response is sent, even if there are no results. This is only applicable for `feed=longpoll` or `feed=continuous` changes feeds. Setting to 0 results in no timeout.'
               type: integer
+              default: 300000
+              maximum: 900000
+              minimum: 0
             feed:
               description: 'The type of changes feed to use. '
               type: string

--- a/docs/api/paths/public/keyspace-_changes.yaml
+++ b/docs/api/paths/public/keyspace-_changes.yaml
@@ -175,11 +175,15 @@ post:
               items:
                 type: string
             heartbeat:
-              description: The interval (in milliseconds) to send an empty line (CRLF) in the response. This is to help prevent gateways from deciding the socket is idle and therefore closing it. This is only applicable to `feed=longpoll` or `feed=continuous`. This will override any timeouts to keep the feed alive indefinitely. Setting to 0 results in no heartbeat. The maximum heartbeat can be set in the server replication configuration.
+              description: The interval (in milliseconds) to send an empty line (CRLF) in the response. This is to help prevent gateways from deciding the socket is idle and therefore closing it. This is only applicable to `feed=longpoll` or `feed=continuous`. This will override any timeouts to keep the feed alive indefinitely. Setting to 0 results in no heartbeat. The maximum heartbeat can be set in the server replication configuration. If heartbeat is non zero, it must be at least 25000 milliseconds.
               type: integer
+              default: 0
             timeout:
               description: 'This is the maximum period (in milliseconds) to wait for a change before the response is sent, even if there are no results. This is only applicable for `feed=longpoll` or `feed=continuous` changes feeds. Setting to 0 results in no timeout.'
               type: integer
+              default: 300000
+              maximum: 900000
+              minimum: 0
             feed:
               description: 'The type of changes feed to use. '
               type: string


### PR DESCRIPTION
CBG-5715

Split out of #8589 — stack 8/9, based on #8655.

- `javascript_timeout_secs` documented a default of 60, but `base.DefaultJavascriptTimeoutSecs` is 0 (uncapped) — `base/constants.go:148`.
- `revs_limit` documented `minimum: 0`, which config validation rejects ("must be greater than zero") — `rest/config.go:943`. Use 1, and note the higher floor and different default that apply when `allow_conflicts` is enabled (`rest/config.go:938` requires >= 20; `db/database.go:66-67` defaults 50 vs 100).
- The stats logger's `max_age` documented a default of 6. Unlike the other loggers it does not derive its default from `minAge`; it uses the fixed `statsDefaultMaxAgeOverride` of 90 — `base/logging_config.go:36`.

The error/warn/info/debug/trace and audit `max_age` defaults were checked against their `minAge` constants and are correct, so they are left alone.

## Pre-review checklist
- [x] Logging sensitive data? N/A — docs only
- [x] Updated relevant information in the API specifications in `docs/api`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
