### PR TITLE
CBG-5750: check terminator on blip throttle channel sends

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -631,7 +631,11 @@ func (bh *blipHandler) sendBatchOfChanges(sender *blip.Sender, changeArray [][]a
 			return ErrClosedBLIPSender
 		}
 
-		bh.inFlightChangesThrottle <- struct{}{}
+		select {
+		case bh.inFlightChangesThrottle <- struct{}{}:
+		case <-bh.terminator:
+			return ErrClosedBLIPSender
+		}
 		atomic.AddInt64(&bh.changesPendingResponseCount, 1)
 
 		bh.replicationStats.SendChangesCount.Add(int64(len(changeArray)))
@@ -825,7 +829,11 @@ func (bh *blipHandler) handleProposeChanges(rq *blip.Message) error {
 
 	// we don't know whether this batch of changes has completed because they look like unsolicited revs to us,
 	// but we can stop clients swarming us with these causing CheckProposedRev work
-	bh.inFlightChangesThrottle <- struct{}{}
+	select {
+	case bh.inFlightChangesThrottle <- struct{}{}:
+	case <-bh.terminator:
+		return ErrClosedBLIPSender
+	}
 	defer func() { <-bh.inFlightChangesThrottle }()
 
 	includeConflictRev := false
@@ -1056,7 +1064,11 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 		default:
 			stats.throttledRevs.Add(1)
 			throttleStart := time.Now()
-			bh.inFlightRevsThrottle <- struct{}{}
+			select {
+			case bh.inFlightRevsThrottle <- struct{}{}:
+			case <-bh.terminator:
+				return ErrClosedBLIPSender
+			}
 			stats.throttledRevTime.Add(time.Since(throttleStart).Nanoseconds())
 		}
 		defer func() { <-bh.inFlightRevsThrottle }()

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1244,10 +1244,11 @@ func TestBlipRevsThrottleUnblockedOnClose(t *testing.T) {
 
 	// Push more revs than there are slots. Responses are never awaited - the point of the test is
 	// what happens to the revs that don't have a slot when the connection goes away.
-	for i := range maxConcurrentRevs + numThrottledRevs {
-		docID := fmt.Sprintf("%s%d", docIDPrefix, i)
-		bt.Send(bt.newRevMessage(docID, "1-abc", []byte(`{"key": "val", "channels": ["user1"]}`), nil))
-	}
+for i := range maxConcurrentRevs + numThrottledRevs {
+	docID := fmt.Sprintf("%s%d", docIDPrefix, i)
+	sent := bt.Send(bt.newRevMessage(docID, "1-abc", []byte(`{"key": "val", "channels": ["user1"]}`), nil))
+	require.True(t, sent, "failed to send rev message for docID %s", docID)
+}
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		assert.Equal(c, int64(maxConcurrentRevs), revsHoldingSlot.Load(), "revs holding a throttle slot")

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1192,6 +1192,77 @@ func TestBlipSendConcurrentRevs(t *testing.T) {
 	t.Logf("Throttled revs: %d, Throttled duration: %s", throttleCount, throttleDuration)
 }
 
+// TestBlipRevsThrottleUnblockedOnClose tests that revs waiting for a free inFlightRevsThrottle slot
+// are released when the connection is closed, instead of staying blocked for as long as the revs
+// holding the slots take to be written.
+func TestBlipRevsThrottleUnblockedOnClose(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeySync, base.KeySyncMsg)
+
+	const (
+		user1 = "user1"
+		// minimum allowed by StartupConfig validation, and the default
+		maxConcurrentRevs = db.DefaultMaxConcurrentRevs
+		// revs that can't get a slot, and so can only be unblocked by the connection closing
+		numThrottledRevs = 3
+	)
+	docIDPrefix := SafeDocumentName(t, t.Name()) + "-"
+
+	// Hold every rev that has a throttle slot inside its write until the end of the test, so that a
+	// slot is never handed back to the revs that are waiting for one.
+	var revsHoldingSlot atomic.Int64
+	releaseRevs := make(chan struct{})
+	rt := NewRestTester(t, &RestTesterConfig{
+		LeakyBucketConfig: &base.LeakyBucketConfig{
+			UpdateCallback: func(docID string) {
+				if !strings.HasPrefix(docID, docIDPrefix) {
+					return
+				}
+				revsHoldingSlot.Add(1)
+				<-releaseRevs
+			},
+		},
+		maxConcurrentRevs: base.Ptr(maxConcurrentRevs),
+	})
+	defer rt.Close()
+	// let the in-flight writes finish before the RestTester is closed
+	defer close(releaseRevs)
+
+	pushStats := rt.GetDatabase().DbStats.CBLReplicationPush()
+	// revsWaitingForSlot is incremented by processRev immediately before it blocks on the throttle
+	revsWaitingForSlot := pushStats.WriteThrottledCount
+	// revsFinished counts the revs that have returned from processRev, successfully or not - both
+	// stats are set by the same deferred function. A rev released by a terminator check returns
+	// ErrClosedBLIPSender, so in practice these all land in DocPushErrorCount, but summing keeps the
+	// assertion about the rev no longer waiting, rather than about how it was ended.
+	revsFinished := func() int64 {
+		return pushStats.DocPushCount.Value() + pushStats.DocPushErrorCount.Value()
+	}
+
+	rt.CreateUser(user1, nil)
+	bt := NewBlipTesterFromSpecWithRT(rt, &BlipTesterSpec{connectingUsername: user1})
+	defer bt.Close()
+
+	// Push more revs than there are slots. Responses are never awaited - the point of the test is
+	// what happens to the revs that don't have a slot when the connection goes away.
+	for i := range maxConcurrentRevs + numThrottledRevs {
+		docID := fmt.Sprintf("%s%d", docIDPrefix, i)
+		bt.Send(bt.newRevMessage(docID, "1-abc", []byte(`{"key": "val", "channels": ["user1"]}`), nil))
+	}
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, int64(maxConcurrentRevs), revsHoldingSlot.Load(), "revs holding a throttle slot")
+		assert.Equal(c, int64(numThrottledRevs), revsWaitingForSlot.Value(), "revs waiting for a throttle slot")
+	}, time.Second*20, time.Millisecond*50, "revs never blocked on a full inFlightRevsThrottle")
+	require.Equal(t, int64(0), revsFinished(), "no rev should have been able to finish yet")
+
+	// Closing the connection should release the revs that are waiting for a throttle slot.
+	bt.sender.Close()
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, int64(numThrottledRevs), revsFinished())
+	}, time.Second*20, time.Millisecond*50, "revs waiting for an inFlightRevsThrottle slot were not released when the connection was closed")
+}
+
 // Test send and retrieval of a doc with a large numeric value.  Ensure proper large number handling.
 //
 //	Validate deleted handling (includes check for https://github.com/couchbase/sync_gateway/issues/3341)

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1244,11 +1244,10 @@ func TestBlipRevsThrottleUnblockedOnClose(t *testing.T) {
 
 	// Push more revs than there are slots. Responses are never awaited - the point of the test is
 	// what happens to the revs that don't have a slot when the connection goes away.
-for i := range maxConcurrentRevs + numThrottledRevs {
-	docID := fmt.Sprintf("%s%d", docIDPrefix, i)
-	sent := bt.Send(bt.newRevMessage(docID, "1-abc", []byte(`{"key": "val", "channels": ["user1"]}`), nil))
-	require.True(t, sent, "failed to send rev message for docID %s", docID)
-}
+	for i := range maxConcurrentRevs + numThrottledRevs {
+		docID := fmt.Sprintf("%s%d", docIDPrefix, i)
+		bt.Send(bt.newRevMessage(docID, "1-abc", []byte(`{"key": "val", "channels": ["user1"]}`), nil))
+	}
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		assert.Equal(c, int64(maxConcurrentRevs), revsHoldingSlot.Load(), "revs holding a throttle slot")


### PR DESCRIPTION
CBG-5750: check terminator on blip throttle channel sends

Goroutines blocked sending to `inFlightChangesThrottle` or `inFlightRevsThrottle` were never woken when the connection closed.

There are several other places of channels that are blocked that don't have terminators/contexts cancelling, I will file followup tickets and fix separately.

###  db/changes.go
- [db/changes.go:297](https://github.com/couchbase/sync_gateway/blob/0a76af569ddc8f4749d29a86229d31f3d052033e/db/changes.go#L297) — buildRevokedFeed — GetChanges error — `feed <- &change`
- [db/changes.go:332](https://github.com/couchbase/sync_gateway/blob/0a76af569ddc8f4749d29a86229d31f3d052033e/db/changes.go#L332) — buildRevokedFeed — wasDocInChannelPriorToRevocation error — `feed <- &change`
- [db/changes.go:348](https://github.com/couchbase/sync_gateway/blob/0a76af569ddc8f4749d29a86229d31f3d052033e/db/changes.go#L348) — buildRevokedFeed — UserHasDocAccess error — `feed <- &change`
- [db/changes.go:506](https://github.com/couchbase/sync_gateway/blob/0a76af569ddc8f4749d29a86229d31f3d052033e/db/changes.go#L506) — changesFeed — GetChanges error — `feed <- &change`

###  db/sequence_allocator.go
- [db/sequence_allocator.go:195](https://github.com/couchbase/sync_gateway/blob/0a76af569ddc8f4749d29a86229d31f3d052033e/db/sequence_allocator.go#L195) — nextSequence — `s.reserveNotify <- struct{}{}`
- [db/sequence_allocator.go:228](https://github.com/couchbase/sync_gateway/blob/0a76af569ddc8f4749d29a86229d31f3d052033e/db/sequence_allocator.go#L228) — nextSequenceGreaterThan — target within allocated range — `s.reserveNotify <- struct{}{}`
- [db/sequence_allocator.go:285](https://github.com/couchbase/sync_gateway/blob/0a76af569ddc8f4749d29a86229d31f3d052033e/db/sequence_allocator.go#L285) — nextSequenceGreaterThan — target below current _sync:seq — `s.reserveNotify <- struct{}{}`
- [db/sequence_allocator.go:321](https://github.com/couchbase/sync_gateway/blob/0a76af569ddc8f4749d29a86229d31f3d052033e/db/sequence_allocator.go#L321) — nextSequenceGreaterThan — after batch allocation — `s.reserveNotify <- struct{}{}`

## Pre-review checklist
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/

<!--
Automated review runs on every non-draft PR raised from this repo (forks are not reviewed automatically).
  - Re-run it, or ask a follow-up, by commenting `@droid <question>`
  - Suppress it with the `droid-skip` label, or `WIP`/`DO NOT MERGE` in the title
-->
