### PR TITLE
CBG-5472 part 2 of 3: mark a database Stopping while it is being closed

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -809,6 +809,9 @@ func (db *DatabaseContext) _stopOnlineProcesses(ctx context.Context) {
 }
 
 func (context *DatabaseContext) Close(ctx context.Context) {
+	// Mark stopping before teardown so the lock-free stats reader skips this database.
+	atomic.StoreUint32(&context.State, DBStopping)
+
 	context.BucketLock.Lock()
 	defer context.BucketLock.Unlock()
 
@@ -837,6 +840,15 @@ func (context *DatabaseContext) Close(ctx context.Context) {
 
 	base.RemovePerDbStats(context.Name)
 
+}
+
+// BucketIfOpen returns the database's bucket, or false if the database has been closed. Callers
+// holding a DatabaseContext they didn't resolve under a lock need this rather than reading Bucket
+// directly, since Close nils it.
+func (context *DatabaseContext) BucketIfOpen() (base.Bucket, bool) {
+	context.BucketLock.RLock()
+	defer context.BucketLock.RUnlock()
+	return context.Bucket, context.Bucket != nil
 }
 
 // stopBackgroundManagers stops any running BackgroundManager.

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -178,6 +178,29 @@ func assertHTTPError(t *testing.T, err error, status int) bool {
 		assert.Equal(t, status, httpErr.Status)
 }
 
+// TestBucketIfOpenAfterClose checks that BucketIfOpen reports a closed database rather than handing
+// back the nil Bucket that Close leaves behind.
+func TestBucketIfOpenAfterClose(t *testing.T) {
+	ctx := base.TestCtx(t)
+	tBucket := base.GetTestBucket(t)
+	defer tBucket.Close(ctx)
+
+	dbCtx, err := NewDatabaseContext(ctx, "db", tBucket, true, DatabaseContextOptions{
+		Scopes: GetScopesOptions(t, tBucket, 1),
+	})
+	require.NoError(t, err)
+
+	bucket, open := dbCtx.BucketIfOpen()
+	require.True(t, open)
+	require.NotNil(t, bucket)
+
+	dbCtx.Close(ctx)
+
+	bucket, open = dbCtx.BucketIfOpen()
+	require.False(t, open)
+	require.Nil(t, bucket)
+}
+
 func TestDatabaseStartOnlineProcessesWhileClosing(t *testing.T) {
 	timeout := 30 * time.Second
 	go func() {

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -290,7 +290,8 @@ func (h *handler) handleDbOnline() error {
 		defer func() {
 			if err != nil {
 				// Reset DB state back to Offline on setup failure to avoid being stuck in DBStarting.
-				atomic.StoreUint32(&h.db.State, db.DBOffline)
+				// CAS rather than store, so a reload that closed this context keeps DBStopping.
+				atomic.CompareAndSwapUint32(&h.db.State, db.DBStarting, db.DBOffline)
 			}
 		}()
 		// If the server was closed during the delay, skip the reload entirely.
@@ -320,7 +321,14 @@ func (h *handler) handleDbOnline() error {
 		} else {
 			var oldConfig DbConfig
 			// persistent config here
-			bucket := h.db.Bucket.GetName()
+			// Close doesn't take AccessLock, so it can nil the bucket after the CAS above succeeded.
+			bucketRef, open := h.db.BucketIfOpen()
+			if !open {
+				err = base.RedactErrorf("database %q was closed while being brought online", base.MD(h.db.Name))
+				base.InfofCtx(contextNoCancel.Ctx, base.KeyCRUD, "%v", err)
+				return
+			}
+			bucket := bucketRef.GetName()
 			dbName := h.db.Name
 			var cas uint64
 			var updatedDbConfig *DatabaseConfig
@@ -476,6 +484,13 @@ func (h *handler) handlePostIndexInit() error {
 		return base.HTTPErrorf(http.StatusBadRequest, "action %q not supported... must be either 'start' or 'stop'", action)
 	}
 
+	// This handler runs offline, so the state check in validateAndWriteHeaders doesn't apply. There's
+	// no point initialising indexes for a database that is being torn down. Stopping an init is still
+	// allowed above, since that doesn't touch the bucket.
+	if atomic.LoadUint32(&h.db.State) == db.DBStopping {
+		return base.HTTPErrorf(http.StatusServiceUnavailable, "Database is stopping, try again later")
+	}
+
 	var req PostIndexInitRequest
 	if err := h.readJSONInto(&req); err != nil {
 		return err
@@ -521,8 +536,14 @@ func (h *handler) handlePostIndexInit() error {
 	// Skip metadata index initialization on _default._default if it has been dropped (e.g. after a
 	// completed metadata migration) — building indexes on a missing collection would retry until the
 	// op times out. Default to attempting init on _default if existence can't be determined.
+	// The state check above is a point-in-time read and this handler holds no AccessLock, so the
+	// database can still be closed underneath us before we get here.
+	bucket, open := h.db.BucketIfOpen()
+	if !open {
+		return base.HTTPErrorf(http.StatusServiceUnavailable, "Database is stopping, try again later")
+	}
 	defaultCollectionPresent := true
-	if exists, existsErr := defaultCollectionExists(h.ctx(), h.db.Bucket); existsErr != nil {
+	if exists, existsErr := defaultCollectionExists(h.ctx(), bucket); existsErr != nil {
 		base.WarnfCtx(h.ctx(), "db:%s unable to determine whether _default._default exists while reinitializing indexes: %v — will attempt index init on _default", base.MD(h.db.Name), existsErr)
 	} else {
 		defaultCollectionPresent = exists

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -1495,6 +1495,25 @@ func TestDBOnlineSingle(t *testing.T) {
 	assert.True(t, body["state"].(string) == "Online")
 }
 
+// TestDBOnlineWhileStopping checks that _online on a database context being torn down reports
+// success and leaves it alone. A concurrent _online reloads the database, which closes the context
+// the second request already resolved, and that request must not fail - see TestDBOnlineConcurrent.
+func TestDBOnlineWhileStopping(t *testing.T) {
+	rt := rest.NewRestTester(t, nil)
+	defer rt.Close()
+
+	dbc := rt.GetDatabase()
+	// _online runs offline, so the state check in validateAndWriteHeaders doesn't reject this.
+	atomic.StoreUint32(&dbc.State, db.DBStopping)
+
+	rest.RequireStatus(t, rt.SendAdminRequest(http.MethodPost, "/db/_online", ""), http.StatusOK)
+
+	// The background goroutine only transitions an Offline database, so the state stays put.
+	require.Never(t, func() bool {
+		return atomic.LoadUint32(&dbc.State) != db.DBStopping
+	}, time.Second, 10*time.Millisecond)
+}
+
 // Take DB online concurrently using two goroutines
 // Both should return success and DB should be online
 // once both goroutines return

--- a/rest/indextest/index_init_api_test.go
+++ b/rest/indextest/index_init_api_test.go
@@ -15,6 +15,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -331,6 +332,23 @@ func TestChangeIndexPartitionsWithViews(t *testing.T) {
 	resp := rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_index_init", `{"num_partitions":2}`)
 	rest.RequireStatus(t, resp, http.StatusBadRequest)
 	rest.AssertHTTPErrorReason(t, resp, http.StatusBadRequest, "_index_init is a GSI-only feature and is not supported when using views")
+}
+
+// TestIndexInitWhileStopping checks that starting an index init against a database being torn down
+// is rejected. _index_init runs offline, so the state check in validateAndWriteHeaders doesn't cover
+// it, and it used to reach h.db.Bucket and panic into a 500 once Close had nilled it.
+func TestIndexInitWhileStopping(t *testing.T) {
+	rt := rest.NewRestTester(t, nil)
+	defer rt.Close()
+
+	atomic.StoreUint32(&rt.GetDatabase().State, db.DBStopping)
+
+	resp := rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_index_init", `{"num_partitions":2}`)
+	rest.AssertHTTPErrorReason(t, resp, http.StatusServiceUnavailable, "Database is stopping, try again later")
+
+	// Stopping an init doesn't touch the bucket, so it stays available.
+	resp = rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_index_init?action=stop", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
 }
 
 func TestChangeIndexSeparatePrincipalIndexes(t *testing.T) {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1310,7 +1310,14 @@ func (sc *ServerContext) asyncDatabaseOnline(nonCancelCtx base.NonCancellableCon
 
 	if !atomic.CompareAndSwapUint32(&dbc.State, db.DBStarting, db.DBOnline) {
 		// 2nd atomic might end up being Starting here if there's a legitimate race, but it's the most we can do for CAS
-		base.PanicfCtx(ctx, "database state wasn't Starting during asyncDatabaseOnline Online transition... now %q", db.RunStateString[atomic.LoadUint32(&dbc.State)])
+		state := atomic.LoadUint32(&dbc.State)
+		// StartOnlineProcesses only takes BucketLock for read, so a Close can mark the database
+		// Stopping while it runs. Losing the transition to a teardown is expected, not a bug.
+		if state == db.DBStopping {
+			base.InfofCtx(ctx, base.KeyAll, "Database was closed while starting online processes, not bringing it online")
+			return
+		}
+		base.PanicfCtx(ctx, "database state wasn't Starting during asyncDatabaseOnline Online transition... now %q", db.RunStateString[state])
 	}
 
 	_ = dbc.EventMgr.RaiseDBStateChangeEvent(ctx, dbc.Name, "online", dbLoadedStateChangeMsg, &sc.Config.API.AdminInterface)

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -377,6 +377,27 @@ func TestStatsLoggerStopped(t *testing.T) {
 	time.Sleep(time.Millisecond * 10)
 }
 
+// TestAsyncDatabaseOnlineClosedDatabase covers asyncDatabaseOnline losing the race with a database
+// teardown. StartOnlineProcesses only takes BucketLock for read, so a Close can mark the database
+// Stopping while it runs, and the online transition then has nothing to do. It used to panic.
+func TestAsyncDatabaseOnlineClosedDatabase(t *testing.T) {
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+
+	sc := rt.ServerContext()
+	// Offline first, so StartOnlineProcesses has something to start.
+	rt.TakeDbOffline()
+
+	dbc := rt.GetDatabase()
+	atomic.StoreUint32(&dbc.State, db.DBStopping)
+
+	// Version must match, or asyncDatabaseOnline returns before reaching the online transition.
+	sc.asyncDatabaseOnline(base.NewNonCancelCtxForDatabase(base.TestCtx(t)), dbc, nil, sc.GetDbVersion(dbc.Name))
+
+	require.Equal(t, db.DBStopping, atomic.LoadUint32(&dbc.State),
+		"a closing database was brought online by asyncDatabaseOnline")
+}
+
 func TestObtainManagementEndpointsFromServerContext(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("Test requires Couchbase Server")


### PR DESCRIPTION
CBG-5472

Part 2 of 3 split from https://github.com/couchbase/sync_gateway/pull/8431 - which had in-PR requested changes that ended up spiralling away from the original ticket.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/

<!--
Automated review runs on every non-draft PR raised from this repo (forks are not reviewed automatically).
  - Re-run it, or ask a follow-up, by commenting `@droid <question>`
  - Suppress it with the `droid-skip` label, or `WIP`/`DO NOT MERGE` in the title
-->
