### PR TITLE
CBG-5472 part 3 of 3: read databases lock-free when collecting calculated stats

### DIFF
--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -73,8 +73,13 @@ type ServerContext struct {
 	_dbRegistry         map[string]struct{}               // _dbRegistry is a map of db names, used to ensure uniqueness even when db isn't active
 	_collectionRegistry map[string]string                 // _collectionRegistry is a map of fully qualified collection name to db name, used for local uniqueness checks
 	_dbConfigs          map[string]*RuntimeDatabaseConfig // _dbConfigs is a map of db name to the RuntimeDatabaseConfig
-	_databases          map[string]*db.DatabaseContext    // _databases is a map of dbname to db.DatabaseContext
+	_databases          map[string]*db.DatabaseContext    // _databases is a map of dbname to db.DatabaseContext. Mutate via _addDatabase/_deleteDatabase/_clearDatabases
 	_databasesLock      sync.RWMutex                      // Lock for _databases and other db-specific maps above
+
+	// databasesSnapshot holds the values of _databases for the stats logger to read without taking
+	// _databasesLock, which a config update can hold for a long time while it waits on index
+	// readiness. Kept in step with _databases by the mutation helpers.
+	databasesSnapshot atomic.Pointer[[]*db.DatabaseContext]
 
 	// serverCtx is cancelled by Close() to broadcast server shutdown to all background
 	// goroutines that hold a reference to this ServerContext (e.g. handleDbOnline).
@@ -320,7 +325,7 @@ func (sc *ServerContext) Close(ctx context.Context) {
 		db.Close(ctx)
 		_ = db.EventMgr.RaiseDBStateChangeEvent(ctx, db.Name, "offline", "Database context closed", &sc.Config.API.AdminInterface)
 	}
-	sc._databases = nil
+	sc._clearDatabases()
 	sc.invalidDatabaseConfigTracking.dbNames = nil
 }
 
@@ -1220,7 +1225,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	}
 
 	// Register it so HTTP handlers can find it:
-	sc._databases[dbcontext.Name] = dbcontext
+	sc._addDatabase(dbcontext)
 	sc._dbConfigs[dbcontext.Name] = &RuntimeDatabaseConfig{DatabaseConfig: config}
 	sc._dbRegistry[dbName] = struct{}{}
 	for _, name := range fqCollections {
@@ -1828,8 +1833,9 @@ func (sc *ServerContext) _unloadDatabase(ctx context.Context, dbName string) boo
 		return false
 	}
 	base.InfofCtx(ctx, base.KeyAll, "Closing db /%s (bucket %q)", base.MD(dbCtx.Name), base.MD(dbCtx.Bucket.GetName()))
+	// Drop it from the snapshot before teardown, so the stats logger stops seeing it first.
+	sc._deleteDatabase(dbName)
 	dbCtx.Close(ctx)
-	delete(sc._databases, dbName)
 	return true
 }
 
@@ -1946,17 +1952,44 @@ func (sc *ServerContext) logNetworkInterfaceStats(ctx context.Context) {
 
 }
 
-// Updates stats that are more efficient to calculate at stats collection time
+// _addDatabase registers a database. The caller must hold sc._databasesLock for write.
+func (sc *ServerContext) _addDatabase(dbContext *db.DatabaseContext) {
+	sc._databases[dbContext.Name] = dbContext
+	sc._updateDatabasesSnapshot()
+}
+
+// _deleteDatabase removes a database. The caller must hold sc._databasesLock for write.
+func (sc *ServerContext) _deleteDatabase(dbName string) {
+	delete(sc._databases, dbName)
+	sc._updateDatabasesSnapshot()
+}
+
+// _clearDatabases removes every database and marks the server context closed, so that
+// _getOrAddDatabaseFromConfig can tell a closed server apart from one with no databases. The caller
+// must hold sc._databasesLock for write.
+func (sc *ServerContext) _clearDatabases() {
+	sc._databases = nil
+	sc._updateDatabasesSnapshot()
+}
+
+// _updateDatabasesSnapshot refreshes databasesSnapshot to match _databases. The caller must hold
+// sc._databasesLock for write.
+func (sc *ServerContext) _updateDatabasesSnapshot() {
+	sc.databasesSnapshot.Store(base.Ptr(slices.Collect(maps.Values(sc._databases))))
+}
+
+// Updates stats that are more efficient to calculate at stats collection time. Reads
+// databasesSnapshot rather than _databases, so it never blocks on _databasesLock.
 func (sc *ServerContext) updateCalculatedStats(ctx context.Context) {
-	sc._databasesLock.RLock()
-	defer sc._databasesLock.RUnlock()
-	for _, dbContext := range sc._databases {
-		dbState := atomic.LoadUint32(&dbContext.State)
-		if dbState == db.DBOnline {
+	snapshot := sc.databasesSnapshot.Load()
+	if snapshot == nil {
+		return
+	}
+	for _, dbContext := range *snapshot {
+		if atomic.LoadUint32(&dbContext.State) == db.DBOnline {
 			dbContext.UpdateCalculatedStats(ctx)
 		}
 	}
-
 }
 
 // initializeGoCBAgent Obtains a gocb agent from the current server connection. Requires the agent to be closed after use.

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -377,6 +377,102 @@ func TestStatsLoggerStopped(t *testing.T) {
 	time.Sleep(time.Millisecond * 10)
 }
 
+// TestStatsLoggerIndependentOfDatabaseLock is a regression test for CBG-5472. A config update can
+// hold _databasesLock for write across a long index-readiness wait. updateCalculatedStats must
+// still complete during that time, because it reads databasesSnapshot instead of the map.
+func TestStatsLoggerIndependentOfDatabaseLock(t *testing.T) {
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+
+	sc := rt.ServerContext()
+	ctx := base.TestCtx(t)
+	require.Len(t, sc.AllDatabases(), 1)
+
+	// Simulate a config update holding the write lock for a long time.
+	sc._databasesLock.Lock()
+	defer sc._databasesLock.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		sc.updateCalculatedStats(ctx)
+		close(done)
+	}()
+
+	// updateCalculatedStats no longer takes _databasesLock, so it returns immediately.
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("updateCalculatedStats blocked on _databasesLock held by a simulated config update (CBG-5472)")
+	}
+}
+
+// TestDatabasesSnapshotTracksDatabases checks that databasesSnapshot stays in sync with _databases
+// as databases are added and removed (CBG-5472).
+func TestDatabasesSnapshotTracksDatabases(t *testing.T) {
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+
+	sc := rt.ServerContext()
+	dbName := rt.GetDatabase().Name
+
+	snapshot := sc.databasesSnapshot.Load()
+	require.NotNil(t, snapshot)
+	require.Len(t, *snapshot, 1)
+
+	require.True(t, sc.RemoveDatabase(base.TestCtx(t), dbName, "test cleanup"))
+
+	snapshot = sc.databasesSnapshot.Load()
+	require.NotNil(t, snapshot)
+	require.Empty(t, *snapshot)
+}
+
+// TestStatsLoggerConcurrentWithDatabaseRemoval runs the lock-free stats reader against a concurrent
+// database removal. The reader no longer holds _databasesLock, so it can see a database that is
+// closing, which must stay memory-safe. Most valuable under -race.
+func TestStatsLoggerConcurrentWithDatabaseRemoval(t *testing.T) {
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+
+	sc := rt.ServerContext()
+	ctx := base.TestCtx(t)
+	dbName := rt.GetDatabase().Name
+
+	var wg sync.WaitGroup
+	defer base.WaitWithTimeout(t, &wg, time.Minute)
+	wg.Go(func() {
+		for range 2000 {
+			sc.updateCalculatedStats(ctx)
+		}
+	})
+
+	require.True(t, sc.RemoveDatabase(ctx, dbName, "concurrent stats test"))
+}
+
+// TestStatsSnapshotExcludesClosedDatabase checks that a database the stats logger can still reach is
+// never one that has been closed. updateCalculatedStats loads the snapshot pointer and then iterates
+// it without a lock, so a removal running alongside leaves it holding a closed DatabaseContext - the
+// DBOnline guard is what stops it collecting stats from one.
+func TestStatsSnapshotExcludesClosedDatabase(t *testing.T) {
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+
+	sc := rt.ServerContext()
+	ctx := base.TestCtx(t)
+	dbName := rt.GetDatabase().Name
+
+	// A stats logger iteration that started before the removal holds this pointer.
+	snapshot := sc.databasesSnapshot.Load()
+	require.NotNil(t, snapshot)
+	require.Len(t, *snapshot, 1)
+
+	require.True(t, sc.RemoveDatabase(ctx, dbName, "closed database stats test"))
+
+	for _, dbContext := range *snapshot {
+		require.NotEqual(t, db.DBOnline, atomic.LoadUint32(&dbContext.State),
+			"closed database %q still reports DBOnline, so updateCalculatedStats operates on it", dbContext.Name)
+	}
+}
+
 // TestAsyncDatabaseOnlineClosedDatabase covers asyncDatabaseOnline losing the race with a database
 // teardown. StartOnlineProcesses only takes BucketLock for read, so a Close can mark the database
 // Stopping while it runs, and the online transition then has nothing to do. It used to panic.


### PR DESCRIPTION
CBG-5472

Part 3 of 3 split from https://github.com/couchbase/sync_gateway/pull/8431 - which had in-PR requested changes that ended up spiralling away from the original ticket.

- [x] Depends on #8683 

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/

<!--
Automated review runs on every non-draft PR raised from this repo (forks are not reviewed automatically).
  - Re-run it, or ask a follow-up, by commenting `@droid <question>`
  - Suppress it with the `droid-skip` label, or `WIP`/`DO NOT MERGE` in the title
-->
