### PR TITLE
CBG-5692: cache tool enhancemnets for perf running

### DIFF
--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -315,6 +315,21 @@ func (c *channelCacheImpl) GetCachedChanges(ctx context.Context, channel channel
 	return changes, nil
 }
 
+// getCachedChangesSince is a cache-only read (never falls back to a view/query) of a channel's
+// changes after `since`. Unlike the diagnostic GetCachedChanges above (which uses since=0 and so
+// copies the whole channel log), this copies only the delta after `since` - the way a real changes
+// feed reads, passing its last-read sequence. Used by cache_perf_tool to model per-feed cursors so
+// the read-path copy/allocation cost reflects production rather than a whole-log copy per wake.
+func (c *channelCacheImpl) getCachedChangesSince(ctx context.Context, channel channels.ID, since uint64) ([]*LogEntry, error) {
+	options := ChangesOptions{Since: SequenceID{Seq: since}}
+	cache, err := c.getChannelCache(ctx, channel)
+	if err != nil {
+		return nil, err
+	}
+	_, changes := cache.GetCachedChanges(options)
+	return changes, nil
+}
+
 // CleanAgedItems prunes the caches based on age of items. Error returned to fulfill BackgroundTaskFunc signature.
 func (c *channelCacheImpl) cleanAgedItems(ctx context.Context) error {
 

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -112,10 +112,16 @@ func (db *DatabaseContext) CallProcessEntry(t *testing.T, ctx context.Context, l
 	db.changeCache.processEntry(ctx, log)
 }
 
-// GetCachedChanges will grab cached changes form channel cache for caching tool, not to be used outside test code.
-func (db *DatabaseContext) GetCachedChanges(t *testing.T, ctx context.Context, chanID channels.ID) ([]*LogEntry, error) {
-	logs, err := db.changeCache.getChannelCache().GetCachedChanges(ctx, chanID)
-	return logs, err
+// GetCachedChangesSince reads only the entries cached for a channel after `since` (cache-only, never
+// falls back to a view/query), so tools can model realistic per-feed cursors instead of copying the
+// whole channel log on every read. Not to be used outside test code.
+func (db *DatabaseContext) GetCachedChangesSince(t *testing.T, ctx context.Context, chanID channels.ID, since uint64) ([]*LogEntry, error) {
+	cc, ok := db.changeCache.getChannelCache().(*channelCacheImpl)
+	if !ok {
+		// Bypass/disabled-cache mode: fall back to the whole-log read.
+		return db.changeCache.getChannelCache().GetCachedChanges(ctx, chanID)
+	}
+	return cc.getCachedChangesSince(ctx, chanID, since)
 }
 
 func (db *DatabaseContext) NewDCPCachingCountWaiter(tb testing.TB) *StatWaiter {

--- a/tools/cache_perf_tool/README.md
+++ b/tools/cache_perf_tool/README.md
@@ -1,0 +1,144 @@
+# cache_perf_tool
+
+A load generator for the Sync Gateway **DCP → change cache → channel cache** write path, run
+in-process against an in-memory Rosmar bucket. It drives the real `changeCache` / `channelCache`
+code with synthetic mutations, so throughput and contention in the caching pipeline can be measured
+without a Couchbase Server cluster, a network, or any client.
+
+It is a measurement harness, not a functional test: nothing is asserted, and the only output is
+statistics.
+
+## Build
+
+```sh
+go build -o cache_perf_tool ./tools/cache_perf_tool          # Community Edition
+```
+
+Enterprise Edition (jsoniter instead of `encoding/json`) needs the build tags and SSH access to the
+private EE repo — see [docs/BUILD.md](../../docs/BUILD.md):
+
+```sh
+go build -tags cb_sg_enterprise,cb_sg_devmode -o cache_perf_tool_ee ./tools/cache_perf_tool
+```
+
+Build the edition you intend to quote numbers for. DCP-mode throughput is lock-bound rather than
+parser-bound, so it measures close to the same in both, but document unmarshalling is ~2x faster
+under EE.
+
+## Modes
+
+**`-mode dcp`** — the full pipeline. Synthetic `DcpMutation`s are fed through a real DCP client's
+worker pool into `ProcessFeedEvent`, so the run exercises DCP event handling, `_sync` xattr
+unmarshalling, sequence buffering (pending/skipped), the channel caches, and the notify/broadcast
+path. This is the mode that reproduces production shape.
+
+**`-mode processEntry`** — calls `changeCache.processEntry` directly, one goroutine per simulated
+Sync Gateway node. It skips DCP delivery and unmarshalling entirely, isolating the sequence-buffering
+and channel-cache write cost.
+
+## Running
+
+```sh
+./cache_perf_tool -mode dcp -duration 10m -writeDelay 0 \
+  -numChannels 1 -totalNumberOfChans 100 \
+  -numChangesFeeds 20000 -channelsPerClient 5 \
+  2> run.csv 1> run_summary.csv
+```
+
+**The two output streams are different things and must be redirected separately:**
+
+- **stderr** — a per-second CSV of cumulative counters, plus interleaved Sync Gateway log lines.
+- **stdout** — the end-of-run summary (see below).
+
+In `-mode dcp` the 1024 vBucket writer goroutines are started 100 ms apart, so there is a **~100 s
+ramp** — and that ramp runs to completion *before* the `-duration` timer starts. A `-duration 10m`
+run therefore takes about 11m40s wall-clock, and the per-second CSV covers the ramp as well as the
+measured period.
+
+`docs_cached_per_sec_steady` is ramp-aware: its window never reaches back past the point the last
+writer started, so it is never contaminated. But that also means a short run leaves it a short window
+— check `docs_cached_per_sec_steady_window_secs`, and give `-duration` at least `5m` for a full
+300 s window.
+
+### Flags
+
+| Flag | Default | Applies to | Meaning |
+| --- | --- | --- | --- |
+| `-mode` | `processEntry` | — | `dcp` or `processEntry`. |
+| `-duration` | `5m` | both | How long to run, e.g. `30s`, `10m`. |
+| `-writeDelay` | `0` | both | Comma-separated per-writer delays in ms; `0` means write as fast as possible. In `dcp` mode the list is assigned round-robin across vBuckets; in `processEntry` mode it must have **exactly one entry per `-sgwNodes`**. `processEntry` mode caps each delay at 150 ms. |
+| `-sgwNodes` | `1` | processEntry | Number of simulated Sync Gateway nodes (writer goroutines), each with its own sequence-allocation batch. |
+| `-batchSize` | `10` | both | Sequences per allocator batch (1–10). |
+| `-numChannels` | `1` | both | Channels assigned to each document. `0` gives a no-channel baseline: documents are cached with no channel-cache writes at all. |
+| `-totalNumberOfChans` | `1` | both | Size of the channel population documents are spread over. Must be `>= -numChannels`. |
+| `-numChangesFeeds` | `0` | dcp | Number of simulated changes feeds. Each is a real `ChangeWaiter` woken by the notify path; on each wake it reads its channels from the channel cache. `0` = no readers. |
+| `-channelsPerClient` | `0` | dcp | Channels each simulated feed watches, allocated round-robin from the channel population. |
+| `-rapidUpdateDocs` | `false` | dcp | Simulate KV-side deduplication on alternating mutations in every vBucket: allocate 5 sequences, then deliver a single event carrying all of them via `RecentSequences`. |
+| `-numDCPWorkers` | `8` | dcp | DCP client worker goroutines. |
+| `-numVBuckets` | `1024` | dcp | vBuckets the DCP client is sized for (worker routing, metadata). **This does not size the generator** — it always starts 1024 vBucket writers, so lowering this does not lower the offered load. |
+| `-profileInterval` | `0` | both | If > 1 s, enable profiling: a whole-run CPU + fgprof profile, plus heap/mutex/block/goroutine profiles written to the working directory at this interval. Must be less than `-duration`. **Profiling perturbs throughput — do not quote numbers from a profiled run.** |
+
+## Output
+
+### stderr: per-second CSV
+
+One row per second, **10 columns**, all values **cumulative since the start of the run**:
+
+```
+timestamp,high_seq_feed,pending_seq_len,high_seq_stable,current_skipped_seq_count,num_skipped_seqs,skipped_sequence_skip_list_nodes,dcp_caching_count,dcp_caching_time,avg_time_per_seq_ms
+```
+
+Sync Gateway log lines are written to stderr too, so filter before parsing — the timestamp column is
+a 10-digit Unix time:
+
+```sh
+grep -aE '^[0-9]{10},' run.csv | awk -F, 'NF==10' > run_data.csv
+```
+
+`avg_time_per_seq_ms` (column 10) is a *running mean over the whole run*, so it lags: a value still
+climbing at the end means the run had not settled.
+
+### stdout: end-of-run summary
+
+The same 10 columns as a header row plus one final row of totals, followed by labelled
+`name,value` lines:
+
+```
+docs_cached_per_sec_overall,183456.123456
+docs_cached_per_sec_steady,190123.456789
+docs_cached_per_sec_steady_window_secs,300
+dcp_received_count,1834561
+seqs_cached_per_event,1.000000
+```
+
+- **`docs_cached_per_sec_steady`** is the headline throughput number: documents cached per second
+  over the last 300 s of the run, which excludes the vBucket ramp. **Use this to compare runs.**
+- `docs_cached_per_sec_overall` covers the whole run *including* ramp, so it reads low.
+- `docs_cached_per_sec_steady_window_secs` is the window actually available. It is less than 300 on a
+  short run — in which case the steady figure still includes ramp and is not comparable — and `0` if
+  the run was too short to measure at all.
+- `dcp_received_count` is DCP events received; `dcp_caching_count` is sequences cached.
+  `seqs_cached_per_event` is their ratio, i.e. how many `processEntry` calls each DCP event costs
+  (> 1 when `-rapidUpdateDocs` is on, or when unused sequences are being released). It is 0 in
+  `processEntry` mode, which bypasses DCP delivery.
+
+To grab throughput from a script:
+
+```sh
+awk -F, '$1=="docs_cached_per_sec_steady"{print $2}' run_summary.csv
+```
+
+## Caveats
+
+- **Rosmar, not Couchbase Server.** The backing store is in-memory and is only used to create the
+  database context; the mutation stream is synthetic. Nothing here measures KV, DCP transport, or
+  disk.
+- **No client, no BLIP, no HTTP.** `-numChangesFeeds` models the *channel-cache read* a woken feed
+  performs — a real feed additionally builds and serialises `ChangeEntry`s, checks user access, and
+  reads its late-sequence feed. Feed cost here is a lower bound.
+- **Notify cadence changes behaviour.** The broadcast ticker runs at 50 ms normally and 500 ms while
+  any sequence is on the skipped list, which moves throughput substantially. A run that accumulates
+  skipped sequences part-way through is measuring two different regimes; check
+  `num_skipped_seqs` before averaging.
+- The tool exits by cancelling its context and waiting for writer goroutines to drain, so the
+  summary appears a moment after `-duration` elapses.

--- a/tools/cache_perf_tool/README.md
+++ b/tools/cache_perf_tool/README.md
@@ -50,10 +50,12 @@ and channel-cache write cost.
 - **stderr** — a per-second CSV of cumulative counters, plus interleaved Sync Gateway log lines.
 - **stdout** — the end-of-run summary (see below).
 
-In `-mode dcp` the 1024 vBucket writer goroutines are started 100 ms apart, so there is a **~100 s
-ramp** — and that ramp runs to completion *before* the `-duration` timer starts. A `-duration 10m`
-run therefore takes about 11m40s wall-clock, and the per-second CSV covers the ramp as well as the
-measured period.
+In `-mode dcp` one writer goroutine is started per vBucket, 100 ms apart, so startup takes
+`-numVBuckets` × 100 ms — a **~100 s ramp** at the default 1024 — and that ramp runs to completion
+*before* the `-duration` timer starts. A default `-duration 10m` run therefore takes about 11m40s
+wall-clock, and the per-second CSV covers the ramp as well as the measured period. Lowering
+`-numVBuckets` shortens the ramp proportionally, which is useful for smoke tests (64 vBuckets ramps
+in ~6 s) — but it also lowers the offered load, so see the flag table below.
 
 `seqs_cached_per_sec_steady` is ramp-aware: its window never reaches back past the point the last
 writer started, so it is never contaminated. But that also means a short run leaves it a short window
@@ -75,7 +77,7 @@ writer started, so it is never contaminated. But that also means a short run lea
 | `-channelsPerClient` | `0` | dcp | Channels each simulated feed watches, allocated round-robin from the channel population. |
 | `-rapidUpdateDocs` | `false` | dcp | Simulate KV-side deduplication on alternating mutations in every vBucket: allocate 5 sequences, then deliver a single event carrying all of them via `RecentSequences`. |
 | `-numDCPWorkers` | `8` | dcp | DCP client worker goroutines. |
-| `-numVBuckets` | `1024` | dcp | vBuckets the DCP client is sized for (worker routing, metadata). **This does not size the generator** — it always starts 1024 vBucket writers, so lowering this does not lower the offered load. |
+| `-numVBuckets` | `1024` | dcp | Number of vBuckets, **1–1024**. Sizes both the DCP client (worker routing, metadata) and the generator, which starts **one writer goroutine per vBucket** — so this is the offered write concurrency. **Runs with different values are not comparable with each other**, and every result in `cacheTestResults.md` was taken at 1024. Startup takes `numVBuckets` × 100 ms before `-duration` begins. |
 | `-profileInterval` | `0` | both | If > 1 s, enable profiling: a whole-run CPU + fgprof profile, plus heap/mutex/block/goroutine profiles written to the working directory at this interval. Must be less than `-duration`. **Profiling perturbs throughput — do not quote numbers from a profiled run.** |
 
 ## Output
@@ -143,5 +145,8 @@ awk -F, '$1=="seqs_cached_per_sec_steady"{print $2}' run_summary.csv
   any sequence is on the skipped list, which moves throughput substantially. A run that accumulates
   skipped sequences part-way through is measuring two different regimes; check
   `num_skipped_seqs` before averaging.
+- **`-numVBuckets` is the offered write concurrency, not just a client setting.** Lowering it makes
+  runs start much faster, but it is a different workload — reduce it for smoke tests and debugging,
+  leave it at 1024 for any number you intend to compare or publish.
 - The tool exits by cancelling its context and waiting for writer goroutines to drain, so the
   summary appears a moment after `-duration` elapses.

--- a/tools/cache_perf_tool/README.md
+++ b/tools/cache_perf_tool/README.md
@@ -55,9 +55,9 @@ ramp** — and that ramp runs to completion *before* the `-duration` timer start
 run therefore takes about 11m40s wall-clock, and the per-second CSV covers the ramp as well as the
 measured period.
 
-`docs_cached_per_sec_steady` is ramp-aware: its window never reaches back past the point the last
+`seqs_cached_per_sec_steady` is ramp-aware: its window never reaches back past the point the last
 writer started, so it is never contaminated. But that also means a short run leaves it a short window
-— check `docs_cached_per_sec_steady_window_secs`, and give `-duration` at least `5m` for a full
+— check `seqs_cached_per_sec_steady_window_secs`, and give `-duration` at least `5m` for a full
 300 s window.
 
 ### Flags
@@ -104,17 +104,20 @@ The same 10 columns as a header row plus one final row of totals, followed by la
 `name,value` lines:
 
 ```
-docs_cached_per_sec_overall,183456.123456
-docs_cached_per_sec_steady,190123.456789
-docs_cached_per_sec_steady_window_secs,300
+seqs_cached_per_sec_overall,183456.123456
+seqs_cached_per_sec_steady,190123.456789
+seqs_cached_per_sec_steady_window_secs,300
 dcp_received_count,1834561
 seqs_cached_per_event,1.000000
 ```
 
-- **`docs_cached_per_sec_steady`** is the headline throughput number: documents cached per second
-  over the last 300 s of the run, which excludes the vBucket ramp. **Use this to compare runs.**
-- `docs_cached_per_sec_overall` covers the whole run *including* ramp, so it reads low.
-- `docs_cached_per_sec_steady_window_secs` is the window actually available. It is less than 300 on a
+- **`seqs_cached_per_sec_steady`** is the headline throughput number: sequences cached per second
+  over the last 300 s of the run, which excludes the vBucket ramp. **Use this to compare runs.** It
+  counts cached *sequences*, not documents — one document contributes several whenever
+  `-rapidUpdateDocs` is on or unused sequences are released, which is what `seqs_cached_per_event`
+  below reports.
+- `seqs_cached_per_sec_overall` covers the whole run *including* ramp, so it reads low.
+- `seqs_cached_per_sec_steady_window_secs` is the window actually available. It is less than 300 on a
   short run — in which case the steady figure still includes ramp and is not comparable — and `0` if
   the run was too short to measure at all.
 - `dcp_received_count` is DCP events received; `dcp_caching_count` is sequences cached.
@@ -125,7 +128,7 @@ seqs_cached_per_event,1.000000
 To grab throughput from a script:
 
 ```sh
-awk -F, '$1=="docs_cached_per_sec_steady"{print $2}' run_summary.csv
+awk -F, '$1=="seqs_cached_per_sec_steady"{print $2}' run_summary.csv
 ```
 
 ## Caveats

--- a/tools/cache_perf_tool/README.md
+++ b/tools/cache_perf_tool/README.md
@@ -98,7 +98,9 @@ grep -aE '^[0-9]{10},' run.csv | awk -F, 'NF==10' > run_data.csv
 ```
 
 `avg_time_per_seq_ms` (column 10) is a *running mean over the whole run*, so it lags: a value still
-climbing at the end means the run had not settled.
+climbing at the end means the run had not settled. It is `dcp_caching_time / dcp_caching_count`; both
+counters are accumulated at the same point, so it covers exactly the sequences `dcp_caching_count`
+counts (see below).
 
 ### stdout: end-of-run summary
 
@@ -110,22 +112,29 @@ seqs_cached_per_sec_overall,183456.123456
 seqs_cached_per_sec_steady,190123.456789
 seqs_cached_per_sec_steady_window_secs,300
 dcp_received_count,1834561
+seqs_per_event,3.000000
 seqs_cached_per_event,1.000000
 ```
 
 - **`seqs_cached_per_sec_steady`** is the headline throughput number: sequences cached per second
-  over the last 300 s of the run, which excludes the vBucket ramp. **Use this to compare runs.** It
-  counts cached *sequences*, not documents — one document contributes several whenever
-  `-rapidUpdateDocs` is on or unused sequences are released, which is what `seqs_cached_per_event`
-  below reports.
+  over the last 300 s of the run, which excludes the vBucket ramp. **Use this to compare runs.**
 - `seqs_cached_per_sec_overall` covers the whole run *including* ramp, so it reads low.
 - `seqs_cached_per_sec_steady_window_secs` is the window actually available. It is less than 300 on a
   short run — in which case the steady figure still includes ramp and is not comparable — and `0` if
   the run was too short to measure at all.
-- `dcp_received_count` is DCP events received; `dcp_caching_count` is sequences cached.
-  `seqs_cached_per_event` is their ratio, i.e. how many `processEntry` calls each DCP event costs
-  (> 1 when `-rapidUpdateDocs` is on, or when unused sequences are being released). It is 0 in
-  `processEntry` mode, which bypasses DCP delivery.
+- `dcp_received_count` is DCP events received (one per `DocChanged`).
+- **`seqs_per_event`** is the `processEntry` fan-out: sequences carried by the feed per DCP event,
+  `high_seq_feed / dcp_received_count`. `1.0` normally, `~3.0` with `-rapidUpdateDocs` (half the
+  events carry 5 sequences). This is the amplification number.
+- **`seqs_cached_per_event`** is `dcp_caching_count / dcp_received_count` — the sequences that were
+  actually *cached*, per event. It stays at `1.0` even with `-rapidUpdateDocs`, and **the gap between
+  it and `seqs_per_event` is the point**: `DCPCachingCount` is incremented at the end of
+  `_addToCache`, *after* the `UnusedSequence` and `IsPrincipal` early returns, and the deduplicated
+  sequences a rapid-update event replays via `RecentSequences` are marked `UnusedSequence` unless
+  they are channel removals. Those sequences are ordered but never cached, so the amplified
+  `processEntry` calls are cheap ordering ops that skip the channel dispatch entirely. **Read
+  `dcp_caching_count` as sequences cached, not sequences processed.**
+- Both ratios are `0` in `processEntry` mode, which bypasses DCP delivery.
 
 To grab throughput from a script:
 

--- a/tools/cache_perf_tool/dcpDataGeneration.go
+++ b/tools/cache_perf_tool/dcpDataGeneration.go
@@ -26,6 +26,12 @@ import (
 
 var hlc = sgbucket.NewHybridLogicalClock()
 
+// syncSeqVBucket is the vBucket the generator treats as the hot _sync:seq vBucket. It is given a long
+// write delay and its own goroutine, so it behaves like the single frequently-updated sequence
+// document rather than a normal data vBucket. Clamped into range when running with fewer vBuckets -
+// see vBucketCreation.
+const syncSeqVBucket = 520
+
 type dcpDataGen struct {
 	seqAlloc          *sequenceAllocator
 	delays            []time.Duration
@@ -34,14 +40,31 @@ type dcpDataGen struct {
 	numChannelsPerDoc int
 	numTotalChannels  int
 	simRapidUpdate    bool
+	numVBuckets       int // number of vBucket writer goroutines to create; also the DCP client's vBucket count
 }
 
+// vBucketCreation starts one writer goroutine per vBucket and returns once they are all running.
+//
+// Writers are staggered by 100ms, so this BLOCKS for numVBuckets*100ms before the caller's -duration
+// timer starts: ~100s at the default 1024 vBuckets, proportionally less below that.
+//
+// numVBuckets is the offered write concurrency, so lowering it lowers the load the run applies. Runs
+// with different vBucket counts are not comparable with each other.
 func (dcp *dcpDataGen) vBucketCreation(ctx context.Context) {
 	delayIndex := 0
+	// The hot sync-seq vBucket has a fixed ID, so with fewer vBuckets than that ID it is clamped to the
+	// last one rather than silently not being created at all. At numVBuckets == 1 it is dropped
+	// entirely (-1 never matches below) so the single vBucket is a data writer - otherwise a 1-vBucket
+	// run would generate almost nothing. At the default 1024 this leaves it exactly where it has
+	// always been.
+	syncSeqVb := -1
+	if dcp.numVBuckets > 1 {
+		syncSeqVb = min(syncSeqVBucket, dcp.numVBuckets-1)
+	}
 	// vBucket creation logic
-	for i := range 1024 {
+	for i := range dcp.numVBuckets {
 		time.Sleep(100 * time.Millisecond) // we need a slight delay each iteration otherwise many vBuckets end up writing at the same times
-		if i == 520 {
+		if i == syncSeqVb {
 			go dcp.syncSeqVBucketCreation(ctx, uint16(i), 2*time.Second) // sync seq hot vBucket so high delay
 		} else {
 			// iterate through provided delays and assign to vBucket, when we get to end of delay list reset index and

--- a/tools/cache_perf_tool/main.go
+++ b/tools/cache_perf_tool/main.go
@@ -53,7 +53,7 @@ func main() {
 	channelsPerClient := flag.Int("channelsPerClient", 0, "Number of channels per client to wait on. Used only for DCP mode.")
 	rapidUpdateDocs := flag.Bool("rapidUpdateDocs", false, "Have documents rapidly updated (use of recent sequences). Used only for DCP mode.")
 	numDCPWorkers := flag.Int("numDCPWorkers", 8, "Number of DCP workers to create. Default is 8. Used only for DCP mode.")
-	numVBuckets := flag.Int("numVBuckets", 1024, "Number of vBuckets the DCP client is sized for (worker routing and metadata). Used only for DCP mode. NOTE this does not change the generator, which always starts 1024 vBucket writer goroutines - lowering it does not lower the offered load. Default is 1024.")
+	numVBuckets := flag.Int("numVBuckets", 1024, "Number of vBuckets (1-1024). Used only for DCP mode. This sizes the DCP client AND the generator, which starts one writer goroutine per vBucket - so it is the offered write concurrency, and runs with different values are not comparable with each other. Writers are staggered by 100ms, so startup takes numVBuckets*100ms before -duration begins. Default is 1024.")
 	flag.Parse()
 
 	if *nodes < 1 {
@@ -86,6 +86,12 @@ func main() {
 	}
 	if *numDCPWorkers < 1 {
 		log.Fatalf("Invalid number of DCP workers: %d", *numDCPWorkers)
+	}
+	// Bounded rather than just >0: the value is cast to uint16 for the DCP client, so anything above
+	// 65535 wraps - and a value wrapping to 0 makes the client fall back to reading the vBucket count
+	// off the bucket, which is a zero-value struct here and panics. 1024 is the real ceiling.
+	if *numVBuckets < 1 || *numVBuckets > 1024 {
+		log.Fatalf("Invalid number of vBuckets: %d, must be in [1,1024]", *numVBuckets)
 	}
 
 	delayList, err := extractDelays(*delays, *mode)
@@ -203,7 +209,7 @@ func main() {
 		// setup dcp generator object and create fake dcp client
 		seqAlloc := newSequenceAllocator(*batchSize, seqAllocator)
 		dcpGen := &dcpDataGen{seqAlloc: seqAlloc, delays: delayList, dbCtx: dbContext, numChannelsPerDoc: *numChannelsPerDoc,
-			numTotalChannels: *totalNumberOfChans, simRapidUpdate: *rapidUpdateDocs}
+			numTotalChannels: *totalNumberOfChans, simRapidUpdate: *rapidUpdateDocs, numVBuckets: *numVBuckets}
 		mutationListener := dbContext.GetMutationListener(t)
 		cacheFeedStatsMap := dbContext.DbStats.Database().CacheFeedMapStats
 		client, err := createDCPClient(t, ctx, bucket, mutationListener.ProcessFeedEvent, cacheFeedStatsMap.Map, *numDCPWorkers, uint16(*numVBuckets))
@@ -214,8 +220,8 @@ func main() {
 		dcpGen.client = client
 
 		// create vBucket mutations. This blocks until every vBucket writer is running - the writers are
-		// staggered by 100ms each, so it takes ~100s for 1024 vBuckets, and only then does the -duration
-		// timer below start.
+		// staggered by 100ms each, so it takes numVBuckets*100ms (~100s at the default 1024), and only
+		// then does the -duration timer below start.
 		dcpGen.vBucketCreation(ctx)
 		runThroughput.markGeneratorReady()
 	} else if *mode == processEntry {

--- a/tools/cache_perf_tool/main.go
+++ b/tools/cache_perf_tool/main.go
@@ -302,7 +302,7 @@ func startChanges(ctx context.Context, t *testing.T, dbContext *db.DatabaseConte
 // during which throughput is still climbing and would drag the whole-run average down.
 const steadyWindowSecs = 300
 
-// throughputSample is one reading of the cumulative documents-cached counter, taken at the same
+// throughputSample is one reading of the cumulative cached-sequence counter, taken at the same
 // moment as (and carrying the same values as) a row of the per-second stderr CSV.
 type throughputSample struct {
 	unixSec int64
@@ -310,7 +310,7 @@ type throughputSample struct {
 }
 
 // runThroughput accumulates the per-second series csvStats already reads, so the end-of-run summary
-// can state documents cached per second directly instead of every consumer re-deriving it from the
+// can state sequences cached per second directly instead of every consumer re-deriving it from the
 // CSV. One sample per second, so the memory cost is negligible even for a multi-hour run.
 var runThroughput throughputSeries
 
@@ -340,7 +340,7 @@ func (s *throughputSeries) record(unixSec int64, count int64) {
 	s.samples = append(s.samples, throughputSample{unixSec: unixSec, count: count})
 }
 
-// rates returns documents cached per second over the whole sampled run, and over the steady-state
+// rates returns sequences cached per second over the whole sampled run, and over the steady-state
 // window: the last windowSecs, never reaching back past the point the generator came up to full
 // load. window is the length of that steady window as actually measured - shorter than windowSecs
 // when the run did not last that long after ramp, and 0 when the run was too short to give a steady
@@ -420,9 +420,11 @@ func printEndofTestStatsFile(ctx context.Context, dbContext *db.DatabaseContext)
 	_, _ = fmt.Fprintf(os.Stdout, "%f", avgTimeMs)
 	_, _ = fmt.Fprintf(os.Stdout, "\n")
 
-	// Documents cached per second, on their own labelled lines so this can be parsed straight out of
+	// Sequences cached per second, on their own labelled lines so this can be parsed straight out of
 	// the summary rather than re-derived from the per-second CSV. Both rates are computed from that
-	// same series, so they agree with it exactly.
+	// same series, so they agree with it exactly. This counts CACHED SEQUENCES, not documents: with
+	// -rapidUpdateDocs, or whenever unused sequences are released, one document contributes several
+	// (which is what seqs_cached_per_event below reports).
 	//
 	//   - _overall covers every sample of the run, so it INCLUDES the ~100s vBucket ramp during which
 	//     throughput is still climbing. Use it only for whole-run accounting.
@@ -432,9 +434,9 @@ func printEndofTestStatsFile(ctx context.Context, dbContext *db.DatabaseContext)
 	//     steadyWindowSecs when the run did not last that long after ramp; if it is 0 the run was too
 	//     short to give a steady window at all and _steady is 0 rather than a ramp-blended number.
 	overallRate, steadyRate, steadyWindow := runThroughput.rates(steadyWindowSecs)
-	_, _ = fmt.Fprintf(os.Stdout, "docs_cached_per_sec_overall,%f\n", overallRate)
-	_, _ = fmt.Fprintf(os.Stdout, "docs_cached_per_sec_steady,%f\n", steadyRate)
-	_, _ = fmt.Fprintf(os.Stdout, "docs_cached_per_sec_steady_window_secs,%d\n", steadyWindow)
+	_, _ = fmt.Fprintf(os.Stdout, "seqs_cached_per_sec_overall,%f\n", overallRate)
+	_, _ = fmt.Fprintf(os.Stdout, "seqs_cached_per_sec_steady,%f\n", steadyRate)
+	_, _ = fmt.Fprintf(os.Stdout, "seqs_cached_per_sec_steady_window_secs,%d\n", steadyWindow)
 
 	// B5 amplification: DCPReceivedCount = one per DCP event (DocChanged); DCPCachingCount = one per
 	// cached sequence (_addToCache). Their ratio is the RecentSequences/UnusedSequences fan-out, i.e.

--- a/tools/cache_perf_tool/main.go
+++ b/tools/cache_perf_tool/main.go
@@ -21,6 +21,7 @@ import (
 	"runtime/pprof"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -52,7 +53,7 @@ func main() {
 	channelsPerClient := flag.Int("channelsPerClient", 0, "Number of channels per client to wait on. Used only for DCP mode.")
 	rapidUpdateDocs := flag.Bool("rapidUpdateDocs", false, "Have documents rapidly updated (use of recent sequences). Used only for DCP mode.")
 	numDCPWorkers := flag.Int("numDCPWorkers", 8, "Number of DCP workers to create. Default is 8. Used only for DCP mode.")
-	numVBuckets := flag.Int("numVBuckets", 1024, "Number of vBuckets to create. Used only for DCP mode. Default is 1024.")
+	numVBuckets := flag.Int("numVBuckets", 1024, "Number of vBuckets the DCP client is sized for (worker routing and metadata). Used only for DCP mode. NOTE this does not change the generator, which always starts 1024 vBucket writer goroutines - lowering it does not lower the offered load. Default is 1024.")
 	flag.Parse()
 
 	if *nodes < 1 {
@@ -67,14 +68,18 @@ func main() {
 	if *timeToRun < 1 {
 		log.Fatalf("Invalid duration: %d", *timeToRun)
 	}
-	if *numChannelsPerDoc < 1 {
+	if *numChannelsPerDoc < 0 {
 		log.Fatalf("Invalid number of channels: %d", *numChannelsPerDoc)
 	}
 	if profileInterval.Seconds() != 0 && *profileInterval >= *timeToRun {
 		log.Fatalf("Invalid profile interval: %d, must be less than the duration of test: %d", *profileInterval, *timeToRun)
 	}
-	if *totalNumberOfChans < 1 && *totalNumberOfChans <= *numChannelsPerDoc {
-		log.Fatalf("Invalid total number of channels: %d", *totalNumberOfChans)
+	// 0 is allowed for both channel flags: it gives a no-channel-cache baseline (documents cached with
+	// no channel population to write into), which isolates the rest of the write path. The check that
+	// matters is that the system has at least as many channels as each document is assigned to,
+	// otherwise the generator wraps and silently assigns fewer channels per document than requested.
+	if *totalNumberOfChans < 0 || (*numChannelsPerDoc > 0 && *totalNumberOfChans < *numChannelsPerDoc) {
+		log.Fatalf("Invalid total number of channels: %d (must be >= 0, and >= numChannels=%d)", *totalNumberOfChans, *numChannelsPerDoc)
 	}
 	if *channelsPerClient < 0 {
 		log.Fatalf("Invalid number of channels per client: %d", *channelsPerClient)
@@ -208,13 +213,17 @@ func main() {
 		}
 		dcpGen.client = client
 
-		// create vBucket mutations
+		// create vBucket mutations. This blocks until every vBucket writer is running - the writers are
+		// staggered by 100ms each, so it takes ~100s for 1024 vBuckets, and only then does the -duration
+		// timer below start.
 		dcpGen.vBucketCreation(ctx)
+		runThroughput.markGeneratorReady()
 	} else if *mode == processEntry {
 		p := &processEntryGen{t: t, dbCtx: dbContext, delays: delayList, seqAlloc: seqAllocator, numNodes: *nodes,
 			batchSize: *batchSize, numChansPerDoc: *numChannelsPerDoc, totalChans: *totalNumberOfChans}
 		// create new sgw node abstraction and spawn write goroutines
 		p.spawnDocCreationGoroutine(ctx)
+		runThroughput.markGeneratorReady()
 	} else {
 		log.Printf("Invalid mode: %s", *mode)
 		return
@@ -260,6 +269,9 @@ func startChanges(ctx context.Context, t *testing.T, dbContext *db.DatabaseConte
 		go func(ctx context.Context, wait *db.ChangeWaiter, chanMap channels.Set) {
 			numGoroutines.Add(1)
 			defer numGoroutines.Add(-1)
+			// Per-feed cursor: remember the last sequence each watched channel has been read up to, so each
+			// wake reads only the delta (like a real changes feed passing `since`), not the whole channel log.
+			sinceByChan := make(map[channels.ID]uint64, len(chanMap))
 			for {
 				if ctx.Err() != nil {
 					return
@@ -270,16 +282,107 @@ func startChanges(ctx context.Context, t *testing.T, dbContext *db.DatabaseConte
 				} else if num == db.WaiterHasChanges {
 					// get cached changes for map, simulating changes feeds actually using the channel cache
 					for id := range chanMap {
-						_, err := dbContext.GetCachedChanges(t, ctx, id)
+						changes, err := dbContext.GetCachedChangesSince(t, ctx, id, sinceByChan[id])
 						if err != nil {
 							log.Printf("Error getting cached changes: %v", err)
 							return
+						}
+						if n := len(changes); n > 0 {
+							sinceByChan[id] = changes[n-1].Sequence
 						}
 					}
 				}
 			}
 		}(ctx, waiter, chans)
 	}
+}
+
+// steadyWindowSecs is the trailing window the steady-state throughput figure is taken over. 300s is
+// long enough to average out the notify cadence and short enough to exclude the ~100s vBucket ramp,
+// during which throughput is still climbing and would drag the whole-run average down.
+const steadyWindowSecs = 300
+
+// throughputSample is one reading of the cumulative documents-cached counter, taken at the same
+// moment as (and carrying the same values as) a row of the per-second stderr CSV.
+type throughputSample struct {
+	unixSec int64
+	count   int64
+}
+
+// runThroughput accumulates the per-second series csvStats already reads, so the end-of-run summary
+// can state documents cached per second directly instead of every consumer re-deriving it from the
+// CSV. One sample per second, so the memory cost is negligible even for a multi-hour run.
+var runThroughput throughputSeries
+
+type throughputSeries struct {
+	lock sync.Mutex
+	// samples is the per-second series, oldest first.
+	samples []throughputSample
+	// readyUnixSec is when the write generator reached full offered load; samples before it are
+	// excluded from the steady-state window. In DCP mode the 1024 vBucket writers are started 100ms
+	// apart, so the run spends its first ~100s ramping - and that ramp happens BEFORE the -duration
+	// timer starts, which is exactly the trap this guards: without it, a run given a -duration shorter
+	// than the steady window would report a steady figure that silently averages in the ramp.
+	readyUnixSec int64
+}
+
+// markGeneratorReady records that every writer is now running, so the steady-state window can start
+// from here rather than from the first sample.
+func (s *throughputSeries) markGeneratorReady() {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.readyUnixSec = time.Now().Unix()
+}
+
+func (s *throughputSeries) record(unixSec int64, count int64) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.samples = append(s.samples, throughputSample{unixSec: unixSec, count: count})
+}
+
+// rates returns documents cached per second over the whole sampled run, and over the steady-state
+// window: the last windowSecs, never reaching back past the point the generator came up to full
+// load. window is the length of that steady window as actually measured - shorter than windowSecs
+// when the run did not last that long after ramp, and 0 when the run was too short to give a steady
+// window at all, in which case steady is 0 too rather than a ramp-contaminated number.
+func (s *throughputSeries) rates(windowSecs int64) (overall, steady float64, window int64) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	n := len(s.samples)
+	if n < 2 {
+		return 0, 0, 0
+	}
+	first, last := s.samples[0], s.samples[n-1]
+	if last.unixSec > first.unixSec {
+		overall = float64(last.count-first.count) / float64(last.unixSec-first.unixSec)
+	}
+
+	cutoff := last.unixSec - windowSecs
+	if s.readyUnixSec > cutoff {
+		cutoff = s.readyUnixSec
+	}
+	// Walk back to the earliest sample still inside the window.
+	var start throughputSample
+	found := false
+	for i := n - 1; i >= 0 && s.samples[i].unixSec >= cutoff; i-- {
+		start = s.samples[i]
+		found = true
+	}
+	if found && last.unixSec > start.unixSec {
+		window = last.unixSec - start.unixSec
+		steady = float64(last.count-start.count) / float64(window)
+	}
+	return overall, steady, window
+}
+
+// avgCachingTimeMs is the running mean time to cache one sequence, in ms. Guarded so a run that has
+// not cached anything yet reports 0 rather than NaN, which would otherwise land in the CSV.
+func avgCachingTimeMs(timeNano, count int64) float64 {
+	if count <= 0 {
+		return 0
+	}
+	return (float64(timeNano) / float64(count)) / 1e6
 }
 
 func printEndofTestStatsFile(ctx context.Context, dbContext *db.DatabaseContext) {
@@ -289,8 +392,7 @@ func printEndofTestStatsFile(ctx context.Context, dbContext *db.DatabaseContext)
 	// calculate here avg time to cache seq in ms
 	count := dbStats.Database().DCPCachingCount.Value()
 	timeNano := dbStats.Database().DCPCachingTime.Value()
-	avgTimeNano := float64(timeNano) / float64(count)
-	avgTimeMs := avgTimeNano / 1e6
+	avgTimeMs := avgCachingTimeMs(timeNano, count)
 	timeMS := timeNano / 1e6
 
 	_, _ = fmt.Fprintf(os.Stdout, "timestamp,")
@@ -317,6 +419,34 @@ func printEndofTestStatsFile(ctx context.Context, dbContext *db.DatabaseContext)
 	_, _ = fmt.Fprintf(os.Stdout, "%d,", timeMS)
 	_, _ = fmt.Fprintf(os.Stdout, "%f", avgTimeMs)
 	_, _ = fmt.Fprintf(os.Stdout, "\n")
+
+	// Documents cached per second, on their own labelled lines so this can be parsed straight out of
+	// the summary rather than re-derived from the per-second CSV. Both rates are computed from that
+	// same series, so they agree with it exactly.
+	//
+	//   - _overall covers every sample of the run, so it INCLUDES the ~100s vBucket ramp during which
+	//     throughput is still climbing. Use it only for whole-run accounting.
+	//   - _steady covers the last steadyWindowSecs of post-ramp run and is the figure to compare
+	//     between runs.
+	//   - _steady_window_secs is the window that was actually measured. It is less than
+	//     steadyWindowSecs when the run did not last that long after ramp; if it is 0 the run was too
+	//     short to give a steady window at all and _steady is 0 rather than a ramp-blended number.
+	overallRate, steadyRate, steadyWindow := runThroughput.rates(steadyWindowSecs)
+	_, _ = fmt.Fprintf(os.Stdout, "docs_cached_per_sec_overall,%f\n", overallRate)
+	_, _ = fmt.Fprintf(os.Stdout, "docs_cached_per_sec_steady,%f\n", steadyRate)
+	_, _ = fmt.Fprintf(os.Stdout, "docs_cached_per_sec_steady_window_secs,%d\n", steadyWindow)
+
+	// B5 amplification: DCPReceivedCount = one per DCP event (DocChanged); DCPCachingCount = one per
+	// cached sequence (_addToCache). Their ratio is the RecentSequences/UnusedSequences fan-out, i.e.
+	// how many processEntry calls each DCP event costs. Labelled lines again, so the positional
+	// per-second CSV recipe is undisturbed.
+	received := dbStats.Database().DCPReceivedCount.Value()
+	var seqsPerEvent float64
+	if received > 0 {
+		seqsPerEvent = float64(count) / float64(received)
+	}
+	_, _ = fmt.Fprintf(os.Stdout, "dcp_received_count,%d\n", received)
+	_, _ = fmt.Fprintf(os.Stdout, "seqs_cached_per_event,%f\n", seqsPerEvent)
 }
 
 func csvStats(ctx context.Context, dbContext *db.DatabaseContext) {
@@ -330,7 +460,7 @@ func csvStats(ctx context.Context, dbContext *db.DatabaseContext) {
 	_, _ = fmt.Fprintf(os.Stderr, "high_seq_stable,")
 	_, _ = fmt.Fprintf(os.Stderr, "current_skipped_seq_count,")
 	_, _ = fmt.Fprintf(os.Stderr, "num_skipped_seqs,")
-	_, _ = fmt.Fprintf(os.Stdout, "skipped_sequence_skip_list_nodes,")
+	_, _ = fmt.Fprintf(os.Stderr, "skipped_sequence_skip_list_nodes,")
 	_, _ = fmt.Fprintf(os.Stderr, "dcp_caching_count,")
 	_, _ = fmt.Fprintf(os.Stderr, "dcp_caching_time,")
 	_, _ = fmt.Fprintf(os.Stderr, "avg_time_per_seq_ms")
@@ -346,16 +476,19 @@ func csvStats(ctx context.Context, dbContext *db.DatabaseContext) {
 			// calculate here avg time to cache seq in ms
 			count := dbStats.Database().DCPCachingCount.Value()
 			timeNano := dbStats.Database().DCPCachingTime.Value()
-			avgTimeNano := float64(timeNano) / float64(count)
-			avgTimeMs := avgTimeNano / 1e6
+			avgTimeMs := avgCachingTimeMs(timeNano, count)
 			timeMS := timeNano / 1e6
-			_, _ = fmt.Fprintf(os.Stderr, "%d,", time.Now().Unix())
+			now := time.Now().Unix()
+			// Keep the series for the end-of-run docs-cached-per-second lines, using the same timestamp
+			// and counter value printed below so the summary and the CSV cannot disagree.
+			runThroughput.record(now, count)
+			_, _ = fmt.Fprintf(os.Stderr, "%d,", now)
 			_, _ = fmt.Fprintf(os.Stderr, "%d,", dbStats.Database().HighSeqFeed.Value())
 			_, _ = fmt.Fprintf(os.Stderr, "%d,", dbStats.Cache().PendingSeqLen.Value())
 			_, _ = fmt.Fprintf(os.Stderr, "%d,", dbStats.Cache().HighSeqStable.Value())
 			_, _ = fmt.Fprintf(os.Stderr, "%d,", dbStats.Cache().NumCurrentSeqsSkipped.Value())
 			_, _ = fmt.Fprintf(os.Stderr, "%d,", dbStats.Cache().NumSkippedSeqs.Value())
-			_, _ = fmt.Fprintf(os.Stdout, "%d,", dbStats.Cache().SkippedSequenceSkiplistNodes.Value())
+			_, _ = fmt.Fprintf(os.Stderr, "%d,", dbStats.Cache().SkippedSequenceSkiplistNodes.Value())
 			_, _ = fmt.Fprintf(os.Stderr, "%d,", count)
 			_, _ = fmt.Fprintf(os.Stderr, "%d,", timeMS)
 			_, _ = fmt.Fprintf(os.Stderr, "%f", avgTimeMs)

--- a/tools/cache_perf_tool/main.go
+++ b/tools/cache_perf_tool/main.go
@@ -382,8 +382,10 @@ func (s *throughputSeries) rates(windowSecs int64) (overall, steady float64, win
 	return overall, steady, window
 }
 
-// avgCachingTimeMs is the running mean time to cache one sequence, in ms. Guarded so a run that has
-// not cached anything yet reports 0 rather than NaN, which would otherwise land in the CSV.
+// avgCachingTimeMs is the running mean time to cache one sequence, in ms - DCPCachingTime and
+// DCPCachingCount are both accumulated at the same point in _addToCache, so they cover the same
+// entries. Guarded so a run that has not cached anything yet reports 0 rather than NaN, which would
+// otherwise land in the CSV.
 func avgCachingTimeMs(timeNano, count int64) float64 {
 	if count <= 0 {
 		return 0
@@ -428,9 +430,14 @@ func printEndofTestStatsFile(ctx context.Context, dbContext *db.DatabaseContext)
 
 	// Sequences cached per second, on their own labelled lines so this can be parsed straight out of
 	// the summary rather than re-derived from the per-second CSV. Both rates are computed from that
-	// same series, so they agree with it exactly. This counts CACHED SEQUENCES, not documents: with
-	// -rapidUpdateDocs, or whenever unused sequences are released, one document contributes several
-	// (which is what seqs_cached_per_event below reports).
+	// same series, so they agree with it exactly.
+	//
+	// These count sequences that were CACHED, which is narrower than sequences processed:
+	// DCPCachingCount is incremented at the end of _addToCache (db/change_cache.go), after the
+	// UnusedSequence and IsPrincipal early returns, so a sequence only lands here if it reached the
+	// channel dispatch. The deduplicated sequences a -rapidUpdateDocs event replays via
+	// RecentSequences are marked UnusedSequence unless they are channel removals, so they are ordered
+	// but never cached, and do not appear in these rates. seqs_per_event below reports that fan-out.
 	//
 	//   - _overall covers every sample of the run, so it INCLUDES the ~100s vBucket ramp during which
 	//     throughput is still climbing. Use it only for whole-run accounting.
@@ -444,17 +451,29 @@ func printEndofTestStatsFile(ctx context.Context, dbContext *db.DatabaseContext)
 	_, _ = fmt.Fprintf(os.Stdout, "seqs_cached_per_sec_steady,%f\n", steadyRate)
 	_, _ = fmt.Fprintf(os.Stdout, "seqs_cached_per_sec_steady_window_secs,%d\n", steadyWindow)
 
-	// B5 amplification: DCPReceivedCount = one per DCP event (DocChanged); DCPCachingCount = one per
-	// cached sequence (_addToCache). Their ratio is the RecentSequences/UnusedSequences fan-out, i.e.
-	// how many processEntry calls each DCP event costs. Labelled lines again, so the positional
-	// per-second CSV recipe is undisturbed.
+	// B5 amplification, as two ratios against DCPReceivedCount (one per DCP event delivered to
+	// DocChanged). Labelled lines again, so the positional per-second CSV recipe is undisturbed.
+	//
+	//   - seqs_per_event is the processEntry fan-out per event, taken from HighSeqFeed: the highest
+	//     sequence processEntry has seen. The generator allocates sequences contiguously from 1 and
+	//     every allocated sequence is delivered - as a document's own sequence, or in its
+	//     RecentSequences - so that high-water mark is the number of sequences the feed carried.
+	//     Expect 1.0 without -rapidUpdateDocs and ~3.0 with it (half the events carry 5 sequences).
+	//   - seqs_cached_per_event uses DCPCachingCount, so it counts only the sequences that became
+	//     real channel-cache entries, and stays at 1.0 under -rapidUpdateDocs. The gap between the two
+	//     ratios is the point: the amplified calls are cheap unused-sequence ordering ops that skip
+	//     the channel dispatch entirely.
+	//
+	// Both are 0 in processEntry mode, which bypasses DCP delivery so DCPReceivedCount stays 0.
 	received := dbStats.Database().DCPReceivedCount.Value()
-	var seqsPerEvent float64
+	var seqsPerEvent, seqsCachedPerEvent float64
 	if received > 0 {
-		seqsPerEvent = float64(count) / float64(received)
+		seqsPerEvent = float64(dbStats.Database().HighSeqFeed.Value()) / float64(received)
+		seqsCachedPerEvent = float64(count) / float64(received)
 	}
 	_, _ = fmt.Fprintf(os.Stdout, "dcp_received_count,%d\n", received)
-	_, _ = fmt.Fprintf(os.Stdout, "seqs_cached_per_event,%f\n", seqsPerEvent)
+	_, _ = fmt.Fprintf(os.Stdout, "seqs_per_event,%f\n", seqsPerEvent)
+	_, _ = fmt.Fprintf(os.Stdout, "seqs_cached_per_event,%f\n", seqsCachedPerEvent)
 }
 
 func csvStats(ctx context.Context, dbContext *db.DatabaseContext) {
@@ -487,7 +506,7 @@ func csvStats(ctx context.Context, dbContext *db.DatabaseContext) {
 			avgTimeMs := avgCachingTimeMs(timeNano, count)
 			timeMS := timeNano / 1e6
 			now := time.Now().Unix()
-			// Keep the series for the end-of-run docs-cached-per-second lines, using the same timestamp
+			// Keep the series for the end-of-run seqs-cached-per-second lines, using the same timestamp
 			// and counter value printed below so the summary and the CSV cannot disagree.
 			runThroughput.record(now, count)
 			_, _ = fmt.Fprintf(os.Stderr, "%d,", now)


### PR DESCRIPTION

CBG-5692

Had claude fix a couple of bugs and then make seqs cached per second easy to extract for a perf job to do. 

## Pre-review checklist
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/

<!--
Automated review runs on every non-draft PR raised from this repo (forks are not reviewed automatically).
  - Re-run it, or ask a follow-up, by commenting `@droid <question>`
  - Suppress it with the `droid-skip` label, or `WIP`/`DO NOT MERGE` in the title
-->
