### PR TITLE
CBG-4625: test-only additional ISGR peers now take same subprotocol

### DIFF
--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -2628,7 +2628,8 @@ func TestProcessRevIncrementsStat(t *testing.T) {
 	sgrRunner := NewSGRTestRunner(t)
 
 	sgrRunner.Run(func(t *testing.T) {
-		activeRT, remoteRT, remoteURLString := sgrRunner.SetupSGRPeers(t)
+		peers := sgrRunner.SetupSGRPeers(t)
+		activeRT, remoteRT, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 		activeCtx := activeRT.Context()
 		remoteURL, err := url.Parse(remoteURLString)
 		require.NoError(t, err)

--- a/rest/replicatortest/replicator_collection_test.go
+++ b/rest/replicatortest/replicator_collection_test.go
@@ -323,7 +323,8 @@ func TestActiveReplicatorMultiCollectionMismatchedLocalRemote(t *testing.T) {
 	sgrRunner := rest.NewSGRTestRunner(t)
 
 	sgrRunner.Run(func(t *testing.T) {
-		activeRT, _, remoteDbURLString := sgrRunner.SetupSGRPeers(t)
+		peers := sgrRunner.SetupSGRPeers(t)
+		activeRT, remoteDbURLString := peers.ActiveRT, peers.PassiveDBURL
 
 		passiveDBURL, err := url.Parse(remoteDbURLString)
 		require.NoError(t, err)
@@ -358,7 +359,8 @@ func TestActiveReplicatorMultiCollectionMissingRemote(t *testing.T) {
 	sgrRunner := rest.NewSGRTestRunner(t)
 
 	sgrRunner.Run(func(t *testing.T) {
-		activeRT, _, remoteDbURLString := sgrRunner.SetupSGRPeers(t)
+		peers := sgrRunner.SetupSGRPeers(t)
+		activeRT, remoteDbURLString := peers.ActiveRT, peers.PassiveDBURL
 
 		localCollection := activeRT.GetSingleDataStore().ScopeName() + "." + activeRT.GetSingleDataStore().CollectionName()
 		localCollections := []string{localCollection}
@@ -397,7 +399,8 @@ func TestActiveReplicatorMultiCollectionMissingLocal(t *testing.T) {
 	sgrRunner := rest.NewSGRTestRunner(t)
 
 	sgrRunner.Run(func(t *testing.T) {
-		activeRT, passiveRT, remoteDbURLString := sgrRunner.SetupSGRPeers(t)
+		peers := sgrRunner.SetupSGRPeers(t)
+		activeRT, passiveRT, remoteDbURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 
 		localCollection := activeRT.GetSingleDataStore().ScopeName() + ".invalid"
 		localCollections := []string{localCollection}

--- a/rest/replicatortest/replicator_conflict_test.go
+++ b/rest/replicatortest/replicator_conflict_test.go
@@ -46,7 +46,8 @@ func TestActiveReplicatorHLVConflictRemoteAndLocalWins(t *testing.T) {
 	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
 		for _, testCase := range testCases {
 			t.Run(testCase.name, func(t *testing.T) {
-				rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+				peers := sgrRunner.SetupSGRPeers(t)
+				rt1, rt2, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 				remoteURL, err := url.Parse(remoteURLString)
 				require.NoError(t, err)
 				ctx1 := rt1.Context()
@@ -192,7 +193,8 @@ func TestActiveReplicatorLWWDefaultResolver(t *testing.T) {
 	sgrRunner := rest.NewSGRTestRunner(t)
 	// v4 protocol only test
 	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
-		rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+		peers := sgrRunner.SetupSGRPeers(t)
+		rt1, rt2, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 		remoteURL, err := url.Parse(remoteURLString)
 		require.NoError(t, err)
 		ctx1 := rt1.Context()
@@ -443,7 +445,8 @@ func TestActiveReplicatorLocalWinsCases(t *testing.T) {
 	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
 		for _, testCase := range testCases {
 			t.Run(testCase.name, func(t *testing.T) {
-				rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+				peers := sgrRunner.SetupSGRPeers(t)
+				rt1, rt2, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 				remoteURL, err := url.Parse(remoteURLString)
 				require.NoError(t, err)
 				ctx1 := rt1.Context()
@@ -744,7 +747,8 @@ func TestActiveReplicatorRemoteWinsCases(t *testing.T) {
 	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
 		for _, testCase := range testCases {
 			t.Run(testCase.name, func(t *testing.T) {
-				rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+				peers := sgrRunner.SetupSGRPeers(t)
+				rt1, rt2, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 				remoteURL, err := url.Parse(remoteURLString)
 				require.NoError(t, err)
 				ctx1 := rt1.Context()
@@ -971,7 +975,8 @@ func TestActiveReplicatorHLVConflictNoCommonMVPV(t *testing.T) {
 	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
 		for _, testCase := range testCases {
 			t.Run(testCase.name, func(t *testing.T) {
-				rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+				peers := sgrRunner.SetupSGRPeers(t)
+				rt1, rt2, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 				remoteURL, err := url.Parse(remoteURLString)
 				require.NoError(t, err)
 				ctx1 := rt1.Context()
@@ -1170,7 +1175,8 @@ func TestActiveReplicatorAttachmentHandling(t *testing.T) {
 	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
 		for _, testCase := range testCases {
 			t.Run(testCase.name, func(t *testing.T) {
-				rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+				peers := sgrRunner.SetupSGRPeers(t)
+				rt1, rt2, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 				remoteURL, err := url.Parse(remoteURLString)
 				require.NoError(t, err)
 				ctx1 := rt1.Context()
@@ -1316,7 +1322,8 @@ func TestActiveReplicatorHLVConflictWinnerIsTombstone(t *testing.T) {
 	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
 		for _, testCase := range testCases {
 			t.Run(testCase.name, func(t *testing.T) {
-				rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+				peers := sgrRunner.SetupSGRPeers(t)
+				rt1, rt2, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 				remoteURL, err := url.Parse(remoteURLString)
 				require.NoError(t, err)
 				ctx1 := rt1.Context()
@@ -1444,7 +1451,8 @@ func TestActiveReplicatorInvalidCustomResolver(t *testing.T) {
 	sgrRunner := rest.NewSGRTestRunner(t)
 	// v4 protocol only test
 	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
-		rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+		peers := sgrRunner.SetupSGRPeers(t)
+		rt1, rt2, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 		remoteURL, err := url.Parse(remoteURLString)
 		require.NoError(t, err)
 		ctx1 := rt1.Context()
@@ -1593,7 +1601,8 @@ func TestActiveReplicatorHLVConflictCustom(t *testing.T) {
 	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
 		for _, testCase := range testCases {
 			t.Run(testCase.name, func(t *testing.T) {
-				rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+				peers := sgrRunner.SetupSGRPeers(t)
+				rt1, rt2, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 				remoteURL, err := url.Parse(remoteURLString)
 				require.NoError(t, err)
 				ctx1 := rt1.Context()
@@ -1738,7 +1747,8 @@ func TestActiveReplicatorHLVConflictWhenNonWinningRevHasMoreRevisions(t *testing
 	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
 		for _, testCase := range testCases {
 			t.Run(testCase.name, func(t *testing.T) {
-				rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+				peers := sgrRunner.SetupSGRPeers(t)
+				rt1, rt2, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 				remoteURL, err := url.Parse(remoteURLString)
 				require.NoError(t, err)
 				ctx1 := rt1.Context()
@@ -1862,7 +1872,8 @@ func TestActiveReplicatorHLVConflictLocalWinsWhenNonWinningRevHasLessRevisionsLo
 	sgrRunner := rest.NewSGRTestRunner(t)
 	// v4 protocol only test
 	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
-		rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+		peers := sgrRunner.SetupSGRPeers(t)
+		rt1, rt2, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 		remoteURL, err := url.Parse(remoteURLString)
 		require.NoError(t, err)
 		ctx1 := rt1.Context()
@@ -1966,7 +1977,8 @@ func TestActiveReplicatorHLVConflictWithBothLocalAndRemoteTombstones(t *testing.
 	sgrRunner := rest.NewSGRTestRunner(t)
 	// v4 protocol only test
 	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
-		rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+		peers := sgrRunner.SetupSGRPeers(t)
+		rt1, rt2, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 		remoteURL, err := url.Parse(remoteURLString)
 		require.NoError(t, err)
 		ctx1 := rt1.Context()
@@ -2059,7 +2071,8 @@ func TestActiveReplicatorConflictRemoveCVFromCache(t *testing.T) {
 	sgrRunner := rest.NewSGRTestRunner(t)
 	// v4 protocol only test
 	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
-		rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+		peers := sgrRunner.SetupSGRPeers(t)
+		rt1, rt2, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 		remoteURL, err := url.Parse(remoteURLString)
 		require.NoError(t, err)
 		ctx1 := rt1.Context()
@@ -2074,8 +2087,7 @@ func TestActiveReplicatorConflictRemoveCVFromCache(t *testing.T) {
 		require.NoError(t, err)
 
 		// add active rt to simulate two nodes on active cluster
-		active := addActiveRT(t, rt1.GetDatabase().Name, rt1.TestBucket)
-		defer active.Close()
+		active := peers.AddActiveRT(t)
 
 		replicationID := rest.SafeDocumentName(t, t.Name())
 		ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
@@ -2130,7 +2142,8 @@ func TestActiveReplicatorV4DefaultResolverWithTombstoneLocal(t *testing.T) {
 	sgrRunner := rest.NewSGRTestRunner(t)
 	// v4 protocol only test
 	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
-		activeRT, passiveRT, remoteURLString := sgrRunner.SetupSGRPeers(t)
+		peers := sgrRunner.SetupSGRPeers(t)
+		activeRT, passiveRT, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 
 		docID := rest.SafeDocumentName(t, t.Name())
 		rt1Version := activeRT.PutDoc(docID, `{"source":"activeRT","channels":["alice"]}`)
@@ -2180,7 +2193,8 @@ func TestActiveReplicatorV4DefaultResolverWithTombstoneRemote(t *testing.T) {
 	sgrRunner := rest.NewSGRTestRunner(t)
 	// v4 protocol only test
 	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
-		activeRT, passiveRT, remoteURLString := sgrRunner.SetupSGRPeers(t)
+		peers := sgrRunner.SetupSGRPeers(t)
+		activeRT, passiveRT, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 		docID := rest.SafeDocumentName(t, t.Name())
 
 		rt2Version := passiveRT.PutDoc(docID, `{"source":"passiveRT","channels":["alice"]}`)
@@ -2234,7 +2248,8 @@ func TestDefaultConflictResolverMatchingTimestamps(t *testing.T) {
 	// digest, not by timestamp), so only the V4 subtest is run.
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
-		activeRT, passiveRT, remoteDBURLString := sgrRunner.SetupSGRPeers(t)
+		peers := sgrRunner.SetupSGRPeers(t)
+		activeRT, passiveRT, remoteDBURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 		remoteURL, err := url.Parse(remoteDBURLString)
 		require.NoError(t, err)
 		activeRTCtx := activeRT.Context()

--- a/rest/replicatortest/replicator_no_race_test.go
+++ b/rest/replicatortest/replicator_no_race_test.go
@@ -46,7 +46,8 @@ func TestReplicationHeartbeatRemovalPushWithConfigReload(t *testing.T) {
 		t.Cleanup(reduceTestCheckpointInterval(50 * time.Millisecond))
 		t.Cleanup(db.SuspendSequenceBatching())
 
-		activeRT, remoteRT, remoteURLString := sgrRunner.SetupSGRPeers(t)
+		peers := sgrRunner.SetupSGRPeers(t)
+		activeRT, remoteRT, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 
 		docABC1 := rest.SafeDocumentName(t, t.Name()+"ABC1")
 		docDEF1 := rest.SafeDocumentName(t, t.Name()+"DEF1")
@@ -63,8 +64,7 @@ func TestReplicationHeartbeatRemovalPushWithConfigReload(t *testing.T) {
 		changesResults := remoteRT.WaitForChanges(2, "/{{.keyspace}}/_changes?since=0", "", true)
 		changesResults.RequireDocIDs(t, []string{docABC1, docDEF1})
 
-		activeRT2 := addActiveRT(t, activeRT.GetDatabase().Name, activeRT.TestBucket)
-		defer activeRT2.Close()
+		activeRT2 := peers.AddActiveRT(t)
 
 		activeRT.WaitForAssignedReplications(1)
 		activeRT2.WaitForAssignedReplications(1)

--- a/rest/replicatortest/replicator_revtree_test.go
+++ b/rest/replicatortest/replicator_revtree_test.go
@@ -44,7 +44,8 @@ func TestActiveReplicatorRevTreeReconciliation(t *testing.T) {
 	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
-				rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+				peers := sgrRunner.SetupSGRPeers(t)
+				rt1, rt2, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 				remoteURL, err := url.Parse(remoteURLString)
 				require.NoError(t, err)
 				ctx1 := rt1.Context()
@@ -70,10 +71,11 @@ func TestActiveReplicatorRevTreeReconciliation(t *testing.T) {
 					ActiveDB: &db.Database{
 						DatabaseContext: rt1.GetDatabase(),
 					},
-					ChangesBatchSize:    200,
-					ReplicationStatsMap: dbReplicatorStats(t, rt1.GetDatabase()),
-					CollectionsEnabled:  !rt1.GetDatabase().OnlyDefaultCollection(),
-					Continuous:          false,
+					ChangesBatchSize:       200,
+					ReplicationStatsMap:    dbReplicatorStats(t, rt1.GetDatabase()),
+					SupportedBLIPProtocols: sgrRunner.SupportedSubprotocols,
+					CollectionsEnabled:     !rt1.GetDatabase().OnlyDefaultCollection(),
+					Continuous:             false,
 				})
 				require.NoError(t, err)
 				defer func() { assert.NoError(t, ar.Stop()) }()
@@ -167,7 +169,8 @@ func TestActiveReplicatorNoHLVConflictConflictInRevTree(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
-		rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+		peers := sgrRunner.SetupSGRPeers(t)
+		rt1, rt2, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 		remoteURL, err := url.Parse(remoteURLString)
 		require.NoError(t, err)
 		ctx1 := rt1.Context()
@@ -192,6 +195,7 @@ func TestActiveReplicatorNoHLVConflictConflictInRevTree(t *testing.T) {
 			ChangesBatchSize:           200,
 			ConflictResolverFuncForHLV: resolverFunc,
 			ReplicationStatsMap:        dbReplicatorStats(t, rt1.GetDatabase()),
+			SupportedBLIPProtocols:     sgrRunner.SupportedSubprotocols,
 			CollectionsEnabled:         !rt1.GetDatabase().OnlyDefaultCollection(),
 			Continuous:                 false,
 		})
@@ -286,7 +290,8 @@ func TestActiveReplicatorRevtreeLargeDiffInSize(t *testing.T) {
 	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
-				rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+				peers := sgrRunner.SetupSGRPeers(t)
+				rt1, rt2, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 				remoteURL, err := url.Parse(remoteURLString)
 				require.NoError(t, err)
 				ctx1 := rt1.Context()
@@ -309,10 +314,11 @@ func TestActiveReplicatorRevtreeLargeDiffInSize(t *testing.T) {
 					ActiveDB: &db.Database{
 						DatabaseContext: rt1.GetDatabase(),
 					},
-					ChangesBatchSize:    200,
-					ReplicationStatsMap: dbReplicatorStats(t, rt1.GetDatabase()),
-					CollectionsEnabled:  !rt1.GetDatabase().OnlyDefaultCollection(),
-					Continuous:          false,
+					ChangesBatchSize:       200,
+					ReplicationStatsMap:    dbReplicatorStats(t, rt1.GetDatabase()),
+					SupportedBLIPProtocols: sgrRunner.SupportedSubprotocols,
+					CollectionsEnabled:     !rt1.GetDatabase().OnlyDefaultCollection(),
+					Continuous:             false,
 				})
 				require.NoError(t, err)
 				defer func() { assert.NoError(t, ar.Stop()) }()

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -474,7 +474,8 @@ func TestPushReplicationAPI(t *testing.T) {
 	sgrRunner := rest.NewSGRTestRunner(t)
 
 	sgrRunner.Run(func(t *testing.T) {
-		rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+		peers := sgrRunner.SetupSGRPeers(t)
+		rt1, rt2, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 
 		// Create doc1 on rt1
 		docID1 := rest.SafeDocumentName(t, t.Name()+"rt1doc")
@@ -519,7 +520,8 @@ func TestPullReplicationAPI(t *testing.T) {
 
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.Run(func(t *testing.T) {
-		rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+		peers := sgrRunner.SetupSGRPeers(t)
+		rt1, rt2, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 
 		// Create doc1 on rt2
 		docID1 := rest.SafeDocumentName(t, t.Name()+"rt2doc")
@@ -560,7 +562,8 @@ func TestDisableConcurrentReplicationLimitDuringReplications(t *testing.T) {
 
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.Run(func(t *testing.T) {
-		rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+		peers := sgrRunner.SetupSGRPeers(t)
+		rt1, rt2, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 
 		resp := rt2.SendAdminRequest(http.MethodPut, "/_config", `{"max_concurrent_replications" : 2}`)
 		rest.RequireStatus(t, resp, http.StatusOK)
@@ -605,7 +608,8 @@ func TestConcurrentReplicationLimitContinuous(t *testing.T) {
 
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.Run(func(t *testing.T) {
-		rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+		peers := sgrRunner.SetupSGRPeers(t)
+		rt1, rt2, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 
 		// update runtime config to limit to 2 concurrent replication connections
 		resp := rt2.SendAdminRequest(http.MethodPut, "/_config", `{"max_concurrent_replications" : 2}`)
@@ -671,7 +675,8 @@ func TestReplicationStatusActions(t *testing.T) {
 		// Increase checkpoint persistence frequency for cross-node status verification
 		reduceCheckpointInterval := reduceTestCheckpointInterval(50 * time.Millisecond)
 		t.Cleanup(reduceCheckpointInterval)
-		rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+		peers := sgrRunner.SetupSGRPeers(t)
+		rt1, rt2, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 
 		// Create doc1 on rt2
 		docID1 := rest.SafeDocumentName(t, t.Name()+"rt2doc")
@@ -761,7 +766,8 @@ func TestReplicationStatusActions(t *testing.T) {
 func TestReplicationRebalanceToZeroNodes(t *testing.T) {
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.Run(func(t *testing.T) {
-		activeRT, remoteRT, _ := sgrRunner.SetupSGRPeers(t)
+		peers := sgrRunner.SetupSGRPeers(t)
+		activeRT, remoteRT := peers.ActiveRT, peers.PassiveRT
 
 		// Build connection string for active RT
 		srv := httptest.NewServer(activeRT.TestPublicHandler())
@@ -798,7 +804,8 @@ func TestReplicationRebalancePull(t *testing.T) {
 		// Increase checkpoint persistence frequency for cross-node status verification
 		reduceCheckpointInterval := reduceTestCheckpointInterval(50 * time.Millisecond)
 		t.Cleanup(reduceCheckpointInterval)
-		activeRT, remoteRT, remoteURLString := sgrRunner.SetupSGRPeers(t)
+		peers := sgrRunner.SetupSGRPeers(t)
+		activeRT, remoteRT, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 
 		// Create docs on remote
 		docABC1 := rest.SafeDocumentName(t, t.Name()+"ABC1")
@@ -832,8 +839,7 @@ func TestReplicationRebalancePull(t *testing.T) {
 		}
 
 		// Add another node to the active cluster
-		activeRT2 := addActiveRT(t, activeRT.GetDatabase().Name, activeRT.TestBucket)
-		defer activeRT2.Close()
+		activeRT2 := peers.AddActiveRT(t)
 
 		// Wait for replication to be rebalanced to activeRT2
 		activeRT.WaitForAssignedReplications(1)
@@ -892,7 +898,8 @@ func TestReplicationRebalancePush(t *testing.T) {
 		// Increase checkpoint persistence frequency for cross-node status verification
 		reduceCheckpointInterval := reduceTestCheckpointInterval(50 * time.Millisecond)
 		t.Cleanup(reduceCheckpointInterval)
-		activeRT, remoteRT, remoteURLString := sgrRunner.SetupSGRPeers(t)
+		peers := sgrRunner.SetupSGRPeers(t)
+		activeRT, remoteRT, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 
 		// Create docs on active
 		docABC1 := rest.SafeDocumentName(t, t.Name()+"ABC1")
@@ -929,8 +936,7 @@ func TestReplicationRebalancePush(t *testing.T) {
 		}
 
 		// Add another node to the active cluster
-		activeRT2 := addActiveRT(t, activeRT.GetDatabase().Name, activeRT.TestBucket)
-		defer activeRT2.Close()
+		activeRT2 := peers.AddActiveRT(t)
 
 		// Wait for replication to be rebalanced to activeRT2
 		activeRT.WaitForAssignedReplications(1)
@@ -978,7 +984,8 @@ func TestPullOneshotReplicationAPI(t *testing.T) {
 
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.Run(func(t *testing.T) {
-		activeRT, remoteRT, remoteURLString := sgrRunner.SetupSGRPeers(t)
+		peers := sgrRunner.SetupSGRPeers(t)
+		activeRT, remoteRT, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 
 		// Create 20 docs on rt2
 		docCount := 20
@@ -1013,8 +1020,7 @@ func TestPullOneshotReplicationAPI(t *testing.T) {
 		assert.Equal(t, int64(docCount), status.DocsRead)
 
 		// Add another node to the active cluster
-		activeRT2 := addActiveRT(t, activeRT.GetDatabase().Name, activeRT.TestBucket)
-		defer activeRT2.Close()
+		activeRT2 := peers.AddActiveRT(t)
 
 		// Get replication status for non-local replication
 		remoteStatus := activeRT2.GetReplicationStatus(replicationID)
@@ -1038,7 +1044,8 @@ func TestReplicationConcurrentPush(t *testing.T) {
 
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.Run(func(t *testing.T) {
-		activeRT, remoteRT, remoteURLString := sgrRunner.SetupSGRPeers(t)
+		peers := sgrRunner.SetupSGRPeers(t)
+		activeRT, remoteRT, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 		// Create push replications, verify running, also verify active replicators are created
 		activeRT.CreateReplication("rep_ABC", remoteURLString, db.ActiveReplicatorTypePush, []string{"ABC"}, true, db.ConflictResolverDefault, "")
 		activeRT.CreateReplication("rep_DEF", remoteURLString, db.ActiveReplicatorTypePush, []string{"DEF"}, true, db.ConflictResolverDefault, "")
@@ -1503,7 +1510,8 @@ func TestReplicationMultiCollectionChannelFilter(t *testing.T) {
 
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.Run(func(t *testing.T) {
-		rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+		peers := sgrRunner.SetupSGRPeers(t)
+		rt1, rt2, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 
 		// Add docs to two channels
 		bulkDocs := `
@@ -1583,7 +1591,8 @@ func TestReplicationConfigChange(t *testing.T) {
 
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.Run(func(t *testing.T) {
-		rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+		peers := sgrRunner.SetupSGRPeers(t)
+		rt1, rt2, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 
 		// Add docs to two channels
 		bulkDocs := `
@@ -1675,7 +1684,8 @@ func TestReplicationHeartbeatRemoval(t *testing.T) {
 		restartBatching := db.SuspendSequenceBatching()
 		t.Cleanup(restartBatching)
 
-		activeRT, remoteRT, remoteURLString := sgrRunner.SetupSGRPeers(t)
+		peers := sgrRunner.SetupSGRPeers(t)
+		activeRT, remoteRT, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 
 		// Create docs on remote
 		docABC1 := rest.SafeDocumentName(t, t.Name()+"ABC1")
@@ -1698,8 +1708,7 @@ func TestReplicationHeartbeatRemoval(t *testing.T) {
 		_ = activeRT.GetDocBody(docDEF1)
 
 		// Add another node to the active cluster
-		activeRT2 := addActiveRT(t, activeRT.GetDatabase().Name, activeRT.TestBucket)
-		defer activeRT2.Close()
+		activeRT2 := peers.AddActiveRT(t)
 
 		// Wait for replication to be rebalanced to activeRT2
 		activeRT.WaitForAssignedReplications(1)
@@ -1831,7 +1840,8 @@ func TestTakeDbOfflineOngoingPushReplication(t *testing.T) {
 
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.Run(func(t *testing.T) {
-		rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+		peers := sgrRunner.SetupSGRPeers(t)
+		rt1, rt2, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 
 		// Create doc1 on rt1
 		docID1 := rest.SafeDocumentName(t, t.Name()+"rt1doc")
@@ -1866,7 +1876,8 @@ func TestPushReplicationAPIUpdateDatabase(t *testing.T) {
 
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.Run(func(t *testing.T) {
-		rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+		peers := sgrRunner.SetupSGRPeers(t)
+		rt1, rt2, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 
 		// Create initial doc on rt1
 		docID := rest.SafeDocumentName(t, t.Name()+"rt1doc")
@@ -1992,7 +2003,8 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.Run(func(t *testing.T) {
 
-		rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+		peers := sgrRunner.SetupSGRPeers(t)
+		rt1, rt2, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 		remoteURL, err := url.Parse(remoteURLString)
 		require.NoError(t, err)
 
@@ -2082,18 +2094,11 @@ func TestActiveReplicatorPullSkippedSequence(t *testing.T) {
 		restartBatching := db.SuspendSequenceBatching()
 		t.Cleanup(restartBatching)
 
-		rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
-			PassiveRestTesterConfig: &rest.RestTesterConfig{
-				DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-					CacheConfig: &rest.CacheConfig{
-						// shorten pending sequence handling to speed up test
-						ChannelCacheConfig: &rest.ChannelCacheConfig{
-							MaxWaitPending: base.Ptr(uint32(1)),
-						},
-					},
-				}},
-			},
+		peers := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+			// shorten pending sequence handling to speed up test
+			PassiveMaxWaitPending: base.Ptr(uint32(1)),
 		})
+		rt1, rt2, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 		remoteURL, err := url.Parse(remoteURLString)
 		require.NoError(t, err)
 		ctx1 := rt1.Context()
@@ -2230,7 +2235,8 @@ func TestReplicatorReconnectBehaviour(t *testing.T) {
 	sgrRunner.Run(func(t *testing.T) {
 		for _, test := range testCases {
 			t.Run(test.name, func(t *testing.T) {
-				activeRT, _, remoteURL := sgrRunner.SetupSGRPeers(t)
+				peers := sgrRunner.SetupSGRPeers(t)
+				activeRT, remoteURL := peers.ActiveRT, peers.PassiveDBURL
 				var resp *rest.TestResponse
 
 				if test.specified {
@@ -2293,7 +2299,8 @@ func TestReconnectReplicator(t *testing.T) {
 	sgrRunner.Run(func(t *testing.T) {
 		for _, test := range testCases {
 			t.Run(test.name, func(t *testing.T) {
-				activeRT, remoteRT, remoteURL := sgrRunner.SetupSGRPeers(t)
+				peers := sgrRunner.SetupSGRPeers(t)
+				activeRT, remoteRT, remoteURL := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 				var resp *rest.TestResponse
 				const replicationName = "replication1"
 
@@ -2343,7 +2350,8 @@ func TestReplicatorReconnectTimeout(t *testing.T) {
 
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.Run(func(t *testing.T) {
-		activeRT, passiveRT, _ := sgrRunner.SetupSGRPeers(t)
+		peers := sgrRunner.SetupSGRPeers(t)
+		activeRT, passiveRT := peers.ActiveRT, peers.PassiveRT
 
 		id, err := base.GenerateRandomID()
 		require.NoError(t, err)
@@ -2405,7 +2413,8 @@ func TestTotalSyncTimeStat(t *testing.T) {
 
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.Run(func(t *testing.T) {
-		activeRT, passiveRT, remoteURL := sgrRunner.SetupSGRPeers(t)
+		peers := sgrRunner.SetupSGRPeers(t)
+		activeRT, passiveRT, remoteURL := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 		const repName = "replication1"
 
 		startValue := passiveRT.GetDatabase().DbStats.DatabaseStats.TotalSyncTime.Value()
@@ -2512,11 +2521,12 @@ func TestActiveReplicatorPullAttachments(t *testing.T) {
 		username = "alice"
 	)
 
-	sgrRuunner := rest.NewSGRTestRunner(t)
-	sgrRuunner.Run(func(t *testing.T) {
-		rt1, rt2, _ := sgrRuunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+	sgrRunner := rest.NewSGRTestRunner(t)
+	sgrRunner.Run(func(t *testing.T) {
+		peers := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
 			UserChannelAccess: []string{username},
 		})
+		rt1, rt2 := peers.ActiveRT, peers.PassiveRT
 
 		attachment := `"_attachments":{"hi.txt":{"data":"aGk=","content_type":"text/plain"}}`
 
@@ -2537,7 +2547,7 @@ func TestActiveReplicatorPullAttachments(t *testing.T) {
 			Continuous:             true,
 			ReplicationStatsMap:    dbReplicatorStats(t, rt1.GetDatabase()),
 			CollectionsEnabled:     !rt1.GetDatabase().OnlyDefaultCollection(),
-			SupportedBLIPProtocols: sgrRuunner.SupportedSubprotocols,
+			SupportedBLIPProtocols: sgrRunner.SupportedSubprotocols,
 		})
 		require.NoError(t, err)
 		defer func() { assert.NoError(t, ar.Stop()) }()
@@ -2548,7 +2558,7 @@ func TestActiveReplicatorPullAttachments(t *testing.T) {
 		assert.NoError(t, ar.Start(ctx1))
 
 		// wait for the document originally written to rt2 to arrive at rt1
-		sgrRuunner.WaitForVersion(docID, rt1, version)
+		sgrRunner.WaitForVersion(docID, rt1, version)
 
 		rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollection()
 		doc, err := rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
@@ -2564,7 +2574,7 @@ func TestActiveReplicatorPullAttachments(t *testing.T) {
 		version = rt2.PutDoc(docID, `{"source":"rt2","doc_num":2,`+attachment+`,"channels":["alice"]}`)
 
 		// wait for the new document written to rt2 to arrive at rt1
-		sgrRuunner.WaitForVersion(docID, rt1, version)
+		sgrRunner.WaitForVersion(docID, rt1, version)
 
 		doc2, err := rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
 		assert.NoError(t, err)
@@ -2663,9 +2673,10 @@ func TestActiveReplicatorPullMergeConflictingAttachments(t *testing.T) {
 				reduceCheckpoint := reduceTestCheckpointInterval(50 * time.Millisecond)
 				t.Cleanup(reduceCheckpoint)
 
-				rt1, rt2, remoteURL := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+				peers := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
 					UserChannelAccess: []string{username},
 				})
+				rt1, rt2, remoteURL := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 
 				resolverCode := `
 					function(conflict) {
@@ -2786,9 +2797,10 @@ func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
 
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.Run(func(t *testing.T) {
-		rt1, rt2, _ := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+		peers := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
 			UserChannelAccess: []string{username},
 		})
+		rt1, rt2 := peers.ActiveRT, peers.PassiveRT
 		// Create first batch of docs
 		docIDPrefix := rest.SafeDocumentName(t, t.Name()) + "rt2doc"
 		for i := range numRT2DocsInitial {
@@ -3080,9 +3092,10 @@ func TestActiveReplicatorPullOneshot(t *testing.T) {
 
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.Run(func(t *testing.T) {
-		rt1, rt2, _ := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+		peers := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
 			UserChannelAccess: []string{username},
 		})
+		rt1, rt2 := peers.ActiveRT, peers.PassiveRT
 
 		docID := rest.SafeDocumentName(t, t.Name()) + "rt2doc1"
 		rt2.PutDoc(docID, `{"source":"rt2","channels":["alice"]}`)
@@ -3127,9 +3140,10 @@ func TestActiveReplicatorPushBasic(t *testing.T) {
 
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.Run(func(t *testing.T) {
-		rt1, rt2, _ := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+		peers := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
 			UserChannelAccess: []string{username},
 		})
+		rt1, rt2 := peers.ActiveRT, peers.PassiveRT
 		ctx1 := rt1.Context()
 
 		docID := rest.SafeDocumentName(t, t.Name()) + "rt1doc1"
@@ -3191,9 +3205,10 @@ func TestActiveReplicatorPushAttachments(t *testing.T) {
 
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.Run(func(t *testing.T) {
-		rt1, rt2, _ := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+		peers := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
 			UserChannelAccess: []string{username},
 		})
+		rt1, rt2 := peers.ActiveRT, peers.PassiveRT
 
 		ctx1 := rt1.Context()
 		attachment := `"_attachments":{"hi.txt":{"data":"aGk=","content_type":"text/plain"}}`
@@ -3280,9 +3295,10 @@ func TestActiveReplicatorPushFromCheckpoint(t *testing.T) {
 
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.Run(func(t *testing.T) {
-		rt1, rt2, _ := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+		peers := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
 			UserChannelAccess: []string{username},
 		})
+		rt1, rt2 := peers.ActiveRT, peers.PassiveRT
 		ctx1 := rt1.Context()
 
 		// Create first batch of docs
@@ -3422,9 +3438,10 @@ func TestActiveReplicatorEdgeCheckpointNameCollisions(t *testing.T) {
 	)
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.Run(func(t *testing.T) {
-		_, rt2, _ := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+		peers := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
 			UserChannelAccess: []string{username},
 		})
+		rt2 := peers.PassiveRT
 		// Create first batch of docs
 		docIDPrefix := rest.SafeDocumentName(t, t.Name()) + "rt1doc"
 		for i := range numRT1DocsInitial {
@@ -3583,7 +3600,8 @@ func TestActiveReplicatorPushOneshot(t *testing.T) {
 	const username = "alice"
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.Run(func(t *testing.T) {
-		rt1, rt2, _ := sgrRunner.SetupSGRPeers(t)
+		peers := sgrRunner.SetupSGRPeers(t)
+		rt1, rt2 := peers.ActiveRT, peers.PassiveRT
 
 		docID := rest.SafeDocumentName(t, t.Name()) + "rt1doc1"
 		version := rt1.PutDoc(docID, `{"source":"rt1","channels":["alice"]}`)
@@ -3643,9 +3661,10 @@ func TestActiveReplicatorPullTombstone(t *testing.T) {
 	const username = "alice"
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.Run(func(t *testing.T) {
-		rt1, rt2, _ := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+		peers := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
 			UserChannelAccess: []string{username},
 		})
+		rt1, rt2 := peers.ActiveRT, peers.PassiveRT
 
 		docID := rest.SafeDocumentName(t, t.Name()) + "rt2doc1"
 		version := rt2.PutDoc(docID, `{"source":"rt2","channels":["alice"]}`)
@@ -3707,9 +3726,10 @@ func TestActiveReplicatorPullPurgeOnRemoval(t *testing.T) {
 	const username = "alice"
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.Run(func(t *testing.T) {
-		rt1, rt2, _ := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+		peers := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
 			UserChannelAccess: []string{username},
 		})
+		rt1, rt2 := peers.ActiveRT, peers.PassiveRT
 		docID := rest.SafeDocumentName(t, t.Name()+"rt2doc1")
 		version := rt2.PutDoc(docID, `{"source":"rt2","channels":["alice"]}`)
 
@@ -3861,7 +3881,8 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 				base.RequireNumTestBuckets(t, 2)
 				base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD)
 
-				rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+				peers := sgrRunner.SetupSGRPeers(t)
+				rt1, rt2, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 				remoteURL, err := url.Parse(remoteURLString)
 				require.NoError(t, err)
 
@@ -4083,7 +4104,8 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 				base.RequireNumTestBuckets(t, 2)
 				base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeySyncMsg, base.KeyChanges, base.KeyCRUD)
 
-				rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+				peers := sgrRunner.SetupSGRPeers(t)
+				rt1, rt2, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 				remoteURL, err := url.Parse(remoteURLString)
 				require.NoError(t, err)
 
@@ -4249,9 +4271,10 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyEnabled(t *testing.T) {
 	const username = "alice"
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.Run(func(t *testing.T) {
-		rt1, rt2, _ := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+		peers := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
 			UserChannelAccess: []string{username},
 		})
+		rt1, rt2 := peers.ActiveRT, peers.PassiveRT
 		ctx1 := rt1.Context()
 
 		docID := rest.SafeDocumentName(t, t.Name()+"rt1doc1")
@@ -4314,9 +4337,10 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyDisabled(t *testing.T) {
 	const username = "alice"
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.Run(func(t *testing.T) {
-		rt1, rt2, _ := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+		peers := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
 			UserChannelAccess: []string{username},
 		})
+		rt1, rt2 := peers.ActiveRT, peers.PassiveRT
 		ctx1 := rt1.Context()
 
 		docID := rest.SafeDocumentName(t, t.Name()+"rt1doc1")
@@ -4689,9 +4713,10 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.Run(func(t *testing.T) {
 		ctx := base.TestCtx(t)
-		activeRT, passiveRT, remoteURLString := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+		peers := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
 			UserChannelAccess: []string{username},
 		})
+		activeRT, passiveRT, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 		remoteURL, err := url.Parse(remoteURLString)
 		require.NoError(t, err)
 
@@ -4833,9 +4858,10 @@ func TestActiveReplicatorRecoverFromMismatchedRev(t *testing.T) {
 	const username = "alice"
 	sgrRunner.Run(func(t *testing.T) {
 		ctx := base.TestCtx(t)
-		rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+		peers := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
 			UserChannelAccess: []string{username},
 		})
+		rt1, rt2, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 		remoteURL, err := url.Parse(remoteURLString)
 		require.NoError(t, err)
 
@@ -4920,9 +4946,10 @@ func TestActiveReplicatorIgnoreNoConflicts(t *testing.T) {
 	const username = "alice"
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.Run(func(t *testing.T) {
-		rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+		peers := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
 			UserChannelAccess: []string{username},
 		})
+		rt1, rt2, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 		remoteURL, err := url.Parse(remoteURLString)
 		require.NoError(t, err)
 		ctx1 := rt1.Context()
@@ -5005,9 +5032,10 @@ func TestActiveReplicatorPullModifiedHash(t *testing.T) {
 
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.Run(func(t *testing.T) {
-		rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+		peers := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
 			UserChannelAccess: []string{"chan1", "chan2"},
 		})
+		rt1, rt2, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 		remoteURL, err := url.Parse(remoteURLString)
 		require.NoError(t, err)
 
@@ -5187,9 +5215,10 @@ func TestActiveReplicatorReconnectOnStart(t *testing.T) {
 				for _, timeoutVal := range timeoutVals {
 					t.Run(test.name+" with timeout "+timeoutVal.String(), func(t *testing.T) {
 						username := "alice"
-						rt1, rt2, _ := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+						peers := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
 							UserChannelAccess: []string{username},
 						})
+						rt1, rt2 := peers.ActiveRT, peers.PassiveRT
 
 						// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1
 						srv := httptest.NewServer(rt2.TestPublicHandler())
@@ -5279,9 +5308,10 @@ func TestActiveReplicatorReconnectOnStartEventualSuccess(t *testing.T) {
 
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.Run(func(t *testing.T) {
-		rt1, rt2, _ := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+		peers := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
 			AvoidUserCreation: true,
 		})
+		rt1, rt2 := peers.ActiveRT, peers.PassiveRT
 		// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1
 		srv := httptest.NewServer(rt2.TestPublicHandler())
 		defer srv.Close()
@@ -5356,7 +5386,8 @@ func TestActiveReplicatorReconnectSendActions(t *testing.T) {
 
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.Run(func(t *testing.T) {
-		rt1, rt2, _ := sgrRunner.SetupSGRPeers(t)
+		peers := sgrRunner.SetupSGRPeers(t)
+		rt1, rt2 := peers.ActiveRT, peers.PassiveRT
 		ctx1 := rt1.Context()
 
 		id, err := base.GenerateRandomID()
@@ -5375,6 +5406,7 @@ func TestActiveReplicatorReconnectSendActions(t *testing.T) {
 			MaxReconnectInterval:     time.Millisecond * 50,
 			TotalReconnectTimeout:    time.Second * 5,
 			ReplicationStatsMap:      dbReplicatorStats(t, rt1.GetDatabase()),
+			SupportedBLIPProtocols:   sgrRunner.SupportedSubprotocols,
 			CollectionsEnabled:       !rt1.GetDatabase().OnlyDefaultCollection(),
 		}
 
@@ -5587,7 +5619,8 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 			t.Run(test.name, func(t *testing.T) {
 				ctx := base.TestCtx(t)
 				base.RequireNumTestBuckets(t, 2)
-				rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+				peers := sgrRunner.SetupSGRPeers(t)
+				rt1, rt2, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 				passiveDBURL, err := url.Parse(remoteURLString)
 				require.NoError(t, err)
 
@@ -5755,7 +5788,8 @@ func TestSGR2TombstoneConflictHandling(t *testing.T) {
 		for _, test := range tombstoneTests {
 			t.Run(test.name, func(t *testing.T) {
 				ctx := base.TestCtx(t)
-				localActiveRT, remotePassiveRT, _ := sgrRunner.SetupSGRPeers(t)
+				peers := sgrRunner.SetupSGRPeers(t)
+				localActiveRT, remotePassiveRT := peers.ActiveRT, peers.PassiveRT
 
 				replConf := `
 			{
@@ -6243,7 +6277,8 @@ func TestLocalWinsConflictResolution(t *testing.T) {
 			t.Run(test.name, func(t *testing.T) {
 				base.RequireNumTestBuckets(t, 2)
 
-				activeRT, remoteRT, remoteURLString := sgrRunner.SetupSGRPeers(t)
+				peers := sgrRunner.SetupSGRPeers(t)
+				activeRT, remoteRT, remoteURLString := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 
 				// Create initial revision(s) on local
 				docID := test.name
@@ -6441,7 +6476,8 @@ func TestReplicatorConflictAttachment(t *testing.T) {
 	sgrRunner.Run(func(t *testing.T) {
 		for _, test := range testCases {
 			t.Run(test.name, func(t *testing.T) {
-				activeRT, passiveRT, passiveDBURL := sgrRunner.SetupSGRPeers(t)
+				peers := sgrRunner.SetupSGRPeers(t)
+				activeRT, passiveRT, passiveDBURL := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 
 				docID := test.name
 
@@ -6528,7 +6564,8 @@ func TestConflictResolveMergeWithMutatedRev(t *testing.T) {
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.Run(func(t *testing.T) {
 		// Passive
-		rt1, rt2, _ := sgrRunner.SetupSGRPeers(t)
+		peers := sgrRunner.SetupSGRPeers(t)
+		rt1, rt2 := peers.ActiveRT, peers.PassiveRT
 		ctx1 := rt1.Context()
 
 		customConflictResolver, err := db.NewCustomConflictResolver(ctx1, `function(conflict){
@@ -6584,26 +6621,10 @@ func TestReplicatorDoNotSendDeltaWhenSrcIsTombstone(t *testing.T) {
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.Run(func(t *testing.T) {
 
-		activeRT, passiveRT, _ := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
-			ActiveRestTesterConfig: &rest.RestTesterConfig{
-				DatabaseConfig: &rest.DatabaseConfig{
-					DbConfig: rest.DbConfig{
-						DeltaSync: &rest.DeltaSyncConfig{
-							Enabled: base.Ptr(true),
-						},
-					},
-				},
-			},
-			PassiveRestTesterConfig: &rest.RestTesterConfig{
-				DatabaseConfig: &rest.DatabaseConfig{
-					DbConfig: rest.DbConfig{
-						DeltaSync: &rest.DeltaSyncConfig{
-							Enabled: base.Ptr(true),
-						},
-					},
-				},
-			},
+		peers := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+			UseDeltas: true,
 		})
+		activeRT, passiveRT := peers.ActiveRT, peers.PassiveRT
 		activeCtx := activeRT.Context()
 
 		// Create a document //
@@ -6678,26 +6699,10 @@ func TestUnprocessableDeltas(t *testing.T) {
 	sgrRunner.Run(func(t *testing.T) {
 		restartBatching := db.SuspendSequenceBatching()
 		t.Cleanup(restartBatching)
-		activeRT, passiveRT, _ := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
-			ActiveRestTesterConfig: &rest.RestTesterConfig{
-				DatabaseConfig: &rest.DatabaseConfig{
-					DbConfig: rest.DbConfig{
-						DeltaSync: &rest.DeltaSyncConfig{
-							Enabled: base.Ptr(true),
-						},
-					},
-				},
-			},
-			PassiveRestTesterConfig: &rest.RestTesterConfig{
-				DatabaseConfig: &rest.DatabaseConfig{
-					DbConfig: rest.DbConfig{
-						DeltaSync: &rest.DeltaSyncConfig{
-							Enabled: base.Ptr(true),
-						},
-					},
-				},
-			},
+		peers := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+			UseDeltas: true,
 		})
+		activeRT, passiveRT := peers.ActiveRT, peers.PassiveRT
 
 		activeCtx := activeRT.Context()
 
@@ -6764,7 +6769,8 @@ func TestReplicatorIgnoreRemovalBodies(t *testing.T) {
 		restartBatching := db.SuspendSequenceBatching()
 		t.Cleanup(restartBatching)
 
-		activeRT, passiveRT, _ := sgrRunner.SetupSGRPeers(t)
+		peers := sgrRunner.SetupSGRPeers(t)
+		activeRT, passiveRT := peers.ActiveRT, peers.PassiveRT
 		activeCtx := activeRT.Context()
 		collection, _ := activeRT.GetSingleTestDatabaseCollection()
 
@@ -6820,7 +6826,8 @@ func TestUnderscorePrefixSupport(t *testing.T) {
 
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.Run(func(t *testing.T) {
-		activeRT, passiveRT, _ := sgrRunner.SetupSGRPeers(t)
+		peers := sgrRunner.SetupSGRPeers(t)
+		activeRT, passiveRT := peers.ActiveRT, peers.PassiveRT
 
 		activeCtx := activeRT.Context()
 
@@ -6910,7 +6917,8 @@ func TestActiveReplicatorBlipsync(t *testing.T) {
 
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.Run(func(t *testing.T) {
-		_, rt, passiveDBURL := sgrRunner.SetupSGRPeers(t)
+		peers := sgrRunner.SetupSGRPeers(t)
+		rt, passiveDBURL := peers.PassiveRT, peers.PassiveDBURL
 		remoteURL, err := url.Parse(passiveDBURL)
 		require.NoError(t, err)
 		ctx := rt.Context()
@@ -7058,7 +7066,8 @@ func TestReplicatorCheckpointOnStop(t *testing.T) {
 
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.Run(func(t *testing.T) {
-		activeRT, passiveRT, remoteURL := sgrRunner.SetupSGRPeers(t)
+		peers := sgrRunner.SetupSGRPeers(t)
+		activeRT, passiveRT, remoteURL := peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 
 		replicationID := rest.SafeDocumentName(t, t.Name())
 
@@ -7818,7 +7827,8 @@ func TestReplicationConfigUpdatedAt(t *testing.T) {
 
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.Run(func(t *testing.T) {
-		activeRT, _, remoteURLString := sgrRunner.SetupSGRPeers(t)
+		peers := sgrRunner.SetupSGRPeers(t)
+		activeRT, remoteURLString := peers.ActiveRT, peers.PassiveDBURL
 
 		// create a replication and assert the updated at field is present in the config
 		activeRT.CreateReplication("replication1", remoteURLString, db.ActiveReplicatorTypePush, nil, true, db.ConflictResolverDefault, "")

--- a/rest/replicatortest/replicator_test_helper.go
+++ b/rest/replicatortest/replicator_test_helper.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbase/sync_gateway/rest"
 	"github.com/couchbase/sync_gateway/testing/assert"
@@ -59,28 +58,6 @@ func requirePersistedReplicationProgress(rt *rest.RestTester, replicationID stri
 		assert.Equal(c, expectedDocs, persistedDocs(status), "%s: %s in persisted replication status document", replicationID, statName)
 	}, 20*time.Second, 10*time.Millisecond)
 	rt.WaitForCheckpointLastSequence(db.RealSpecialDocID(db.DocTypeLocal, db.CheckpointDocIDPrefix+checkpointID))
-}
-
-// AddActiveRT returns a new RestTester backed by a no-close clone of TestBucket
-func addActiveRT(t *testing.T, dbName string, testBucket *base.TestBucket) (activeRT *rest.RestTester) {
-
-	// Create a new rest tester, using a NoCloseClone of testBucket, which disables the TestBucketPool teardown
-	activeRT = rest.NewRestTester(t,
-		&rest.RestTesterConfig{
-			CustomTestBucket:   testBucket.NoCloseClone(),
-			SgReplicateEnabled: true,
-			SyncFn:             channels.DocChannelsSyncFunction,
-			DatabaseConfig: &rest.DatabaseConfig{
-				DbConfig: rest.DbConfig{
-					Name: dbName,
-				},
-			},
-		})
-
-	// Trigger the lazy load of bucket for RestTester startup
-	_ = activeRT.Bucket()
-
-	return activeRT
 }
 
 // createOrUpdateDoc creates a new document the specified document id, and body value in a channel named "alice".

--- a/rest/replicatortest/replicator_test_legacy_rev_test.go
+++ b/rest/replicatortest/replicator_test_legacy_rev_test.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbase/sync_gateway/rest"
 	"github.com/couchbase/sync_gateway/testing/assert"
@@ -30,9 +29,10 @@ func TestActiveReplicatorPushPullLegacyRev(t *testing.T) {
 
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
-		rt1, rt2, _ := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+		peers := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
 			UserChannelAccess: []string{username},
 		})
+		rt1, rt2 := peers.ActiveRT, peers.PassiveRT
 
 		docIDRT2 := rest.SafeDocumentName(t, t.Name()+"rt2doc1")
 		rt2InitDoc := rt2.CreateDocNoHLV(docIDRT2, db.Body{"source": "rt2", "channels": []string{username}})
@@ -113,9 +113,10 @@ func TestActiveReplicatorBiDirectionalPreUpgradedDocOnPeer(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				// Active is SGW1 in diagram above
 				// Passive is SGW2 in diagram above
-				rt1, rt2, _ := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+				peers := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
 					UserChannelAccess: []string{username},
 				})
+				rt1, rt2 := peers.ActiveRT, peers.PassiveRT
 				ctx1 := rt1.Context()
 
 				docID := rest.SafeDocumentName(t, t.Name())
@@ -228,9 +229,10 @@ func TestActiveReplicatorBiDirectionalPreUpgradedDocOnBothSidesAlreadyKnownRev(t
 	// Active is SGW1 in diagram above
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
-		rt1, rt2, _ := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+		peers := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
 			UserChannelAccess: []string{username},
 		})
+		rt1, rt2 := peers.ActiveRT, peers.PassiveRT
 		ctx1 := rt1.Context()
 
 		docID := rest.SafeDocumentName(t, t.Name())
@@ -344,9 +346,10 @@ func TestActiveReplicatorBiDirectionalPreUpgradedRevInHistory(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				// Active is SGW1 in diagram above
 				// Passive is SGW2 in diagram above
-				rt1, rt2, _ := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+				peers := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
 					UserChannelAccess: []string{username},
 				})
+				rt1, rt2 := peers.ActiveRT, peers.PassiveRT
 				ctx1 := rt1.Context()
 
 				docID := rest.SafeDocumentName(t, t.Name())
@@ -484,9 +487,10 @@ func TestActiveReplicatorPushPullNewDocLegacyRevAndAllowUpdateAfter(t *testing.T
 	const username = "alice"
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
-		rt1, rt2, _ := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+		peers := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
 			UserChannelAccess: []string{username},
 		})
+		rt1, rt2 := peers.ActiveRT, peers.PassiveRT
 		ctx1 := rt1.Context()
 
 		docIDToPush := rest.SafeDocumentName(t, t.Name()+"_push")
@@ -579,9 +583,10 @@ func TestActiveReplicatorPushConflictingPreUpgradedVersion(t *testing.T) {
 	// Passive is SGW2 in diagram above
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
-		rt1, rt2, _ := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+		peers := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
 			UserChannelAccess: []string{username},
 		})
+		rt1, rt2 := peers.ActiveRT, peers.PassiveRT
 		ctx1 := rt1.Context()
 
 		docID := rest.SafeDocumentName(t, t.Name())
@@ -688,9 +693,10 @@ func TestActiveReplicatorConflictPreUpgradedVersionEachSide(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				// Passive is SGW2 in diagram above
 				// Active is SGW1 in diagram above
-				rt1, rt2, _ := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+				peers := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
 					UserChannelAccess: []string{username},
 				})
+				rt1, rt2 := peers.ActiveRT, peers.PassiveRT
 				ctx1 := rt1.Context()
 
 				docID := rest.SafeDocumentName(t, t.Name())
@@ -863,9 +869,10 @@ func TestActiveReplicatorConflictPreUpgradedVersionOneSide(t *testing.T) {
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
 				// Passive (SGW2 in diagram above)
-				rt1, rt2, _ := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+				peers := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
 					UserChannelAccess: []string{username},
 				})
+				rt1, rt2 := peers.ActiveRT, peers.PassiveRT
 				ctx1 := rt1.Context()
 
 				docID := rest.SafeDocumentName(t, t.Name())
@@ -1029,27 +1036,11 @@ func TestActiveReplicatorDeltaSyncWhenBothSidesLegacy(t *testing.T) {
 	const username = "alice"
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
-		rt1, rt2, _ := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+		peers := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
 			UserChannelAccess: []string{username},
-			ActiveRestTesterConfig: &rest.RestTesterConfig{
-				SyncFn: channels.DocChannelsSyncFunction,
-				DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-					Name: "activedb",
-					DeltaSync: &rest.DeltaSyncConfig{
-						Enabled: base.Ptr(true),
-					},
-				}},
-			},
-			PassiveRestTesterConfig: &rest.RestTesterConfig{
-				SyncFn: channels.DocChannelsSyncFunction,
-				DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-					Name: "passivedb",
-					DeltaSync: &rest.DeltaSyncConfig{
-						Enabled: base.Ptr(true),
-					},
-				}},
-			},
+			UseDeltas:         true,
 		})
+		rt1, rt2 := peers.ActiveRT, peers.PassiveRT
 		ctx1 := rt1.Context()
 
 		docIDToPush := rest.SafeDocumentName(t, t.Name()+"_push")
@@ -1115,27 +1106,11 @@ func TestDeltaSyncWhenOneSideHasEncodedCV(t *testing.T) {
 	const username = "alice"
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
-		rt1, rt2, _ := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+		peers := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
 			UserChannelAccess: []string{username},
-			ActiveRestTesterConfig: &rest.RestTesterConfig{
-				SyncFn: channels.DocChannelsSyncFunction,
-				DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-					Name: "activedb",
-					DeltaSync: &rest.DeltaSyncConfig{
-						Enabled: base.Ptr(true),
-					},
-				}},
-			},
-			PassiveRestTesterConfig: &rest.RestTesterConfig{
-				SyncFn: channels.DocChannelsSyncFunction,
-				DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-					Name: "passivedb",
-					DeltaSync: &rest.DeltaSyncConfig{
-						Enabled: base.Ptr(true),
-					},
-				}},
-			},
+			UseDeltas:         true,
 		})
+		rt1, rt2 := peers.ActiveRT, peers.PassiveRT
 		ctx1 := rt1.Context()
 
 		docIDToPush := rest.SafeDocumentName(t, t.Name()+"_push")

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -432,7 +432,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 		// testBucket's closeFn
 		rt.TestBucket.Bucket = dbc.Bucket
 
-		// This is a hack to ensure that ISGR subprotcols are set before replications start.
+		// This is a hack to ensure that ISGR subprotocols are set before replications start.
 		if rt.ISGRSupportedBLIPSubprotocols != nil {
 			dbc.SGReplicateMgr.SupportedBLIPSubprotocols = rt.ISGRSupportedBLIPSubprotocols
 		}

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -64,6 +64,7 @@ type RestTesterConfig struct {
 	LeakyBucketConfig                *base.LeakyBucketConfig     // Set to create and use a leaky bucket on the RT and DB. A test bucket cannot be passed in if using this option.
 	adminInterface                   string                      // adminInterface overrides the default admin interface.
 	SgReplicateEnabled               bool                        // SgReplicateManager disabled by default for RestTester
+	ISGRSupportedBLIPSubprotocols    []string                    // Forces the BLIP subprotocols used by this node's ISGR active replicators - see Bucket(). Not supported with PersistentConfig.
 	AutoImport                       *bool
 	HideProductInfo                  bool
 	AdminInterfaceAuthentication     bool
@@ -414,18 +415,33 @@ func (rt *RestTester) Bucket() base.Bucket {
 			_, err := rt.TestBucket.GetMetadataStore().Incr(ctx, syncSeqKey, 0, rt.InitSyncSeq, 0)
 			require.NoError(rt.TB(), err)
 		}
+		// ISGRSupportedBLIPSubprotocols has no config surface, so it is written onto the SGReplicateMgr below,
+		// after the database exists. Give the database a fresh, unclosed hasStarted so startReplications waits on
+		// it until the close(hasStarted) at the end of this function, once the subprotocols are set. That wait is
+		// bounded: startReplications gives up after 10s and starts replications anyway.
+		rt.RestTesterServerContext.hasStarted = make(chan struct{})
+
 		_, err := rt.RestTesterServerContext.AddDatabaseFromConfig(ctx, *rt.DatabaseConfig)
 		require.NoError(rt.TB(), err)
 		ctx = rt.Context() // get new ctx with db info before passing it down
 
+		dbc := rt.RestTesterServerContext.Database(ctx, rt.DatabaseConfig.Name)
+
 		// Update the testBucket Bucket to the one associated with the database context.  The new (dbContext) bucket
 		// will be closed when the rest tester closes the server context. The original bucket will be closed using the
 		// testBucket's closeFn
-		rt.TestBucket.Bucket = rt.RestTesterServerContext.Database(ctx, rt.DatabaseConfig.Name).Bucket
+		rt.TestBucket.Bucket = dbc.Bucket
+
+		// This is a hack to ensure that ISGR subprotcols are set before replications start.
+		if rt.ISGRSupportedBLIPSubprotocols != nil {
+			dbc.SGReplicateMgr.SupportedBLIPSubprotocols = rt.ISGRSupportedBLIPSubprotocols
+		}
 
 		if rt.DatabaseConfig.Guest == nil {
 			rt.SetAdminParty(rt.GuestEnabled)
 		}
+	} else {
+		require.Empty(rt.TB(), rt.ISGRSupportedBLIPSubprotocols, "ISGRSupportedBLIPSubprotocols is not supported with PersistentConfig - the database is created by the test, after the server context has started")
 	}
 
 	// PostStartup (without actually waiting 5 seconds)

--- a/rest/utilities_testing_isgr.go
+++ b/rest/utilities_testing_isgr.go
@@ -24,7 +24,7 @@ import (
 // TestISGRPeerOpts has configuration for ISGR peers in a test setup. Everything else about the peers is set by
 // SetupISGRPeersWithOpts.
 type TestISGRPeerOpts struct {
-	// supported protocols for the active peer for ISGR only. Empty means the default protocols.
+	// supported protocols for the active peer for ISGR only. Nil means the default protocols; a non-empty slice forces a specific set of protocols.
 	ActivePeerSupportedBLIPSubProtocols []string
 	// UseDeltas enables delta sync on both peers - a replication only uses deltas if both ends have them enabled.
 	UseDeltas bool
@@ -46,7 +46,7 @@ func deltaSyncConfig(enabled bool) *DeltaSyncConfig {
 
 // TestISGRPeers contains two RestTesters to be used for ISGR testing.
 type TestISGRPeers struct {
-	// ActiveRT represents the peer that initiatiates a replication.
+	// ActiveRT represents the peer that initiates a replication.
 	ActiveRT *RestTester
 	// PassiveRT represents the peer that receives a replication.
 	PassiveRT *RestTester

--- a/rest/utilities_testing_isgr.go
+++ b/rest/utilities_testing_isgr.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"slices"
+	"sync/atomic"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -20,20 +21,27 @@ import (
 	"github.com/couchbase/sync_gateway/testing/require"
 )
 
-// TestISGRPeerOpts has configuration for ISGR peers in a test setup.
+// TestISGRPeerOpts has configuration for ISGR peers in a test setup. Everything else about the peers is set by
+// SetupISGRPeersWithOpts.
 type TestISGRPeerOpts struct {
 	// supported protocols for the active peer for ISGR only. Empty means the default protocols.
 	ActivePeerSupportedBLIPSubProtocols []string
-	// UseDeltas indicates whether to enable delta sync on the ISGR replication
+	// UseDeltas enables delta sync on both peers - a replication only uses deltas if both ends have them enabled.
 	UseDeltas bool
-	// ActiveRestTesterConfig allows passing a custom RestTesterConfig for the active peer.
-	ActiveRestTesterConfig *RestTesterConfig
-	// PassiveRestTesterConfig allows passing a custom RestTesterConfig for the passive peer.
-	PassiveRestTesterConfig *RestTesterConfig
+	// PassiveMaxWaitPending sets the passive peer's channel cache max_wait_pending, in milliseconds.
+	PassiveMaxWaitPending *uint32
 	// UserChannelAccess is list of channels the passive side user needs access to
 	UserChannelAccess []string
 	// AvoidUserCreation if true, don't create the user on the passive peer
 	AvoidUserCreation bool
+}
+
+// deltaSyncConfig returns a delta sync config when enabled, and nil - the database default - when not.
+func deltaSyncConfig(enabled bool) *DeltaSyncConfig {
+	if !enabled {
+		return nil
+	}
+	return &DeltaSyncConfig{Enabled: base.Ptr(true)}
 }
 
 // TestISGRPeers contains two RestTesters to be used for ISGR testing.
@@ -44,10 +52,41 @@ type TestISGRPeers struct {
 	PassiveRT *RestTester
 	// PassiveDBURL is used to create replications from ActiveRT to PassiveRT and contains a username+addr.
 	PassiveDBURL string
+	// opts and activeTestBucket are what nodes in the active cluster are built from - see activeRTConfig.
+	opts             TestISGRPeerOpts
+	activeTestBucket *base.TestBucket
+}
+
+// activeRTConfig returns the config for a node in the active cluster. Built per node, since RestTester rewrites the
+// config it holds as it starts up.
+func (p *TestISGRPeers) activeRTConfig() *RestTesterConfig {
+	return &RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+			Name:      "activedb",
+			DeltaSync: deltaSyncConfig(p.opts.UseDeltas),
+		}},
+		SgReplicateEnabled:            true,
+		SyncFn:                        channels.DocChannelsSyncFunction,
+		ISGRSupportedBLIPSubprotocols: p.opts.ActivePeerSupportedBLIPSubProtocols,
+		CustomTestBucket:              p.activeTestBucket.NoCloseClone(),
+	}
+}
+
+// AddActiveRT starts another node in the active cluster and returns it, for tests that need more than one active
+// node - replication rebalance, cross-node status. It shares ActiveRT's bucket, database and config group ID, which
+// is what puts them in the same SGR cluster. Closed when the test ends, so don't close it.
+func (p *TestISGRPeers) AddActiveRT(t *testing.T) *RestTester {
+	activeRT := NewRestTester(t, p.activeRTConfig())
+	t.Cleanup(activeRT.Close)
+	// Trigger the lazy load of bucket for RestTester startup
+	_ = activeRT.Bucket()
+	return activeRT
 }
 
 type SGRTestRunner struct {
-	t                           *testing.T
+	// t is the subtest Run/RunSubprotocolV3/RunSubprotocolV4 is currently executing, or the test the runner was
+	// created with outside of those. Failures raised against the parent from a subtest go to the wrong test.
+	t                           atomic.Pointer[testing.T]
 	initialisedInsideRunnerCode bool
 	SkipSubtest                 map[string]bool
 	SupportedSubprotocols       []string
@@ -65,77 +104,94 @@ func NewSGRTestRunner(t *testing.T) *SGRTestRunner {
 	})
 	db.BypassReleasedSequenceWait.Store(false)
 
-	return &SGRTestRunner{
-		t:           t,
+	runner := &SGRTestRunner{
 		SkipSubtest: make(map[string]bool),
 	}
+	runner.t.Store(t)
+	return runner
 }
 
+// TB returns the testing.TB the runner is currently using.
 func (runner *SGRTestRunner) TB() testing.TB {
-	return runner.t
+	return runner.t.Load()
 }
 
+// Run will call create two subtests for revtree and version vector modes.
 func (runner *SGRTestRunner) Run(test func(t *testing.T)) {
 	if runner.initialisedInsideRunnerCode {
 		require.FailNow(runner.TB(), "must not initialise SGRPeers outside Run() method")
 	}
 
+	parentT := runner.t.Load()
 	runner.initialisedInsideRunnerCode = true
 	defer func() {
 		// reset bool post test run to ensure no one can setup SetupSGRPeers outside run method upon completion of Run()
 		runner.initialisedInsideRunnerCode = false
+		runner.t.Store(parentT)
 	}()
 
 	if !runner.SkipSubtest[RevtreeSubtestName] {
-		runner.t.Run(RevtreeSubtestName, func(t *testing.T) {
+		parentT.Run(RevtreeSubtestName, func(t *testing.T) {
+			runner.t.Store(t)
 			runner.SupportedSubprotocols = []string{db.CBMobileReplicationV3.SubprotocolString()}
 			test(t)
 		})
 	}
 	if !runner.SkipSubtest[VersionVectorSubtestName] {
-		runner.t.Run(VersionVectorSubtestName, func(t *testing.T) {
+		parentT.Run(VersionVectorSubtestName, func(t *testing.T) {
+			runner.t.Store(t)
 			runner.SupportedSubprotocols = []string{db.CBMobileReplicationV4.SubprotocolString()}
 			test(t)
 		})
 	}
 }
 
+// RunSubprotocolV3 forces a run of revtree protocol only.
 func (runner *SGRTestRunner) RunSubprotocolV3(test func(t *testing.T)) {
 	if runner.initialisedInsideRunnerCode {
 		require.FailNow(runner.TB(), "must not initialise SGRPeers outside Run() method")
 	}
+	parentT := runner.t.Load()
 	runner.initialisedInsideRunnerCode = true
 	defer func() {
 		// reset bool post test run to ensure no one can setup SetupSGRPeers outside
 		runner.initialisedInsideRunnerCode = false
+		runner.t.Store(parentT)
 	}()
+
 	if !runner.SkipSubtest[RevtreeSubtestName] {
-		runner.t.Run(RevtreeSubtestName, func(t *testing.T) {
+		parentT.Run(RevtreeSubtestName, func(t *testing.T) {
+			runner.t.Store(t)
 			runner.SupportedSubprotocols = []string{db.CBMobileReplicationV3.SubprotocolString()}
 			test(t)
 		})
 	}
 }
 
+// RunSubprotocolV4 forces a run of version vectors only.
 func (runner *SGRTestRunner) RunSubprotocolV4(test func(t *testing.T)) {
 	if runner.initialisedInsideRunnerCode {
 		require.FailNow(runner.TB(), "must not initialise SGRPeers outside Run() method")
 	}
 
+	parentT := runner.t.Load()
 	runner.initialisedInsideRunnerCode = true
 	defer func() {
 		// reset bool post test run to ensure no one can setup SetupSGRPeers outside run method upon completion of Run()
 		runner.initialisedInsideRunnerCode = false
+		runner.t.Store(parentT)
 	}()
 
 	if !runner.SkipSubtest[VersionVectorSubtestName] {
-		runner.t.Run(VersionVectorSubtestName, func(t *testing.T) {
+		parentT.Run(VersionVectorSubtestName, func(t *testing.T) {
+			runner.t.Store(t)
 			runner.SupportedSubprotocols = []string{db.CBMobileReplicationV4.SubprotocolString()}
 			test(t)
 		})
 	}
 }
 
+// IsV4Protocol is true if the underlying RestTesters are using version vectors for their BLIP communication.
 func (runner *SGRTestRunner) IsV4Protocol() bool {
 	return slices.Contains(runner.SupportedSubprotocols, db.CBMobileReplicationV4.SubprotocolString())
 }
@@ -168,65 +224,60 @@ func (p *TestISGRPeers) Run(t *testing.T, name string, test func(*testing.T)) {
 		defer p.ActiveRT.UpdateTB(originalActiveTB)
 		originalPassiveTB := p.PassiveRT.TB()
 		defer p.PassiveRT.UpdateTB(originalPassiveTB)
+		p.ActiveRT.UpdateTB(t)
+		p.PassiveRT.UpdateTB(t)
 		test(t)
 	})
 }
 
-// SetupSGRPeers sets up two rest testers to be used for ISGR testing with the following configuration:
+// SetupSGRPeers sets up two rest testers to be used for ISGR testing:
 //
-//	activeRT:
+//	ActiveRT:
 //	  - backed by test bucket
-//	passiveRT:
+//	PassiveRT:
 //	  - backed by different test bucket
 //	  - user 'alice' created with star channel access
-//	  - http server wrapping the public API, remoteDBURLString targets the rt2 database as user alice (e.g. http://alice:pass@host/db)
-func (runner *SGRTestRunner) SetupSGRPeers(t *testing.T) (activeRT *RestTester, passiveRT *RestTester, remoteDBURLString string) {
-	if !runner.initialisedInsideRunnerCode {
-		require.FailNow(runner.TB(), "must initialise ISGRPeers inside Run() method")
-	}
-	peers := SetupISGRPeersWithOpts(t, TestISGRPeerOpts{
-		ActivePeerSupportedBLIPSubProtocols: runner.SupportedSubprotocols,
-	})
-	return peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
+//	  - http server wrapping the public API, PassiveDBURL targets its database as alice (e.g. http://alice:pass@host/db)
+func (runner *SGRTestRunner) SetupSGRPeers(t *testing.T) *TestISGRPeers {
+	return runner.SetupSGRPeersWithOptions(t, TestISGRPeerOpts{})
 }
 
-func (runner *SGRTestRunner) SetupSGRPeersWithOptions(t *testing.T, opts TestISGRPeerOpts) (activeRT *RestTester, passiveRT *RestTester, remoteDBURLString string) {
+// SetupSGRPeersWithOptions is SetupSGRPeers with the configuration in opts. The runner's current subprotocols are
+// used unless opts names its own.
+func (runner *SGRTestRunner) SetupSGRPeersWithOptions(t *testing.T, opts TestISGRPeerOpts) *TestISGRPeers {
 	if !runner.initialisedInsideRunnerCode {
 		require.FailNow(runner.TB(), "must initialise ISGRPeers inside Run() method")
 	}
 	if len(opts.ActivePeerSupportedBLIPSubProtocols) == 0 {
 		opts.ActivePeerSupportedBLIPSubProtocols = runner.SupportedSubprotocols
 	}
-	peers := SetupISGRPeersWithOpts(t, opts)
-	return peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
+	return SetupISGRPeersWithOpts(t, opts)
 }
 
 // SetupISGRPeersWithOpts sets up two rest testers backed by separate buckets.
 // PassiveRT has user 'alice' created with star channel access and is listening on an HTTP port.
-func SetupISGRPeersWithOpts(t *testing.T, opts TestISGRPeerOpts) TestISGRPeers {
+func SetupISGRPeersWithOpts(t *testing.T, opts TestISGRPeerOpts) *TestISGRPeers {
 	ctx := base.TestCtx(t)
 	// Set up passive RestTester (rt2)
-	var passiveRTConfig *RestTesterConfig
-	if opts.PassiveRestTesterConfig != nil {
-		passiveRTConfig = opts.PassiveRestTesterConfig
-	} else {
-		passiveRTConfig = &RestTesterConfig{
-			DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-				Name: "passivedb",
-			}},
-			SyncFn: channels.DocChannelsSyncFunction,
+	passiveRTConfig := &RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+			Name:      "passivedb",
+			DeltaSync: deltaSyncConfig(opts.UseDeltas),
+		}},
+		SyncFn: channels.DocChannelsSyncFunction,
+	}
+	if opts.PassiveMaxWaitPending != nil {
+		passiveRTConfig.DatabaseConfig.CacheConfig = &CacheConfig{
+			ChannelCacheConfig: &ChannelCacheConfig{
+				MaxWaitPending: opts.PassiveMaxWaitPending,
+			},
 		}
 	}
-	// Take a bucket from the pool only once we know the config doesn't already bring one, and hand it
-	// to the RestTester rather than letting NewRestTester fetch its own. Either half of that - a bucket
-	// obtained and left unused, or a config left without one - reserves two pool buckets for this peer
-	// instead of one, doubling the test's real requirement past its RequireNumTestBuckets(t, 2), which
-	// stalls for waitForReadyBucketTimeout and then fails whenever the pool is smaller than that.
-	if passiveRTConfig.CustomTestBucket == nil {
-		passiveTestBucket := base.GetTestBucket(t)
-		t.Cleanup(func() { passiveTestBucket.Close(ctx) })
-		passiveRTConfig.CustomTestBucket = passiveTestBucket.NoCloseClone()
-	}
+	// Hand the bucket to the RestTester rather than letting NewRestTester fetch its own: taking one and leaving it
+	// unused reserves two pool buckets per peer, so a test asking for RequireNumTestBuckets(t, 2) needs four.
+	passiveTestBucket := base.GetTestBucket(t)
+	t.Cleanup(func() { passiveTestBucket.Close(ctx) })
+	passiveRTConfig.CustomTestBucket = passiveTestBucket.NoCloseClone()
 	passiveRT := NewRestTester(t, passiveRTConfig)
 	t.Cleanup(passiveRT.Close)
 
@@ -244,38 +295,24 @@ func SetupISGRPeersWithOpts(t *testing.T, opts TestISGRPeerOpts) TestISGRPeers {
 	t.Cleanup(srv.Close)
 
 	// Build passiveDBURL with basic auth creds
-	passiveDBURL, _ := url.Parse(srv.URL + "/" + passiveRT.GetDatabase().Name)
+	passiveDBURL, err := url.Parse(srv.URL + "/" + passiveRT.GetDatabase().Name)
+	require.NoError(t, err)
 	passiveDBURL.User = url.UserPassword("alice", RestTesterDefaultUserPassword)
 
-	var activeRTConfig *RestTesterConfig
-	if opts.ActiveRestTesterConfig != nil {
-		activeRTConfig = opts.ActiveRestTesterConfig
-	} else {
-		activeRTConfig = &RestTesterConfig{
-			DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-				Name: "activedb",
-			}},
-			SgReplicateEnabled: true,
-			SyncFn:             channels.DocChannelsSyncFunction,
-		}
-	}
-	// As above - only take a pool bucket if the caller's config didn't supply one.
-	if activeRTConfig.CustomTestBucket == nil {
-		activeTestBucket := base.GetTestBucket(t)
-		t.Cleanup(func() { activeTestBucket.Close(ctx) })
-		activeRTConfig.CustomTestBucket = activeTestBucket.NoCloseClone()
-	}
-	activeRT := NewRestTester(t, activeRTConfig)
-	t.Cleanup(activeRT.Close)
-	// Initialize RT and bucket
-	_ = activeRT.Bucket()
-	activeRT.GetDatabase().SGReplicateMgr.SupportedBLIPSubprotocols = opts.ActivePeerSupportedBLIPSubProtocols
+	// As above for the active cluster's bucket, shared by every node in it.
+	activeTestBucket := base.GetTestBucket(t)
+	t.Cleanup(func() { activeTestBucket.Close(ctx) })
 
-	return TestISGRPeers{
-		ActiveRT:     activeRT,
-		PassiveRT:    passiveRT,
-		PassiveDBURL: passiveDBURL.String(),
+	// ActiveRT is built by AddActiveRT, like any node added later.
+	peers := &TestISGRPeers{
+		PassiveRT:        passiveRT,
+		PassiveDBURL:     passiveDBURL.String(),
+		opts:             opts,
+		activeTestBucket: activeTestBucket,
 	}
+	peers.ActiveRT = peers.AddActiveRT(t)
+
+	return peers
 }
 
 // DbReplicatorStats returns the replication stats for the given database and replication ID. Stats are cached per


### PR DESCRIPTION
CBG-4625: test-only additional ISGR peers now take same subprotocol

addActiveRT built extra active nodes without ISGRSupportedBLIPSubprotocols, so in revtree subtests node 2 negotiated CBMobile_4, causing occaisonal downstream failure. A replication
reassigned to it re-pulled already-replicated docs over V4 and wrote them as new revs, adding sequences and breaking the "exactly N changes since X" assertions (TestReplicationHeartbeatRemoval flake). If the replication didn't get reassigned, the test would pass.

- Do a magic dance of recreating open channel for DatabaseConfig.ServerContextHasStarted and closing it after setting subprotocol.
- DatabaseConfig is a mutable object when adding to a Database, so removed RestTesterConfig from places in order to add the specific options.
- Now match the SyncFn and other parameters for second RestTester

## Pre-review checklist
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/1106/

<!--
Automated review runs on every non-draft PR raised from this repo (forks are not reviewed automatically).
  - Re-run it, or ask a follow-up, by commenting `@droid <question>`
  - Suppress it with the `droid-skip` label, or `WIP`/`DO NOT MERGE` in the title
-->
