### PR TITLE
[4.1.2 Backport] CBG-5760: don't restart ISGR replications when closing db

### DIFF
--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -33,6 +33,10 @@ const (
 	maxSGRClusterCasRetries = 100          // Maximum number of CAS retries when attempting to update the sgr cluster configuration
 	sgrClusterMgrContextID  = "sgr-mgr-"   // logging context ID prefix for sgreplicate manager
 	defaultChangesBatchSize = 200          // default changes batch size if replication batch_size is unset
+
+	// sgReplicateStartupWait is how long the replication startup goroutine waits for the server context to
+	// start before starting replications anyway.
+	sgReplicateStartupWait = 10 * time.Second
 )
 
 var DefaultCheckpointInterval = time.Second * 5 // default value used for time-based checkpointing
@@ -389,6 +393,45 @@ func (rc *ReplicationConfig) Redacted(ctx context.Context) *ReplicationConfig {
 	return &config
 }
 
+// clusterUpdater serialises cluster config updates against manager teardown.  Updates run on the caller's
+// goroutine, so they cannot be tracked on closeWg: an Add racing its Wait is a misuse panic, not a wait.
+type clusterUpdater struct {
+	lock       sync.RWMutex  // Read-held for the duration of an update, so stopUpdating can drain in-flight ones
+	stopped    bool          // Guarded by lock - once set, no further updates run
+	terminator chan struct{} // Closed by stopUpdating - see terminated
+}
+
+func newClusterUpdater() *clusterUpdater {
+	return &clusterUpdater{terminator: make(chan struct{})}
+}
+
+// terminated is closed when teardown begins.  An in-flight update holds lock until it returns, so it can
+// never see stopped being set - this channel is the only way its CAS retry loop learns to give up.
+func (c *clusterUpdater) terminated() <-chan struct{} {
+	return c.terminator
+}
+
+// run calls fn with the gate read-held, so stopUpdating waits for it.  No-ops once updates have stopped.
+func (c *clusterUpdater) run(fn func() error) error {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	if c.stopped {
+		return nil
+	}
+	return fn()
+}
+
+// stopUpdating tells in-flight updates to give up, waits for them, and refuses any that start afterwards.
+func (c *clusterUpdater) stopUpdating() {
+	// Before requesting the write side, not after: otherwise an in-flight update works through all its CAS
+	// retries before the drain can complete.
+	close(c.terminator)
+
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.stopped = true
+}
+
 // sgReplicateManager should be used for all interactions with the stored cluster definition.
 type sgReplicateManager struct {
 	cfg                        cbgt.Cfg                      // Key-value store implementation
@@ -397,9 +440,9 @@ type sgReplicateManager struct {
 	localNodeUUID              string                        // nodeUUID for this SG node
 	activeReplicators          map[string]*ActiveReplicator  // currently assigned replications
 	activeReplicatorsLock      sync.RWMutex                  // Mutex for activeReplications
-	clusterUpdateTerminator    chan struct{}                 // Terminator for cluster update retry
+	clusterUpdater             *clusterUpdater               // Serialises cluster config updates against manager teardown
 	clusterSubscribeTerminator chan struct{}                 // Terminator for cluster change monitoring
-	closeWg                    sync.WaitGroup                // Teardown waitgroup for subscribe and retry goroutines
+	closeWg                    sync.WaitGroup                // Teardown waitgroup for goroutines this manager owns (startup, subscribe, heartbeat)
 	dbContext                  *DatabaseContext              // reference to the parent DatabaseContext
 	CheckpointInterval         time.Duration                 // The value to be used for time-based checkpoints
 	SupportedBLIPSubprotocols  []string                      // Optional specification to force the subprotocol of the active replicator.
@@ -462,7 +505,7 @@ func (dbc *DatabaseContext) startReplications(ctx context.Context) {
 			defer dbc.SGReplicateMgr.closeWg.Done()
 
 			// Wait for the server context to be started
-			t := time.NewTimer(time.Second * 10)
+			t := time.NewTimer(sgReplicateStartupWait)
 			defer t.Stop()
 			select {
 			case <-dbc.ServerContextHasStarted:
@@ -471,6 +514,9 @@ func (dbc *DatabaseContext) startReplications(ctx context.Context) {
 				base.InfofCtx(dbc.SGReplicateMgr.loggingCtx, base.KeyReplicate, "Timed out waiting for server context startup... starting ISGR replications for %q anyway", dbc.Name)
 			case <-dbc.terminator:
 				base.DebugfCtx(dbc.SGReplicateMgr.loggingCtx, base.KeyReplicate, "Database context for %q closed before starting ISGR replications - aborting...", dbc.Name)
+				return
+			case <-dbc.SGReplicateMgr.clusterSubscribeTerminator:
+				base.DebugfCtx(dbc.SGReplicateMgr.loggingCtx, base.KeyReplicate, "Replication manager for %q stopped before starting ISGR replications - aborting...", dbc.Name)
 				return
 			}
 
@@ -492,8 +538,8 @@ func NewSGReplicateManager(ctx context.Context, dbContext *DatabaseContext, cfg 
 	return &sgReplicateManager{
 		cfg:                        cfg,
 		loggingCtx:                 base.CorrelationIDLogCtx(ctx, sgrClusterMgrContextID),
-		clusterUpdateTerminator:    make(chan struct{}),
 		clusterSubscribeTerminator: make(chan struct{}),
+		clusterUpdater:             newClusterUpdater(),
 		dbContext:                  dbContext,
 		activeReplicators:          make(map[string]*ActiveReplicator),
 		CheckpointInterval:         DefaultCheckpointInterval,
@@ -530,6 +576,11 @@ func (m *sgReplicateManager) StartLocalNode(nodeUUID string, heartbeater base.He
 // assigned to this node, and starts the process to monitor future changes to the cluster config.
 func (m *sgReplicateManager) startReplications(ctx context.Context) error {
 
+	if m.isStopping() {
+		base.DebugfCtx(ctx, base.KeyCluster, "Manager is stopping - skipping replication startup before cluster read")
+		return nil
+	}
+
 	replications, err := m.GetReplications()
 	if err != nil {
 		return err
@@ -537,24 +588,66 @@ func (m *sgReplicateManager) startReplications(ctx context.Context) error {
 	m.validateReplications(ctx, replications)
 	for replicationID, replicationCfg := range replications {
 		base.DebugfCtx(m.loggingCtx, base.KeyCluster, "Replication %s is assigned to node %s (local node is %s) on start up", replicationID, replicationCfg.AssignedNode, m.localNodeUUID)
-		if replicationCfg.AssignedNode == m.localNodeUUID {
-			activeReplicator, err := m.InitializeReplication(replicationCfg)
-			if err != nil {
-				base.WarnfCtx(m.loggingCtx, "Error initializing replication %s: %v", replicationID, err)
-				m.saveInitializationError(replicationCfg, err)
-				continue
-			}
-			m.activeReplicatorsLock.Lock()
-			m.activeReplicators[replicationID] = activeReplicator
-			m.activeReplicatorsLock.Unlock()
-			if replicationCfg.TargetState == "" || replicationCfg.TargetState == ReplicationStateRunning {
-				if startErr := activeReplicator.Start(ctx); startErr != nil {
-					base.WarnfCtx(m.loggingCtx, "Unable to start replication %s: %v", replicationID, startErr)
-				}
-			}
+		if replicationCfg.AssignedNode != m.localNodeUUID {
+			continue
+		}
+		if stopping := m.startAssignedReplication(ctx, replicationID, replicationCfg); stopping {
+			return nil
 		}
 	}
+
+	// Check for return to avoid launching new goroutines if Stop called when Start is still running
+	if m.isStopping() {
+		base.DebugfCtx(ctx, base.KeyCluster, "Manager is stopping - not subscribing to cluster config changes")
+		return nil
+	}
 	return m.SubscribeCfgChanges(ctx)
+}
+
+// startAssignedReplication initializes and starts a single replication assigned to the local node, and
+// returns true if the manager began stopping, in which case nothing was started and no further replications
+// should be either.
+//
+// The stopping check only avoids opening connections Stop is about to close - Stop's drain is what
+// guarantees nothing is left running.  activeReplicatorsLock is deliberately not held across Start, unlike
+// RefreshReplicationCfg, because Start's reachability request has no timeout and would block every reader of
+// activeReplicators, including the replication status endpoints.
+func (m *sgReplicateManager) startAssignedReplication(ctx context.Context, replicationID string, replicationCfg *ReplicationCfg) (stopping bool) {
+	activeReplicator, err := m.InitializeReplication(replicationCfg)
+	if err != nil {
+		base.WarnfCtx(m.loggingCtx, "Error initializing replication %s: %v", replicationID, err)
+		// An error persisted here outlives the database, and would report the replication as errored purely
+		// because this node was shutting down.
+		if m.isStopping() {
+			return true
+		}
+		m.saveInitializationError(replicationCfg, err)
+		return false
+	}
+
+	if stopping := m.storeActiveReplicator(replicationID, activeReplicator); stopping {
+		base.DebugfCtx(m.loggingCtx, base.KeyCluster, "Manager is stopping - not starting replication %s", replicationID)
+		return true
+	}
+
+	if replicationCfg.TargetState == "" || replicationCfg.TargetState == ReplicationStateRunning {
+		if startErr := activeReplicator.Start(ctx); startErr != nil {
+			base.WarnfCtx(m.loggingCtx, "Unable to start replication %s: %v", replicationID, startErr)
+		}
+	}
+	return false
+}
+
+// storeActiveReplicator adds activeReplicator to the set of replications running on this node, and returns
+// true if the manager began stopping, in which case nothing was stored.
+func (m *sgReplicateManager) storeActiveReplicator(replicationID string, activeReplicator *ActiveReplicator) (stopping bool) {
+	m.activeReplicatorsLock.Lock()
+	defer m.activeReplicatorsLock.Unlock()
+	if m.isStopping() {
+		return true
+	}
+	m.activeReplicators[replicationID] = activeReplicator
+	return false
 }
 
 // NewActiveReplicatorConfig converts an incoming ReplicationCfg to an ActiveReplicatorConfig
@@ -761,36 +854,61 @@ func (m *sgReplicateManager) saveInitializationError(config *ReplicationCfg, ini
 	}
 }
 
+// isStopping returns true once Stop has begun.
+func (m *sgReplicateManager) isStopping() bool {
+	select {
+	case <-m.clusterSubscribeTerminator:
+		return true
+	default:
+		return false
+	}
+}
+
 func (m *sgReplicateManager) Stop() {
 
-	// Close subscribe terminator first to stop subscribing/responding to cluster config changes prior to
-	// stopping replications and removing node
+	// Stop subscribing/responding to cluster config changes, and stop the heartbeat listener, before
+	// tearing anything down.
 	close(m.clusterSubscribeTerminator)
-
-	// Stop active replications
-	m.activeReplicatorsLock.Lock()
-
-	for _, repl := range m.activeReplicators {
-		err := repl.Stop()
-		if err != nil {
-			base.WarnfCtx(m.loggingCtx, "Error stopping replication %s during manager stop: %v", repl.ID, err)
-		}
+	if m.heartbeatListener != nil {
+		// Must be before the Wait below: its goroutine is on closeWg but exits only on this terminator.
+		m.heartbeatListener.Stop()
 	}
-	m.activeReplicatorsLock.Unlock()
+
+	// Drain these before stopping replications, so the loop below is the last word on what is running:
+	// 1. SubscribeCfgChanges: waiting for events to call RefreshReplicationCfg on
+	// 2. startReplications: goroutine that handles initial startup of ISGR replications after database goes online
+	// 3. subscribeNodeSetChanges: the heartbeat listener's node set subscription, stopped just above
+	m.closeWg.Wait()
+
+	m.stopActiveReplicators()
+
+	// Remove the node only once its replications are stopped, so that another node does not pick them up
+	// while they are still running here.
 	if err := m.RemoveNode(m.localNodeUUID); err != nil {
 		base.WarnfCtx(m.loggingCtx, "Attempt to remove node %v from sg-replicate cfg got error: %v", m.localNodeUUID, err)
 	}
-	if m.heartbeatListener != nil {
-		m.heartbeatListener.Stop()
-	}
-	close(m.clusterUpdateTerminator)
+	m.clusterUpdater.stopUpdating()
+}
 
-	m.closeWg.Wait()
+// stopActiveReplicators stops all replications currently running on this node.
+func (m *sgReplicateManager) stopActiveReplicators() {
+	m.activeReplicatorsLock.Lock()
+	defer m.activeReplicatorsLock.Unlock()
+	for _, repl := range m.activeReplicators {
+		if err := repl.Stop(); err != nil {
+			base.WarnfCtx(m.loggingCtx, "Error stopping replication %s during manager stop: %v", repl.ID, err)
+		}
+	}
 }
 
 // RefreshReplicationCfg is called when the cfg changes.  Checks whether replications
 // have been added to or removed from this node
 func (m *sgReplicateManager) RefreshReplicationCfg(ctx context.Context) error {
+
+	if m.isStopping() {
+		base.DebugfCtx(m.loggingCtx, base.KeyCluster, "Manager is stopping - skipping replication cfg refresh before cluster read")
+		return nil
+	}
 
 	base.InfofCtx(m.loggingCtx, base.KeyCluster, "Replication definitions changed - refreshing...")
 	configReplications, err := m.GetReplications()
@@ -800,6 +918,11 @@ func (m *sgReplicateManager) RefreshReplicationCfg(ctx context.Context) error {
 
 	m.activeReplicatorsLock.Lock()
 	defer m.activeReplicatorsLock.Unlock()
+
+	if m.isStopping() {
+		base.DebugfCtx(m.loggingCtx, base.KeyCluster, "Manager is stopping - skipping replication cfg refresh after cluster read")
+		return nil
+	}
 
 	// check for active replications that should be stopped
 	for replicationID, activeReplicator := range m.activeReplicators {
@@ -938,13 +1061,18 @@ func (m *sgReplicateManager) loadSGRCluster() (sgrCluster *SGRCluster, cas uint6
 	return sgrCluster, cas, nil
 }
 
-// updateCluster manages CAS retry for SGRCluster updates.
+// updateCluster manages CAS retry for SGRCluster updates.  No-ops once the manager has stopped.
 func (m *sgReplicateManager) updateCluster(callback ClusterUpdateFunc) error {
-	m.closeWg.Add(1)
-	defer m.closeWg.Done()
+	return m.clusterUpdater.run(func() error {
+		return m._updateCluster(callback)
+	})
+}
+
+// _updateCluster is the CAS retry loop for updateCluster.  Requires the cluster update gate to be held.
+func (m *sgReplicateManager) _updateCluster(callback ClusterUpdateFunc) error {
 	for i := 1; i <= maxSGRClusterCasRetries; i++ {
 		select {
-		case <-m.clusterUpdateTerminator:
+		case <-m.clusterUpdater.terminated():
 			base.DebugfCtx(m.loggingCtx, base.KeyReplicate, "manager terminated, bailing out of update retry loop")
 			return nil
 		default:

--- a/db/sg_replicate_cfg_test.go
+++ b/db/sg_replicate_cfg_test.go
@@ -12,9 +12,14 @@ package db
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/couchbase/cbgt"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -796,4 +801,574 @@ func TestReplicateGroupIDAssignedNodes(t *testing.T) {
 	cfg, exists = replications["repl"]
 	require.True(t, exists, "Replicator not found")
 	assert.Equal(t, "nodeGroupB", cfg.AssignedNode)
+}
+
+// pausingCfg parks the first read of cfgKeySGRCluster made once armed, holding its caller between the
+// cluster read and whatever it does next - the window Stop() runs in.
+type pausingCfg struct {
+	cbgt.Cfg
+	armed    atomic.Bool
+	readDone chan struct{}
+	release  chan struct{}
+
+	// subscribes counts cfgKeySGRCluster subscriptions - see TestStartReplicationsDoesNotSubscribeAfterStop.
+	subscribes atomic.Int64
+}
+
+func (c *pausingCfg) Subscribe(key string, ch chan cbgt.CfgEvent) error {
+	if key == cfgKeySGRCluster {
+		c.subscribes.Add(1)
+	}
+	return c.Cfg.Subscribe(key, ch)
+}
+
+func (c *pausingCfg) Get(key string, cas uint64) ([]byte, uint64, error) {
+	b, gotCas, err := c.Cfg.Get(key, cas)
+	if key == cfgKeySGRCluster && c.armed.CompareAndSwap(true, false) {
+		c.readDone <- struct{}{}
+		<-c.release
+	}
+	return b, gotCas, err
+}
+
+// TestRefreshReplicationCfgRacesStopTeardown asserts that a RefreshReplicationCfg in flight when Stop() runs
+// cannot restart a replication.  The refresh reads the cluster cfg - local node registered, replication
+// assigned and running - then blocks on activeReplicatorsLock held by Stop's teardown loop, and would
+// otherwise proceed on that stale snapshot to restart a replication nobody owns.  This is the only coverage
+// for the isStopping() check under activeReplicatorsLock.
+//
+// pausingCfg parks the refresh between the read and the lock, so the interleaving is deterministic.  Nothing
+// re-registers the node: Stop does not RemoveNode until after the teardown loop, so the read stays valid.
+func TestRefreshReplicationCfgRacesStopTeardown(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyReplicate, base.KeyCluster)
+
+	testDB, ctx := setupTestDB(t)
+	defer testDB.Close(ctx)
+
+	wrapped := &pausingCfg{Cfg: testDB.CfgSG, readDone: make(chan struct{}, 1), release: make(chan struct{})}
+
+	const (
+		localNodeUUID = "localNode"
+		replicationID = "rep1"
+	)
+
+	mgr, err := NewSGReplicateManager(ctx, testDB.DatabaseContext, wrapped)
+	require.NoError(t, err)
+	require.NoError(t, mgr.StartLocalNode(localNodeUUID, nil))
+	require.NoError(t, mgr.AddReplication(&ReplicationCfg{
+		ReplicationConfig: ReplicationConfig{
+			ID:                 replicationID,
+			Direction:          ActiveReplicatorTypePush,
+			Remote:             "http://localhost:4984/remotedb",
+			Continuous:         true,
+			CollectionsEnabled: base.TestsUseNamedCollections(),
+		},
+		AssignedNode: localNodeUUID,
+		TargetState:  ReplicationStateStopped,
+	}))
+
+	// Register the replicator, target state stopped so nothing reaches the remote.
+	require.NoError(t, mgr.RefreshReplicationCfg(ctx))
+	repl := mgr.GetActiveReplicator(replicationID)
+	require.NotNil(t, repl, "replicator was not registered")
+	state, _ := repl.State(ctx)
+	require.Equal(t, ReplicationStateStopped, state, "replicator should not be running yet")
+	defer func() { _ = repl.Stop() }()
+
+	// Target state running is what the racing refresh reads, and what makes it restart the replicator.
+	require.NoError(t, mgr.UpdateReplicationState(replicationID, ReplicationStateRunning))
+
+	// Step 1: the refresh reads the cfg, then parks.
+	wrapped.armed.Store(true)
+	var (
+		wg         sync.WaitGroup
+		refreshErr error
+	)
+	wg.Go(func() {
+		refreshErr = mgr.RefreshReplicationCfg(ctx)
+	})
+	base.RequireChanRecv(t, wrapped.readDone)
+
+	// Steps 2 and 3: Stop() runs to completion while the refresh holds its stale snapshot.
+	mgr.Stop()
+
+	// Step 4: the refresh proceeds.
+	close(wrapped.release)
+	base.WaitWithTimeout(t, &wg, time.Minute)
+	require.NoError(t, refreshErr)
+
+	stateAfter, _ := repl.State(ctx)
+	assert.Equal(t, ReplicationStateStopped, stateAfter,
+		"RefreshReplicationCfg restarted a replication on a stopped manager - nothing will ever stop it")
+}
+
+// TestStartReplicationsRacesStopTeardown asserts that a startReplications in flight when Stop() runs does not
+// start a replication.  The startup reads the cluster cfg - replication assigned to the local node, target
+// state running - then parks; by the time it proceeds Stop has begun, so the isStopping() check under
+// activeReplicatorsLock skips it rather than registering and starting.  This is the startup-path counterpart
+// to TestRefreshReplicationCfgRacesStopTeardown, and the only coverage for that check.
+func TestStartReplicationsRacesStopTeardown(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyReplicate, base.KeyCluster)
+
+	testDB, ctx := setupTestDB(t)
+	defer testDB.Close(ctx)
+
+	wrapped := &pausingCfg{Cfg: testDB.CfgSG, readDone: make(chan struct{}, 1), release: make(chan struct{})}
+
+	const (
+		localNodeUUID = "localNode"
+		replicationID = "rep1"
+	)
+
+	mgr, err := NewSGReplicateManager(ctx, testDB.DatabaseContext, wrapped)
+	require.NoError(t, err)
+	require.NoError(t, mgr.StartLocalNode(localNodeUUID, nil))
+	require.NoError(t, mgr.AddReplication(&ReplicationCfg{
+		ReplicationConfig: ReplicationConfig{
+			ID:                 replicationID,
+			Direction:          ActiveReplicatorTypePush,
+			Remote:             "http://localhost:4984/remotedb",
+			Continuous:         true,
+			CollectionsEnabled: base.TestsUseNamedCollections(),
+		},
+		AssignedNode: localNodeUUID,
+		TargetState:  ReplicationStateRunning,
+	}))
+
+	// Step 1: startReplications reads the cfg, then parks, as production does inside a closeWg-tracked
+	// goroutine.
+	wrapped.armed.Store(true)
+	var startWg sync.WaitGroup
+	mgr.closeWg.Add(1)
+	startWg.Go(func() {
+		defer mgr.closeWg.Done()
+		assert.NoError(t, mgr.startReplications(ctx))
+	})
+	base.RequireChanRecv(t, wrapped.readDone)
+
+	// Step 2: Stop() blocks in closeWg.Wait() waiting for the parked startup.
+	var stopWg sync.WaitGroup
+	stopWg.Go(mgr.Stop)
+	// Stop() closes clusterSubscribeTerminator before taking activeReplicatorsLock, so waiting on it here
+	// guarantees the parked startup sees a stopping manager once released.
+	<-mgr.clusterSubscribeTerminator
+
+	// Step 3: the startup proceeds.
+	close(wrapped.release)
+	base.WaitWithTimeout(t, &startWg, time.Minute)
+	base.WaitWithTimeout(t, &stopWg, time.Minute)
+
+	repl := mgr.GetActiveReplicator(replicationID)
+	if repl != nil {
+		defer func() { _ = repl.Stop() }()
+		state, _ := repl.State(ctx)
+		assert.Equal(t, ReplicationStateStopped, state,
+			"startReplications started a replication on a stopped manager - nothing will ever stop it")
+	}
+	assert.Equal(t, 0, mgr.GetNumberActiveReplicators(),
+		"stopped manager still holds active replicators registered by startReplications")
+}
+
+// TestStopInterruptsReplicationStartupWait asserts that Stop() does not have to wait out the startup timer in
+// DatabaseContext.startReplications.  That goroutine is tracked by closeWg, so with no signal from the
+// manager it blocks Stop() in closeWg.Wait() for the full timer duration whenever Stop is called without the
+// database context being closed - Close closes dbc.terminator first, so it does not pay this cost.
+func TestStopInterruptsReplicationStartupWait(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyReplicate, base.KeyCluster)
+
+	testDB, ctx := setupTestDB(t)
+	defer testDB.Close(ctx)
+
+	// ServerContextHasStarted is never signalled here, so the startup goroutine has only the timer to wait on.
+	require.Nil(t, testDB.ServerContextHasStarted)
+	testDB.Options.SGReplicateOptions.Enabled = true
+	testDB.startReplications(ctx)
+
+	mgr := testDB.SGReplicateMgr
+	start := time.Now()
+	mgr.Stop()
+	// Comfortably under the timer - interrupting it takes well under a millisecond.
+	require.Less(t, time.Since(start), sgReplicateStartupWait/2,
+		"Stop() waited out the ISGR startup timer instead of interrupting it")
+
+	// Clear the manager only after Stop, whose closeWg.Wait orders this write after the startup goroutine's
+	// last read of the field.  Close would otherwise stop the manager a second time, panicking on the
+	// already-closed terminators.
+	testDB.SGReplicateMgr = nil
+}
+
+// TestStartReplicationsRacesStopTeardownDuringStart asserts that a replication whose Start is in flight when
+// Stop() runs is left stopped.  The startup registers it then blocks inside Start - the remote accepts the
+// connection and never answers, which has no timeout - so Stop waits for it in closeWg.Wait(), and only then
+// does its teardown loop stop the replication.  The outcome counterpart to
+// TestStopDrainsStartupBeforeStoppingReplications, which pins the ordering itself.
+//
+// Stop leaves entries in activeReplicators, so this asserts replication state rather than map membership.
+func TestStartReplicationsRacesStopTeardownDuringStart(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyReplicate, base.KeyCluster)
+
+	testDB, ctx := setupTestDB(t)
+	defer testDB.Close(ctx)
+
+	// The remote accepts the request and holds it, parking Start inside its reachability check.
+	connectStarted := make(chan struct{}, 1)
+	release := make(chan struct{})
+	var remoteHit atomic.Bool
+	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if remoteHit.CompareAndSwap(false, true) {
+			connectStarted <- struct{}{}
+			<-release
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer remote.Close()
+
+	const (
+		localNodeUUID = "localNode"
+		replicationID = "rep1"
+	)
+
+	// The database's own manager and cfg, so the test exercises whichever cbgt.Cfg this edition uses.
+	mgr := testDB.SGReplicateMgr
+	require.NoError(t, mgr.StartLocalNode(localNodeUUID, nil))
+	require.NoError(t, mgr.AddReplication(&ReplicationCfg{
+		ReplicationConfig: ReplicationConfig{
+			ID:                 replicationID,
+			Direction:          ActiveReplicatorTypePush,
+			Remote:             remote.URL + "/remotedb",
+			Continuous:         true,
+			CollectionsEnabled: base.TestsUseNamedCollections(),
+		},
+		AssignedNode: localNodeUUID,
+		TargetState:  ReplicationStateRunning,
+	}))
+
+	// Step 1: the startup registers the replication, then parks inside Start.
+	var startWg sync.WaitGroup
+	mgr.closeWg.Add(1)
+	startWg.Go(func() {
+		defer mgr.closeWg.Done()
+		assert.NoError(t, mgr.startReplications(ctx))
+	})
+	base.RequireChanRecv(t, connectStarted)
+	repl := mgr.GetActiveReplicator(replicationID)
+	require.NotNil(t, repl, "replication should be registered before Start")
+
+	// Step 2: Stop() waits in closeWg.Wait() for a startup whose Start has not returned yet.
+	var stopWg sync.WaitGroup
+	stopWg.Go(mgr.Stop)
+	<-mgr.clusterSubscribeTerminator
+
+	// Step 3: Start completes, the drain finishes, and the teardown loop stops the replication.
+	close(release)
+	base.WaitWithTimeout(t, &startWg, time.Minute)
+	base.WaitWithTimeout(t, &stopWg, time.Minute)
+
+	state, _ := repl.State(ctx)
+	assert.Equal(t, ReplicationStateStopped, state,
+		"replication started during manager stop was left running - nothing will ever stop it")
+	assert.False(t, repl.Push.reconnectActive.IsTrue(),
+		"replication started during manager stop was left reconnecting")
+
+	// Clear the manager only after Stop, whose closeWg.Wait orders this write after the startup goroutine.
+	// Close would otherwise stop it a second time, panicking on the already-closed terminators.
+	testDB.SGReplicateMgr = nil
+}
+
+// TestStopDrainsStartupBeforeStoppingReplications asserts Stop() waits for an in-flight replication startup
+// before stopping any replication.  Stopping first lets one that is registered but not yet started slip past
+// the teardown loop: repl.Stop is a no-op until Start sets arc.ctx, so Start then brings up a replication
+// with nothing left to stop it.
+//
+// Observed through activeReplicatorsLock, which the teardown loop must hold to run - so Stop holding it
+// while Start is parked means it did not drain first.
+func TestStopDrainsStartupBeforeStoppingReplications(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyReplicate, base.KeyCluster)
+
+	// The remote accepts the request and holds it, parking Start inside its reachability check.
+	connectStarted := make(chan struct{}, 1)
+	release := make(chan struct{})
+	var remoteHit atomic.Bool
+	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if remoteHit.CompareAndSwap(false, true) {
+			connectStarted <- struct{}{}
+			<-release
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer remote.Close()
+
+	testDB, ctx := setupTestDB(t)
+	defer testDB.Close(ctx)
+
+	const (
+		localNodeUUID = "localNode"
+		replicationID = "rep1"
+	)
+
+	mgr := testDB.SGReplicateMgr
+	require.NoError(t, mgr.StartLocalNode(localNodeUUID, nil))
+	require.NoError(t, mgr.AddReplication(&ReplicationCfg{
+		ReplicationConfig: ReplicationConfig{
+			ID:                 replicationID,
+			Direction:          ActiveReplicatorTypePush,
+			Remote:             remote.URL + "/remotedb",
+			Continuous:         true,
+			CollectionsEnabled: base.TestsUseNamedCollections(),
+		},
+		AssignedNode: localNodeUUID,
+		TargetState:  ReplicationStateRunning,
+	}))
+
+	// The startup registers the replication, then parks inside Start.
+	var startWg sync.WaitGroup
+	mgr.closeWg.Add(1)
+	startWg.Go(func() {
+		defer mgr.closeWg.Done()
+		assert.NoError(t, mgr.startReplications(ctx))
+	})
+	base.RequireChanRecv(t, connectStarted)
+	repl := mgr.GetActiveReplicator(replicationID)
+	require.NotNil(t, repl, "replication should be registered before Start")
+
+	var stopWg sync.WaitGroup
+	stopWg.Go(mgr.Stop)
+	base.RequireChanClosed(t, mgr.clusterSubscribeTerminator)
+
+	// Never, not Eventually: the lock must stay free for as long as Stop waits, not become free.  assert, not
+	// require, so a failure still reaches close(release) - otherwise the test deadlocks instead of failing.
+	assert.Never(t, func() bool {
+		if mgr.activeReplicatorsLock.TryRLock() {
+			mgr.activeReplicatorsLock.RUnlock()
+			return false
+		}
+		return true
+	}, time.Second, 10*time.Millisecond,
+		"Stop() held activeReplicatorsLock while a Start was in flight, so it was already in its teardown loop - it did not drain the startup first")
+
+	// Start completes, the drain finishes, and the teardown loop then stops the replication.
+	close(release)
+	base.WaitWithTimeout(t, &startWg, time.Minute)
+	base.WaitWithTimeout(t, &stopWg, time.Minute)
+
+	state, _ := repl.State(ctx)
+	assert.Equal(t, ReplicationStateStopped, state,
+		"replication was left running after the manager stopped - nothing will ever stop it")
+	assert.False(t, repl.Push.reconnectActive.IsTrue(),
+		"replication was left reconnecting after the manager stopped")
+
+	// Clear the manager only after Stop, whose closeWg.Wait orders this write after the startup goroutine.
+	// Close would otherwise stop it a second time, panicking on the already-closed terminators.
+	testDB.SGReplicateMgr = nil
+}
+
+// TestStartReplicationsDoesNotSubscribeAfterStop asserts a startReplications in flight when Stop() runs does
+// not register a cfg subscription.  The tail call is reached whenever no replication triggers the early
+// return - here a cluster defining none - and cbgt.Cfg has no Unsubscribe, so the subscription would outlive
+// the manager with nobody reading its channel.
+func TestStartReplicationsDoesNotSubscribeAfterStop(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyReplicate, base.KeyCluster)
+
+	testDB, ctx := setupTestDB(t)
+	defer testDB.Close(ctx)
+
+	wrapped := &pausingCfg{Cfg: testDB.CfgSG, readDone: make(chan struct{}, 1), release: make(chan struct{})}
+
+	mgr, err := NewSGReplicateManager(ctx, testDB.DatabaseContext, wrapped)
+	require.NoError(t, err)
+	require.NoError(t, mgr.StartLocalNode("localNode", nil))
+	require.Zero(t, wrapped.subscribes.Load(), "nothing should have subscribed yet")
+
+	// The startup reads the cluster - finding no replications - then parks.
+	wrapped.armed.Store(true)
+	var startWg sync.WaitGroup
+	mgr.closeWg.Add(1)
+	startWg.Go(func() {
+		defer mgr.closeWg.Done()
+		assert.NoError(t, mgr.startReplications(ctx))
+	})
+	base.RequireChanRecv(t, wrapped.readDone)
+
+	var stopWg sync.WaitGroup
+	stopWg.Go(mgr.Stop)
+	base.RequireChanClosed(t, mgr.clusterSubscribeTerminator)
+
+	close(wrapped.release)
+	base.WaitWithTimeout(t, &startWg, time.Minute)
+	base.WaitWithTimeout(t, &stopWg, time.Minute)
+
+	assert.Zero(t, wrapped.subscribes.Load(),
+		"startReplications subscribed to cfg changes on a stopped manager - the subscription is never undone")
+}
+
+// TestStartReplicationsSkipsInitErrorWhenStopping asserts a stopping manager does not persist an error for a
+// replication it was never going to start.  The status outlives the database, so the replication reads as
+// errored on whichever node next serves _replicationStatus, purely because this node was shutting down.
+func TestStartReplicationsSkipsInitErrorWhenStopping(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyReplicate, base.KeyCluster)
+
+	testDB, ctx := setupTestDB(t)
+	defer testDB.Close(ctx)
+
+	wrapped := &pausingCfg{Cfg: testDB.CfgSG, readDone: make(chan struct{}, 1), release: make(chan struct{})}
+
+	const (
+		localNodeUUID = "localNode"
+		replicationID = "rep1"
+	)
+
+	mgr, err := NewSGReplicateManager(ctx, testDB.DatabaseContext, wrapped)
+	require.NoError(t, err)
+	require.NoError(t, mgr.StartLocalNode(localNodeUUID, nil))
+	// No remote, so InitializeReplication fails re-validating the persisted config.  AddReplication does not
+	// validate, which is exactly how a config like this reaches startup in the first place.
+	require.NoError(t, mgr.AddReplication(&ReplicationCfg{
+		ReplicationConfig: ReplicationConfig{
+			ID:        replicationID,
+			Direction: ActiveReplicatorTypePush,
+		},
+		AssignedNode: localNodeUUID,
+		TargetState:  ReplicationStateRunning,
+	}))
+
+	statusKey := testDB.MetadataKeys.ReplicationStatusKey(PushCheckpointID(replicationID))
+	statusDoc, err := getLocalStatusDoc(ctx, testDB.MetadataStore, statusKey)
+	require.NoError(t, err)
+	require.Nil(t, statusDoc, "no status should be persisted yet")
+
+	// The startup reads the cluster, then parks.
+	wrapped.armed.Store(true)
+	var startWg sync.WaitGroup
+	mgr.closeWg.Add(1)
+	startWg.Go(func() {
+		defer mgr.closeWg.Done()
+		assert.NoError(t, mgr.startReplications(ctx))
+	})
+	base.RequireChanRecv(t, wrapped.readDone)
+
+	var stopWg sync.WaitGroup
+	stopWg.Go(mgr.Stop)
+	base.RequireChanClosed(t, mgr.clusterSubscribeTerminator)
+
+	close(wrapped.release)
+	base.WaitWithTimeout(t, &startWg, time.Minute)
+	base.WaitWithTimeout(t, &stopWg, time.Minute)
+
+	statusDoc, err = getLocalStatusDoc(ctx, testDB.MetadataStore, statusKey)
+	require.NoError(t, err)
+	assert.Nil(t, statusDoc,
+		"a stopping manager persisted an initialization error for a replication it never tried to start")
+}
+
+// TestSGReplicateManagerStopDoesNotPanicOnConcurrentClusterUpdate asserts a cluster config write racing Stop()
+// does not panic.  Cluster updates run on the caller's goroutine, so tracking them on closeWg - the
+// waitgroup Stop waits on - makes a write arriving during Stop a WaitGroup misuse panic rather than a wait.  In
+// production that is any request writing cluster config during a database close or config reload.  Driven
+// through RegisterNode so it exercises a reachable path, and looped because the window is small.
+func TestSGReplicateManagerStopDoesNotPanicOnConcurrentClusterUpdate(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelWarn, base.KeyCluster)
+
+	testDB, ctx := setupTestDB(t)
+	defer testDB.Close(ctx)
+
+	const attempts = 200
+	for i := range attempts {
+		// A distinct cfg prefix and node per attempt, so attempts do not interfere.
+		cfgSG, err := base.NewCfgSG(ctx, testDB.MetadataStore, fmt.Sprintf("p%d", i), false)
+		require.NoError(t, err)
+		mgr, err := NewSGReplicateManager(ctx, testDB.DatabaseContext, cfgSG)
+		require.NoError(t, err)
+		require.NoError(t, mgr.StartLocalNode(fmt.Sprintf("n%d", i), nil))
+		// Registers a goroutine on closeWg, so Stop's Wait blocks and there is a waiter to misuse.
+		require.NoError(t, mgr.SubscribeCfgChanges(ctx))
+
+		var recovered atomic.Value
+		catch := func(fn func()) {
+			defer func() {
+				if r := recover(); r != nil {
+					recovered.CompareAndSwap(nil, fmt.Sprint(r))
+				}
+			}()
+			fn()
+		}
+
+		var hammer sync.WaitGroup
+		stopHammer := make(chan struct{})
+		for range 4 {
+			hammer.Go(func() {
+				catch(func() {
+					for {
+						select {
+						case <-stopHammer:
+							return
+						default:
+						}
+						_ = mgr.RegisterNode(fmt.Sprintf("hammer%d", i))
+					}
+				})
+			})
+		}
+		catch(mgr.Stop)
+		close(stopHammer)
+		base.WaitWithTimeout(t, &hammer, time.Minute)
+
+		if r := recovered.Load(); r != nil {
+			t.Fatalf("attempt %d: cluster config write concurrent with Stop() panicked: %v", i, r)
+		}
+	}
+}
+
+// TestSGReplicateManagerStopDrainsClusterUpdates asserts that no cluster update runs past Stop: Stop blocks
+// until an in-flight update finishes, and an update starting afterwards is refused rather than run against a
+// torn-down manager.
+func TestSGReplicateManagerStopDrainsClusterUpdates(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCluster)
+
+	testDB, ctx := setupTestDB(t)
+	defer testDB.Close(ctx)
+
+	cfgSG, err := base.NewCfgSG(ctx, testDB.MetadataStore, "", false)
+	require.NoError(t, err)
+	mgr, err := NewSGReplicateManager(ctx, testDB.DatabaseContext, cfgSG)
+	require.NoError(t, err)
+	require.NoError(t, mgr.StartLocalNode("localNode", nil))
+
+	// An update parks inside its callback, so it is in flight for as long as the test wants.
+	inUpdate := make(chan struct{})
+	release := make(chan struct{})
+	var updateWg sync.WaitGroup
+	updateWg.Go(func() {
+		assert.NoError(t, mgr.updateCluster(func(*SGRCluster) (bool, error) {
+			inUpdate <- struct{}{}
+			<-release
+			return true, nil // cancel, so there is no CAS write to retry
+		}))
+	})
+	base.RequireChanRecv(t, inUpdate)
+
+	stopDone := make(chan struct{})
+	var stopWg sync.WaitGroup
+	stopWg.Go(func() {
+		mgr.Stop()
+		close(stopDone)
+	})
+
+	// Stop must not complete while the update is still in flight.
+	select {
+	case <-stopDone:
+		require.Fail(t, "Stop returned while a cluster update was still in flight")
+	case <-time.After(500 * time.Millisecond):
+	}
+
+	close(release)
+	base.WaitWithTimeout(t, &updateWg, time.Minute)
+	base.WaitWithTimeout(t, &stopWg, time.Minute)
+
+	// An update starting after Stop is refused outright, so it cannot touch a torn-down manager.
+	ran := false
+	require.NoError(t, mgr.updateCluster(func(*SGRCluster) (bool, error) {
+		ran = true
+		return true, nil
+	}))
+	require.False(t, ran, "cluster update ran after Stop returned")
 }

--- a/rest/replicatortest/replicator_no_race_test.go
+++ b/rest/replicatortest/replicator_no_race_test.go
@@ -1,0 +1,134 @@
+//  Copyright 2026-Present Couchbase, Inc.
+//
+//  Use of this software is governed by the Business Source License included
+//  in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+//  in that file, in accordance with the Business Source License, use of this
+//  software will be governed by the Apache License, Version 2.0, included in
+//  the file licenses/APL2.txt.
+
+// Tests that can't run under the race detector.  Consider moving back to replicator_test.go after CBG-5472.
+//
+// base.SyncGatewayStats.DbStats is a process-global map keyed by database name, so two RestTesters sharing a
+// name share one entry - the later registration replaces the earlier, and DatabaseContext.Close clears
+// whichever *DbStats the entry holds rather than its own.  Harmless with two contexts, since the last to
+// register is the last to close.  A config reload adds a third, so one database's close clears stats still
+// being written by another that is open (SubscribeCfgChanges -> InitializeReplication), once per stat field.
+//go:build !race
+// +build !race
+
+package replicatortest
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
+	"github.com/couchbase/sync_gateway/rest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestReplicationHeartbeatRemovalPushWithConfigReload is a push variant of TestReplicationHeartbeatRemoval
+// that races the heartbeat-driven node removal against a db config reload, and checks the cluster settles:
+// both nodes re-register with one replication each, later writes reach the remote, both report running.
+func TestReplicationHeartbeatRemovalPushWithConfigReload(t *testing.T) {
+	if !base.IsEnterpriseEdition() {
+		t.Skipf("test is EE only (replication rebalance)")
+	}
+
+	base.RequireNumTestBuckets(t, 2)
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
+
+	sgrRunner := rest.NewSGRTestRunner(t)
+	sgrRunner.Run(func(t *testing.T) {
+		t.Cleanup(reduceTestCheckpointInterval(50 * time.Millisecond))
+		t.Cleanup(db.SuspendSequenceBatching())
+
+		activeRT, remoteRT, remoteURLString := sgrRunner.SetupSGRPeers(t)
+
+		docABC1 := rest.SafeDocumentName(t, t.Name()+"ABC1")
+		docDEF1 := rest.SafeDocumentName(t, t.Name()+"DEF1")
+		_ = activeRT.PutDoc(docABC1, `{"source":"activeRT","channels":["ABC"]}`)
+		_ = activeRT.PutDoc(docDEF1, `{"source":"activeRT","channels":["DEF"]}`)
+		activeRT.WaitForPendingChanges()
+
+		activeRT.CreateReplication("rep_ABC", remoteURLString, db.ActiveReplicatorTypePush, []string{"ABC"}, true, db.ConflictResolverDefault, "")
+		activeRT.CreateReplication("rep_DEF", remoteURLString, db.ActiveReplicatorTypePush, []string{"DEF"}, true, db.ConflictResolverDefault, "")
+		activeRT.WaitForAssignedReplications(2)
+		activeRT.WaitForReplicationStatus("rep_ABC", db.ReplicationStateRunning)
+		activeRT.WaitForReplicationStatus("rep_DEF", db.ReplicationStateRunning)
+
+		changesResults := remoteRT.WaitForChanges(2, "/{{.keyspace}}/_changes?since=0", "", true)
+		changesResults.RequireDocIDs(t, []string{docABC1, docDEF1})
+
+		activeRT2 := addActiveRT(t, activeRT.GetDatabase().Name, activeRT.TestBucket)
+		defer activeRT2.Close()
+
+		activeRT.WaitForAssignedReplications(1)
+		activeRT2.WaitForAssignedReplications(1)
+
+		activeRTUUID := activeRT.GetDatabase().UUID
+		activeRT2UUID := activeRT2.GetDatabase().UUID
+		activeRTMgr := activeRT.GetDatabase().SGReplicateMgr
+		activeRT2Mgr := activeRT2.GetDatabase().SGReplicateMgr
+		dbName := activeRT.GetDatabase().Name
+		currentConfig := activeRT.ServerContext().GetDatabaseConfig(dbName).DatabaseConfig
+
+		// The production combination: PUT /db/_config landing while node membership flaps.  Reload the
+		// current config unchanged, to avoid unrelated REST-layer config validation quirks.
+		var wg sync.WaitGroup
+		wg.Go(func() {
+			// Can't distinguish "removed" from "skipped" - updateCluster returns nil once stopped.
+			assert.NoError(t, activeRTMgr.RemoveNode(activeRT2UUID))
+		})
+		wg.Go(func() {
+			err := activeRT.ServerContext().ReloadDatabaseWithConfig(base.NewNonCancelCtx(), currentConfig)
+			t.Logf("ReloadDatabaseWithConfig error: %v", err)
+		})
+		base.WaitWithTimeout(t, &wg, time.Minute)
+
+		// The reload already removed activeRTUUID, since each DatabaseContext registers a fresh one, so
+		// re-removing it would no-op.  Re-reading also confirms the reload happened.
+		reloadedUUID := activeRT.GetDatabase().UUID
+		require.NotEqual(t, activeRTUUID, reloadedUUID, "config reload did not replace the DatabaseContext")
+
+		// Wait for the reloaded context to register, or the removal races registration and no-ops again.
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			cluster, err := activeRT2Mgr.GetSGRCluster()
+			if !assert.NoError(c, err) {
+				return
+			}
+			_, ok := cluster.Nodes[reloadedUUID]
+			assert.True(c, ok)
+		}, time.Second*20, time.Millisecond*100, "reloaded node never registered in the cluster cfg")
+
+		assert.NoError(t, activeRT2Mgr.RemoveNode(reloadedUUID))
+
+		// Wait for nodes to re-register, re-fetching the manager in case the reload replaced it.
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			clusterDef, err := activeRT.GetDatabase().SGReplicateMgr.GetSGRCluster()
+			if !assert.NoError(c, err) {
+				return
+			}
+			assert.Len(c, clusterDef.Nodes, 2)
+		}, time.Second*20, time.Millisecond*100, "Nodes did not re-register after removal")
+
+		activeRT.WaitForAssignedReplications(1)
+		activeRT2.WaitForAssignedReplications(1)
+
+		docABC2 := rest.SafeDocumentName(t, t.Name()+"ABC2")
+		_ = activeRT.PutDoc(docABC2, `{"source":"activeRT","channels":["ABC"]}`)
+		docDEF2 := rest.SafeDocumentName(t, t.Name()+"DEF2")
+		_ = activeRT.PutDoc(docDEF2, `{"source":"activeRT","channels":["DEF"]}`)
+
+		// Post-reload writes must still reach the remote, whichever node now owns the replications.
+		changesResults = remoteRT.WaitForChanges(2, "/{{.keyspace}}/_changes?since="+changesResults.Last_Seq.String(), "", true)
+		changesResults.RequireDocIDs(t, []string{docABC2, docDEF2})
+
+		// Status is shared across nodes, so either node running is enough.
+		activeRT.WaitForReplicationStatus("rep_ABC", db.ReplicationStateRunning)
+		activeRT.WaitForReplicationStatus("rep_DEF", db.ReplicationStateRunning)
+	})
+}

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -875,12 +875,6 @@ func TestReplicationRebalancePull(t *testing.T) {
 			t.Logf("activeRT2 rep_DEF DocsRead: %d", actual)
 			return actual == 2
 		})
-
-		// explicitly stop the SGReplicateMgrs on the active nodes, to prevent a node rebalance during test teardown.
-		activeRT.GetDatabase().SGReplicateMgr.Stop()
-		activeRT.GetDatabase().SGReplicateMgr = nil
-		activeRT2.GetDatabase().SGReplicateMgr.Stop()
-		activeRT2.GetDatabase().SGReplicateMgr = nil
 	})
 }
 
@@ -983,12 +977,6 @@ func TestReplicationRebalancePush(t *testing.T) {
 			t.Logf("activeRT2 rep_DEF DocsCheckedPush: %d", actual)
 			return actual == 2
 		})
-
-		// explicitly stop the SGReplicateMgrs on the active nodes, to prevent a node rebalance during test teardown.
-		activeRT.GetDatabase().SGReplicateMgr.Stop()
-		activeRT.GetDatabase().SGReplicateMgr = nil
-		activeRT2.GetDatabase().SGReplicateMgr.Stop()
-		activeRT2.GetDatabase().SGReplicateMgr = nil
 	})
 }
 
@@ -1791,12 +1779,6 @@ func TestReplicationHeartbeatRemoval(t *testing.T) {
 
 		changesResults = activeRT.WaitForChanges(2, "/{{.keyspace}}/_changes?since="+changesResults.Last_Seq.String(), "", true)
 		changesResults.RequireDocIDs(t, []string{docABC3, docDEF3})
-
-		// explicitly stop the SGReplicateMgrs on the active nodes, to prevent a node rebalance during test teardown.
-		activeRT.GetDatabase().SGReplicateMgr.Stop()
-		activeRT.GetDatabase().SGReplicateMgr = nil
-		activeRT2.GetDatabase().SGReplicateMgr.Stop()
-		activeRT2.GetDatabase().SGReplicateMgr = nil
 	})
 }
 


### PR DESCRIPTION
CBG-5760

Unclean cherry pick of #8608 to 4.1.2
Changes from main commit:
- `db/sg_replicate_cfg_test.go`, `rest/replicatortest/replicator_no_race_test.go` — 4.1.2 predates the `testing/assert` and `testing/require` wrappers; imports renamed back to `github.com/stretchr/testify/{assert,require}`. Assertions unchanged.
- `rest/replicatortest/replicator_test.go` — the removal of the three explicit `SGReplicateMgr.Stop()` teardown blocks applied as upstream; the surrounding stat assertions are 4.1.2's own `rest.WaitAndAssertCondition` form, since the `require.EventuallyWithT` rewrite is from a separate commit that is not on this branch.

`db/sg_replicate_cfg.go` is byte-identical to the main commit.

The nine new `db` tests pass with and without `-race`. `TestReplicationRebalancePull`, `TestReplicationRebalancePush`, `TestReplicationHeartbeatRemoval` and the new `TestReplicationHeartbeatRemovalPushWithConfigReload` are EE-only; all pass with `cb_sg_enterprise,cb_sg_devmode`. Not run against Couchbase Server.

Note: CBG-5760 is a clone of CBG-5736, which was closed as fixed by this commit rather than by a commit of its own.

🤖 Opened with the `sync-gateway-backport` skill in [Claude Code](https://claude.com/claude-code)
