### PR TITLE
[3.3.8 Backport] CBG-5302: persist an error status for a replication that fails to initialise

### DIFF
--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -539,6 +539,7 @@ func (m *sgReplicateManager) StartReplications(ctx context.Context) error {
 			activeReplicator, err := m.InitializeReplication(replicationCfg)
 			if err != nil {
 				base.WarnfCtx(m.loggingCtx, "Error initializing replication %s: %v", replicationID, err)
+				m.saveInitializationError(replicationCfg, err)
 				continue
 			}
 			m.activeReplicatorsLock.Lock()
@@ -716,6 +717,29 @@ func (m *sgReplicateManager) replicationComplete(replicationID string) {
 	}
 }
 
+// saveInitializationError persists an error status for a replication that failed to initialise,
+// so that GetReplicationStatus returns ReplicationStateError instead of the target state.
+func (m *sgReplicateManager) saveInitializationError(config *ReplicationCfg, initErr error) {
+	status := &ReplicationStatus{
+		ID:           config.ID,
+		Status:       ReplicationStateError,
+		ErrorMessage: initErr.Error(),
+	}
+	expirySecs := int(m.dbContext.Options.LocalDocExpirySecs)
+	if config.Direction == ActiveReplicatorTypePush || config.Direction == ActiveReplicatorTypePushAndPull {
+		pushKey := m.dbContext.MetadataKeys.ReplicationStatusKey(PushCheckpointID(config.ID))
+		if err := setLocalStatus(m.loggingCtx, m.dbContext.MetadataStore, pushKey, status, expirySecs); err != nil {
+			base.WarnfCtx(m.loggingCtx, "Unable to persist error status for replication %s: %v", base.UD(config.ID), err)
+		}
+	}
+	if config.Direction == ActiveReplicatorTypePull || config.Direction == ActiveReplicatorTypePushAndPull {
+		pullKey := m.dbContext.MetadataKeys.ReplicationStatusKey(PullCheckpointID(config.ID))
+		if err := setLocalStatus(m.loggingCtx, m.dbContext.MetadataStore, pullKey, status, expirySecs); err != nil {
+			base.WarnfCtx(m.loggingCtx, "Unable to persist error status for replication %s: %v", base.UD(config.ID), err)
+		}
+	}
+}
+
 func (m *sgReplicateManager) Stop() {
 
 	// Close subscribe terminator first to stop subscribing/responding to cluster config changes prior to
@@ -785,6 +809,7 @@ func (m *sgReplicateManager) RefreshReplicationCfg(ctx context.Context) error {
 				replicator, initError := m.InitializeReplication(replicationCfg)
 				if initError != nil {
 					base.WarnfCtx(m.loggingCtx, "Error initializing upserted replication %s: %v", replicationID, initError)
+					m.saveInitializationError(replicationCfg, initError)
 				} else {
 					m.activeReplicators[replicationID] = replicator
 					activeReplicator = replicator
@@ -814,6 +839,7 @@ func (m *sgReplicateManager) RefreshReplicationCfg(ctx context.Context) error {
 				replicator, initError := m.InitializeReplication(replicationCfg)
 				if initError != nil {
 					base.WarnfCtx(m.loggingCtx, "Error initializing replication %s: %v", replicationID, initError)
+					m.saveInitializationError(replicationCfg, initError)
 					continue
 				}
 				m.activeReplicators[replicationID] = replicator


### PR DESCRIPTION
CBG-5302

Partial cherry pick of #8205 to 3.3.8 — the `saveInitializationError` helper and its three init-failure call sites only.

**Deliberately excluded**, so this carries the helper without CBG-5302's behaviour change:
- `db/sg_replicate_cfg.go` — the `NewActiveReplicatorConfig` `user == nil` check that makes a non-existent `run_as` user an error. That is the CBG-5302 fix proper.
- `rest/replicatortest/replicator_test.go` — the CBG-5302 tests, which exercise that check and cannot pass without it.

Middle of a 3-layer stack, on top of #8700. This is a **prerequisite** for #8702, the CBG-5762 backport of CBG-5694 (#8608), whose `startAssignedReplication` calls this helper and whose `TestStartReplicationsSkipsInitErrorWhenStopping` covers suppressing the write during shutdown.

**CBG-5302 has no 3.3.8 backport ticket of its own** — happy to create the clone if you want one.

🤖 Opened with the `sync-gateway-backport` skill in [Claude Code](https://claude.com/claude-code)
