### PR TITLE
CBG-5751: fix TestLateLogsBoundedWhenConsumerStops flake

### DIFF
--- a/db/channel_cache_latelog_test.go
+++ b/db/channel_cache_latelog_test.go
@@ -27,6 +27,8 @@ import (
 // drainUntilWait reads events from a continuous _changes feed until MultiChangesFeed sends its nil
 // "caught up, waiting" marker, returning the sequences delivered in this drain. Callers that only need
 // the barrier behaviour can ignore the return value.
+//
+// The nil marker means the feed had nothing sendable that iteration, not that it saw the caller's last write.
 func drainUntilWait(t *testing.T, feed <-chan *ChangeEntry) (drained []uint64) {
 	t.Helper()
 	for {
@@ -94,6 +96,10 @@ func shortWaitCacheWithLateLogMax(lateLogMax int) CacheOptions {
 // by ChannelCacheMaxLength instead of growing forever. Without the length cap this same scenario grows the
 // count unbounded with the cycle count (the behaviour the reproduction test used to assert); with the
 // cap, _purgeLateLogEntries force-drops the stalled feed's pinned lastSequence and the queue plateaus.
+//
+// The assertions use listeners registered against the cache, not feed2: an un-drained feed isn't reliably
+// parked (buffered output channel, waitForCacheUpdate's 100ms poll), so it may return after the cap pruned it
+// and be rolled back - correctly - which is why the rollback count is logged rather than asserted on.
 func TestLateLogsBoundedWhenConsumerStops(t *testing.T) {
 	base.LongRunningTest(t)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyCache)
@@ -133,6 +139,12 @@ func TestLateLogsBoundedWhenConsumerStops(t *testing.T) {
 	drainUntilWait(t, feed1)
 	drainUntilWait(t, feed2)
 
+	// stalledSince never advances, standing in for the hung client's pin; healthySince reads every cycle.
+	stalledSince := abcCache.RegisterLateSequenceClient()
+	healthySince := abcCache.RegisterLateSequenceClient()
+	require.Equal(t, uint64(0), stalledSince)
+	require.Equal(t, uint64(0), healthySince)
+
 	// A skip/late cycle so both feeds register a late-sequence listener, then abandon feed2.
 	writeSeq(1)
 	drainUntilWait(t, feed2)
@@ -142,7 +154,7 @@ func TestLateLogsBoundedWhenConsumerStops(t *testing.T) {
 
 	// Repeat the skip/late cycle many times with feed2 abandoned. Each late-resolution write triggers
 	// AddLateSequence -> _purgeLateLogEntries, which must keep lateLogs at or below the cap by
-	// force-dropping feed2's stuck lastSequence - even though feed2's goroutine never advances it.
+	// force-dropping the stalled listener's pinned entry - even though it is never released.
 	const numCycles = 40
 	seq := uint64(3)
 	for range numCycles {
@@ -151,18 +163,21 @@ func TestLateLogsBoundedWhenConsumerStops(t *testing.T) {
 		writeSeq(seq - 1) // resolves seq-1 late -> AddLateSequence -> force-prune
 
 		require.LessOrEqualf(t, abcCache.lateLogCount(), int64(lateLogMax),
-			"ABC's lateLogs must stay bounded by ChannelCacheMaxLength (%d) even though feed2 is abandoned - "+
-				"the length cap should force-prune its stuck lastSequence", lateLogMax)
+			"ABC's lateLogs must stay bounded by ChannelCacheMaxLength (%d) even though the stalled listener "+
+				"still pins the front of the queue", lateLogMax)
+
+		_, healthySince, err = abcCache.GetLateSequencesSince(healthySince)
+		require.NoErrorf(t, err, "a listener that reads every cycle must not be force-pruned (pinned at #%d)", healthySince)
 	}
 
-	// The abandoned feed never returns to read, so it never observes that its lastSequence was pruned -
-	// no rollback is ever counted. The memory is reclaimed by the force-prune alone. (A returning feed
-	// would increment this - see TestLateLogsForcedRollbackResetsSlowFeed.)
-	require.Equal(t, int64(0), forcedRollbacks(),
-		"an abandoned feed's lateLogs are reclaimed by the force-prune without any rollback being counted")
+	// The stalled pin is what the cap reclaimed: reading from it must now fail. The probe is itself a rollback.
+	feedRollbacks := forcedRollbacks()
+	_, _, err = abcCache.GetLateSequencesSince(stalledSince)
+	require.ErrorContains(t, err, "Missing previous sequence",
+		"the stalled listener's pinned entry (#%d) should have been force-pruned from lateLogs", stalledSince)
 
-	t.Logf("ABC late entries after %d cycles with feed2 abandoned: %d (cap %d); total num_entries_in_late_feed: %d",
-		numCycles, abcCache.lateLogCount(), lateLogMax, numEntriesInLateFeed())
+	t.Logf("ABC late entries after %d cycles with feed2 abandoned: %d (cap %d); total num_entries_in_late_feed: %d; feed rollbacks: %d",
+		numCycles, abcCache.lateLogCount(), lateLogMax, numEntriesInLateFeed(), feedRollbacks)
 }
 
 // TestLateLogsForcedRollbackResetsSlowFeed shows the safety-net side of the cap: when a slow (but not


### PR DESCRIPTION
CBG-5751: fix TestLateLogsBoundedWhenConsumerStops flake

```
require.Equal(t, int64(0), forcedRollbacks(),
    "an abandoned feed's lateLogs are reclaimed by the force-prune without any rollback being counted")
```

That assertion assumed a fact about goroutine scheduling: that once the test stops draining feed2, feed2's MultiChangesFeed goroutine is permanently parked and can never read its late feed again. 

From claude for a long explanation: 

`MultiChangesFeed`'s output channel is **buffered 50 deep** (`db/changes.go:740`). An
undrained feed keeps iterating — each iteration it calls `getLateFeed` →
`GetLateSequencesSince(lastSequence)`, re-pinning to the newest late entry — until it has
pushed 50 items (entries *plus* the nil "waiting" markers) and finally blocks on the send.
Between iterations it sits in `changeWaiter.Wait` (`db/changes.go:1169`), which any
subsequent write wakes.

So there are two states:

- **wakeable** — `changeWaiter.Wait`, or `waitForCacheUpdate`'s 100 ms ticker
- **truly stuck** — blocked on a full output buffer (`db/changes.go:1142`)

Only the second one satisfies the assertion, and which one the feed lands in is timing.

## Evidence

Instrumenting the pre-fix test with per-cycle goroutine stacks and a dump of ABC's
`lateLogs` (`#seq(l=listenerCount)`):

```
CYCLE  9 [feed2 WAIT]         queue=[#20(l=0) #22(l=2)]   rollbacks=0   <- still reading every cycle
CYCLE 12 [feed2 BLOCKED-SEND] queue=[#26(l=1) #28(l=1)]   rollbacks=0   <- buffer full, pinned at #26
CYCLE 15 [feed2 BLOCKED-SEND] queue=[#26(l=1) ... #34(l=1)]             <- queue hits cap 5
CYCLE 16 [feed2 BLOCKED-SEND] queue=[#34(l=0) #36(l=1)]                 <- cap force-drops #26
```

The margin is **four cycles, roughly 30 ms**. `feed2` fills its buffer at cycle 12;
`_purgeLateLogEntries` (`db/channel_cache_single.go:906`) evicts its pinned `#26` at cycle
16. If a scheduling stall or coarser entry batching under load delays the buffer filling
past cycle 16 — or gives `feed2` a single wake after it — that iteration's
`GetLateSequencesSince` misses its `sinceSequence`, hits the `!previousFound` branch at
`db/channel_cache_single.go:768`, and bumps `LateFeedForcedRollbacks` to 1. Permanently.
The assertion then fails at the end of the test even though the cap did its job correctly.

Forcing exactly that window by freeing one buffer slot at cycle 30 (equivalent to a
descheduled-then-resumed goroutine):

```
after waking feed2: rollbacks=1
CYCLE 30 [feed2 @changes.go:1108]  queue=[#62(l=1) #64(l=1)]  rollbacks=1
```

Tellingly, that injection is itself a coin flip — one run of it produced `rollbacks=0`, and
merely adding the per-cycle queue logging (which shifts timing by microseconds) flipped it
to 1.

On this machine the unmodified test never fails:

| Configuration | Runs | Result |
| --- | --- | --- |
| plain | 30 | all pass, `rollbacks=0` |
| `-race`, 6× parallel load | 48 | all pass, `rollbacks=0` |
| `GOMAXPROCS=1 / 2 / 4` | 10 each | all pass, `rollbacks=0` |

It needs CI-grade scheduling noise.

## Secondary contributor

`drainUntilWait`'s nil marker means "the feed had nothing sendable this iteration", not
"the feed observed your last write". So the setup phase never establishes a known position
for `feed2` before abandoning it, which shifts when its buffer fills. This is now
documented in the fix.

## Why the fix holds

The commit stops inferring the pin from a live feed and instead registers two listeners
directly on the cache:

- `stalledSince` — never advanced, standing in for the hung client's pin
- `healthySince` — read every cycle

so the pin the cap must reclaim and the pin it must not touch are both under the test's
control. `feed2`'s rollback count is now logged rather than asserted, since a returning
feed being rolled back is correct behaviour, not a failure.

The real invariants are all still asserted:

1. queue bounded by `ChannelCacheMaxLength`
2. healthy reader never force-pruned
3. stalled pin reclaimed (its next read fails with "Missing previous sequence")

and `TestLateLogsForcedRollbackResetsSlowFeed` covers the rollback path deterministically.