### PR TITLE
CBG-5338: Avoid re-initializing external logger globals after first init()

### DIFF
--- a/base/logger_external.go
+++ b/base/logger_external.go
@@ -23,8 +23,12 @@ import (
 const remapGoCBLogLevels = true
 
 // This file implements wrappers around the loggers of external packages
-// so that all of SG's logging output is consistent
-func initExternalLoggers() {
+// so that all of SG's logging output is consistent.
+//
+// These are set in init and never again - the external packages hold them in plain unsynchronised
+// globals, so writing them once anything else could be logging is a data race. Only the log levels are
+// adjustable at runtime, via updateExternalLoggers.
+func init() {
 	if remapGoCBLogLevels {
 		gocb.SetLogger(GoCBLoggerRemapped{})
 		gocbcore.SetLogger(GoCBCoreLoggerRemapped{})
@@ -37,14 +41,12 @@ func initExternalLoggers() {
 	// Set the clog level to DEBUG and do filtering for debug inside ClogCallback functions
 	clog.SetLevel(clog.LevelDebug)
 
-	// Redirect Walrus logging to SG logs, and set an appropriate level:
+	// Redirect Rosmar logging to SG logs
 	rosmar.LoggingCallback = rosmarLogger
-
-	updateExternalLoggers()
 }
 
 func updateExternalLoggers() {
-	// use context.Background() since this is called from init or to reset test logging
+	// use context.Background() since this is called on logging config changes and to reset test logging
 	logger := consoleLogger.Load()
 	if logger.shouldLog(context.Background(), LevelDebug, KeyWalrus) {
 		rosmar.SetLogLevel(rosmar.LevelDebug)

--- a/base/logger_external_test.go
+++ b/base/logger_external_test.go
@@ -11,9 +11,12 @@ package base
 import (
 	"testing"
 
+	"github.com/couchbase/clog"
 	"github.com/couchbase/gocb/v2"
 	"github.com/couchbase/gocbcore/v10"
 	"github.com/couchbase/sync_gateway/testing/assert"
+	"github.com/couchbase/sync_gateway/testing/require"
+	"github.com/couchbaselabs/rosmar"
 )
 
 func TestGoCBLogLevelEquality(t *testing.T) {
@@ -28,4 +31,32 @@ func TestGoCBLogLevelEquality(t *testing.T) {
 	assert.Equal(t, gocb.LogDebug, gocb.LogLevel(gocbcore.LogDebug))
 
 	assert.Equal(t, gocb.LogTrace, gocb.LogLevel(gocbcore.LogTrace))
+}
+
+// TestExternalLoggersWiredAtInit ensures the external packages' logging is redirected into SG's logs by
+// init. Those packages hold their loggers in plain unsynchronised globals, so init is the only point at
+// which they can safely be set - anywhere later races with whatever is already logging through them.
+func TestExternalLoggersWiredAtInit(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected string
+		logFn    func()
+	}{
+		{
+			name:     "rosmar",
+			expected: "[WRN] Rosmar: external logger check",
+			logFn:    func() { rosmar.LoggingCallback(rosmar.LevelWarn, "external logger check") },
+		},
+		{
+			name:     "clog",
+			expected: "[INF] DCP: external logger check",
+			logFn:    func() { clog.Warnf("external logger check") },
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			logs := captureConsoleLogs(t, LevelDebug, []LogKey{KeyAll}, test.logFn)
+			require.Contains(t, logs, test.expected)
+		})
+	}
 }

--- a/base/logging.go
+++ b/base/logging.go
@@ -124,7 +124,7 @@ func initializeLoggers(ctx context.Context) {
 	initialCollationBufferSize := 0
 
 	consoleLogger.Store(mustInitConsoleLogger(context.Background(), &ConsoleLoggerConfig{LogKeys: []string{logKeyNames[KeyHTTP]}, FileLoggerConfig: FileLoggerConfig{Enabled: Ptr(true), CollationBufferSize: &initialCollationBufferSize}}))
-	initExternalLoggers()
+	updateExternalLoggers()
 }
 
 type logFn func(ctx context.Context, format string, args ...any)

--- a/base/logging_config.go
+++ b/base/logging_config.go
@@ -140,8 +140,8 @@ func InitLogging(ctx context.Context, logFilePath string,
 	}
 	auditLogger.Store(rawAuditLogger)
 
-	// Initialize external loggers too
-	initExternalLoggers()
+	// Pick up any console log level/key changes for the external loggers too
+	updateExternalLoggers()
 
 	return nil
 }

--- a/base/logging_context_test.go
+++ b/base/logging_context_test.go
@@ -19,12 +19,18 @@ import (
 
 const standardMessage = "foobar"
 
-// RequireLogIs asserts that the logs produced by function f contain string s.
-func requireLogIs(t testing.TB, s string, f func()) {
+// captureConsoleLogs returns the console output produced by f, logged at the given level and keys.
+func captureConsoleLogs(t testing.TB, logLevel LogLevel, logKeys []LogKey, f func()) string {
 	t.Helper()
 	b := bytes.Buffer{}
 
+	keyNames := make([]string, 0, len(logKeys))
+	for _, logKey := range logKeys {
+		keyNames = append(keyNames, logKey.String())
+	}
 	config := &ConsoleLoggerConfig{
+		LogLevel:     &logLevel,
+		LogKeys:      keyNames,
 		ColorEnabled: Ptr(false),
 		FileLoggerConfig: FileLoggerConfig{
 			Enabled: Ptr(true),
@@ -33,7 +39,6 @@ func requireLogIs(t testing.TB, s string, f func()) {
 	tempLogger, err := NewConsoleLogger(TestCtx(t), false, config)
 	require.NoError(t, err)
 	tempLogger.logger.SetOutput(&b)
-	timestampLength := len(time.Now().Format(ISO8601Format) + " ")
 
 	// Temporarily override logger output for the given function call
 	oldLogger := consoleLogger.Swap(tempLogger)
@@ -44,7 +49,15 @@ func requireLogIs(t testing.TB, s string, f func()) {
 	f()
 
 	FlushLogBuffers()
-	originalLog := b.String()
+	return b.String()
+}
+
+// RequireLogIs asserts that the logs produced by function f contain string s.
+func requireLogIs(t testing.TB, s string, f func()) {
+	t.Helper()
+	timestampLength := len(time.Now().Format(ISO8601Format) + " ")
+
+	originalLog := captureConsoleLogs(t, LevelInfo, nil, f)
 	require.GreaterOrEqual(t, len(originalLog), timestampLength, "%q is not a valid log line, needs to contain timestamp", originalLog)
 	log := originalLog[timestampLength:]
 	require.Equal(t, s, log)


### PR DESCRIPTION
CBG-5338

Fixes `-race` caused by `initExternalLoggers()` being invoked multiple times unnecessarily.

- `initExternalLoggers` wired up SG's loggers with external module loggers - this PR is intentionally dropping the function so that it is not accidentally called from elsewhere in future. This is only ever required once, and doesn't depend on SG's logging configuration so can be done at `init()` time.
- `updateExternalLoggers` sets the external logger levels based on SG's configuration. This is thread-safe and is only required for Rosmar - since it has its own log level config and doesn't directly rely on SG's. Arguably an anti-pattern but not one I want to tackle with this change.

```
=== RUN   TestParseCommandLine
==================
WARNING: DATA RACE
Write at 0x000003da0df8 by goroutine 367809:
  github.com/couchbase/sync_gateway/base.initExternalLoggers()
      /home/ubuntu/workspace/Pipeline_PR-8684/base/logger_external.go:41 +0x1f1
  github.com/couchbase/sync_gateway/base.initializeLoggers()
      /home/ubuntu/workspace/Pipeline_PR-8684/base/logging.go:127 +0x34a
  github.com/couchbase/sync_gateway/rest.ClearServerContextLoggingGlobals.ResetGlobalTestLogging.func2()
      /home/ubuntu/workspace/Pipeline_PR-8684/base/util_testing.go:656 +0xec
  testing.(*common).Cleanup.func1()
      /home/ubuntu/sdk/go1.26.6/src/testing/testing.go:1317 +0x168
  testing.(*common).runCleanup()
      /home/ubuntu/sdk/go1.26.6/src/testing/testing.go:1667 +0x225
  testing.tRunner.func2()
      /home/ubuntu/sdk/go1.26.6/src/testing/testing.go:2030 +0x4c
  runtime.deferreturn()
      /home/ubuntu/sdk/go1.26.6/src/runtime/panic.go:668 +0x5d
  testing.(*T).Run.gowrap1()
      /home/ubuntu/sdk/go1.26.6/src/testing/testing.go:2101 +0x38

Previous read at 0x000003da0df8 by goroutine 367803:
  github.com/couchbaselabs/rosmar.info()
      /home/ubuntu/go/pkg/mod/github.com/couchbaselabs/rosmar@v0.0.0-20260814160154-fdadaf72889b/logging.go:68 +0x55
  github.com/couchbaselabs/rosmar.(*Bucket).doExpiration()
      /home/ubuntu/go/pkg/mod/github.com/couchbaselabs/rosmar@v0.0.0-20260814160154-fdadaf72889b/bucket_api.go:381 +0x1b9
  github.com/couchbaselabs/rosmar.(*Bucket).doExpiration-fm()
      <autogenerated>:1 +0x3e
  github.com/couchbaselabs/rosmar.(*expiryManager).runExpiry()
      /home/ubuntu/go/pkg/mod/github.com/couchbaselabs/rosmar@v0.0.0-20260814160154-fdadaf72889b/expiry_manager.go:109 +0xf9
  github.com/couchbaselabs/rosmar.(*expiryManager).runExpiry-fm()
      <autogenerated>:1 +0x2e

Goroutine 367809 (running) created at:
  testing.(*T).Run()
      /home/ubuntu/sdk/go1.26.6/src/testing/testing.go:2101 +0xb12
  testing.runTests.func1()
      /home/ubuntu/sdk/go1.26.6/src/testing/testing.go:2585 +0x84
  testing.tRunner()
      /home/ubuntu/sdk/go1.26.6/src/testing/testing.go:2036 +0x21c
  testing.runTests()
      /home/ubuntu/sdk/go1.26.6/src/testing/testing.go:2583 +0x9e9
  testing.(*M).Run()
      /home/ubuntu/sdk/go1.26.6/src/testing/testing.go:2443 +0xf4b
  github.com/couchbase/sync_gateway/base.TestBucketPoolMain()
      /home/ubuntu/workspace/Pipeline_PR-8684/base/main_test_bucket_pool.go:963 +0x8b2
  github.com/couchbase/sync_gateway/db.TestBucketPoolWithIndexes()
      /home/ubuntu/workspace/Pipeline_PR-8684/db/util_testing.go:519 +0x292
  github.com/couchbase/sync_gateway/rest.TestBucketPoolRestWithIndexes()
      /home/ubuntu/workspace/Pipeline_PR-8684/rest/utilities_testing.go:2801 +0x188
  github.com/couchbase/sync_gateway/rest.TestMain()
      /home/ubuntu/workspace/Pipeline_PR-8684/rest/main_test.go:192 +0x1aa
  main.main()
      _testmain.go:1616 +0x16d

Goroutine 367803 (finished) created at:
  time.goFunc()
      /home/ubuntu/sdk/go1.26.6/src/time/sleep.go:215 +0x44
==================
    testing.go:1712: race detected during execution of test
--- FAIL: TestParseCommandLine (0.00s)
```

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- n/a

<!--
Automated review runs on every non-draft PR raised from this repo (forks are not reviewed automatically).
  - Re-run it, or ask a follow-up, by commenting `@droid <question>`
  - Suppress it with the `droid-skip` label, or `WIP`/`DO NOT MERGE` in the title
-->
