### PR TITLE
CBG-5715: fix _changes filter name, compound seq, and dumpchannel since

### DIFF
--- a/docs/api/components/parameters.yaml
+++ b/docs/api/components/parameters.yaml
@@ -493,6 +493,7 @@ stale:
     enum:
       - ok
       - update_after
+      - "false"
 key:
   name: key
   in: query

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -419,6 +419,7 @@ User-session-information:
           additionalProperties:
             x-additionalPropertiesName: channelName
             type: integer
+            format: int64
             minimum: 1
             description: The sequence number the user was granted access.
             title: sequence number
@@ -589,6 +590,7 @@ Changes-feed:
             description: The change sequence number. This is usually a plain integer, but can be a compound (string) sequence value in some cases, such as during a channel backfill.
             oneOf:
               - type: integer
+                format: int64
               - type: string
           id:
             description: The document ID the change happened on.

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1615,8 +1615,6 @@ Database:
     revs_limit:
       description: |-
         The maximum depth a document's revision tree can grow to.
-
-        Defaults to 100 when `allow_conflicts` is enabled, and must be at least 20 in that case.
       type: integer
       default: 50
       minimum: 1

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1615,6 +1615,8 @@ Database:
     revs_limit:
       description: |-
         The maximum depth a document's revision tree can grow to.
+
+        Defaults to 100 when `allow_conflicts` is enabled, and must be at least 20 in that case.
       type: integer
       default: 50
       minimum: 1

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -586,7 +586,7 @@ Changes-feed:
         type: object
         properties:
           seq:
-            description: The change sequence number.
+            description: The change sequence number. This is usually a plain integer, but can be a compound (string) sequence value in some cases, such as during a channel backfill.
             oneOf:
               - type: integer
               - type: string
@@ -2777,7 +2777,7 @@ Logging-config:
           readOnly: true
     stats:
       type: object
-      description: Trace logging configuration.
+      description: Stats logging configuration.
       properties:
         enabled:
           description: Toggle for this log output

--- a/docs/api/paths/admin/keyspace-_dumpchannel-channel.yaml
+++ b/docs/api/paths/admin/keyspace-_dumpchannel-channel.yaml
@@ -30,6 +30,8 @@ get:
       description: Starts the results from the change immediately after the given sequence number.
       schema:
         type: integer
+        format: int64
+        minimum: 0
   responses:
     '200':
       description: Successfully got all documents in the channel

--- a/docs/api/paths/admin/keyspace-_dumpchannel-channel.yaml
+++ b/docs/api/paths/admin/keyspace-_dumpchannel-channel.yaml
@@ -27,9 +27,9 @@ get:
   parameters:
     - name: since
       in: query
-      description: Starts the results from the change immediately after the given sequence ID. Sequence IDs should be considered opaque; they come from the last_seq property of a prior response.
+      description: Starts the results from the change immediately after the given sequence number.
       schema:
-        type: string
+        type: integer
   responses:
     '200':
       description: Successfully got all documents in the channel


### PR DESCRIPTION
CBG-5715

Split out of #8589 — stack 9/9, based on #8656.

- The channel filter is `sync_gateway/bychannel` (`base.ByChannelFilter`, `base/constants.go:137`), not `sync_gateway/bychannels`. The `filter` enum already had it right; four `channels` descriptions did not. (Raised by @factory-droid on #8589.)
- `Changes-feed.seq` was documented as an integer, but `SequenceID.MarshalJSON` (`db/sequence_id.go:155`) emits a quoted compound string whenever `TriggeredBy` or `LowSeq` is set (e.g. during a channel backfill), so clients must handle both.
- `_dumpchannel?since` is read with `getIntQuery` (`rest/bulk_api.go:359`), so it is a plain sequence number, not the opaque `last_seq` value the description described.
- `stale` also accepts `false`, which is the value Sync Gateway's own view queries use. Worth a reviewer's eye: `rest/view_api.go:100` passes `stale` through to the view engine verbatim, so nothing in SG validates the value set — the enum as a whole is unverifiable from the code, and dropping it may be more honest than extending it.
- The stats logging block was described as "Trace logging configuration".

## Pre-review checklist
- [x] Logging sensitive data? N/A — docs only
- [x] Updated relevant information in the API specifications in `docs/api`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
