### PR TITLE
[4.1.2 Backport] CBG-5759: add missing pauser pattern (test-only)

### DIFF
--- a/rest/attachmentcompactiontest/attachment_compaction_api_test.go
+++ b/rest/attachmentcompactiontest/attachment_compaction_api_test.go
@@ -137,7 +137,7 @@ func TestAttachmentCompactionPersistence(t *testing.T) {
 		CustomTestBucket: noCloseTB,
 	})
 	rt2 := rest.NewRestTesterDefaultCollection(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb,
+		CustomTestBucket: tb.LeakyBucketClone(base.LeakyBucketConfig{}),
 	})
 	defer rt2.Close()
 	defer rt1.Close()
@@ -184,14 +184,30 @@ func TestAttachmentCompactionPersistence(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, db.BackgroundProcessStateStopped, rt2AttachmentStatus.State)
 
+	// Add a second legacy attachment now that the run is genuinely stopped. On a real cluster,
+	// stopping isn't instant, so the first attachment may already be marked by this point (the
+	// blocked mark call completes once Release lets it through) -- a fresh doc created after
+	// Stopped is confirmed is guaranteed unmarked, giving the resumed run below something to
+	// genuinely block on.
+	rest.CreateLegacyAttachmentDoc(t, ctx, collection, t.Name()+"_resume", []byte("{}"), "att-resume", []byte("att body 2"))
+
+	// Pause again, bound to rt2's own leaky datastore this time -- the resumed run below performs
+	// its writes through rt2, so a pauser bound to rt1 wouldn't intercept them.
+	pauser2 := newCompactionPauser(rt2)
+	defer pauser2.Close()
+	pauser2.Pause()
+
 	// Attempt to start again from rt2 --> Should resume based on aborted state (same compactionID)
 	resp = rt2.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
+	pauser2.WaitUntilBlocked()
 	status := rt2.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateRunning)
 	assert.Equal(t, compactID, status.CompactID)
+	pauser2.Release()
 
 	// Wait for compaction to complete
-	_ = rt1.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateCompleted)
+	status = rt1.WaitForAttachmentCompactionStatus(db.BackgroundProcessStateCompleted)
+	assert.Equal(t, compactID, status.CompactID)
 }
 
 func TestAttachmentCompactionDryRun(t *testing.T) {

--- a/rest/attachmentmigrationtest/attachment_migration_api_test.go
+++ b/rest/attachmentmigrationtest/attachment_migration_api_test.go
@@ -30,6 +30,7 @@ func TestAttachmentMigrationAPI(t *testing.T) {
 		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
 			AutoImport: false, // turn off import feed to stop the feed migrating attachments
 		}},
+		LeakyBucketConfig: &base.LeakyBucketConfig{},
 	})
 	defer rt.Close()
 	collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
@@ -51,15 +52,24 @@ func TestAttachmentMigrationAPI(t *testing.T) {
 	_ = rt.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateCompleted)
 
 	// add some docs for migration
-	numDocs, _ := addDocsForMigrationProcess(t, ctx, collection, rt.Bucket())
+	numDocs, legacyKeys := addDocsForMigrationProcess(t, ctx, collection, rt.Bucket())
+
+	// Pause migration at the first legacy doc so the duplicate start request below is
+	// guaranteed to arrive while the run is genuinely still in progress.
+	pauser := newMigrationPauser(rt)
+	defer pauser.Close()
+	pauser.Pause(legacyKeys[0])
 
 	// kick off migration
 	resp = rt.SendAdminRequest("POST", "/{{.db}}/_attachment_migration", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
+	pauser.WaitUntilBlocked()
 
 	// attempt to kick off again, should error
 	resp = rt.SendAdminRequest("POST", "/{{.db}}/_attachment_migration", "")
 	rest.RequireStatus(t, resp, http.StatusServiceUnavailable)
+
+	pauser.Release()
 
 	// Wait for run to complete
 	_ = rt.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateCompleted)
@@ -191,7 +201,7 @@ func TestAttachmentMigrationMultiNode(t *testing.T) {
 		DatabaseConfig:   dbCfg,
 	})
 	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb,
+		CustomTestBucket: tb.LeakyBucketClone(base.LeakyBucketConfig{}),
 		DatabaseConfig:   dbCfg,
 	})
 	defer rt2.Close()
@@ -242,12 +252,26 @@ func TestAttachmentMigrationMultiNode(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, db.BackgroundProcessStateStopped, rt2MigrationStatus.State)
 
+	// Add a fresh legacy attachment now that the run is genuinely stopped. On a real cluster (and
+	// even Rosmar), stopping isn't instant, so the original vBucket 0 docs may already be migrated
+	// by this point -- a doc created after Stopped is confirmed is guaranteed unmigrated, giving the
+	// resumed run below something to genuinely block on.
+	resumeDocID := base.VBucket0DocIDs(t, rt1.Bucket(), 6)[5]
+	rest.CreateLegacyAttachmentDoc(t, ctx, collection, resumeDocID, []byte(`{}`), "att", []byte("att body"))
+
+	// Pause again, bound to rt2's own leaky datastore this time -- the resumed run below performs
+	// its writes through rt2, so a pauser bound to rt1 wouldn't intercept them.
+	pauser2 := newMigrationPauser(rt2)
+	defer pauser2.Close()
+	pauser2.Pause(resumeDocID)
+
 	// kick off migration run again on node 2. Should resume and have same migration id.
-	// Note: with the small Rosmar test dataset the resumed migration can finish before the
-	// transient Running state is observable, so we don't poll for it here — the resume is
-	// instead verified by the migrationID equality check on the final Completed status below.
 	resp = rt2.SendAdminRequest("POST", "/{{.db}}/_attachment_migration?action=start", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
+	pauser2.WaitUntilBlocked()
+	status = rt2.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateRunning)
+	assert.Equal(t, migrationID, status.MigrationID)
+	pauser2.Release()
 
 	// Wait for run to be marked as complete on both nodes
 	status = rt1.WaitForAttachmentMigrationStatus(db.BackgroundProcessStateCompleted)


### PR DESCRIPTION
CBG-5759

Clean cherry pick of #8458 to 4.1.2. No conflicts; resulting diff is 2 files, +47/-7 — identical line counts to the upstream commit.

#8668 backported only the first CBG-5509 PR (#8414), which added the `migrationPauser`/`compactionPauser` helpers and applied them to most call sites. The follow-up #8458 applied the pauser to the two spots #8414 missed, and that half never came across, so 4.1.2 still flakes on them. Seen on #8635, where `test (ubuntu)` and `test-disable-rev-cache` both failed on the same assertion:

```
    attachment_migration_api_test.go:62:
        	Error:      	Not equal:
        	            	expected: 503
        	            	actual  : 200
        	Test:       	TestAttachmentMigrationAPI
        	Messages:   	Response status 200 "OK" (expected 503 "Service Unavailable")
```

The migration over the 10-doc dataset finishes ~1ms before the duplicate start request lands, so nothing is running and the second POST opens a fresh run with 200 instead of rejecting with 503.

- `TestAttachmentMigrationAPI` — adds `LeakyBucketConfig`, pauses at `legacyKeys[0]` and waits for the block before the duplicate-start 503 check.
- `TestAttachmentMigrationMultiNode` — `pauser2` bound to rt2's own leaky datastore for the resumed run, plus a legacy doc created after Stopped is confirmed so the resumed run has something unmigrated to block on.
- `TestAttachmentCompactionPersistence` — same treatment for the compaction resume path.

Verified with `-count=10` on `TestAttachmentMigrationAPI`, `TestAttachmentMigrationMultiNode` and `TestAttachmentCompactionPersistence`, plus both packages in full.

test-only — both changed files are `_test.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
