### PR TITLE
[3.3.8 Backport] CBG-5398: Track heartbeat listener goroutine in sgReplicateManager.closeWg

### DIFF
--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -1603,8 +1603,10 @@ func (l *ReplicationHeartbeatListener) subscribeNodeSetChanges() error {
 		base.DebugfCtx(l.mgr.loggingCtx, base.KeyCluster, "Error subscribing to %s key changes: %v", cfgKeySGRCluster, err)
 		return err
 	}
+	l.mgr.closeWg.Add(1)
 	go func() {
 		defer base.FatalPanicHandler()
+		defer l.mgr.closeWg.Done()
 		for {
 			select {
 			case <-cfgEvents:


### PR DESCRIPTION
CBG-5398

Unclean cherry pick of #8283 to 3.3.8
Changes from main commit:
- `db/sg_replicate_cfg.go` — `base.FatalPanicHandler` takes no `ctx` on this branch (CBG-5360, #8224, is not backported), so the branch's existing call is kept. The two added lines are otherwise identical.

Bottom of a 3-layer stack. This is a **prerequisite** for #8702, the CBG-5762 backport of CBG-5694 (#8608): that change makes `Stop()` drain `closeWg` before stopping replications, and removes the explicit `SGReplicateMgr.Stop()` teardown calls from the rebalance tests. Without the heartbeat listener goroutine on `closeWg`, the drain does not cover it and the race this ticket fixed can resurface.

**CBG-5398 has no 3.3.8 backport ticket of its own** — happy to create the clone if you want one.

🤖 Opened with the `sync-gateway-backport` skill in [Claude Code](https://claude.com/claude-code)
