### PR TITLE
CBG-5472 part 1 of 3: reduce lock scope and fix races in stats serialization

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -12,9 +12,11 @@ package base
 
 import (
 	"context"
+	"encoding/json"
 	"expvar"
 	"fmt"
 	"log"
+	"maps"
 	"math"
 	"slices"
 	"strconv"
@@ -106,13 +108,24 @@ const (
 	StatStabilityInternal  = "internal"
 )
 
-type SgwStats struct {
+// sgwStatsFields holds every serialized field of SgwStats. String() copies this struct whole, so a
+// stat added here reaches the output without String() having to name it.
+type sgwStatsFields struct {
 	GlobalStats     *GlobalStat         `json:"global"`
 	DbStats         map[string]*DbStats `json:"per_db"`
 	ReplicatorStats *ReplicatorStats    `json:"per_replication,omitempty"`
+}
+
+// SgwStats is the root of the stats tree serialized to the expvar/stats log output.
+// Declare new serialized stats in sgwStatsFields, not here.
+type SgwStats struct {
+	sgwStatsFields
 
 	dbStatsMapMutex sync.Mutex
 }
+
+// Compile-time interface check.
+var _ expvar.Var = &SgwStats{}
 
 var SyncGatewayStats *SgwStats
 
@@ -128,8 +141,10 @@ func NewSyncGatewayStats() (*SgwStats, error) {
 		return nil, err
 	}
 	sgwStats := SgwStats{
-		GlobalStats: globalStats,
-		DbStats:     map[string]*DbStats{},
+		sgwStatsFields: sgwStatsFields{
+			GlobalStats: globalStats,
+			DbStats:     map[string]*DbStats{},
+		},
 	}
 
 	err = sgwStats.initReplicationStats()
@@ -162,11 +177,20 @@ func init() {
 	expvar.Publish(StatsGroupKeySyncGateway, SyncGatewayStats)
 }
 
+// cloneDbStatsMap returns a shallow copy of the DbStats map, to hold the map lock for as short a time as possible.
+func (s *SgwStats) cloneDbStatsMap() map[string]*DbStats {
+	s.dbStatsMapMutex.Lock()
+	defer s.dbStatsMapMutex.Unlock()
+	return maps.Clone(s.DbStats)
+}
+
 // This String() is to satisfy the expvar.Var interface which is used to produce the expvar endpoint output.
 func (s *SgwStats) String() string {
-	s.dbStatsMapMutex.Lock()
-	bytes, err := JSONMarshalCanonical(s)
-	s.dbStatsMapMutex.Unlock()
+	// Copy every serialized field, then swap in a clone of the map that cannot be read unguarded.
+	statsCopy := s.sgwStatsFields
+	statsCopy.DbStats = s.cloneDbStatsMap()
+
+	bytes, err := JSONMarshalCanonical(statsCopy)
 	if err != nil {
 		ErrorfCtx(context.Background(), "Unable to Marshal SgwStats: %v", err)
 		return "null"
@@ -424,8 +448,9 @@ type AuditStat struct {
 	NumAuditsFilteredByRole *SgwIntStat `json:"num_audits_filtered_by_role"`
 }
 
-type DbStats struct {
-	dbName                  string
+// dbStatsFields holds every serialized field of DbStats. MarshalJSON copies this struct whole, so a
+// stat added here reaches the output without MarshalJSON having to name it.
+type dbStatsFields struct {
 	CacheStats              *CacheStats                   `json:"cache,omitempty"`
 	CBLReplicationPullStats *CBLReplicationPullStats      `json:"cbl_replication_pull,omitempty"`
 	CBLReplicationPushStats *CBLReplicationPushStats      `json:"cbl_replication_push,omitempty"`
@@ -437,7 +462,37 @@ type DbStats struct {
 	SharedBucketImportStats *SharedBucketImportStats      `json:"shared_bucket_import,omitempty"`
 	MigrationStats          *MigrationStats               `json:"metadata_migration,omitempty"`
 	CollectionStats         map[string]*CollectionStats   `json:"per_collection,omitempty"`
-	dbReplicatorStatsMutex  sync.Mutex
+}
+
+// DbStats is the per-database stats tree.
+// Declare new serialized stats in dbStatsFields, not here.
+type DbStats struct {
+	dbStatsFields
+
+	dbName                 string
+	dbReplicatorStatsMutex sync.Mutex
+}
+
+// Compile-time interface check.
+var _ json.Marshaler = &DbStats{}
+
+// cloneDbReplicatorStatsMap returns a shallow copy of the DbReplicatorStats map, to hold the
+// replicator lock for as short a time as possible.
+func (d *DbStats) cloneDbReplicatorStatsMap() map[string]*DbReplicatorStats {
+	d.dbReplicatorStatsMutex.Lock()
+	defer d.dbReplicatorStatsMutex.Unlock()
+	return maps.Clone(d.DbReplicatorStats)
+}
+
+// MarshalJSON serializes the database stats. DBReplicatorStats writes DbReplicatorStats lazily
+// whenever a replication first reports a stat, so the map is swapped for a clone that no other
+// goroutine can write.
+func (d *DbStats) MarshalJSON() ([]byte, error) {
+	// Copy every serialized field, then swap in a clone of the map that cannot be read unguarded.
+	statsCopy := d.dbStatsFields
+	statsCopy.DbReplicatorStats = d.cloneDbReplicatorStatsMap()
+
+	return JSONMarshalCanonical(statsCopy)
 }
 
 type CacheStats struct {
@@ -1355,11 +1410,12 @@ type QueryStat struct {
 }
 
 func (s *SgwStats) NewDBStats(name string, deltaSyncEnabled bool, importEnabled bool, viewsEnabled bool, metadataMigrationEnabled bool, queryNames []string, collections []string) (*DbStats, error) {
-	s.dbStatsMapMutex.Lock()
-	defer s.dbStatsMapMutex.Unlock()
+	// Build and register dbStats before taking the map lock, so Prometheus registration stays outside it.
 	dbStats := &DbStats{
-		dbName:            name,
-		DbReplicatorStats: make(map[string]*DbReplicatorStats),
+		dbName: name,
+		dbStatsFields: dbStatsFields{
+			DbReplicatorStats: make(map[string]*DbReplicatorStats),
+		},
 	}
 
 	// These have a pretty good chance of being used so we'll initialise these for every database stat struct created
@@ -1425,51 +1481,56 @@ func (s *SgwStats) NewDBStats(name string, deltaSyncEnabled bool, importEnabled 
 		return nil, err
 	}
 
+	s.dbStatsMapMutex.Lock()
+	defer s.dbStatsMapMutex.Unlock()
 	s.DbStats[name] = dbStats
+
 	return dbStats, nil
 }
 
 func (s *SgwStats) ClearDBStats(name string) {
-	s.dbStatsMapMutex.Lock()
-	defer s.dbStatsMapMutex.Unlock()
-
-	if _, ok := s.DbStats[name]; !ok {
+	dbStats, ok := s.popDbStats(name)
+	if !ok {
 		return
 	}
 
-	for scopeAndCollectionName := range s.DbStats[name].CollectionStats {
-		s.DbStats[name].unregisterCollectionStats(scopeAndCollectionName)
+	for scopeAndCollectionName := range dbStats.CollectionStats {
+		dbStats.unregisterCollectionStats(scopeAndCollectionName)
 	}
 
-	s.DbStats[name].unregisterCacheStats()
-	s.DbStats[name].unregisterCBLReplicationPullStats()
-	s.DbStats[name].unregisterCBLReplicationPushStats()
-	for replName := range s.DbStats[name].DbReplicatorStats {
-		s.DbStats[name].unregisterReplicationStats(replName)
-	}
-	s.DbStats[name].unregisterDatabaseStats()
-	s.DbStats[name].unregisterSecurityStats()
+	dbStats.unregisterCacheStats()
+	dbStats.unregisterCBLReplicationPullStats()
+	dbStats.unregisterCBLReplicationPushStats()
+	dbStats.unregisterAllReplicationStats()
+	dbStats.unregisterDatabaseStats()
+	dbStats.unregisterSecurityStats()
 
-	if s.DbStats[name].DeltaSyncStats != nil {
-		s.DbStats[name].unregisterDeltaSyncStats()
+	if dbStats.DeltaSyncStats != nil {
+		dbStats.unregisterDeltaSyncStats()
 	}
 
-	if s.DbStats[name].SharedBucketImportStats != nil {
-		s.DbStats[name].unregisterSharedBucketImportStats()
+	if dbStats.SharedBucketImportStats != nil {
+		dbStats.unregisterSharedBucketImportStats()
 	}
 
-	if s.DbStats[name].MigrationStats != nil {
-		s.DbStats[name].unregisterMigrationStats()
+	if dbStats.MigrationStats != nil {
+		dbStats.unregisterMigrationStats()
 	}
 
-	s.DbStats[name].unregisterQueryStats()
-	delete(s.DbStats, name)
+	dbStats.unregisterQueryStats()
 }
 
 // Removes the per-database stats for this database by removing the database from the map
 func RemovePerDbStats(dbName string) {
 	// Clear out the stats for this db since they will no longer be updated.
 	SyncGatewayStats.ClearDBStats(dbName)
+}
+
+// popDbStats removes the named database's stats from the map, and reports whether they were present.
+func (s *SgwStats) popDbStats(name string) (*DbStats, bool) {
+	s.dbStatsMapMutex.Lock()
+	defer s.dbStatsMapMutex.Unlock()
+	return PopMapEntry(s.DbStats, name)
 }
 
 func (d *DbStats) initCacheStats() error {
@@ -2222,6 +2283,17 @@ func (d *DbStats) initSecurityStats() error {
 	return nil
 }
 
+// unregisterAllReplicationStats unregisters the stats of every replication on this database.
+// DBReplicatorStats writes the map lazily, and can run while the database is torn down, so the
+// mutex is held for the whole iteration.
+func (d *DbStats) unregisterAllReplicationStats() {
+	d.dbReplicatorStatsMutex.Lock()
+	defer d.dbReplicatorStatsMutex.Unlock()
+	for replicationID := range d.DbReplicatorStats {
+		d.unregisterReplicationStats(replicationID)
+	}
+}
+
 func (d *DbStats) unregisterReplicationStats(replicationID string) {
 	if d.DbReplicatorStats[replicationID] == nil {
 		return
@@ -2366,15 +2438,18 @@ func (d *DbStats) InitCollectionStats(scopeAndCollectionNames ...string) error {
 	return nil
 }
 
+// DBReplicatorStats returns the stats for replicationID, building and registering them on first
+// use. The mutex is held throughout so the entry is only published once every stat is set.
 func (d *DbStats) DBReplicatorStats(replicationID string) (*DbReplicatorStats, error) {
 	d.dbReplicatorStatsMutex.Lock()
 	defer d.dbReplicatorStatsMutex.Unlock()
 
-	if _, ok := d.DbReplicatorStats[replicationID]; ok {
-		return d.DbReplicatorStats[replicationID], nil
+	if existing, ok := d.DbReplicatorStats[replicationID]; ok {
+		return existing, nil
 	}
-	var err error
+
 	resUtil := &DbReplicatorStats{}
+	var err error
 	labelKeys := []string{DatabaseLabelKey, ReplicationLabelKey}
 	labelVals := []string{d.dbName, replicationID}
 
@@ -2492,8 +2567,7 @@ func (d *DbStats) DBReplicatorStats(replicationID string) (*DbReplicatorStats, e
 	}
 
 	d.DbReplicatorStats[replicationID] = resUtil
-
-	return d.DbReplicatorStats[replicationID], nil
+	return resUtil, nil
 }
 
 // Reset replication stats to zero

--- a/base/stats_test.go
+++ b/base/stats_test.go
@@ -11,9 +11,17 @@ licenses/APL2.txt.
 package base
 
 import (
+	"encoding/json"
 	"expvar"
+	"fmt"
+	"maps"
 	"math"
+	"reflect"
+	"slices"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/couchbase/sync_gateway/testing/require"
 
@@ -198,4 +206,231 @@ func TestSgwFloatStatMarshalNonFinite(t *testing.T) {
 			require.Equal(t, 0.0, viaString)
 		})
 	}
+}
+
+// newTestSgwStats returns an empty stats tree, separate from the package-level SyncGatewayStats.
+func newTestSgwStats() *SgwStats {
+	return &SgwStats{sgwStatsFields: sgwStatsFields{DbStats: map[string]*DbStats{}}}
+}
+
+// TestSerializedStatFieldsAreEmbedded fails when an exported field is declared on SgwStats or
+// DbStats instead of its embedded fields struct, because the marshaller copies only the embedded
+// struct and would drop it.
+func TestSerializedStatFieldsAreEmbedded(t *testing.T) {
+	for outer, inner := range map[reflect.Type]string{
+		reflect.TypeFor[SgwStats](): "sgwStatsFields",
+		reflect.TypeFor[DbStats]():  "dbStatsFields",
+	} {
+		t.Run(outer.Name(), func(t *testing.T) {
+			for _, field := range reflect.VisibleFields(outer) {
+				if !field.IsExported() {
+					continue
+				}
+				// Promoted fields have an index path through the embedded struct, declared fields do not.
+				assert.Greater(t, len(field.Index), 1,
+					"%s.%s must be declared in %s so it is serialized", outer.Name(), field.Name, inner)
+			}
+		})
+	}
+}
+
+// TestClearDBStatsRemovesFromSerialization checks that a database removed by ClearDBStats no longer
+// appears in the expvar/stats log output.
+func TestClearDBStatsRemovesFromSerialization(t *testing.T) {
+	stats := newTestSgwStats()
+	const dbName = "TestClearDBStatsRemovesFromSerialization_db"
+
+	_, err := stats.NewDBStats(dbName, false, false, false, false, nil, nil)
+	require.NoError(t, err)
+	assert.Contains(t, stats.String(), dbName)
+
+	stats.ClearDBStats(dbName)
+	require.NotContains(t, stats.String(), dbName)
+}
+
+// TestStatsSerializationConcurrentWithDBRegistration is a -race guard on the narrowed
+// dbStatsMapMutex section (CBG-5472): String() marshals a shallow copy of the map outside the lock,
+// so it can read a *DbStats that ClearDBStats is unregistering from Prometheus. This is not a
+// reproducer for the stats logger stall - that was on _databasesLock, see
+// rest.TestStatsLoggerIndependentOfDatabaseLock.
+func TestStatsSerializationConcurrentWithDBRegistration(t *testing.T) {
+	// TestMain sets this true, which would skip the Prometheus path this test wants to exercise.
+	defer func(skip bool) { SkipPrometheusStatsRegistration = skip }(SkipPrometheusStatsRegistration)
+	SkipPrometheusStatsRegistration = false
+
+	stats := newTestSgwStats()
+
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Go(func() {
+			for range 1000 {
+				_ = stats.String()
+			}
+		})
+	}
+	for i := range 10 {
+		wg.Go(func() {
+			// Distinct db name per goroutine so concurrent registrations never collide in Prometheus.
+			name := fmt.Sprintf("TestStatsSerializationConcurrentWithDBRegistration_db_%d", i)
+			for range 100 {
+				_, err := stats.NewDBStats(name, false, false, false, false, nil, nil)
+				assert.NoError(t, err)
+				stats.ClearDBStats(name)
+			}
+		})
+	}
+	WaitWithTimeout(t, &wg, time.Minute)
+}
+
+// TestClearDBStatsConcurrentWithReplicatorRegistration is a regression test for ClearDBStats
+// iterating DbReplicatorStats without dbReplicatorStatsMutex, which panicked with "concurrent map
+// read and map write" when a replication registered during teardown. Fails without -race too.
+func TestClearDBStatsConcurrentWithReplicatorRegistration(t *testing.T) {
+	stats := newTestSgwStats()
+	const dbName = "TestClearDBStatsConcurrentWithReplicatorRegistration_db"
+
+	dbStats, err := stats.NewDBStats(dbName, false, false, false, false, nil, nil)
+	require.NoError(t, err)
+
+	// Pre-populate the map so ClearDBStats takes longer to iterate, widening the race window.
+	for i := range 100 {
+		_, err := dbStats.DBReplicatorStats(fmt.Sprintf("seed_%d", i))
+		require.NoError(t, err)
+	}
+
+	var wg sync.WaitGroup
+	defer WaitWithTimeout(t, &wg, time.Minute)
+	wg.Go(func() {
+		for i := range 100 {
+			_, err := dbStats.DBReplicatorStats(fmt.Sprintf("repl_%d", i))
+			assert.NoError(t, err)
+		}
+	})
+
+	// Iterates DbReplicatorStats concurrently with the registrations above.
+	stats.ClearDBStats(dbName)
+}
+
+// TestStatsSerializationConcurrentWithReplicatorRegistration is a regression test for the stats
+// output iterating DbReplicatorStats without dbReplicatorStatsMutex, which crashed the process with
+// "concurrent map iteration and map write" when a replication registered mid-serialization. Fails
+// without -race too.
+func TestStatsSerializationConcurrentWithReplicatorRegistration(t *testing.T) {
+	stats := newTestSgwStats()
+	const dbName = "TestStatsSerializationConcurrentWithReplicatorRegistration_db"
+
+	dbStats, err := stats.NewDBStats(dbName, false, false, false, false, nil, nil)
+	require.NoError(t, err)
+
+	// The map is cheapest to marshal, and the window widest, while it is still small.
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		for i := range 500 {
+			_, err := dbStats.DBReplicatorStats(fmt.Sprintf("repl_%d", i))
+			if !assert.NoError(t, err) {
+				return
+			}
+		}
+	})
+	wg.Go(func() {
+		for range 500 {
+			_ = stats.String()
+		}
+	})
+	WaitWithTimeout(t, &wg, time.Minute)
+}
+
+// TestDbStatsSerializedShape pins the stat groups DbStats.MarshalJSON emits, since a hand-written
+// marshaller can silently drop one.
+func TestDbStatsSerializedShape(t *testing.T) {
+	stats := newTestSgwStats()
+	const dbName = "TestDbStatsSerializedShape_db"
+
+	dbStats, err := stats.NewDBStats(dbName, true, true, false, true, []string{"queryName"}, []string{"scope.collection"})
+	require.NoError(t, err)
+	_, err = dbStats.DBReplicatorStats("repl")
+	require.NoError(t, err)
+
+	marshalled, err := JSONMarshalCanonical(dbStats)
+	require.NoError(t, err)
+
+	var groups map[string]json.RawMessage
+	require.NoError(t, JSONUnmarshal(marshalled, &groups))
+	require.ElementsMatch(t, []string{
+		"cache", "cbl_replication_pull", "cbl_replication_push", "database", "delta_sync",
+		"gsi_views", "replications", "security", "shared_bucket_import", "metadata_migration",
+		"per_collection",
+	}, slices.Collect(maps.Keys(groups)))
+}
+
+// newTestDbStats returns a DbStats holding only the replicator map, bypassing NewDBStats so a test
+// can use the same dbName twice.
+func newTestDbStats(dbName string) *DbStats {
+	return &DbStats{
+		dbName:        dbName,
+		dbStatsFields: dbStatsFields{DbReplicatorStats: map[string]*DbReplicatorStats{}},
+	}
+}
+
+// TestDBReplicatorStatsFailedRegistrationNotCached checks that a DBReplicatorStats call which fails
+// partway through registration caches nothing, so a caller can never be handed a half-populated
+// entry - the failure is reported again instead.
+func TestDBReplicatorStatsFailedRegistrationNotCached(t *testing.T) {
+	// TestMain sets this true, which would skip registration and so never produce a failure.
+	defer func(skip bool) { SkipPrometheusStatsRegistration = skip }(SkipPrometheusStatsRegistration)
+	SkipPrometheusStatsRegistration = false
+
+	const dbName = "TestDBReplicatorStatsFailedRegistrationNotCached_db"
+	const replicationID = "repl"
+
+	// Two DbStats sharing a dbName describe identical Prometheus metrics, so the second
+	// registration of the same replication ID collides and fails.
+	first, second := newTestDbStats(dbName), newTestDbStats(dbName)
+
+	firstStats, err := first.DBReplicatorStats(replicationID)
+	require.NoError(t, err)
+	require.NotNil(t, firstStats.NumAttachmentBytesPushed)
+	defer first.unregisterReplicationStats(replicationID)
+
+	_, err = second.DBReplicatorStats(replicationID)
+	require.Error(t, err, "expected the duplicate Prometheus registration to fail")
+
+	require.NotContains(t, maps.Keys(second.DbReplicatorStats), replicationID,
+		"a failed registration was cached")
+
+	_, err = second.DBReplicatorStats(replicationID)
+	require.Error(t, err, "expected the retry to report the registration failure again")
+}
+
+// TestDBReplicatorStatsConcurrentSameID checks that concurrent callers for one replication ID never
+// see the entry before its stats are populated.
+func TestDBReplicatorStatsConcurrentSameID(t *testing.T) {
+	dbStats := newTestDbStats("TestDBReplicatorStatsConcurrentSameID_db")
+
+	var partial atomic.Int64
+	var wg sync.WaitGroup
+	// Each replication ID is one chance to observe the window, so use plenty.
+	for i := range 50 {
+		replicationID := fmt.Sprintf("repl_%d", i)
+		start := make(chan struct{})
+		for range 4 {
+			wg.Go(func() {
+				<-start
+				replicatorStats, err := dbStats.DBReplicatorStats(replicationID)
+				if !assert.NoError(t, err) {
+					return
+				}
+				// The last field DBReplicatorStats populates, so it is the one left nil by an
+				// entry published before it was finished.
+				if replicatorStats.ProcessedSequenceLenPostCleanup == nil {
+					partial.Add(1)
+				}
+			})
+		}
+		close(start)
+	}
+	WaitWithTimeout(t, &wg, time.Minute)
+
+	require.Zero(t, partial.Load(),
+		"%d callers received an entry before its stats were populated", partial.Load())
 }

--- a/base/util.go
+++ b/base/util.go
@@ -1864,6 +1864,16 @@ func KeysPresent[K comparable, V any](m map[K]V, keys []K) []K {
 	return result
 }
 
+// PopMapEntry removes key from m and returns the value it held, and whether it was present.
+// Popping from a nil map returns the zero value and false.
+func PopMapEntry[M ~map[K]V, K comparable, V any](m M, key K) (V, bool) {
+	value, ok := m[key]
+	if ok {
+		delete(m, key)
+	}
+	return value, ok
+}
+
 // IsRevTreeID checks if the string looks like a RevTree ID.
 func IsRevTreeID(s string) bool {
 	// If we scan forwards past each digit until we hit `-`, we know this is a RevTree ID.

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -1921,6 +1921,48 @@ func TestKeysPresent(t *testing.T) {
 	}
 }
 
+func TestPopMapEntry(t *testing.T) {
+	t.Run("present", func(t *testing.T) {
+		m := map[string]int{"a": 1, "b": 2}
+		value, ok := PopMapEntry(m, "a")
+		assert.True(t, ok)
+		assert.Equal(t, 1, value)
+		assert.Equal(t, map[string]int{"b": 2}, m)
+	})
+
+	t.Run("absent leaves map untouched", func(t *testing.T) {
+		m := map[string]int{"a": 1}
+		value, ok := PopMapEntry(m, "x")
+		assert.False(t, ok)
+		assert.Equal(t, 0, value, "expected zero value for an absent key")
+		assert.Equal(t, map[string]int{"a": 1}, m)
+	})
+
+	t.Run("zero value stored for key", func(t *testing.T) {
+		// ok has to tell a stored zero value apart from an absent key.
+		m := map[string]int{"a": 0}
+		value, ok := PopMapEntry(m, "a")
+		assert.True(t, ok)
+		assert.Equal(t, 0, value)
+		assert.Empty(t, m)
+	})
+
+	t.Run("nil map", func(t *testing.T) {
+		var m map[string]*int
+		value, ok := PopMapEntry(m, "a")
+		assert.False(t, ok)
+		assert.Nil(t, value)
+	})
+
+	t.Run("named map type", func(t *testing.T) {
+		type stringSet map[string]struct{}
+		m := stringSet{"a": {}}
+		_, ok := PopMapEntry(m, "a")
+		assert.True(t, ok)
+		assert.Empty(t, m)
+	})
+}
+
 func TestIsRevTreeID(t *testing.T) {
 	tests := []struct {
 		value    string


### PR DESCRIPTION
CBG-5472

Part 1 of 3 split from #8431 - which had in-PR requested changes that ended up spiralling away from the original ticket.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/

<!--
Automated review runs on every non-draft PR raised from this repo (forks are not reviewed automatically).
  - Re-run it, or ask a follow-up, by commenting `@droid <question>`
  - Suppress it with the `droid-skip` label, or `WIP`/`DO NOT MERGE` in the title
-->
