### PR TITLE
[4.1.2 Backport] CBG-5756: keep attachment metadata on metadata-only writes

### DIFF
--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -19,7 +19,9 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
+	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/stretchr/testify/assert"
@@ -1519,4 +1521,290 @@ func TestLargeAttachments(t *testing.T) {
 	})
 	require.ErrorAs(t, err, &httpErr, "Created doc with huge attachment")
 	require.Equal(t, http.StatusRequestEntityTooLarge, httpErr.Status)
+}
+
+// bodyWithAttachment is a document body with a single inline attachment, used by the attachment metadata
+// write-path tests.
+func bodyWithAttachment() Body {
+	return Body{
+		"value":         1234,
+		BodyAttachments: map[string]any{"myatt": map[string]any{"content_type": "text/plain", "data": "SGVsbG8gV29ybGQh"}},
+	}
+}
+
+// requireAttachmentMetadataPreserved asserts that the named attachment is still described by
+// _globalSync.attachments_meta with the given digest and length, and that no metadata was left behind in
+// _sync.attachments. Revpos is deliberately not asserted, as write paths legitimately re-stamp it.
+func requireAttachmentMetadataPreserved(t *testing.T, ds base.DataStore, docID, attName, digest string, length int) {
+	t.Helper()
+	require.Empty(t, GetRawSyncXattr(t, ds, docID).AttachmentsPre4dot0, "attachment metadata should not be left in _sync")
+	atts := GetRawGlobalSyncAttachments(t, ds, docID)
+	att, ok := atts[attName]
+	require.True(t, ok, "attachment %q missing from _globalSync.attachments_meta, found %v", attName, atts)
+	require.Equal(t, digest, att.Digest)
+	require.Equal(t, length, att.Length)
+}
+
+// TestVersionCASCorrectionPreservesGlobalXattr covers the corrective re-stamp path
+// (correctVersionAheadOfCAS -> restampVersionCAS), which re-persists _sync, _vv and _mou from the in-memory
+// document after a write. That marshal excludes the global xattr, so the re-stamp must leave the attachment
+// metadata the write itself put in _globalSync alone.
+//
+// TestWritePathsPreserveUnmigratedAttachmentMetadata covers the same path against a document whose
+// attachment metadata has not been migrated out of _sync yet.
+//
+// The _mou the re-stamp writes is not asserted here, and is wrong: updateAndReturnDoc reads the document
+// without the revSeqNo virtual xattr, so doc.RevSeqNo is zero and _mou.pRev is written as 0 instead of
+// naming the mutation that last wrote the body. Tracked by CBG-5764.
+func TestVersionCASCorrectionPreservesGlobalXattr(t *testing.T) {
+	dbc, ctx := setupTestDB(t)
+	defer dbc.Close(ctx)
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, dbc)
+	ds := collection.GetCollectionDatastore()
+	retryCount := dbc.DbStats.Database().HLVVersionCASRetryCount
+
+	// put the Sync Gateway clock 100ms ahead of the clock assigning the CAS, so the write generates a version
+	// ahead of its CAS and updateAndReturnDoc corrects it with a re-stamp. Derived from the same source the
+	// bucket uses, so the injected offset is the only difference.
+	dbc.hlc.SetClockForTest(func() uint64 { return uint64(time.Now().UnixNano()) + uint64(100*time.Millisecond) })
+	defer dbc.hlc.SetClockForTest(func() uint64 { return uint64(time.Now().UnixNano()) })
+
+	docID := t.Name()
+	before := retryCount.Value()
+	_, _, err := collection.Put(ctx, docID, bodyWithAttachment())
+	require.NoError(t, err)
+	require.Equal(t, before+1, retryCount.Value(), "expected a corrective re-stamp for this write")
+
+	requireAttachmentMetadataPreserved(t, ds, docID, "myatt", "sha1-Lve95gjOVATpfV8EL5X4nxwjKHE=", 12)
+}
+
+// unmigratedAttachmentWritePath is one Sync Gateway code path that persists a document's _sync xattr,
+// exercised below against a document whose pre-4.0 attachment metadata has not been migrated yet.
+type unmigratedAttachmentWritePath struct {
+	name string
+	// needsImport leaves the document looking like a write from outside Sync Gateway, so that the path under
+	// test imports it.
+	needsImport bool
+	// create replaces the default document setup (a Put of a document with an inline attachment). It returns
+	// the revision ID of the created document.
+	create func(t *testing.T, ctx context.Context, collection *DatabaseCollectionWithUser, docID string) string
+	// alreadyUnmigrated skips moving the attachment metadata back into _sync, for a create that writes a
+	// document in the pre-4.0 layout itself.
+	alreadyUnmigrated bool
+	run               func(t *testing.T, ctx context.Context, dbc *Database, collection *DatabaseCollectionWithUser, docID, rev1ID string)
+}
+
+// TestWritePathsPreserveUnmigratedAttachmentMetadata pins the invariant that no code path which rewrites a
+// document's _sync xattr may lose pre-4.0 attachment metadata.
+//
+// unmarshalDocumentWithXattrs moves attachment metadata out of _sync.attachments and onto the document's
+// global sync data, so a write that persists _sync without also persisting _globalSync destroys it: for a
+// document attachment migration has not yet reached, the _sync copy is the only copy. Each path below must
+// therefore leave the metadata in _globalSync.attachments_meta with nothing in _sync.attachments.
+//
+// Listing a path here is also a statement that it is expected to keep working against documents written
+// before 4.0.
+//
+// Only the attachment metadata is asserted. Most of these paths are metadata-only updates that also write
+// _mou, whose previous values are wrong today - _mou.pRev names the mutation before the one pCas names
+// whenever a metadata-only update lands on a document another metadata-only update left behind, and the
+// version-CAS correction always writes it as 0. Tracked by CBG-5764.
+func TestWritePathsPreserveUnmigratedAttachmentMetadata(t *testing.T) {
+	const (
+		attName   = "myatt"
+		attDigest = "sha1-Lve95gjOVATpfV8EL5X4nxwjKHE="
+		attLength = 12
+	)
+
+	// putWithAttachmentStub updates the document, carrying its existing attachment forward as a stub, the way
+	// a client updating a document with an attachment does.
+	putWithAttachmentStub := func(t *testing.T, ctx context.Context, collection *DatabaseCollectionWithUser, docID, rev1ID string) error {
+		body := unmarshalBody(t, `{"value": 5678, "_attachments": {"myatt": {"stub": true, "revpos": 1}}}`)
+		body[BodyRev] = rev1ID
+		_, _, err := collection.Put(ctx, docID, body)
+		return err
+	}
+
+	testCases := []unmigratedAttachmentWritePath{
+		{
+			// updateAndReturnDoc, the path shared by REST, BLIP and inter-Sync Gateway writes
+			name: "Sync Gateway write",
+			run: func(t *testing.T, ctx context.Context, _ *Database, collection *DatabaseCollectionWithUser, docID, rev1ID string) {
+				require.NoError(t, putWithAttachmentStub(t, ctx, collection, docID, rev1ID))
+			},
+		},
+		{
+			// correctVersionAheadOfCAS/restampVersionCAS re-persist _sync, _vv and _mou after the write above
+			name: "Sync Gateway write with version-CAS correction",
+			run: func(t *testing.T, ctx context.Context, dbc *Database, collection *DatabaseCollectionWithUser, docID, rev1ID string) {
+				retryCount := dbc.DbStats.Database().HLVVersionCASRetryCount
+				before := retryCount.Value()
+
+				// put the Sync Gateway clock ahead of the clock assigning the CAS, so the write generates a
+				// version ahead of its CAS and is corrected by a re-stamp
+				dbc.hlc.SetClockForTest(func() uint64 { return uint64(time.Now().UnixNano()) + uint64(100*time.Millisecond) })
+				defer dbc.hlc.SetClockForTest(func() uint64 { return uint64(time.Now().UnixNano()) })
+
+				require.NoError(t, putWithAttachmentStub(t, ctx, collection, docID, rev1ID))
+				require.Equal(t, before+1, retryCount.Value(), "expected a corrective re-stamp for this write")
+			},
+		},
+		{
+			// MigrateAttachmentMetadata, used by the import feed and the attachment migration background job
+			name: "attachment migration",
+			run: func(t *testing.T, ctx context.Context, _ *Database, collection *DatabaseCollectionWithUser, docID, _ string) {
+				xattrs, cas, err := collection.dataStore.GetXattrs(ctx, docID, []string{base.SyncXattrName})
+				require.NoError(t, err)
+				var syncData SyncData
+				require.NoError(t, base.JSONUnmarshal(xattrs[base.SyncXattrName], &syncData))
+				require.NoError(t, collection.MigrateAttachmentMetadata(ctx, docID, cas, &syncData))
+			},
+		},
+		{
+			// ImportDocRaw via OnDemandImportForGet
+			name:        "on-demand import for get",
+			needsImport: true,
+			run: func(t *testing.T, ctx context.Context, _ *Database, collection *DatabaseCollectionWithUser, docID, _ string) {
+				_, err := collection.GetDocument(ctx, docID, DocUnmarshalAll)
+				require.NoError(t, err)
+			},
+		},
+		{
+			// ImportDoc via OnDemandImportForWrite. The import creates a revision for the external write, so
+			// the update that triggered it is then rejected as a conflict - the import is the write under test.
+			name:        "on-demand import for write",
+			needsImport: true,
+			run: func(t *testing.T, ctx context.Context, _ *Database, collection *DatabaseCollectionWithUser, docID, rev1ID string) {
+				err := putWithAttachmentStub(t, ctx, collection, docID, rev1ID)
+				require.Error(t, err)
+				status, _ := base.ErrorAsHTTPStatus(err)
+				require.Equal(t, http.StatusConflict, status)
+			},
+		},
+		{
+			// migrateMetadata, the read-side upgrade of a document written before Sync Gateway 3.0 with its
+			// sync metadata inline in the body
+			name:              "metadata migration from inline sync data",
+			alreadyUnmigrated: true,
+			create: func(t *testing.T, ctx context.Context, collection *DatabaseCollectionWithUser, docID string) string {
+				added, err := collection.dataStore.Add(ctx, docID, 0, rawDocWithInlineSyncMetaAndAttachment())
+				require.NoError(t, err)
+				require.True(t, added)
+				return ""
+			},
+			run: func(t *testing.T, ctx context.Context, _ *Database, collection *DatabaseCollectionWithUser, docID, _ string) {
+				_, existingBucketDoc, err := collection.GetDocWithXattrs(ctx, docID, DocUnmarshalAll)
+				require.NoError(t, err)
+				_, err = collection.migrateMetadata(ctx, docID, existingBucketDoc, &sgbucket.MutateInOptions{})
+				require.NoError(t, err)
+			},
+		},
+		{
+			// CompactDocChannelHistory, reachable through POST /{keyspace}/_channel_history/{docid}/compact
+			name: "channel history compaction",
+			create: func(t *testing.T, ctx context.Context, collection *DatabaseCollectionWithUser, docID string) string {
+				// compaction only writes when there is ended channel history to prune, so move the document
+				// from one channel to another first
+				_, err := collection.UpdateSyncFun(ctx, `function(doc){channel(doc.chan);}`)
+				require.NoError(t, err)
+
+				body := bodyWithAttachment()
+				body["chan"] = "A"
+				rev1ID, _, err := collection.Put(ctx, docID, body)
+				require.NoError(t, err)
+
+				update := unmarshalBody(t, `{"chan": "B", "_attachments": {"myatt": {"stub": true, "revpos": 1}}}`)
+				update[BodyRev] = rev1ID
+				rev2ID, _, err := collection.Put(ctx, docID, update)
+				require.NoError(t, err)
+				return rev2ID
+			},
+			run: func(t *testing.T, ctx context.Context, _ *Database, collection *DatabaseCollectionWithUser, docID, _ string) {
+				compacted, err := collection.CompactDocChannelHistory(ctx, docID, 100)
+				require.NoError(t, err)
+				require.NotEmpty(t, compacted, "compaction should have pruned channel history, or no write happens")
+			},
+		},
+		{
+			// ResyncDocument
+			name: "resync",
+			run: func(t *testing.T, ctx context.Context, _ *Database, collection *DatabaseCollectionWithUser, docID, _ string) {
+				// resync only writes when the sync function changes the document's channels
+				_, err := collection.UpdateSyncFun(ctx, `function(doc){channel("postResync");}`)
+				require.NoError(t, err)
+				require.NoError(t, collection.ResyncDocument(ctx, docID, getBucketDocument(t, collection.DatabaseCollection, docID), false))
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dbc, ctx := setupTestDB(t)
+			defer dbc.Close(ctx)
+			collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, dbc)
+			ds := collection.GetCollectionDatastore()
+
+			_, err := collection.UpdateSyncFun(ctx, `function(doc){channel("preResync");}`)
+			require.NoError(t, err)
+
+			docID := SafeDocumentName(t, t.Name())
+			var rev1ID string
+			if tc.create != nil {
+				rev1ID = tc.create(t, ctx, collection, docID)
+			} else {
+				rev1ID, _, err = collection.Put(ctx, docID, bodyWithAttachment())
+				require.NoError(t, err)
+			}
+			if !tc.alreadyUnmigrated {
+				require.NotEmpty(t, GetRawGlobalSyncAttachments(t, ds, docID))
+
+				// move the attachment metadata back into _sync, as a pre-4.0 version of Sync Gateway would
+				// have written it. For the import paths, write a new body without macro expanding _sync.cas
+				// as well, so the document looks like an unimported external write.
+				value, _, err := ds.GetRaw(ctx, docID)
+				require.NoError(t, err)
+				if tc.needsImport {
+					value = []byte(`{"value": "external write"}`)
+				}
+				MoveAttachmentXattrFromGlobalToSync(t, ds, docID, value, !tc.needsImport)
+				require.NotEmpty(t, GetRawSyncXattr(t, ds, docID).AttachmentsPre4dot0, "setup should leave pre-4.0 attachment metadata in _sync")
+			}
+
+			tc.run(t, ctx, dbc, collection, docID, rev1ID)
+
+			requireAttachmentMetadataPreserved(t, ds, docID, attName, attDigest, attLength)
+		})
+	}
+}
+
+// rawDocWithInlineSyncMetaAndAttachment returns a document as Sync Gateway wrote it before 3.0: sync
+// metadata in the body rather than an xattr, with pre-4.0 attachment metadata inside it.
+func rawDocWithInlineSyncMetaAndAttachment() []byte {
+	return []byte(`
+{
+    "_sync": {
+        "rev": "1-ca9ad22802b66f662ff171f226211d5c",
+        "sequence": 1,
+        "recent_sequences": [1],
+        "history": {
+            "revs": ["1-ca9ad22802b66f662ff171f226211d5c"],
+            "parents": [-1],
+            "channels": [null]
+        },
+        "attachments": {
+            "myatt": {
+                "content_type": "text/plain",
+                "digest": "sha1-Lve95gjOVATpfV8EL5X4nxwjKHE=",
+                "length": 12,
+                "revpos": 1,
+                "stub": true,
+                "ver": 2
+            }
+        },
+        "cas": "",
+        "time_saved": "2017-11-29T12:46:13.456631-08:00"
+    },
+    "field": "value"
+}
+`)
 }

--- a/db/crud.go
+++ b/db/crud.go
@@ -392,9 +392,17 @@ func (c *DatabaseCollection) CompactDocChannelHistory(ctx context.Context, docid
 	}
 	opts.PreserveExpiry = true // if doc has expiry, we should preserve this
 
+	rawGlobalSync, err := doc.marshalGlobalXattr()
+	if err != nil {
+		return nil, base.RedactErrorf("failed to marshal global sync data when trying to compact channel history for doc:%s. Error: %v", base.UD(docid), err)
+	}
+
 	updatedXattr := map[string][]byte{
 		base.SyncXattrName: rawSyncXattr,
 		base.MouXattrName:  rawMouXattr,
+	}
+	if rawGlobalSync != nil {
+		updatedXattr[base.GlobalXattrName] = rawGlobalSync
 	}
 	_, err = c.dataStore.UpdateXattrs(ctx, key, 0, cas, updatedXattr, opts)
 	compactedChannelArray := compactedChannels.ToArray()

--- a/db/database.go
+++ b/db/database.go
@@ -1991,13 +1991,17 @@ func (db *DatabaseCollectionWithUser) ResyncDocument(ctx context.Context, docid 
 
 		// Update MetadataOnlyUpdate based on previous Cas, MetadataOnlyUpdate
 		doc.MetadataOnlyUpdate = computeMetadataOnlyUpdate(doc.Cas, doc.RevSeqNo, doc.MetadataOnlyUpdate)
-		_, rawSyncXattr, _, rawMouXattr, _, err := updatedDoc.MarshalWithXattrs()
+		_, rawSyncXattr, _, rawMouXattr, rawGlobalSync, err := updatedDoc.MarshalWithXattrs()
+		xattrs := map[string][]byte{
+			base.SyncXattrName: rawSyncXattr,
+			base.MouXattrName:  rawMouXattr,
+		}
+		if rawGlobalSync != nil {
+			xattrs[base.GlobalXattrName] = rawGlobalSync
+		}
 		updatedDoc := sgbucket.UpdatedDoc{
-			Doc: nil, // Resync does not require document body update
-			Xattrs: map[string][]byte{
-				base.SyncXattrName: rawSyncXattr,
-				base.MouXattrName:  rawMouXattr,
-			},
+			Doc:    nil, // Resync does not require document body update
+			Xattrs: xattrs,
 			Expiry: updatedExpiry,
 			Spec: []sgbucket.MacroExpansionSpec{
 				sgbucket.NewMacroExpansionSpec(XattrMouCasPath(), sgbucket.MacroCas),

--- a/db/document.go
+++ b/db/document.go
@@ -1437,15 +1437,27 @@ func (doc *Document) MarshalWithXattrs() (data, syncXattr, vvXattr, mouXattr, gl
 			return nil, nil, nil, nil, nil, pkgerrors.WithStack(base.RedactErrorf("Failed to MarshalWithXattrs() doc MouData with id: %s.  Error: %v", base.UD(doc.ID), err))
 		}
 	}
-	// marshal global xattrs if there are attachments defined
-	if len(doc.Attachments()) > 0 {
-		globalXattr, err = base.JSONMarshal(doc._globalSync)
-		if err != nil {
-			return nil, nil, nil, nil, nil, pkgerrors.WithStack(base.RedactErrorf("Failed to MarshalWithXattrs() doc GlobalXattr with id: %s.  Error: %v", base.UD(doc.ID), err))
-		}
+	globalXattr, err = doc.marshalGlobalXattr()
+	if err != nil {
+		return nil, nil, nil, nil, nil, pkgerrors.WithStack(base.RedactErrorf("Failed to MarshalWithXattrs() doc GlobalXattr with id: %s.  Error: %v", base.UD(doc.ID), err))
 	}
 
 	return data, syncXattr, vvXattr, mouXattr, globalXattr, nil
+}
+
+// marshalGlobalXattr returns the marshalled global sync xattr, or nil when the document has no attachments -
+// the only thing GlobalSyncData carries. A nil return means "no global xattr to write", which
+// updateAndReturnDoc turns into a delete of any existing one, so a field added to GlobalSyncData that can
+// outlive a document's attachments would need this gate widened to match.
+//
+// Attachment metadata written before 4.0 is moved out of the sync xattr onto the global sync data when the
+// document is unmarshalled, so a write that persists the sync xattr must persist this alongside it: for a
+// document attachment migration has not yet reached, the sync xattr held the only copy.
+func (doc *Document) marshalGlobalXattr() ([]byte, error) {
+	if len(doc.Attachments()) == 0 {
+		return nil, nil
+	}
+	return base.JSONMarshal(doc._globalSync)
 }
 
 // channelsForRevTreeID returns the set of channels the given revision is in for the document

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -1655,3 +1655,171 @@ func getBucketDocument(t *testing.T, collection *DatabaseCollection, docID strin
 		IsTombstone: len(body) == 0,
 	}
 }
+
+// TestImportTombstoneAttachmentMetadata records the attachment metadata an import leaves on a tombstone,
+// which is not what a Sync Gateway delete leaves.
+//
+// A Sync Gateway delete creates a revision with no attachments, so there is no global xattr to marshal and
+// updateAndReturnDoc adds _globalSync to XattrsToDelete: the tombstone carries no attachment metadata. An
+// import never reaches that delete. updateAndReturnDoc derives isNewDocCreation from currentValue == nil,
+// and an SDK delete has already removed the body, so importing an existing tombstone is misclassified as a
+// document creation and the delete is suppressed. On the ImportDoc path the hand-built existingBucketDoc
+// (db/import.go) carries no _globalSync either, so the guard is missed twice over - fixing one of the two
+// leaves the behaviour below unchanged. Whatever the bucket held survives:
+//   - already migrated: _globalSync is left in place, so the tombstone keeps attachment metadata that a
+//     Sync Gateway delete would have dropped
+//   - not yet migrated: there is no global xattr to leave alone, and unmarshalDocumentWithXattrs has already
+//     cleared SyncData.AttachmentsPre4dot0, so the tombstone ends up with none
+//
+// The second case is the one that matches a Sync Gateway delete. The first is a leftover rather than a
+// guarantee, and a harmless one: the attachment compaction mark phase skips tombstones (it returns early on
+// len(event.Value) == 0), so nothing reads it and the attachment blobs are swept either way.
+func TestImportTombstoneAttachmentMetadata(t *testing.T) {
+	const (
+		attName   = "myatt"
+		attDigest = "sha1-Lve95gjOVATpfV8EL5X4nxwjKHE="
+		attLength = 12
+	)
+
+	testCases := []struct {
+		name      string
+		unmigrate bool
+	}{
+		{name: "migrated attachment metadata", unmigrate: false},
+		{name: "unmigrated attachment metadata", unmigrate: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// no import listener, so the SDK tombstone created below stays unimported until this test
+			// imports it, as OnDemandImportForWrite does when a write lands on top of a tombstone
+			dbc, ctx := setupTestDB(t)
+			defer dbc.Close(ctx)
+			collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, dbc)
+			ds := collection.GetCollectionDatastore()
+
+			docID := "importTombstoneDoc"
+			_, _, err := collection.Put(ctx, docID, bodyWithAttachment())
+			require.NoError(t, err)
+			require.NotEmpty(t, GetRawGlobalSyncAttachments(t, ds, docID))
+
+			if tc.unmigrate {
+				// make the document look like it was written by a pre-4.0 version of Sync Gateway:
+				// attachment metadata in _sync.attachments, no _globalSync xattr
+				value, _, err := ds.GetRaw(ctx, docID)
+				require.NoError(t, err)
+				MoveAttachmentXattrFromGlobalToSync(t, ds, docID, value, true)
+				require.NotEmpty(t, GetRawSyncXattr(t, ds, docID).AttachmentsPre4dot0)
+			}
+
+			// delete through the SDK. The body is removed but the system xattrs are preserved, leaving a
+			// tombstone that Sync Gateway did not write and so requires import.
+			require.NoError(t, ds.Delete(ctx, docID))
+
+			// load the tombstone without triggering the on-demand import that GetDocument would perform,
+			// so ImportDoc is called with the same document state OnDemandImportForWrite passes it
+			existingDoc, _, err := collection.getDocWithXattrs(ctx, docID, collection.syncGlobalSyncMouRevSeqNoAndUserXattrKeys(), DocUnmarshalAll)
+			require.NoError(t, err)
+			require.True(t, existingDoc.Deleted, "SDK delete should leave a body-less document")
+			require.NotEmpty(t, existingDoc.Attachments(), "attachment metadata should be visible on the loaded tombstone")
+
+			importedDoc, err := collection.ImportDoc(ctx, docID, existingDoc, importDocOptions{ // nolint:staticcheck
+				isDelete: true,
+				mode:     ImportOnDemand,
+				revSeqNo: existingDoc.RevSeqNo,
+			})
+			require.NoError(t, err)
+			require.True(t, importedDoc.IsDeleted(), "import of an SDK delete should produce a tombstone revision")
+
+			// the pre-4.0 location must not be left populated by the import
+			require.Empty(t, GetRawSyncXattr(t, ds, docID).AttachmentsPre4dot0)
+
+			xattrs, _, err := ds.GetXattrs(ctx, docID, []string{base.GlobalXattrName})
+			require.True(t, err == nil || base.IsXattrNotFoundError(err), "unexpected error reading global xattr: %v", err)
+			atts := attachmentMetaFromGlobalXattr(t, xattrs[base.GlobalXattrName])
+
+			if tc.unmigrate {
+				require.Empty(t, atts, "an unmigrated document leaves no attachment metadata, matching a Sync Gateway delete")
+				return
+			}
+			att, ok := atts[attName]
+			require.True(t, ok, "attachment %q missing from _globalSync.attachments_meta, found %v", attName, atts)
+			require.Equal(t, attDigest, att.Digest)
+			require.Equal(t, attLength, att.Length)
+		})
+	}
+}
+
+// TestOnDemandImportForWriteOverLegacyTombstone drives the tombstone branch of ImportDoc through its only
+// production caller, OnDemandImportForWrite: a Sync Gateway write landing on an unimported SDK tombstone
+// whose attachment metadata was never migrated out of _sync.
+//
+// The import runs first and advances the document to a new tombstone revision, so the write itself is
+// rejected as a conflict - what a client sees when a resurrection races the import of a tombstone. What the
+// tombstone is left holding depends on the backing store, because it depends on whether the enclosing write
+// re-runs its callback after the import changed the document's CAS:
+//   - Couchbase Server: it does not, so the import persists the document the tombstone branch built, which
+//     carries no global xattr, and the tombstone ends up with no attachment metadata.
+//   - Rosmar: the write retries, re-reading the full xattr set, so the import sees the legacy
+//     _sync.attachments merged in and writes them to _globalSync.
+//
+// The Couchbase Server outcome is the one that matches a Sync Gateway delete, which drops _globalSync
+// deliberately - see TestImportTombstoneAttachmentMetadata. Both are deterministic (verified over 25 runs
+// against Couchbase Server and 200 against Rosmar), and neither leaves metadata behind in the pre-4.0
+// location, which is what this test is here to pin.
+func TestOnDemandImportForWriteOverLegacyTombstone(t *testing.T) {
+	dbc, ctx := setupTestDB(t)
+	defer dbc.Close(ctx)
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, dbc)
+	ds := collection.GetCollectionDatastore()
+
+	docID := "resurrectedLegacyTombstone"
+	_, _, err := collection.Put(ctx, docID, bodyWithAttachment())
+	require.NoError(t, err)
+
+	// make the document look like it was written by a pre-4.0 version of Sync Gateway: attachment metadata
+	// in _sync.attachments, no _globalSync xattr
+	value, _, err := ds.GetRaw(ctx, docID)
+	require.NoError(t, err)
+	MoveAttachmentXattrFromGlobalToSync(t, ds, docID, value, true)
+	require.NotEmpty(t, GetRawSyncXattr(t, ds, docID).AttachmentsPre4dot0)
+
+	// delete through the SDK, leaving a tombstone Sync Gateway did not write
+	require.NoError(t, ds.Delete(ctx, docID))
+
+	// attempt to resurrect the document. The write triggers OnDemandImportForWrite for the tombstone before
+	// applying the update, and is then rejected as a conflict.
+	_, _, err = collection.Put(ctx, docID, Body{
+		"value":         5678,
+		BodyAttachments: map[string]any{"newatt": map[string]any{"content_type": "text/plain", "data": "Z29vZGJ5ZQ=="}},
+	})
+	require.Error(t, err)
+	status, _ := base.ErrorAsHTTPStatus(err)
+	require.Equal(t, http.StatusConflict, status)
+
+	// whatever the backing store does with the global xattr, the pre-4.0 location must not be left populated
+	require.Empty(t, GetRawSyncXattr(t, ds, docID).AttachmentsPre4dot0)
+
+	if base.UnitTestUrlIsWalrus() {
+		requireAttachmentMetadataPreserved(t, ds, docID, "myatt", "sha1-Lve95gjOVATpfV8EL5X4nxwjKHE=", 12)
+		return
+	}
+	xattrs, _, err := ds.GetXattrs(ctx, docID, []string{base.GlobalXattrName})
+	require.True(t, err == nil || base.IsXattrNotFoundError(err), "unexpected error reading global xattr: %v", err)
+	require.Empty(t, attachmentMetaFromGlobalXattr(t, xattrs[base.GlobalXattrName]),
+		"tombstone import against Couchbase Server leaves the tombstone with no attachment metadata")
+}
+
+// attachmentMetaFromGlobalXattr unmarshals attachment metadata from a raw _globalSync xattr, returning nil
+// for an absent xattr.
+func attachmentMetaFromGlobalXattr(t *testing.T, rawGlobalSync []byte) AttachmentMap {
+	t.Helper()
+	if len(rawGlobalSync) == 0 {
+		return nil
+	}
+	var globalSyncData struct {
+		Attachments AttachmentMap `json:"attachments_meta"`
+	}
+	require.NoError(t, base.JSONUnmarshal(rawGlobalSync, &globalSyncData))
+	return globalSyncData.Attachments
+}


### PR DESCRIPTION
CBG-5756

Unclean cherry pick of #8690 to 4.1.2
Changes from main commit:
- `db/attachment_test.go` — `sgbucket.HLCWallClock` does not exist in the sg-bucket version 4.1.2 pins; the injected clock uses `uint64(time.Now().UnixNano())`, the idiom the branch's own `TestHLVVersionAheadOfCASCorrection` uses.

That is the only deviation — the rest of the diff is byte-identical to the main commit.

🤖 Opened with the `sync-gateway-backport` skill in [Claude Code](https://claude.com/claude-code)
