### PR TITLE
CBG-5647: Convert the integration test jobs from Jenkins freestyle to pipeline

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,8 +11,8 @@ Describe your PR here...
 - [ ] Link upstream PRs
 - [ ] Update Go module dependencies when merged
 
-## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
-- [ ] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
+## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration-Pipeline/build?delay=0sec)
+- [ ] https://jenkins.sgwdev.com/job/SyncGatewayIntegration-Pipeline/0000/
 
 <!--
 Automated review runs on every non-draft PR raised from this repo (forks are not reviewed automatically).

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -199,7 +199,7 @@ pipeline {
                                 echo 'Queueing Integration test for branch "main" ...'
                                 // Queues up an async integration test run using default build params (main branch),
                                 // but waits up to an hour for batches of PR merges before actually running (via quietPeriod)
-                                build job: 'MainIntegration', quietPeriod: 3600, wait: false
+                                build job: 'MainIntegration-Pipeline', quietPeriod: 3600, wait: false
 
                                 echo 'Queueing E2E test runs (rosmar/cbs) for branch "main" ...'
                                 script {

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Sync Gateway Documentation](https://img.shields.io/badge/documentation-current-blue.svg)][SG_DOCS]
 [![GoDoc](https://godoc.org/github.com/couchbase/sync_gateway?status.svg)](https://godoc.org/github.com/couchbase/sync_gateway)
 [![Go Report Card](https://goreportcard.com/badge/github.com/couchbase/sync_gateway)](https://goreportcard.com/report/github.com/couchbase/sync_gateway)
-[![Code Coverage](https://jenkins.sgwdev.com/buildStatus/icon?job=MasterIntegration&subject=coverage&status=${lineCoverage}&color=${colorLineCoverage})](https://jenkins.sgwdev.com/job/MasterIntegration/lastBuild/coverage/)
+[![Code Coverage](https://jenkins.sgwdev.com/buildStatus/icon?job=MainIntegration-Pipeline&subject=coverage&status=${lineCoverage}&color=${colorLineCoverage})](https://jenkins.sgwdev.com/job/MainIntegration-Pipeline/lastBuild/coverage/)
 [![License](https://img.shields.io/badge/license-BSL%201.1-lightgrey)](https://github.com/couchbase/sync_gateway/blob/main/LICENSE)
 
 Sync Gateway is a horizontally scalable web server that securely manages the access control and

--- a/integration-test/MainIntegration/Jenkinsfile
+++ b/integration-test/MainIntegration/Jenkinsfile
@@ -1,0 +1,143 @@
+// Automatically run for every commit to main (within a 1 hour quiet period, see the "Integration" stage
+// in the top-level Jenkinsfile). Coverage takes into account Rosmar and Couchbase Server runs in combination
+// for a complete summary.
+
+// Details block included in every Slack message for this pipeline (see integration-test/slackUtils.groovy).
+// Server version and edition are deliberately absent - see the note on parameters below.
+def slackDetails(slackUtils) {
+    def details = [
+        SG_COMMIT: params.SG_COMMIT,
+        GIT_COMMIT: slackUtils.githubCommitLink(env.GIT_COMMIT),
+    ]
+    def ticketLink = slackUtils.jiraLinkForBranch(params.SG_COMMIT)
+    if (ticketLink) {
+        details['Ticket'] = ticketLink
+    }
+    return details
+}
+
+// Sends the build result to Slack. slackUtils.groovy is fetched in the Checkout stage, so it can be absent
+// if the build failed before that point - fall back to a bare message rather than throwing out of the post
+// block, which would leave the failure unreported entirely.
+// TODO(pre-merge): while the switch-to-pipeline branch is unmerged, every notification goes to a single
+// Slack DM instead of #syncgatewaybot / #syncgatewaybot-alerts, so test runs of this new job don't spam the
+// channels. Before merging, restore channel 'syncgatewaybot' for 'passed', and slackUtils.slackSendFailure()
+// (which DMs the triggering user or escalates to #syncgatewaybot-alerts) for 'unstable'/'build failure'.
+def notifySlack(String status) {
+    def channel = 'U03D1N4373N' // torcolvin, per .github/slack_usernames.yaml
+    def color = ['passed': 'good', 'aborted': 'warning'].get(status, 'danger')
+    if (!fileExists('integration-test/slackUtils.groovy')) {
+        slackSend(channel: channel, color: color, message: ":x: *MainIntegration ${status}* - ${currentBuild.fullDisplayName}\n${env.BUILD_URL}")
+        return
+    }
+    def slackUtils = load('integration-test/slackUtils.groovy')
+    if (status == 'aborted' && slackUtils.isSelfCancelledAdhocBuild()) {
+        echo('Build was started and cancelled by the same user - skipping Slack notification')
+        return
+    }
+    slackSend(channel: channel, color: color, message: slackUtils.slackMessage('MainIntegration', status, env.BUILD_URL, slackDetails(slackUtils)))
+}
+
+pipeline {
+    agent { label 'integration-test' }
+
+    options {
+        skipDefaultCheckout()
+        // A wedged run would otherwise hold one of the two integration-test agents indefinitely.
+        timeout(time: 3, unit: 'HOURS')
+        buildDiscarder(logRotator(daysToKeepStr: '-1', numToKeepStr: '-1', artifactDaysToKeepStr: '30', artifactNumToKeepStr: '30'))
+        githubProjectProperty(projectUrlStr: 'https://github.com/couchbase/sync_gateway/')
+    }
+
+    // Only the two parameters the run actually honours. The -m block in jenkins-integration-build.sh
+    // hardcodes the server version, edition, target test and package, GSI and TLS settings, overwriting
+    // whatever this job sets - change those there, not here, and don't report them in Slack from here.
+    parameters {
+        string(name: 'SG_COMMIT', defaultValue: 'main', description: 'Revision of Sync Gateway to build.')
+        string(name: 'SG_TEST_BUCKET_POOL_SIZE', defaultValue: '4', description: 'Number of buckets created by the test harness.')
+    }
+
+    // TODO(pre-merge): restricts the run to the auth package so this new pipeline can be smoke-tested in
+    // minutes rather than hours. Delete this whole environment block before merging - the full run needs
+    // TARGET_PACKAGE to fall back to "..." (all packages) inside jenkins-integration-build.sh's -m block.
+    environment {
+        TARGET_PACKAGE = 'auth'
+    }
+
+    stages {
+        stage('Checkout') {
+            steps {
+                cleanWs(disableDeferredWipeout: false)
+                script {
+                    // The `git` step only returns GIT_COMMIT rather than populating env, so assign it
+                    // manually for the Slack commit link below. It also has no refspec option, so
+                    // SG_COMMIT must name a branch or tag - a bare SHA won't resolve. Fine for this job;
+                    // integration-test/e2e/Jenkinsfile has the checkout+refspec form if that changes.
+                    def scmVars = git(
+                        url: 'git@github.com:couchbase/sync_gateway.git',
+                        branch: "${params.SG_COMMIT}",
+                        credentialsId: 'CB_SG_Robot_Github_SSH_Key'
+                    )
+                    env.GIT_COMMIT = scmVars.GIT_COMMIT
+                }
+                // SG_COMMIT can in principle be overridden to an arbitrary branch, whose copy of
+                // slackUtils.groovy may be stale or missing helpers the post blocks below need - always
+                // load the current one from main instead (same fix as integration-test/e2e/Jenkinsfile
+                // uses for the same reason).
+                // TODO(pre-merge): temporarily pointed at the switch-to-pipeline branch so test runs pick
+                // up its slackUtils.groovy. This MUST be reverted to main before merging: `curl -sSf` exits
+                // non-zero on a 404, so once the branch is deleted this step - and therefore every build of
+                // this job - fails in Checkout.
+                sh 'curl -sSf https://raw.githubusercontent.com/couchbase/sync_gateway/switch-to-pipeline/integration-test/slackUtils.groovy -o integration-test/slackUtils.groovy'
+            }
+        }
+        stage('Integration Tests') {
+            steps {
+                sshagent(credentials: ['CB_SG_Robot_Github_SSH_Key']) {
+                    script {
+                        // jenkins-integration-build.sh separates test failures (exit 50 -> UNSTABLE) from a
+                        // test setup failure or unrecovered panic (exit 1 -> FAILURE). A plain sh step would
+                        // collapse both into FAILURE, so the unstable post block below would never run.
+                        def exitCode = sh(script: './jenkins-integration-build.sh -m', returnStatus: true)
+                        if (exitCode == 50) {
+                            unstable('At least one integration test failed')
+                        } else if (exitCode != 0) {
+                            error("jenkins-integration-build.sh exited ${exitCode}")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            // Empty archives/results are tolerated so that a failure before the tests produce any output
+            // (checkout, curl, Couchbase Server startup) doesn't throw here, skip the rest of this block,
+            // and mask the real cause.
+            archiveArtifacts artifacts: 'verbose*', allowEmptyArchive: true, fingerprint: false
+            junit testResults: 'verbose*.xml', allowEmptyResults: true
+            recordCoverage(tools: [[parser: 'GO_COV', pattern: 'coverage_*.out']])
+        }
+        success {
+            script {
+                notifySlack('passed')
+            }
+        }
+        unstable {
+            script {
+                notifySlack('unstable')
+            }
+        }
+        failure {
+            script {
+                notifySlack('build failure')
+            }
+        }
+        aborted {
+            script {
+                notifySlack('aborted')
+            }
+        }
+    }
+}

--- a/integration-test/MainIntegration/Jenkinsfile
+++ b/integration-test/MainIntegration/Jenkinsfile
@@ -19,15 +19,10 @@ def slackDetails(slackUtils) {
 // Sends the build result to Slack. slackUtils.groovy is fetched in the Checkout stage, so it can be absent
 // if the build failed before that point - fall back to a bare message rather than throwing out of the post
 // block, which would leave the failure unreported entirely.
-// TODO(pre-merge): while the switch-to-pipeline branch is unmerged, every notification goes to a single
-// Slack DM instead of #syncgatewaybot / #syncgatewaybot-alerts, so test runs of this new job don't spam the
-// channels. Before merging, restore channel 'syncgatewaybot' for 'passed', and slackUtils.slackSendFailure()
-// (which DMs the triggering user or escalates to #syncgatewaybot-alerts) for 'unstable'/'build failure'.
 def notifySlack(String status) {
-    def channel = 'U03D1N4373N' // torcolvin, per .github/slack_usernames.yaml
     def color = ['passed': 'good', 'aborted': 'warning'].get(status, 'danger')
     if (!fileExists('integration-test/slackUtils.groovy')) {
-        slackSend(channel: channel, color: color, message: ":x: *MainIntegration ${status}* - ${currentBuild.fullDisplayName}\n${env.BUILD_URL}")
+        slackSend(channel: 'syncgatewaybot', color: color, message: ":x: *MainIntegration ${status}* - ${currentBuild.fullDisplayName}\n${env.BUILD_URL}")
         return
     }
     def slackUtils = load('integration-test/slackUtils.groovy')
@@ -35,7 +30,13 @@ def notifySlack(String status) {
         echo('Build was started and cancelled by the same user - skipping Slack notification')
         return
     }
-    slackSend(channel: channel, color: color, message: slackUtils.slackMessage('MainIntegration', status, env.BUILD_URL, slackDetails(slackUtils)))
+    // Only a genuine failure goes through slackSendFailure(), which DMs the triggering user or escalates
+    // to #syncgatewaybot-alerts. An abort nobody chose is still worth recording, but not escalating.
+    if (status == 'unstable' || status == 'build failure') {
+        slackUtils.slackSendFailure('MainIntegration', status, env.BUILD_URL, slackDetails(slackUtils))
+        return
+    }
+    slackSend(channel: 'syncgatewaybot', color: color, message: slackUtils.slackMessage('MainIntegration', status, env.BUILD_URL, slackDetails(slackUtils)))
 }
 
 pipeline {
@@ -55,13 +56,6 @@ pipeline {
     parameters {
         string(name: 'SG_COMMIT', defaultValue: 'main', description: 'Revision of Sync Gateway to build.')
         string(name: 'SG_TEST_BUCKET_POOL_SIZE', defaultValue: '4', description: 'Number of buckets created by the test harness.')
-    }
-
-    // TODO(pre-merge): restricts the run to the auth package so this new pipeline can be smoke-tested in
-    // minutes rather than hours. Delete this whole environment block before merging - the full run needs
-    // TARGET_PACKAGE to fall back to "..." (all packages) inside jenkins-integration-build.sh's -m block.
-    environment {
-        TARGET_PACKAGE = 'auth'
     }
 
     stages {
@@ -84,11 +78,7 @@ pipeline {
                 // slackUtils.groovy may be stale or missing helpers the post blocks below need - always
                 // load the current one from main instead (same fix as integration-test/e2e/Jenkinsfile
                 // uses for the same reason).
-                // TODO(pre-merge): temporarily pointed at the switch-to-pipeline branch so test runs pick
-                // up its slackUtils.groovy. This MUST be reverted to main before merging: `curl -sSf` exits
-                // non-zero on a 404, so once the branch is deleted this step - and therefore every build of
-                // this job - fails in Checkout.
-                sh 'curl -sSf https://raw.githubusercontent.com/couchbase/sync_gateway/switch-to-pipeline/integration-test/slackUtils.groovy -o integration-test/slackUtils.groovy'
+                sh 'curl -sSf https://raw.githubusercontent.com/couchbase/sync_gateway/main/integration-test/slackUtils.groovy -o integration-test/slackUtils.groovy'
             }
         }
         stage('Integration Tests') {

--- a/integration-test/SyncGatewayIntegration/Jenkinsfile
+++ b/integration-test/SyncGatewayIntegration/Jenkinsfile
@@ -126,7 +126,7 @@ To use pre-release versions, find the number on https://github.com/orgs/cb-vanil
         booleanParam(
             name: 'TLS_SKIP_VERIFY',
             defaultValue: true,
-            description: 'Do not verify certificates when talking to Couchbase Server. This only has an effect if COUCHBASE_SERVER_PROTOCOL is set to couchbases://'
+            description: 'Do not verify certificates when talking to Couchbase Server. This only has an effect if COUCHBASE_SERVER_PROTOCOL is set to couchbases.'
         )
         string(name: 'PARENT_JOB_NAME', defaultValue: '', description: 'If set, uses this in some build names as a helpful indication of what triggered this job.')
     }

--- a/integration-test/SyncGatewayIntegration/Jenkinsfile
+++ b/integration-test/SyncGatewayIntegration/Jenkinsfile
@@ -166,7 +166,8 @@ To use pre-release versions, find the number on https://github.com/orgs/cb-vanil
                     // "<branch> for <whoever triggered it> on <server version>". PARENT_JOB_NAME is only
                     // set for an upstream-triggered build and the build user only for a manual one, so at
                     // most one of the two is present and the space between them collapses when it isn't.
-                    def buildUser = currentBuild.getBuildCauses('hudson.model.Cause$UserIdCause').collect { it.userId }[0] ?: ''
+                    def userIdCauses = currentBuild.getBuildCauses('hudson.model.Cause$UserIdCause')
+                    def buildUser = userIdCauses ? (userIdCauses[0].userId ?: '') : ''
                     def parentJobName = params.PARENT_JOB_NAME ? (params.PARENT_JOB_NAME - ~/:\s*$/) : ''
                     def triggeredBy = [parentJobName, buildUser].findAll { it }.join(' ')
                     currentBuild.displayName = params.PARENT_JOB_NAME ? "#${env.BUILD_NUMBER} ${params.PARENT_JOB_NAME}" : "#${env.BUILD_NUMBER}"

--- a/integration-test/SyncGatewayIntegration/Jenkinsfile
+++ b/integration-test/SyncGatewayIntegration/Jenkinsfile
@@ -1,0 +1,246 @@
+// Intended to be run adhoc by developers against arbitrary commits/branches. Coverage is recorded but is
+// not especially meaningful here, unlike MainIntegration which combines Rosmar + Couchbase Server runs.
+
+// Note for whoever creates this job: its *first* build runs with no parameter values at all. Jenkins
+// registers the parameters{} block when it first evaluates this file, but only applies the defaults from the
+// second build onwards, so that first run dies in jenkins-integration-build.sh's REQUIRED_VARS check with
+// "COUCHBASE_SERVER_PROTOCOL environment variable is required to be set". Just run it again - it isn't a
+// misconfiguration.
+
+// Details block included in every Slack message for this pipeline (see integration-test/slackUtils.groovy).
+def slackDetails(slackUtils) {
+    def details = [
+        SG_COMMIT: params.SG_COMMIT,
+        GIT_COMMIT: slackUtils.githubCommitLink(env.GIT_COMMIT),
+        COUCHBASE_SERVER_VERSION: params.COUCHBASE_SERVER_VERSION,
+    ]
+    def ticketLink = slackUtils.jiraLinkForBranch(params.SG_COMMIT)
+    if (ticketLink) {
+        details['Ticket'] = ticketLink
+    }
+    return details
+}
+
+// Sends the build result to Slack. slackUtils.groovy is fetched in the Checkout stage, so it can be absent
+// if the build failed before that point - fall back to a bare message rather than throwing out of the post
+// block, which would leave the failure unreported entirely.
+// TODO(pre-merge): while the switch-to-pipeline branch is unmerged, every notification goes to a single
+// Slack DM instead of #syncgatewaybot / #syncgatewaybot-alerts, so test runs of this new job don't spam the
+// channels. Before merging, restore channel 'syncgatewaybot' for 'passed', and slackUtils.slackSendFailure()
+// (which DMs the triggering user or escalates to #syncgatewaybot-alerts) for 'unstable'/'build failure'.
+def notifySlack(String status) {
+    def channel = 'U03D1N4373N' // torcolvin, per .github/slack_usernames.yaml
+    def color = ['passed': 'good', 'aborted': 'warning'].get(status, 'danger')
+    if (!fileExists('integration-test/slackUtils.groovy')) {
+        slackSend(channel: channel, color: color, message: ":x: *SyncGatewayIntegration ${status}* - ${currentBuild.fullDisplayName}\n${env.BUILD_URL}")
+        return
+    }
+    def slackUtils = load('integration-test/slackUtils.groovy')
+    if (status == 'aborted' && slackUtils.isSelfCancelledAdhocBuild()) {
+        echo('Build was started and cancelled by the same user - skipping Slack notification')
+        return
+    }
+    slackSend(channel: channel, color: color, message: slackUtils.slackMessage('SyncGatewayIntegration', status, env.BUILD_URL, slackDetails(slackUtils)))
+}
+
+// Posts the sgw-jenkins-integration-test status that shows up on PRs: PENDING once the commit is known,
+// then SUCCESS, FAILURE for unstable, or ERROR. An aborted run reports ERROR too - GitHub has no cancelled
+// state, and staying quiet would strand the pending status on that commit forever. Account, repo and sha
+// are passed explicitly because githubNotify can't reliably infer them from an explicit checkout.
+def notifyGitHub(String status) {
+    if (!env.GIT_COMMIT) {
+        echo('No GIT_COMMIT captured (checkout failed) - skipping GitHub commit status')
+        return
+    }
+    githubNotify(
+        credentialsId: 'github_cb-robot-sg_access_token',
+        account: 'couchbase',
+        repo: 'sync_gateway',
+        sha: env.GIT_COMMIT,
+        context: 'sgw-jenkins-integration-test',
+        description: "Integration tests ${status}",
+        status: ['running': 'PENDING', 'passed': 'SUCCESS', 'unstable': 'FAILURE'].get(status, 'ERROR')
+    )
+}
+
+pipeline {
+    agent { label 'integration-test' }
+
+    options {
+        skipDefaultCheckout()
+        // A wedged run would otherwise hold one of the two integration-test agents indefinitely.
+        timeout(time: 3, unit: 'HOURS')
+        // Deliberately asymmetric with MainIntegration/TopologyTests: this job caps build records and keeps
+        // artifacts by age, they cap artifacts and keep records. Not an oversight.
+        buildDiscarder(logRotator(daysToKeepStr: '-1', numToKeepStr: '30', artifactDaysToKeepStr: '30', artifactNumToKeepStr: '-1'))
+        githubProjectProperty(projectUrlStr: 'https://github.com/couchbase/sync_gateway/')
+    }
+
+    parameters {
+        string(name: 'SG_COMMIT', defaultValue: 'main', description: 'Revision of Sync Gateway to build.')
+        // TODO(pre-merge): default restricted to the auth package so this new pipeline can be smoke-tested
+        // in minutes rather than hours. Restore defaultValue: '...' (all packages) before merging.
+        string(name: 'TARGET_PACKAGE', defaultValue: 'auth', description: '')
+        string(
+            name: 'COUCHBASE_SERVER_VERSION',
+            defaultValue: 'enterprise-8.0.2',
+            description: '''Version of couchbase server to run with. This is docker images:
+enterprise-7.6.7 : couchbase/server:enterprise-7.6.7
+community-7.6.7 : couchbase/server:community-7.6.7
+To use pre-release versions, find the number on https://github.com/orgs/cb-vanilla/packages/container/package/server and use ghcr.io/cb-vanilla/server:enterprise-8.1.0'''
+        )
+        choice(
+            name: 'COUCHBASE_SERVER_PROTOCOL',
+            choices: ['couchbase', 'couchbases'],
+            description: 'Use couchbase to connect to Couchbase Server without TLS and couchbases to connect with TLS.'
+        )
+        booleanParam(name: 'FAIL_FAST', defaultValue: false, description: 'If checked, run go test with -failfast to fail as soon as a test fails.')
+        booleanParam(name: 'GSI', defaultValue: true, description: 'Run tests with GSI. Uncheck this box to run tests with views.')
+        booleanParam(name: 'DISABLE_REV_CACHE', defaultValue: false, description: 'If set integration test will run without rev cache enabled. ')
+        choice(
+            name: 'SG_EDITION',
+            choices: ['EE', 'CE'],
+            description: 'Version of Sync Gateway to run. EE - Enterprise Edition CE - Community Edition'
+        )
+        string(name: 'SG_TEST_BUCKET_POOL_SIZE', defaultValue: '4', description: 'Number of buckets to create in by the test harness.')
+        string(name: 'RUN_COUNT', defaultValue: '', description: 'Adds -count <n> parameter to test runs. Default is not specified.')
+        // jenkins-integration-build.sh reads RUN_WALRUS unconditionally under `set -u`, so it has to be set.
+        // Declaring it here is enough: Jenkins exposes parameters as environment variables.
+        booleanParam(name: 'RUN_WALRUS', defaultValue: false, description: 'Run rosmar tests in addition to the Couchbase Server tests.')
+        booleanParam(name: 'SG_TEST_BUCKET_POOL_DEBUG', defaultValue: false, description: 'This will log the test bucket pool creation and cleanup.')
+        booleanParam(
+            name: 'SG_TEST_SKIP_SERVER_VERSION_CHECK',
+            defaultValue: false,
+            description: 'allows tests to run against a server version that is not presumed compatible with version of Couchbase Server running'
+        )
+        string(
+            name: 'TARGET_TEST',
+            defaultValue: 'ALL',
+            description: 'This should be ALL to run all tests but can be any expression used by the go test -run option to run specific tests.'
+        )
+        booleanParam(
+            name: 'TEST_DEBUG',
+            defaultValue: false,
+            description: 'If true, sets SG_TEST_LOG_LEVEL=debug and SG_TEST_BUCKET_POOL_DEBUG=true. This can be used to force all tests to use debug logging and overwrite SetUpTestLogging as well as debug bucket pool issues.'
+        )
+        booleanParam(
+            name: 'TLS_SKIP_VERIFY',
+            defaultValue: true,
+            description: 'Do not verify certificates when talking to Couchbase Server. This only has an effect if COUCHBASE_SERVER_PROTOCOL is set to couchbases://'
+        )
+        string(name: 'PARENT_JOB_NAME', defaultValue: '', description: 'If set, uses this in some build names as a helpful indication of what triggered this job.')
+    }
+
+    stages {
+        stage('Checkout') {
+            steps {
+                cleanWs(disableDeferredWipeout: true)
+                script {
+                    // checkout only returns GIT_COMMIT/GIT_BRANCH rather than populating env, so assign
+                    // them manually for later stages and post blocks. SG_COMMIT is frequently a bare SHA
+                    // for this job, and the build chooser only resolves a branch spec against existing
+                    // remote-tracking refs - hence the refspec, which fetches it into a ref of that name.
+                    def scmVars = checkout(scmGit(
+                        branches: [[name: params.SG_COMMIT]],
+                        extensions: [cleanBeforeCheckout(deleteUntrackedNestedRepositories: false)],
+                        userRemoteConfigs: [[
+                            url: 'git@github.com:couchbase/sync_gateway.git',
+                            credentialsId: 'CB_SG_Robot_Github_SSH_Key',
+                            refspec: "+${params.SG_COMMIT}:refs/remotes/origin/${params.SG_COMMIT}"
+                        ]]
+                    ))
+                    env.GIT_COMMIT = scmVars.GIT_COMMIT
+                    env.GIT_BRANCH = scmVars.GIT_BRANCH
+                    // Posted here rather than before the checkout, since the commit status needs a SHA.
+                    notifyGitHub('running')
+                }
+                // SG_COMMIT can be an arbitrary developer branch, whose copy of slackUtils.groovy may be
+                // stale or missing helpers the post blocks below need - always load the current one from
+                // main instead (same fix as integration-test/e2e/Jenkinsfile uses for the same reason).
+                // TODO(pre-merge): temporarily pointed at the switch-to-pipeline branch so test runs pick
+                // up its slackUtils.groovy. This MUST be reverted to main before merging: `curl -sSf` exits
+                // non-zero on a 404, so once the branch is deleted this step - and therefore every build of
+                // this job - fails in Checkout.
+                sh 'curl -sSf https://raw.githubusercontent.com/couchbase/sync_gateway/switch-to-pipeline/integration-test/slackUtils.groovy -o integration-test/slackUtils.groovy'
+                script {
+                    // "<branch> for <whoever triggered it> on <server version>". PARENT_JOB_NAME is only
+                    // set for an upstream-triggered build and the build user only for a manual one, so at
+                    // most one of the two is present and the space between them collapses when it isn't.
+                    def buildUser = currentBuild.getBuildCauses('hudson.model.Cause$UserIdCause').collect { it.userId }[0] ?: ''
+                    def parentJobName = params.PARENT_JOB_NAME ? (params.PARENT_JOB_NAME - ~/:\s*$/) : ''
+                    def triggeredBy = [parentJobName, buildUser].findAll { it }.join(' ')
+                    currentBuild.displayName = params.PARENT_JOB_NAME ? "#${env.BUILD_NUMBER} ${params.PARENT_JOB_NAME}" : "#${env.BUILD_NUMBER}"
+                    currentBuild.description = "${env.GIT_BRANCH} for ${triggeredBy} on ${params.COUCHBASE_SERVER_VERSION}"
+                }
+            }
+        }
+        stage('Integration Tests') {
+            steps {
+                sshagent(credentials: ['CB_SG_Robot_Github_SSH_Key']) {
+                    withCredentials([usernamePassword(credentialsId: 'github_ghcr_pat', usernameVariable: 'GHCR_USER', passwordVariable: 'GHCR_TOKEN')]) {
+                        script {
+                            // `set -e` propagates jenkins-integration-build.sh's exit status, which separates
+                            // test failures (50 -> UNSTABLE) from a test setup failure or unrecovered panic
+                            // (1 -> FAILURE). A plain sh step would collapse both into FAILURE, so the
+                            // unstable post block below would never run.
+                            def exitCode = sh(returnStatus: true, script: '''#!/bin/bash
+                                set -eu
+                                echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+                                # ensure any image tag being used is up to date before running
+                                IMAGE=${COUCHBASE_SERVER_VERSION}
+                                if [[ ! "${COUCHBASE_SERVER_VERSION}" =~ ^ghcr\\.io/ ]]; then
+                                    IMAGE="couchbase/server:${COUCHBASE_SERVER_VERSION}"
+                                fi
+                                docker pull "$IMAGE"
+                                ./jenkins-integration-build.sh
+                            ''')
+                            if (exitCode == 50) {
+                                unstable('At least one integration test failed')
+                            } else if (exitCode != 0) {
+                                error("Integration test run exited ${exitCode}")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            // Empty archives/results are tolerated so that a failure before the tests produce any output
+            // (checkout, curl, docker login/pull, Couchbase Server startup) doesn't throw here, skip the
+            // rest of this block, and mask the real cause.
+            archiveArtifacts artifacts: 'verbose*.out', allowEmptyArchive: true, fingerprint: false
+            junit testResults: 'verbose*.xml', allowEmptyResults: true, checksName: 'sgw-jenkins-integration-test-junit'
+            // Gives the coverage report a baseline to diff against. Must come before recordCoverage, as
+            // in the top-level Jenkinsfile.
+            discoverGitReferenceBuild(referenceJob: 'MainIntegration-Pipeline', maxCommits: 50)
+            recordCoverage(tools: [[parser: 'GO_COV', pattern: 'coverage*.out']])
+        }
+        success {
+            script {
+                notifyGitHub('passed')
+                notifySlack('passed')
+            }
+        }
+        unstable {
+            script {
+                notifyGitHub('unstable')
+                notifySlack('unstable')
+            }
+        }
+        failure {
+            script {
+                notifyGitHub('build failure')
+                notifySlack('build failure')
+            }
+        }
+        aborted {
+            script {
+                notifyGitHub('aborted')
+                notifySlack('aborted')
+            }
+        }
+    }
+}

--- a/integration-test/SyncGatewayIntegration/Jenkinsfile
+++ b/integration-test/SyncGatewayIntegration/Jenkinsfile
@@ -24,15 +24,10 @@ def slackDetails(slackUtils) {
 // Sends the build result to Slack. slackUtils.groovy is fetched in the Checkout stage, so it can be absent
 // if the build failed before that point - fall back to a bare message rather than throwing out of the post
 // block, which would leave the failure unreported entirely.
-// TODO(pre-merge): while the switch-to-pipeline branch is unmerged, every notification goes to a single
-// Slack DM instead of #syncgatewaybot / #syncgatewaybot-alerts, so test runs of this new job don't spam the
-// channels. Before merging, restore channel 'syncgatewaybot' for 'passed', and slackUtils.slackSendFailure()
-// (which DMs the triggering user or escalates to #syncgatewaybot-alerts) for 'unstable'/'build failure'.
 def notifySlack(String status) {
-    def channel = 'U03D1N4373N' // torcolvin, per .github/slack_usernames.yaml
     def color = ['passed': 'good', 'aborted': 'warning'].get(status, 'danger')
     if (!fileExists('integration-test/slackUtils.groovy')) {
-        slackSend(channel: channel, color: color, message: ":x: *SyncGatewayIntegration ${status}* - ${currentBuild.fullDisplayName}\n${env.BUILD_URL}")
+        slackSend(channel: 'syncgatewaybot', color: color, message: ":x: *SyncGatewayIntegration ${status}* - ${currentBuild.fullDisplayName}\n${env.BUILD_URL}")
         return
     }
     def slackUtils = load('integration-test/slackUtils.groovy')
@@ -40,7 +35,13 @@ def notifySlack(String status) {
         echo('Build was started and cancelled by the same user - skipping Slack notification')
         return
     }
-    slackSend(channel: channel, color: color, message: slackUtils.slackMessage('SyncGatewayIntegration', status, env.BUILD_URL, slackDetails(slackUtils)))
+    // Only a genuine failure goes through slackSendFailure(), which DMs the triggering user or escalates
+    // to #syncgatewaybot-alerts. An abort nobody chose is still worth recording, but not escalating.
+    if (status == 'unstable' || status == 'build failure') {
+        slackUtils.slackSendFailure('SyncGatewayIntegration', status, env.BUILD_URL, slackDetails(slackUtils))
+        return
+    }
+    slackSend(channel: 'syncgatewaybot', color: color, message: slackUtils.slackMessage('SyncGatewayIntegration', status, env.BUILD_URL, slackDetails(slackUtils)))
 }
 
 // Posts the sgw-jenkins-integration-test status that shows up on PRs: PENDING once the commit is known,
@@ -78,9 +79,7 @@ pipeline {
 
     parameters {
         string(name: 'SG_COMMIT', defaultValue: 'main', description: 'Revision of Sync Gateway to build.')
-        // TODO(pre-merge): default restricted to the auth package so this new pipeline can be smoke-tested
-        // in minutes rather than hours. Restore defaultValue: '...' (all packages) before merging.
-        string(name: 'TARGET_PACKAGE', defaultValue: 'auth', description: '')
+        string(name: 'TARGET_PACKAGE', defaultValue: '...', description: '')
         string(
             name: 'COUCHBASE_SERVER_VERSION',
             defaultValue: 'enterprise-8.0.2',
@@ -157,11 +156,7 @@ To use pre-release versions, find the number on https://github.com/orgs/cb-vanil
                 // SG_COMMIT can be an arbitrary developer branch, whose copy of slackUtils.groovy may be
                 // stale or missing helpers the post blocks below need - always load the current one from
                 // main instead (same fix as integration-test/e2e/Jenkinsfile uses for the same reason).
-                // TODO(pre-merge): temporarily pointed at the switch-to-pipeline branch so test runs pick
-                // up its slackUtils.groovy. This MUST be reverted to main before merging: `curl -sSf` exits
-                // non-zero on a 404, so once the branch is deleted this step - and therefore every build of
-                // this job - fails in Checkout.
-                sh 'curl -sSf https://raw.githubusercontent.com/couchbase/sync_gateway/switch-to-pipeline/integration-test/slackUtils.groovy -o integration-test/slackUtils.groovy'
+                sh 'curl -sSf https://raw.githubusercontent.com/couchbase/sync_gateway/main/integration-test/slackUtils.groovy -o integration-test/slackUtils.groovy'
                 script {
                     // "<branch> for <whoever triggered it> on <server version>". PARENT_JOB_NAME is only
                     // set for an upstream-triggered build and the build user only for a manual one, so at

--- a/integration-test/TopologyTests/Jenkinsfile
+++ b/integration-test/TopologyTests/Jenkinsfile
@@ -1,0 +1,160 @@
+// Runs topologytests, which exercise real XDCR and Couchbase Lite. They are slow enough that it's
+// worth splitting out from MainIntegration; this job fires after every MainIntegration build (success
+// or failure) via the upstream trigger below.
+
+// Note for whoever creates this job: its *first* build runs with no parameter values at all. Jenkins
+// registers the parameters{} block when it first evaluates this file, but only applies the defaults from the
+// second build onwards, so that first run dies in jenkins-integration-build.sh's REQUIRED_VARS check with
+// "COUCHBASE_SERVER_PROTOCOL environment variable is required to be set". Just run it again - it isn't a
+// misconfiguration.
+
+// Details block included in every Slack message for this pipeline (see integration-test/slackUtils.groovy).
+def slackDetails(slackUtils) {
+    def details = [
+        SG_COMMIT: params.SG_COMMIT,
+        GIT_COMMIT: slackUtils.githubCommitLink(env.GIT_COMMIT),
+        COUCHBASE_SERVER_VERSION: params.COUCHBASE_SERVER_VERSION,
+    ]
+    def ticketLink = slackUtils.jiraLinkForBranch(params.SG_COMMIT)
+    if (ticketLink) {
+        details['Ticket'] = ticketLink
+    }
+    return details
+}
+
+// Sends the build result to Slack. slackUtils.groovy is fetched in the Checkout stage, so it can be absent
+// if the build failed before that point - fall back to a bare message rather than throwing out of the post
+// block, which would leave the failure unreported entirely.
+// TODO(pre-merge): while the switch-to-pipeline branch is unmerged, every notification goes to a single
+// Slack DM instead of #syncgatewaybot / #syncgatewaybot-alerts, so test runs of this new job don't spam the
+// channels. Before merging, restore channel 'syncgatewaybot' for 'passed', and slackUtils.slackSendFailure()
+// (which DMs the triggering user or escalates to #syncgatewaybot-alerts) for 'unstable'/'build failure'.
+def notifySlack(String status) {
+    def channel = 'U03D1N4373N' // torcolvin, per .github/slack_usernames.yaml
+    def color = ['passed': 'good', 'aborted': 'warning'].get(status, 'danger')
+    if (!fileExists('integration-test/slackUtils.groovy')) {
+        slackSend(channel: channel, color: color, message: ":x: *TopologyTests ${status}* - ${currentBuild.fullDisplayName}\n${env.BUILD_URL}")
+        return
+    }
+    def slackUtils = load('integration-test/slackUtils.groovy')
+    if (status == 'aborted' && slackUtils.isSelfCancelledAdhocBuild()) {
+        echo('Build was started and cancelled by the same user - skipping Slack notification')
+        return
+    }
+    slackSend(channel: channel, color: color, message: slackUtils.slackMessage('TopologyTests', status, env.BUILD_URL, slackDetails(slackUtils)))
+}
+
+pipeline {
+    agent { label 'integration-test' }
+
+    options {
+        skipDefaultCheckout()
+        // A wedged run would otherwise hold one of the two integration-test agents indefinitely.
+        timeout(time: 3, unit: 'HOURS')
+        buildDiscarder(logRotator(daysToKeepStr: '90', numToKeepStr: '-1', artifactDaysToKeepStr: '30', artifactNumToKeepStr: '30'))
+        githubProjectProperty(projectUrlStr: 'https://github.com/couchbase/sync_gateway/')
+    }
+
+    triggers {
+        // Fires after every completed MainIntegration-Pipeline build (threshold FAILURE = SUCCESS,
+        // UNSTABLE, or FAILURE), i.e. anything except ABORTED/NOT_BUILT.
+        upstream(upstreamProjects: 'MainIntegration-Pipeline', threshold: hudson.model.Result.FAILURE)
+    }
+
+    parameters {
+        string(name: 'SG_COMMIT', defaultValue: 'main', description: 'Revision of Sync Gateway to build.')
+        string(name: 'COUCHBASE_SERVER_VERSION', defaultValue: 'enterprise-7.6.7', description: '')
+        booleanParam(name: 'GSI', defaultValue: true, description: '')
+        string(name: 'TARGET_TEST', defaultValue: 'ALL', description: '')
+        string(name: 'COUCHBASE_SERVER_PROTOCOL', defaultValue: 'couchbase', description: '')
+        booleanParam(name: 'TLS_SKIP_VERIFY', defaultValue: true, description: '')
+        string(name: 'SG_EDITION', defaultValue: 'EE', description: '')
+        string(name: 'SG_TEST_BUCKET_POOL_SIZE', defaultValue: '4', description: '')
+        booleanParam(name: 'SG_TEST_BUCKET_POOL_DEBUG', defaultValue: false, description: '')
+    }
+
+    environment {
+        // jenkins-integration-build.sh reads RUN_WALRUS unconditionally under `set -u`, so it has to be
+        // set even though this job never runs the Rosmar leg.
+        RUN_WALRUS = 'false'
+        // TODO(pre-merge): temporarily the auth package rather than topologytest, so this new pipeline can be
+        // smoke-tested in minutes rather than hours. Restore 'topologytest' before merging.
+        TARGET_PACKAGE = 'auth'
+        SG_TEST_TOPOLOGY_TESTS = 'true'
+    }
+
+    stages {
+        stage('Checkout') {
+            steps {
+                cleanWs(disableDeferredWipeout: false)
+                script {
+                    // The `git` step only returns GIT_COMMIT rather than populating env, so assign it
+                    // manually for the Slack commit link below. It also has no refspec option, so
+                    // SG_COMMIT must name a branch or tag - a bare SHA won't resolve. Fine for this job;
+                    // integration-test/e2e/Jenkinsfile has the checkout+refspec form if that changes.
+                    def scmVars = git(
+                        url: 'git@github.com:couchbase/sync_gateway.git',
+                        branch: "${params.SG_COMMIT}",
+                        credentialsId: 'CB_SG_Robot_Github_SSH_Key'
+                    )
+                    env.GIT_COMMIT = scmVars.GIT_COMMIT
+                }
+                // SG_COMMIT can be an arbitrary developer branch, whose copy of slackUtils.groovy may be
+                // stale or missing helpers the post blocks below need - always load the current one from
+                // main instead (same fix as integration-test/e2e/Jenkinsfile uses for the same reason).
+                // TODO(pre-merge): temporarily pointed at the switch-to-pipeline branch so test runs pick
+                // up its slackUtils.groovy. This MUST be reverted to main before merging: `curl -sSf` exits
+                // non-zero on a 404, so once the branch is deleted this step - and therefore every build of
+                // this job - fails in Checkout.
+                sh 'curl -sSf https://raw.githubusercontent.com/couchbase/sync_gateway/switch-to-pipeline/integration-test/slackUtils.groovy -o integration-test/slackUtils.groovy'
+            }
+        }
+        stage('Integration Tests') {
+            steps {
+                sshagent(credentials: ['CB_SG_Robot_Github_SSH_Key']) {
+                    script {
+                        // jenkins-integration-build.sh separates test failures (exit 50 -> UNSTABLE) from a
+                        // test setup failure or unrecovered panic (exit 1 -> FAILURE). A plain sh step would
+                        // collapse both into FAILURE, so the unstable post block below would never run.
+                        def exitCode = sh(script: './jenkins-integration-build.sh', returnStatus: true)
+                        if (exitCode == 50) {
+                            unstable('At least one topology test failed')
+                        } else if (exitCode != 0) {
+                            error("jenkins-integration-build.sh exited ${exitCode}")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            // Empty archives/results are tolerated so that a failure before the tests produce any output
+            // (checkout, curl, Couchbase Server startup) doesn't throw here, skip the rest of this block,
+            // and mask the real cause.
+            archiveArtifacts artifacts: 'verbose*', allowEmptyArchive: true, fingerprint: false
+            junit testResults: 'verbose*.xml', allowEmptyResults: true
+        }
+        success {
+            script {
+                notifySlack('passed')
+            }
+        }
+        unstable {
+            script {
+                notifySlack('unstable')
+            }
+        }
+        failure {
+            script {
+                notifySlack('build failure')
+            }
+        }
+        aborted {
+            script {
+                notifySlack('aborted')
+            }
+        }
+    }
+}

--- a/integration-test/TopologyTests/Jenkinsfile
+++ b/integration-test/TopologyTests/Jenkinsfile
@@ -25,15 +25,10 @@ def slackDetails(slackUtils) {
 // Sends the build result to Slack. slackUtils.groovy is fetched in the Checkout stage, so it can be absent
 // if the build failed before that point - fall back to a bare message rather than throwing out of the post
 // block, which would leave the failure unreported entirely.
-// TODO(pre-merge): while the switch-to-pipeline branch is unmerged, every notification goes to a single
-// Slack DM instead of #syncgatewaybot / #syncgatewaybot-alerts, so test runs of this new job don't spam the
-// channels. Before merging, restore channel 'syncgatewaybot' for 'passed', and slackUtils.slackSendFailure()
-// (which DMs the triggering user or escalates to #syncgatewaybot-alerts) for 'unstable'/'build failure'.
 def notifySlack(String status) {
-    def channel = 'U03D1N4373N' // torcolvin, per .github/slack_usernames.yaml
     def color = ['passed': 'good', 'aborted': 'warning'].get(status, 'danger')
     if (!fileExists('integration-test/slackUtils.groovy')) {
-        slackSend(channel: channel, color: color, message: ":x: *TopologyTests ${status}* - ${currentBuild.fullDisplayName}\n${env.BUILD_URL}")
+        slackSend(channel: 'syncgatewaybot', color: color, message: ":x: *TopologyTests ${status}* - ${currentBuild.fullDisplayName}\n${env.BUILD_URL}")
         return
     }
     def slackUtils = load('integration-test/slackUtils.groovy')
@@ -41,7 +36,13 @@ def notifySlack(String status) {
         echo('Build was started and cancelled by the same user - skipping Slack notification')
         return
     }
-    slackSend(channel: channel, color: color, message: slackUtils.slackMessage('TopologyTests', status, env.BUILD_URL, slackDetails(slackUtils)))
+    // Only a genuine failure goes through slackSendFailure(), which DMs the triggering user or escalates
+    // to #syncgatewaybot-alerts. An abort nobody chose is still worth recording, but not escalating.
+    if (status == 'unstable' || status == 'build failure') {
+        slackUtils.slackSendFailure('TopologyTests', status, env.BUILD_URL, slackDetails(slackUtils))
+        return
+    }
+    slackSend(channel: 'syncgatewaybot', color: color, message: slackUtils.slackMessage('TopologyTests', status, env.BUILD_URL, slackDetails(slackUtils)))
 }
 
 pipeline {
@@ -77,9 +78,7 @@ pipeline {
         // jenkins-integration-build.sh reads RUN_WALRUS unconditionally under `set -u`, so it has to be
         // set even though this job never runs the Rosmar leg.
         RUN_WALRUS = 'false'
-        // TODO(pre-merge): temporarily the auth package rather than topologytest, so this new pipeline can be
-        // smoke-tested in minutes rather than hours. Restore 'topologytest' before merging.
-        TARGET_PACKAGE = 'auth'
+        TARGET_PACKAGE = 'topologytest'
         SG_TEST_TOPOLOGY_TESTS = 'true'
     }
 
@@ -102,11 +101,7 @@ pipeline {
                 // SG_COMMIT can be an arbitrary developer branch, whose copy of slackUtils.groovy may be
                 // stale or missing helpers the post blocks below need - always load the current one from
                 // main instead (same fix as integration-test/e2e/Jenkinsfile uses for the same reason).
-                // TODO(pre-merge): temporarily pointed at the switch-to-pipeline branch so test runs pick
-                // up its slackUtils.groovy. This MUST be reverted to main before merging: `curl -sSf` exits
-                // non-zero on a 404, so once the branch is deleted this step - and therefore every build of
-                // this job - fails in Checkout.
-                sh 'curl -sSf https://raw.githubusercontent.com/couchbase/sync_gateway/switch-to-pipeline/integration-test/slackUtils.groovy -o integration-test/slackUtils.groovy'
+                sh 'curl -sSf https://raw.githubusercontent.com/couchbase/sync_gateway/main/integration-test/slackUtils.groovy -o integration-test/slackUtils.groovy'
             }
         }
         stage('Integration Tests') {

--- a/integration-test/slackUtils.groovy
+++ b/integration-test/slackUtils.groovy
@@ -33,7 +33,7 @@ def testSummary() {
 // (insertion order preserved, so pass a LinkedHashMap / map literal), the JUnit test summary, and
 // a trailing link.
 def slackMessage(String title, String status, String link, Map details = [:]) {
-    def emoji = status == 'passed' ? ':white_check_mark:' : ':x:'
+    def emoji = ['passed': ':white_check_mark:', 'aborted': ':no_entry_sign:'].get(status, ':x:')
     def lines = ["${emoji} *${title} ${status}* — ${currentBuild.fullDisplayName}"]
     if (details) {
         lines << ''
@@ -61,6 +61,29 @@ def refLink(String ref) {
     return "<https://github.com/couchbase/sync_gateway/commit/${ref}|${ref}>"
 }
 
+// Formats a commit SHA as a Slack link to its GitHub commit page, showing the short SHA as the
+// link text. Returns 'n/a' if commit is null/empty (e.g. GIT_COMMIT wasn't captured).
+def githubCommitLink(String commit) {
+    if (!commit) {
+        return 'n/a'
+    }
+    return "<https://github.com/couchbase/sync_gateway/commit/${commit}|${commit.take(8)}>"
+}
+
+// Looks for a CBG-<digits> ticket reference (e.g. from a branch name like 'torcolvin/CBG-1234-fix')
+// and formats it as a Slack link to the corresponding Jira issue. Returns null if no match is found.
+def jiraLinkForBranch(String branch) {
+    if (!branch) {
+        return null
+    }
+    def matcher = (branch =~ /(?i)CBG-(\d+)/)
+    if (!matcher.find()) {
+        return null
+    }
+    def ticket = "CBG-${matcher.group(1)}"
+    return "<https://jira.issues.couchbase.com/browse/${ticket}|${ticket}>"
+}
+
 // Looks up the Slack member ID of whoever manually triggered this build in the UI, via
 // .github/slack_usernames.yaml (Jenkins usernames are identical to GitHub usernames in this org).
 // Returns null for non-user-triggered builds (e.g. an automatic fan-out from an upstream job,
@@ -83,6 +106,19 @@ def slackUserIdForBuild() {
         return null
     }
     return slackUserId
+}
+
+// Returns true if this build was both started by a user and then interrupted by a user - i.e. somebody
+// kicked off an adhoc run and cancelled it themselves, so there is nobody who needs telling. An abort with
+// any other cause (agent lost, timeout, an automated build cancelled by the system) returns false, since
+// nobody chose that and it's worth reporting.
+def isSelfCancelledAdhocBuild() {
+    if (!currentBuild.getBuildCauses('hudson.model.Cause$UserIdCause')) {
+        return false
+    }
+    return currentBuild.rawBuild.getActions(jenkins.model.InterruptedBuildAction).any { action ->
+        action.causes.any { it instanceof jenkins.model.CauseOfInterruption.UserInterruption }
+    }
 }
 
 // Returns true if this build is for a pull request, which Jenkins signals by setting CHANGE_ID.

--- a/jenkins-integration-build.sh
+++ b/jenkins-integration-build.sh
@@ -15,7 +15,9 @@ set -e # Abort on errors
 if [ "${1:-}" == "-m" ]; then
     echo "Running in automated master integration mode"
     # Set automated setting parameters
-    TARGET_PACKAGE="..."
+    # TODO(pre-merge): TARGET_PACKAGE is honoured if already set, so the MainIntegration pipeline can be
+    # smoke-tested against a single package. Restore the unconditional TARGET_PACKAGE="..." before merging.
+    TARGET_PACKAGE="${TARGET_PACKAGE:-...}"
     TARGET_TEST="ALL"
     RUN_WALRUS="true"
     DETECT_RACES="false"

--- a/jenkins-integration-build.sh
+++ b/jenkins-integration-build.sh
@@ -15,9 +15,7 @@ set -e # Abort on errors
 if [ "${1:-}" == "-m" ]; then
     echo "Running in automated master integration mode"
     # Set automated setting parameters
-    # TODO(pre-merge): TARGET_PACKAGE is honoured if already set, so the MainIntegration pipeline can be
-    # smoke-tested against a single package. Restore the unconditional TARGET_PACKAGE="..." before merging.
-    TARGET_PACKAGE="${TARGET_PACKAGE:-...}"
+    TARGET_PACKAGE="..."
     TARGET_TEST="ALL"
     RUN_WALRUS="true"
     DETECT_RACES="false"

--- a/jenkins/update-git-docs-tag/Jenkinsfile
+++ b/jenkins/update-git-docs-tag/Jenkinsfile
@@ -1,0 +1,79 @@
+// Moves one of the *-docs tags (3.2-docs, 4.0-docs, ...) onto the tip of a release branch, so the docs
+// site picks up that branch's API specs. The tag has to exist already - this job only moves an existing
+// one, by deleting it locally and remotely and recreating it at the new commit.
+
+pipeline {
+    // Any agent will do - this is a handful of git commands, not a build.
+    agent any
+
+    options {
+        skipDefaultCheckout()
+        // Two runs racing to delete and recreate the same tag would be a bad time.
+        disableConcurrentBuilds()
+        githubProjectProperty(projectUrlStr: 'https://github.com/couchbase/sync_gateway/')
+    }
+
+    parameters {
+        string(
+            name: 'BRANCH',
+            defaultValue: '',
+            trim: true,
+            description: '''This is the branch to tag. This is typically the latest release branch, like:
+
+release/3.2.6
+release/4.0.0'''
+        )
+        // Populated from the repository's existing tags by the git-parameter plugin, newest first.
+        gitParameter(
+            name: 'TAG',
+            type: 'PT_TAG',
+            tagFilter: '*-docs',
+            branchFilter: '.*',
+            sortMode: 'DESCENDING_SMART',
+            selectedValue: 'NONE',
+            defaultValue: '',
+            quickFilterEnabled: true,
+            listSize: '0',
+            requiredParameter: true,
+            description: 'The tag to apply. If you need a new tag, this must be done manually (for now).'
+        )
+    }
+
+    stages {
+        stage('Checkout') {
+            steps {
+                // Checking BRANCH out here means a typo'd branch name fails immediately, rather than
+                // part-way through the tag juggling below.
+                checkout(scmGit(
+                    branches: [[name: params.BRANCH]],
+                    userRemoteConfigs: [[
+                        url: 'git@github.com:couchbase/sync_gateway.git',
+                        credentialsId: 'CB_SG_Robot_Github_SSH_Key'
+                    ]]
+                ))
+                script {
+                    // Which tag moved where is the only thing worth knowing when reading this job's history.
+                    currentBuild.displayName = "#${env.BUILD_NUMBER} ${params.TAG} -> ${params.BRANCH}"
+                }
+            }
+        }
+        stage('Move tag') {
+            steps {
+                sshagent(credentials: ['CB_SG_Robot_Github_SSH_Key']) {
+                    // Both deletes are load-bearing under `set -e`: if TAG doesn't already exist locally
+                    // and remotely this fails rather than creating it, which is what the TAG parameter's
+                    // description means by "this must be done manually (for now)".
+                    sh '''#!/bin/bash
+                        set -eux -o pipefail
+
+                        git fetch --tags
+                        git tag -d "${TAG}"
+                        git push --delete origin "${TAG}"
+                        git tag "${TAG}"
+                        git push origin "${TAG}"
+                    '''
+                }
+            }
+        }
+    }
+}

--- a/jenkins/update-git-docs-tag/Jenkinsfile
+++ b/jenkins/update-git-docs-tag/Jenkinsfile
@@ -42,6 +42,13 @@ release/4.0.0'''
     stages {
         stage('Checkout') {
             steps {
+                // An empty BRANCH is not a checkout failure - the git plugin treats it as "any branch"
+                // and would move the tag onto an arbitrary commit - so reject it before checking out.
+                script {
+                    if (!params.BRANCH || !params.TAG) {
+                        error('BRANCH and TAG are both required.')
+                    }
+                }
                 // Checking BRANCH out here means a typo'd branch name fails immediately, rather than
                 // part-way through the tag juggling below.
                 checkout(scmGit(


### PR DESCRIPTION
CBG-5647: Convert the integration test jobs from Jenkins freestyle to pipeline

Replaces the MainIntegration, SyncGatewayIntegration and TopologyTests freestyle jobs with Jenkinsfiles in this repo, so the definitions are reviewable and versioned with the code they test. Also converts update-git-docs-tag, and points the top-level Jenkinsfile's Integration stage at MainIntegration-Pipeline.

Written from the freestyle definitions with help of cluade, then checked two ways: a review of the diff, and an element-by-element comparison against each job's live config.xml.

The review found:

- that test failures were being reported as build failures (jenkins-integration-build.sh exits 50 for a test failure and 1 for a setup failure, but a plain sh step collapses both into FAILURE)
- a bare SHA in SG_COMMIT wouldn't check out
- that an early failure threw in archiveArtifacts and again while loading slackUtils.groovy

The config.xml comparison found dropped behaviour:

- SyncGatewayIntegration's GitHub commit status, coverage reference build and named JUnit check, plus aborted builds going unreported. It also confirmed the asymmetric build discarder settings and MainIntegration's missing build description were faithful, so they stayed.

Beyond parity: a pending GitHub status at the start of a run, a 3 hour timeout, no per-job `tools { go }` block (the build script installs the go.mod toolchain itself), and the workspace is no longer wiped afterwards since it is wiped at the start.

## Testing 

Real builds on jenkins.sgwdev.com, with the jobs pointed at this branch:

  - SyncGatewayIntegration #8-#10 green on the auth package. #11 UNSTABLE against a throwaway branch carrying a deliberately failing test - 1 of 347 failed, commit status FAILURE. That path had never worked.
  - MainIntegration #1 a full run: 20798 tests, 0 failed, 125 min, both Rosmar and Couchbase Server legs, coverage recorded. #2 the same job on auth only: 1038 tests, 6 min.
  - TopologyTests #2 failed on its first build (see below), usefully exercising the exit 1 -> FAILURE path and confirming the build still reports to Slack rather than dying in post.always. #3 green.

Not exercised: the aborted post block and its self-cancelled-build suppression.


### Changes to make before merge

Several hacks are in place that need to be removed before merging. `grep -rn 'TODO(pre-merge)'` finds all ten markers.

- [ ] Undo the auth-package restriction: jenkins-integration-build.sh back to TARGET_PACKAGE="..."; delete MainIntegration's environment block; SyncGatewayIntegration's TARGET_PACKAGE default back to '...'; TopologyTests back to 'topologytest'.
- [ ] Repoint the slackUtils.groovy curl from /switch-to-pipeline/ to /main/ in all three. Load-bearing: curl -sSf exits non-zero on a 404, so every build fails at Checkout once the branch is gone.
- [ ] Restore the Slack channels in notifySlack(): 'syncgatewaybot' for passed, slackUtils.slackSendFailure() for unstable and build failure. Decide 'aborted' separately - it postdates those markers, and slackSendFailure() would escalate an aborted automated run to #syncgatewaybot-alerts.
- [ ] Point the three -Pipeline jobs' SCM branch back at main. Recorded only in Jenkins, not here.
- [ ] Retire the three freestyle jobs; until then both they and the pipeline jobs write the sgw-jenkins-integration-test commit status.

The first build of each new job runs with no parameter values, since Jenkins applies parameters{} defaults only from the second build onwards, so SyncGatewayIntegration and TopologyTests will fail it in the REQUIRED_VARS check. Just run them again.

