### PR TITLE
[3.3.8 Backport] CBG-5409: don't respond with Set-Cookie for one_time session

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,22 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ !contains(github.ref, 'release/') && !contains(github.ref, 'main') }}
 
+env:
+  # Pinned action versions, referenced by the steps below through their YAML anchors.
+  ACTIONS_CHECKOUT_VERSION: &actions_checkout_version actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+  ACTIONS_CHECKOUT_V5_VERSION: &actions_checkout_v5_version actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+  ACTIONS_SETUP_GO_VERSION: &actions_setup_go_version actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+  ACTIONS_GOLANGCI_LINT_VERSION: &actions_golangci_lint_version golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7
+  ACTIONS_GO_TEST_ANNOTATIONS_VERSION: &actions_go_test_annotations_version guyarb/golang-test-annotations@2941118d7ef622b1b3771d1ff6eae9e90659eb26 # v0.8.0
+  ACTIONS_RUFF_VERSION: &actions_ruff_version astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3
+  ACTIONS_SETUP_UV_VERSION: &actions_setup_uv_version astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: *actions_checkout_version
+      - uses: *actions_setup_go_version
         with:
           go-version: 1.24.4
       - name: go-build
@@ -44,8 +54,8 @@ jobs:
     name: addlicense
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: *actions_checkout_version
+      - uses: *actions_setup_go_version
         with:
           go-version: 1.24.4
       - run: go install github.com/google/addlicense@latest
@@ -55,12 +65,12 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: *actions_checkout_version
+      - uses: *actions_setup_go_version
         with:
           go-version: 1.24.4
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: *actions_golangci_lint_version
         with:
           version: v2.0.2
           args: --config=.golangci-strict.yml
@@ -82,8 +92,8 @@ jobs:
       MallocNanoZone: 0
     name: test (${{ matrix.name }})
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: *actions_checkout_version
+      - uses: *actions_setup_go_version
         with:
           go-version: 1.24.4
       - name: Build
@@ -93,7 +103,7 @@ jobs:
         shell: bash
       - name: Annotate Failures
         if: always()
-        uses: guyarb/golang-test-annotations@v0.8.0
+        uses: *actions_go_test_annotations_version
         with:
           test-results: test.json
 
@@ -102,8 +112,8 @@ jobs:
     env:
       GOPRIVATE: github.com/couchbaselabs
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: *actions_checkout_version
+      - uses: *actions_setup_go_version
         with:
           go-version: 1.24.4
       - name: Run Tests
@@ -111,7 +121,7 @@ jobs:
         shell: bash
       - name: Annotate Failures
         if: always()
-        uses: guyarb/golang-test-annotations@v0.8.0
+        uses: *actions_go_test_annotations_version
         with:
           test-results: test.json
 
@@ -121,8 +131,8 @@ jobs:
       GOPRIVATE: github.com/couchbaselabs
       SG_TEST_USE_DEFAULT_COLLECTION: true
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: *actions_checkout_version
+      - uses: *actions_setup_go_version
         with:
           go-version: 1.24.4
       - name: Run Tests
@@ -130,7 +140,7 @@ jobs:
         shell: bash
       - name: Annotate Failures
         if: always()
-        uses: guyarb/golang-test-annotations@v0.8.0
+        uses: *actions_go_test_annotations_version
         with:
           test-results: test.json
 
@@ -140,8 +150,8 @@ jobs:
       GOPRIVATE: github.com/couchbaselabs
       SG_TEST_USE_XATTRS: false
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: *actions_checkout_version
+      - uses: *actions_setup_go_version
         with:
           go-version: 1.24.4
       - name: Run Tests
@@ -149,22 +159,22 @@ jobs:
         shell: bash
       - name: Annotate Failures
         if: always()
-        uses: guyarb/golang-test-annotations@v0.8.0
+        uses: *actions_go_test_annotations_version
         with:
           test-results: test.json
 
   python-format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v3
+      - uses: *actions_checkout_version
+      - uses: *actions_ruff_version
         with:
           args: 'format --check'
   python-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v3
+      - uses: *actions_checkout_version
+      - uses: *actions_ruff_version
   test-sgcollect:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -172,8 +182,8 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
     steps:
-      - uses: actions/checkout@v5
-      - uses: astral-sh/setup-uv@v7
+      - uses: *actions_checkout_v5_version
+      - uses: *actions_setup_uv_version
       - name: Run test
         run: |
           uv run -- pytest
@@ -188,8 +198,8 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: *actions_checkout_version
+      - uses: *actions_setup_go_version
         with:
           go-version: 1.24.4
       - name: Build
@@ -201,8 +211,8 @@ jobs:
     runs-on: ubuntu-latest
     name: build cache perf tool
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: *actions_checkout_version
+      - uses: *actions_setup_go_version
         with:
           go-version: 1.24.4
       - name: Build

--- a/.github/workflows/openapi-pr.yml
+++ b/.github/workflows/openapi-pr.yml
@@ -23,19 +23,24 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ !contains(github.ref, 'release/')}}
 
+env:
+  # Pinned action versions, referenced by the steps below through their YAML anchors.
+  ACTIONS_FIND_COMMENT_VERSION: &actions_find_comment_version peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3
+  ACTIONS_CREATE_OR_UPDATE_COMMENT_VERSION: &actions_create_or_update_comment_version peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
+
 jobs:
   redocly_preview_links:
     runs-on: ubuntu-latest
     steps:
       - name: Find Comment
-        uses: peter-evans/find-comment@v3
+        uses: *actions_find_comment_version
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
           body-includes: Redocly previews
       - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: *actions_create_or_update_comment_version
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -36,14 +36,21 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ !contains(github.ref, 'release/')}}
 
+env:
+  # Pinned action versions, referenced by the steps below through their YAML anchors.
+  ACTIONS_CHECKOUT_VERSION: &actions_checkout_version actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+  ACTIONS_REDOCLY_PROBLEM_MATCHERS_VERSION: &actions_redocly_problem_matchers_version r7kamura/redocly-problem-matchers@3b6f82af579316596ff52f605498423b2a69e483 # v1
+  ACTIONS_REDOC_LINT_VERSION: &actions_redoc_lint_version mhiew/redoc-lint-github-action@1b3526395495e5c1346ebb81a67813aee757e86b # v4
+  ACTIONS_YAMLLINT_VERSION: &actions_yamllint_version karancode/yamllint-github-action@4052d365f09b8d34eb552c363d1141fd60e2aeb2 # master
+
 jobs:
   api_validation:
     runs-on: ubuntu-latest
     name: OpenAPI Validation
     steps:
-      - uses: actions/checkout@v4
-      - uses: r7kamura/redocly-problem-matchers@v1
-      - uses: mhiew/redoc-lint-github-action@v4
+      - uses: *actions_checkout_version
+      - uses: *actions_redocly_problem_matchers_version
+      - uses: *actions_redoc_lint_version
         with:
           args: '--format stylish'
         env:
@@ -53,7 +60,7 @@ jobs:
     name: 'yamllint'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: karancode/yamllint-github-action@master
+      - uses: *actions_checkout_version
+      - uses: *actions_yamllint_version
         with:
           yamllint_file_or_dir: 'docs/api'

--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -35,14 +35,19 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ !contains(github.ref, 'release/')}}
 
+env:
+  # Pinned action versions, referenced by the steps below through their YAML anchors.
+  ACTIONS_CHECKOUT_VERSION: &actions_checkout_version actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+  ACTIONS_SETUP_GO_VERSION: &actions_setup_go_version actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+
 jobs:
   scripts:
     runs-on: ubuntu-latest
     name: Verify service script installation.
     steps:
-      - uses: actions/checkout@v4
+      - uses: *actions_checkout_version
       # build sync gateway since the executable is needed for service installation
-      - uses: actions/setup-go@v5
+      - uses: *actions_setup_go_version
         with:
           go-version: 1.23.3
       - name: "Build Sync Gateway"

--- a/auth/session.go
+++ b/auth/session.go
@@ -58,7 +58,8 @@ func (auth *Authenticator) AuthenticateCookie(rq *http.Request, response http.Re
 	// SessionTimeElapsed and tenPercentOfTtl use Nanoseconds for more precision when converting to int
 	sessionTimeElapsed := int((time.Now().Add(duration).Sub(session.Expiration)).Nanoseconds())
 	tenPercentOfTtl := int(duration.Nanoseconds()) / 10
-	if sessionTimeElapsed > tenPercentOfTtl {
+	// One-time sessions must not refresh the cookie — they will be deleted on this request.
+	if sessionTimeElapsed > tenPercentOfTtl && (session.OneTime == nil || !*session.OneTime) {
 		session.Expiration = time.Now().Add(duration)
 		if err = auth.datastore.Set(auth.DocIDForSession(session.ID), base.DurationToCbsExpiry(duration), nil, session); err != nil {
 			return nil, err

--- a/auth/session_test.go
+++ b/auth/session_test.go
@@ -367,6 +367,90 @@ func TestUserDeleteAllSessions(t *testing.T) {
 	require.EqualError(t, err, "401 Session no longer valid for user")
 }
 
+// TestAuthenticateCookieOneTimeSession verifies one-time session behaviour in AuthenticateCookie:
+//   - The session is consumed on first use and rejected on the second.
+//   - No Set-Cookie header is ever written, including when the normal TTL-refresh branch would
+//     fire for a regular session (sessionTimeElapsed > 10% of TTL).
+func TestAuthenticateCookieOneTimeSession(t *testing.T) {
+	ctx := base.TestCtx(t)
+	testBucket := base.GetTestBucket(t)
+	defer testBucket.Close(ctx)
+	dataStore := testBucket.GetSingleDataStore()
+	a := NewTestAuthenticator(t, dataStore, nil, DefaultAuthenticatorOptions(ctx))
+
+	const username = "Alice"
+	user, err := a.NewUser(username, "password", base.Set{})
+	require.NoError(t, err)
+	require.NoError(t, a.Save(user))
+
+	t.Run("one-time session authenticates once then is deleted", func(t *testing.T) {
+		session, err := a.CreateSession(ctx, user, 2*time.Hour, true)
+		require.NoError(t, err)
+
+		req, err := http.NewRequest(http.MethodGet, "", nil)
+		require.NoError(t, err)
+		req.AddCookie(a.MakeSessionCookie(session, false, false, http.SameSiteDefaultMode))
+
+		authedUser, err := a.AuthenticateCookie(req, httptest.NewRecorder())
+		require.NoError(t, err)
+		require.NotNil(t, authedUser)
+		assert.Equal(t, username, authedUser.Name())
+
+		_, err = a.AuthenticateCookie(req, httptest.NewRecorder())
+		require.Error(t, err)
+		assert.Equal(t, http.StatusUnauthorized, err.(*base.HTTPError).Status)
+	})
+
+	t.Run("one-time session does not set cookie even when TTL refresh would trigger", func(t *testing.T) {
+		// Expiration=now+2h with Ttl=24h means sessionTimeElapsed≈22h > tenPercentOfTtl≈2.4h,
+		// so a regular session would call http.SetCookie here — a one-time session must not.
+		oneTime := true
+		sessionID, err := base.GenerateRandomSecret()
+		require.NoError(t, err)
+		session := &LoginSession{
+			ID:          sessionID,
+			Username:    username,
+			Expiration:  time.Now().Add(2 * time.Hour),
+			Ttl:         24 * time.Hour,
+			SessionUUID: user.GetSessionUUID(),
+			OneTime:     &oneTime,
+		}
+		require.NoError(t, dataStore.Set(a.DocIDForSession(sessionID), base.DurationToCbsExpiry(24*time.Hour), nil, session))
+
+		req, err := http.NewRequest(http.MethodGet, "", nil)
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: a.SessionCookieName, Value: sessionID})
+		recorder := httptest.NewRecorder()
+		authedUser, err := a.AuthenticateCookie(req, recorder)
+		require.NoError(t, err)
+		require.NotNil(t, authedUser)
+		assert.Empty(t, recorder.Header().Get("Set-Cookie"), "one-time session must not set a cookie even when TTL refresh would trigger")
+	})
+
+	t.Run("regular session refreshes cookie when TTL threshold met", func(t *testing.T) {
+		// Same setup without OneTime — the refresh branch should fire and Set-Cookie should be present.
+		sessionID, err := base.GenerateRandomSecret()
+		require.NoError(t, err)
+		session := &LoginSession{
+			ID:          sessionID,
+			Username:    username,
+			Expiration:  time.Now().Add(2 * time.Hour),
+			Ttl:         24 * time.Hour,
+			SessionUUID: user.GetSessionUUID(),
+		}
+		require.NoError(t, dataStore.Set(a.DocIDForSession(sessionID), base.DurationToCbsExpiry(24*time.Hour), nil, session))
+
+		req, err := http.NewRequest(http.MethodGet, "", nil)
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: a.SessionCookieName, Value: sessionID})
+		recorder := httptest.NewRecorder()
+		authedUser, err := a.AuthenticateCookie(req, recorder)
+		require.NoError(t, err)
+		require.NotNil(t, authedUser)
+		assert.NotEmpty(t, recorder.Header().Get("Set-Cookie"), "regular session should refresh cookie when TTL threshold is met")
+	})
+}
+
 func TestCreateOneTimeSession(t *testing.T) {
 	ctx := base.TestCtx(t)
 	testBucket := base.GetTestBucket(t)

--- a/docs/api/paths/public/db-_session.yaml
+++ b/docs/api/paths/public/db-_session.yaml
@@ -26,7 +26,7 @@ post:
     If `Origin` header is passed to this endpoint, the `Origin` header must match both the `cors.login_origin` and `cors.origin` configuration options.
   parameters:
     - name: one_time
-      description: Sets the session to only be valid for a single authentication. This session will expire in 5 minutes if not used.
+      description: Sets the session to only be valid for a single authentication. This session will expire in 5 minutes if not used. If this is set the session cookie is only returned in the response body, and not the header.
       in: query
       schema:
         type: boolean

--- a/rest/blip_sync_test.go
+++ b/rest/blip_sync_test.go
@@ -117,6 +117,7 @@ func TestOneTimeSessionBlipSyncAuthentication(t *testing.T) {
 		secWebSocketProtocolHeader: blipSessionIDPrefix + sessionResp.SessionID,
 	})
 	RequireStatus(t, resp, http.StatusUpgradeRequired)
+	assert.Empty(t, resp.Header().Get("Set-Cookie"), "one-time session auth must not set a session cookie")
 
 	// one time token is expired
 	resp = rt.SendRequestWithHeaders(http.MethodGet, "/{{.db}}/_blipsync", "", map[string]string{

--- a/rest/session_api.go
+++ b/rest/session_api.go
@@ -150,9 +150,11 @@ func (h *handler) makeSessionWithTTL(user auth.User, expiry time.Duration, oneTi
 	if err != nil {
 		return "", err
 	}
-	cookie := auth.MakeSessionCookie(session, h.db.Options.SecureCookieOverride, h.db.Options.SessionCookieHttpOnly, h.db.SameSiteCookieMode)
-	base.AddDbPathToCookie(h.rq, cookie)
-	http.SetCookie(h.response, cookie)
+	if !oneTime {
+		cookie := auth.MakeSessionCookie(session, h.db.Options.SecureCookieOverride, h.db.Options.SessionCookieHttpOnly, h.db.SameSiteCookieMode)
+		base.AddDbPathToCookie(h.rq, cookie)
+		http.SetCookie(h.response, cookie)
+	}
 	return session.ID, nil
 }
 

--- a/rest/session_test.go
+++ b/rest/session_test.go
@@ -753,6 +753,49 @@ func TestSessionExpirationDateTimeFormat(t *testing.T) {
 	assert.True(t, expires.Sub(time.Now()).Hours() <= 24, "Couldn't validate session expiration")
 }
 
+// TestSessionCreationCookieBehavior verifies that POST /_session sets a cookie for regular sessions
+// and does not set a cookie for one-time sessions (whose ID is delivered via the JSON body instead).
+func TestSessionCreationCookieBehavior(t *testing.T) {
+	rt := NewRestTesterPersistentConfig(t)
+	defer rt.Close()
+
+	username := "alice"
+	rt.CreateUser(username, []string{"*"})
+
+	dbName := rt.GetDatabase().Name
+
+	t.Run("regular session sets cookie", func(t *testing.T) {
+		resp := rt.SendUserRequest(http.MethodPost, "/{{.db}}/_session", "", username)
+		RequireStatus(t, resp, http.StatusOK)
+
+		cookie, err := http.ParseSetCookie(resp.Header().Get("Set-Cookie"))
+		require.NoError(t, err)
+		assert.Equal(t, auth.DefaultCookieName, cookie.Name)
+		assert.NotEmpty(t, cookie.Value)
+		assert.Equal(t, "/"+dbName, cookie.Path)
+		assert.True(t, cookie.Expires.After(time.Now()), "cookie expiration should be in the future")
+
+		var body struct {
+			OneTimeSessionID string `json:"one_time_session_id"`
+		}
+		require.NoError(t, base.JSONUnmarshal(resp.BodyBytes(), &body))
+		assert.Empty(t, body.OneTimeSessionID, "regular session response must not include one_time_session_id")
+	})
+
+	t.Run("one-time session sets no cookie", func(t *testing.T) {
+		resp := rt.SendUserRequest(http.MethodPost, "/{{.db}}/_session?one_time=true", "", username)
+		RequireStatus(t, resp, http.StatusOK)
+
+		assert.Empty(t, resp.Header().Get("Set-Cookie"), "one-time session creation must not set a cookie")
+
+		var body struct {
+			OneTimeSessionID string `json:"one_time_session_id"`
+		}
+		require.NoError(t, base.JSONUnmarshal(resp.BodyBytes(), &body))
+		assert.NotEmpty(t, body.OneTimeSessionID, "one-time session response must include one_time_session_id")
+	})
+}
+
 func TestOneTimeSessionWithCookie(t *testing.T) {
 	rt := NewRestTesterPersistentConfig(t)
 	defer rt.Close()
@@ -762,9 +805,16 @@ func TestOneTimeSessionWithCookie(t *testing.T) {
 
 	resp := rt.SendUserRequest(http.MethodPost, "/{{.db}}/_session?one_time=true", "", username)
 	RequireStatus(t, resp, http.StatusOK)
+	assert.Empty(t, resp.Header().Get("Set-Cookie"), "one-time session creation must not set a cookie")
+
+	var sessionResp struct {
+		SessionID string `json:"one_time_session_id"`
+	}
+	require.NoError(t, base.JSONUnmarshal(resp.BodyBytes(), &sessionResp))
+	require.NotEmpty(t, sessionResp.SessionID)
 
 	headers := map[string]string{
-		"Cookie": resp.Header().Get("Set-Cookie"),
+		"Cookie": auth.DefaultCookieName + "=" + sessionResp.SessionID,
 	}
 
 	resp = rt.SendRequestWithHeaders(http.MethodGet, "/{{.db}}/", "", headers)

--- a/tools-tests/password_remover_test.py
+++ b/tools-tests/password_remover_test.py
@@ -81,7 +81,6 @@ class TestRemovePasswords(unittest.TestCase):
         """
         with_passwords_removed = password_remover.remove_passwords(db_config)
         assert "foobar" not in with_passwords_removed
-        pass
 
     def test_non_parseable_config(self):
         """
@@ -201,8 +200,8 @@ class TestConvertToValidJSON(unittest.TestCase):
             parsed_json = json.loads(valid_json)
             json.dumps(parsed_json, indent=4)
             got_exception = False
-        except Exception as e:
-            print("Exception: {0}".format(e))
+        except Exception as e:  # noqa: BLE001
+            print(f"Exception: {e}")
 
         assert got_exception is False, "Failed to convert to valid JSON"
 
@@ -266,8 +265,8 @@ class TestConvertToValidJSON(unittest.TestCase):
             parsed_json = json.loads(valid_json)
             json.dumps(parsed_json, indent=4)
             got_exception = False
-        except Exception as e:
-            print("Exception: {0}".format(e))
+        except Exception as e:  # noqa: BLE001
+            print(f"Exception: {e}")
 
         assert got_exception is False, "Failed to convert to valid JSON"
 

--- a/tools-tests/sgcollect_info_test.py
+++ b/tools-tests/sgcollect_info_test.py
@@ -11,7 +11,6 @@ import os
 import pathlib
 import unittest.mock
 import urllib.error
-from typing import Optional
 
 import pytest
 import sgcollect
@@ -54,9 +53,7 @@ def test_make_collect_logs_heap_profile(tmpdir):
     with unittest.mock.patch(
         "sgcollect.urlopen",
         return_value=io.BytesIO(
-            '{{"logfilepath": "{logpath}"}}'.format(
-                logpath=normalize_path_for_json(tmpdir),
-            ).encode("utf-8")
+            f'{{"logfilepath": "{normalize_path_for_json(tmpdir)}"}}'.encode()
         ),
     ):
         pprof_file = tmpdir.join("pprof_heap_high_01.pb.gz")
@@ -100,8 +97,8 @@ def test_make_collect_logs_tasks_duplicate_files(should_redact, tmp_path):
             auth_headers={},
         )
         # assert all tasks have unique log_file names
-        assert len(set(t.log_file for t in tasks)) == len(tasks)
-        assert set(t.log_file for t in tasks) == {
+        assert len({t.log_file for t in tasks}) == len(tasks)
+        assert {t.log_file for t in tasks} == {
             "sg_info.log",
             "sg_info.log.1",
             "sg_info-01.log.gz",
@@ -154,8 +151,8 @@ def test_get_paths_from_expvars_no_url() -> None:
 )
 def test_get_paths_from_expvars(
     expvar_output: bytes,
-    expected_sg_path: Optional[str],
-    expected_config_path: Optional[str],
+    expected_sg_path: str | None,
+    expected_config_path: str | None,
     tmpdir: pathlib.Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -350,17 +347,19 @@ def test_get_auth_headers() -> None:
         }
         # Is the right behavior to ignore empty username, in the case that admin auth is disabled?
         assert sgcollect.get_auth_headers(username="") == {}
-    with unittest.mock.patch.dict("os.environ", {"SG_USERNAME": "envusername"}):
-        with unittest.mock.patch(
+    with (
+        unittest.mock.patch.dict("os.environ", {"SG_USERNAME": "envusername"}),
+        unittest.mock.patch(
             "getpass.getpass", return_value="stdinpassword", autospec=True
-        ):
-            assert sgcollect.get_auth_headers(username="") == {
-                "Authorization": sgcollect.get_basic_authorization_header(
-                    "envusername", "stdinpassword"
-                )
-            }
-            assert sgcollect.get_auth_headers(username="cmdlineusername") == {
-                "Authorization": sgcollect.get_basic_authorization_header(
-                    "cmdlineusername", "stdinpassword"
-                )
-            }
+        ),
+    ):
+        assert sgcollect.get_auth_headers(username="") == {
+            "Authorization": sgcollect.get_basic_authorization_header(
+                "envusername", "stdinpassword"
+            )
+        }
+        assert sgcollect.get_auth_headers(username="cmdlineusername") == {
+            "Authorization": sgcollect.get_basic_authorization_header(
+                "cmdlineusername", "stdinpassword"
+            )
+        }

--- a/tools-tests/tasks_test.py
+++ b/tools-tests/tasks_test.py
@@ -235,5 +235,6 @@ def test_log_redact_file(tmp_path):
     ]
     updated_text = os.linesep.join(output_log_lines).encode("utf-8")
 
-    redacted_text = gzip.open(redacted_file).read()
+    with gzip.open(redacted_file) as f:
+        redacted_text = f.read()
     assert redacted_text == updated_text

--- a/tools-tests/upload_test.py
+++ b/tools-tests/upload_test.py
@@ -81,11 +81,13 @@ class FakeFailureUrlOpener:
 @pytest.mark.usefixtures("main_norun")
 @pytest.mark.parametrize("args", [[], ["--log-redaction-level", "none"]])
 def test_main_output_exists(args, taskrunner_workdir):
-    with pytest.raises(SystemExit, check=lambda e: e.code == 0):
-        with unittest.mock.patch(
+    with (
+        pytest.raises(SystemExit, check=lambda e: e.code == 0),
+        unittest.mock.patch(
             "sys.argv", ["sg_collect", *args, "--tmp-dir", taskrunner_workdir, ZIP_NAME]
-        ):
-            sgcollect.main()
+        ),
+    ):
+        sgcollect.main()
     assert pathlib.Path(ZIP_NAME).exists()
     assert not pathlib.Path(REDACTED_ZIP_NAME).exists()
     assert not [x for x in taskrunner_workdir.iterdir()]
@@ -93,8 +95,9 @@ def test_main_output_exists(args, taskrunner_workdir):
 
 @pytest.mark.usefixtures("main_norun_redacted_zip")
 def test_main_output_exists_with_redacted(taskrunner_workdir):
-    with pytest.raises(SystemExit, check=lambda e: e.code == 0):
-        with unittest.mock.patch(
+    with (
+        pytest.raises(SystemExit, check=lambda e: e.code == 0),
+        unittest.mock.patch(
             "sys.argv",
             [
                 "sg_collect",
@@ -104,8 +107,9 @@ def test_main_output_exists_with_redacted(taskrunner_workdir):
                 taskrunner_workdir,
                 ZIP_NAME,
             ],
-        ):
-            sgcollect.main()
+        ),
+    ):
+        sgcollect.main()
     assert pathlib.Path(ZIP_NAME).exists()
     assert pathlib.Path(REDACTED_ZIP_NAME).exists()
     assert not [x for x in taskrunner_workdir.iterdir()]
@@ -114,8 +118,9 @@ def test_main_output_exists_with_redacted(taskrunner_workdir):
 @pytest.mark.usefixtures("main_norun")
 @pytest.mark.parametrize("args", [[], ["--log-redaction-level", "none"]])
 def test_main_zip_deleted_on_upload_success(args, taskrunner_workdir):
-    with unittest.mock.patch("tasks.urllib.request.build_opener", FakeSuccessUrlOpener):
-        with unittest.mock.patch(
+    with (
+        unittest.mock.patch("tasks.urllib.request.build_opener", FakeSuccessUrlOpener),
+        unittest.mock.patch(
             "sys.argv",
             [
                 "sg_collect",
@@ -128,10 +133,11 @@ def test_main_zip_deleted_on_upload_success(args, taskrunner_workdir):
                 taskrunner_workdir,
                 ZIP_NAME,
             ],
-        ):
-            with pytest.raises(SystemExit) as exc:
-                sgcollect.main()
-            assert exc.value.code == 0
+        ),
+    ):
+        with pytest.raises(SystemExit) as exc:
+            sgcollect.main()
+        assert exc.value.code == 0
     assert not pathlib.Path(ZIP_NAME).exists()
     assert not pathlib.Path(REDACTED_ZIP_NAME).exists()
     assert not [x for x in taskrunner_workdir.iterdir()]
@@ -140,8 +146,9 @@ def test_main_zip_deleted_on_upload_success(args, taskrunner_workdir):
 @pytest.mark.usefixtures("main_norun")
 @pytest.mark.parametrize("args", [[], ["--log-redaction-level", "none"]])
 def test_main_zip_deleted_on_upload_failure(args, taskrunner_workdir):
-    with unittest.mock.patch("tasks.urllib.request.build_opener", FakeFailureUrlOpener):
-        with unittest.mock.patch(
+    with (
+        unittest.mock.patch("tasks.urllib.request.build_opener", FakeFailureUrlOpener),
+        unittest.mock.patch(
             "sys.argv",
             [
                 "sg_collect",
@@ -152,10 +159,11 @@ def test_main_zip_deleted_on_upload_failure(args, taskrunner_workdir):
                 "fakeCustomer",
                 ZIP_NAME,
             ],
-        ):
-            with pytest.raises(SystemExit) as exc:
-                sgcollect.main()
-            assert exc.value.code == 1
+        ),
+    ):
+        with pytest.raises(SystemExit) as exc:
+            sgcollect.main()
+        assert exc.value.code == 1
     assert not pathlib.Path(ZIP_NAME).exists()
     assert not pathlib.Path(REDACTED_ZIP_NAME).exists()
     assert not [x for x in taskrunner_workdir.iterdir()]
@@ -163,8 +171,9 @@ def test_main_zip_deleted_on_upload_failure(args, taskrunner_workdir):
 
 @pytest.mark.usefixtures("main_norun_redacted_zip")
 def test_main_redacted_zip_deleted_on_upload_success(taskrunner_workdir):
-    with unittest.mock.patch("tasks.urllib.request.build_opener", FakeSuccessUrlOpener):
-        with unittest.mock.patch(
+    with (
+        unittest.mock.patch("tasks.urllib.request.build_opener", FakeSuccessUrlOpener),
+        unittest.mock.patch(
             "sys.argv",
             [
                 "sg_collect",
@@ -178,10 +187,11 @@ def test_main_redacted_zip_deleted_on_upload_success(taskrunner_workdir):
                 taskrunner_workdir,
                 ZIP_NAME,
             ],
-        ):
-            with pytest.raises(SystemExit) as exc:
-                sgcollect.main()
-            assert exc.value.code == 0
+        ),
+    ):
+        with pytest.raises(SystemExit) as exc:
+            sgcollect.main()
+        assert exc.value.code == 0
     assert not pathlib.Path(ZIP_NAME).exists()
     assert not pathlib.Path(REDACTED_ZIP_NAME).exists()
     assert not [x for x in taskrunner_workdir.iterdir()]
@@ -189,8 +199,9 @@ def test_main_redacted_zip_deleted_on_upload_success(taskrunner_workdir):
 
 @pytest.mark.usefixtures("main_norun_redacted_zip")
 def test_main_redacted_zip_deleted_on_upload_failure(taskrunner_workdir):
-    with unittest.mock.patch("tasks.urllib.request.build_opener", FakeFailureUrlOpener):
-        with unittest.mock.patch(
+    with (
+        unittest.mock.patch("tasks.urllib.request.build_opener", FakeFailureUrlOpener),
+        unittest.mock.patch(
             "sys.argv",
             [
                 "sg_collect",
@@ -204,10 +215,11 @@ def test_main_redacted_zip_deleted_on_upload_failure(taskrunner_workdir):
                 taskrunner_workdir,
                 ZIP_NAME,
             ],
-        ):
-            with pytest.raises(SystemExit) as exc:
-                sgcollect.main()
-            assert exc.value.code == 1
+        ),
+    ):
+        with pytest.raises(SystemExit) as exc:
+            sgcollect.main()
+        assert exc.value.code == 1
     assert not pathlib.Path(ZIP_NAME).exists()
     assert not pathlib.Path(REDACTED_ZIP_NAME).exists()
     assert not [x for x in taskrunner_workdir.iterdir()]
@@ -216,8 +228,9 @@ def test_main_redacted_zip_deleted_on_upload_failure(taskrunner_workdir):
 @pytest.mark.usefixtures("main_norun")
 @pytest.mark.parametrize("args", [[], ["--log-redaction-level", "none"]])
 def test_main_keep_zip_on_upload_success(args, taskrunner_workdir):
-    with unittest.mock.patch("tasks.urllib.request.build_opener", FakeSuccessUrlOpener):
-        with unittest.mock.patch(
+    with (
+        unittest.mock.patch("tasks.urllib.request.build_opener", FakeSuccessUrlOpener),
+        unittest.mock.patch(
             "sys.argv",
             [
                 "sg_collect",
@@ -231,10 +244,11 @@ def test_main_keep_zip_on_upload_success(args, taskrunner_workdir):
                 taskrunner_workdir,
                 ZIP_NAME,
             ],
-        ):
-            with pytest.raises(SystemExit) as exc:
-                sgcollect.main()
-            assert exc.value.code == 0
+        ),
+    ):
+        with pytest.raises(SystemExit) as exc:
+            sgcollect.main()
+        assert exc.value.code == 0
     assert pathlib.Path(ZIP_NAME).exists()
     assert not pathlib.Path(REDACTED_ZIP_NAME).exists()
     assert not [x for x in taskrunner_workdir.iterdir()]
@@ -243,8 +257,9 @@ def test_main_keep_zip_on_upload_success(args, taskrunner_workdir):
 @pytest.mark.usefixtures("main_norun")
 @pytest.mark.parametrize("args", [[], ["--log-redaction-level", "none"]])
 def test_main_keep_zip_on_upload_failure(args, taskrunner_workdir):
-    with unittest.mock.patch("tasks.urllib.request.build_opener", FakeFailureUrlOpener):
-        with unittest.mock.patch(
+    with (
+        unittest.mock.patch("tasks.urllib.request.build_opener", FakeFailureUrlOpener),
+        unittest.mock.patch(
             "sys.argv",
             [
                 "sg_collect",
@@ -258,10 +273,11 @@ def test_main_keep_zip_on_upload_failure(args, taskrunner_workdir):
                 taskrunner_workdir,
                 ZIP_NAME,
             ],
-        ):
-            with pytest.raises(SystemExit) as exc:
-                sgcollect.main()
-            assert exc.value.code == 1
+        ),
+    ):
+        with pytest.raises(SystemExit) as exc:
+            sgcollect.main()
+        assert exc.value.code == 1
     assert pathlib.Path(ZIP_NAME).exists()
     assert not pathlib.Path(REDACTED_ZIP_NAME).exists()
     assert not [x for x in taskrunner_workdir.iterdir()]
@@ -269,8 +285,9 @@ def test_main_keep_zip_on_upload_failure(args, taskrunner_workdir):
 
 @pytest.mark.usefixtures("main_norun_redacted_zip")
 def test_main_keep_zip_deleted_on_upload_success(taskrunner_workdir):
-    with unittest.mock.patch("tasks.urllib.request.build_opener", FakeSuccessUrlOpener):
-        with unittest.mock.patch(
+    with (
+        unittest.mock.patch("tasks.urllib.request.build_opener", FakeSuccessUrlOpener),
+        unittest.mock.patch(
             "sys.argv",
             [
                 "sg_collect",
@@ -285,10 +302,11 @@ def test_main_keep_zip_deleted_on_upload_success(taskrunner_workdir):
                 taskrunner_workdir,
                 ZIP_NAME,
             ],
-        ):
-            with pytest.raises(SystemExit) as exc:
-                sgcollect.main()
-            assert exc.value.code == 0
+        ),
+    ):
+        with pytest.raises(SystemExit) as exc:
+            sgcollect.main()
+        assert exc.value.code == 0
     assert pathlib.Path(ZIP_NAME).exists()
     assert pathlib.Path(REDACTED_ZIP_NAME).exists()
     assert not [x for x in taskrunner_workdir.iterdir()]
@@ -296,8 +314,9 @@ def test_main_keep_zip_deleted_on_upload_success(taskrunner_workdir):
 
 @pytest.mark.usefixtures("main_norun_redacted_zip")
 def test_main_keep_zip_deleted_on_upload_failure(taskrunner_workdir):
-    with unittest.mock.patch("tasks.urllib.request.build_opener", FakeFailureUrlOpener):
-        with unittest.mock.patch(
+    with (
+        unittest.mock.patch("tasks.urllib.request.build_opener", FakeFailureUrlOpener),
+        unittest.mock.patch(
             "sys.argv",
             [
                 "sg_collect",
@@ -312,10 +331,11 @@ def test_main_keep_zip_deleted_on_upload_failure(taskrunner_workdir):
                 taskrunner_workdir,
                 ZIP_NAME,
             ],
-        ):
-            with pytest.raises(SystemExit) as exc:
-                sgcollect.main()
-            assert exc.value.code == 1
+        ),
+    ):
+        with pytest.raises(SystemExit) as exc:
+            sgcollect.main()
+        assert exc.value.code == 1
     assert pathlib.Path(ZIP_NAME).exists()
     assert pathlib.Path(REDACTED_ZIP_NAME).exists()
     assert not [x for x in taskrunner_workdir.iterdir()]
@@ -344,8 +364,7 @@ def test_stream_large_file(tmpdir, httpserver):
     """
     p = tmpdir.join("testfile.txt")
     with open(p, "wb") as f:
-        for i in range(2200):
-            f.write(os.urandom(1_000_000))
+        f.writelines(os.urandom(1_000_000) for i in range(2200))
 
     def handler(request):
         pass

--- a/tools/password_remover.py
+++ b/tools/password_remover.py
@@ -13,7 +13,6 @@ Redacts sensitive data in config files
 import json
 import re
 import traceback
-from typing import Union
 from urllib.parse import urlparse
 
 
@@ -39,11 +38,9 @@ def tag_userdata_in_server_config(json_text):
         formatted_json_string = json.dumps(parsed_json, indent=4)
         return formatted_json_string
 
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         print(
-            "Exception trying to tag config user data in {0}.  Exception: {1}".format(
-                json_text, e
-            )
+            f"Exception trying to tag config user data in {json_text}.  Exception: {e}"
         )
         traceback.print_exc()
         return '{"Error":"Error in sgcollect_info password_remover.py trying to tag config user data.  See logs for details"}'
@@ -76,11 +73,9 @@ def tag_userdata_in_db_config(json_text):
         formatted_json_string = json.dumps(parsed_json, indent=4)
         return formatted_json_string
 
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         print(
-            "Exception trying to tag db config user data in {0}.  Exception: {1}".format(
-                json_text, e
-            )
+            f"Exception trying to tag db config user data in {json_text}.  Exception: {e}"
         )
         traceback.print_exc()
         return '{"Error":"Error in sgcollect_info password_remover.py trying to tag db config user data.  See logs for details"}'
@@ -130,7 +125,7 @@ def UD(value):
     """
     Tags the given value with User Data tags.
     """
-    return "<ud>{0}</ud>".format(value)
+    return f"<ud>{value}</ud>"
 
 
 def remove_passwords_from_config(config_fragment):
@@ -167,12 +162,8 @@ def remove_passwords(json_text):
         formatted_json_string = json.dumps(parsed_json, indent=4) + "\n"
         return formatted_json_string
 
-    except Exception as e:
-        print(
-            "Exception trying to remove passwords from {0}.  Exception: {1}".format(
-                json_text, e
-            )
-        )
+    except Exception as e:  # noqa: BLE001
+        print(f"Exception trying to remove passwords from {json_text}.  Exception: {e}")
         traceback.print_exc()
         return '{"Error":"Error in sgcollect_info password_remover.py trying to remove passwords.  See logs for details"}'
 
@@ -189,7 +180,7 @@ def lower_keys_dict(json_text):
         return k.lower() if isinstance(k, str) else k
 
     def lower_level(kv):
-        return dict((lower(k), iterate(v)) for k, v in kv.items())
+        return {lower(k): iterate(v) for k, v in kv.items()}
 
     json_dict = json.loads(json_text)
     return lower_level(json_dict)
@@ -202,10 +193,8 @@ def pretty_print_json(json_text):
     """
     try:
         json_text = json.dumps(json.loads(json_text), indent=4)
-    except Exception as e:
-        print(
-            "Exception trying to parse JSON {0}.  Exception: {1}".format(json_text, e)
-        )
+    except Exception as e:  # noqa: BLE001
+        print(f"Exception trying to parse JSON {json_text}.  Exception: {e}")
     return json_text + "\n"
 
 
@@ -225,13 +214,7 @@ def strip_password_from_url(url_string):
     if parsed_url.username is None and parsed_url.password is None:
         return url_string
 
-    new_url = "{0}://{1}:*****@{2}:{3}/{4}".format(
-        parsed_url.scheme,
-        parsed_url.username,
-        parsed_url.hostname,
-        parsed_url.port,
-        parsed_url.query,
-    )
+    new_url = f"{parsed_url.scheme}://{parsed_url.username}:*****@{parsed_url.hostname}:{parsed_url.port}/{parsed_url.query}"
     return new_url
 
 
@@ -267,7 +250,7 @@ def replace_backticks_with_double_quotes(match):
     return expr
 
 
-def convert_to_valid_json(invalid_json: Union[bytes, str]) -> str:
+def convert_to_valid_json(invalid_json: bytes | str) -> str:
     """
     Converts json text from a sync gateway config file to valid json by replacing backticks with double quotes and escaping invalid json characters inside the backquotes.
     """

--- a/tools/sgcollect.py
+++ b/tools/sgcollect.py
@@ -27,7 +27,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 import uuid
-from typing import List, Literal, NoReturn, Optional, Union
+from typing import Literal, NoReturn
 
 import password_remover
 from tasks import (
@@ -90,11 +90,11 @@ def delete_zip(filename):
     """
     try:
         os.remove(filename)
-        print("Zipfile deleted: {0}".format(filename))
+        print(f"Zipfile deleted: {filename}")
     except FileNotFoundError:
         pass
-    except Exception as e:
-        print("Zipfile ({0}) deletion failed: {1}".format(filename, e))
+    except Exception as e:  # noqa: BLE001
+        print(f"Zipfile ({filename}) deletion failed: {e}")
 
 
 def sync_gateway_option_callback(
@@ -116,8 +116,8 @@ class HelpFormatter(optparse.IndentedHelpFormatter):
         self,
         indent_increment: int = 2,
         max_help_position: int = 24,
-        width: Optional[int] = None,
-        short_first: Union[bool, Literal[0, 1]] = 1,
+        width: int | None = None,
+        short_first: bool | Literal[0, 1] = 1,
     ):
         # match width from argparse implementation
         width = shutil.get_terminal_size().columns - 2
@@ -244,7 +244,7 @@ def create_option_parser():
 
 
 def expvar_url(sg_url):
-    return "{0}/_expvar".format(sg_url)
+    return f"{sg_url}/_expvar"
 
 
 def make_http_client_pprof_tasks(
@@ -262,16 +262,16 @@ def make_http_client_pprof_tasks(
         "mutex",
     ]
 
-    base_pprof_url = "{0}/_debug/pprof".format(sg_url)
+    base_pprof_url = f"{sg_url}/_debug/pprof"
 
     pprof_tasks = []
     for profile_type in profile_types:
-        sg_pprof_url = "{0}/{1}".format(base_pprof_url, profile_type)
+        sg_pprof_url = f"{base_pprof_url}/{profile_type}"
         clean_task = make_curl_task(
-            name="Collect {0} pprof via http client".format(profile_type),
+            name=f"Collect {profile_type} pprof via http client",
             auth_headers=auth_headers,
             url=sg_pprof_url,
-            log_file="pprof_{0}.pb.gz".format(profile_type),
+            log_file=f"pprof_{profile_type}.pb.gz",
         )
         clean_task.no_header = True
         pprof_tasks.append(clean_task)
@@ -357,9 +357,9 @@ def get_unique_filename(filenames: set[str], original_filename: str) -> str:
 
 def make_collect_logs_tasks(
     sg_url: str,
-    sg_config_file_path: Optional[str],
+    sg_config_file_path: str | None,
     auth_headers: dict[str, str],
-) -> List[PythonTask]:
+) -> list[PythonTask]:
     sg_log_files = {
         "sg_error.log": "sg_error.log",
         "sg_warn.log": "sg_warn.log",
@@ -382,7 +382,7 @@ def make_collect_logs_tasks(
     ]
     # Try to find user-specified log path
     if sg_url:
-        config_url = "{0}/_config?include_runtime=true".format(sg_url)
+        config_url = f"{sg_url}/_config?include_runtime=true"
         try:
             response = urlopen(config_url, auth_headers)
         except urllib.error.URLError:
@@ -403,8 +403,8 @@ def make_collect_logs_tasks(
             with open(sg_config_file_path) as fd:
                 print("Loading SG config from path on disk.")
                 config_str = fd.read()
-        except Exception as e:
-            print("Failed to load SG config from disk: {0}".format(e))
+        except Exception as e:  # noqa: BLE001
+            print(f"Failed to load SG config from disk: {e}")
 
     # Find log file path from old style top level config
     guessed_log_path = extract_element_from_config("LogFilePath", config_str)
@@ -425,7 +425,7 @@ def make_collect_logs_tasks(
     sg_log_file_paths: set[pathlib.Path] = set()
     output_basenames: set[str] = set()
 
-    sg_tasks: List[PythonTask] = []
+    sg_tasks: list[PythonTask] = []
 
     def add_file_collection_task(filename: str):
         canonical_filename = pathlib.Path(filename)
@@ -444,12 +444,12 @@ def make_collect_logs_tasks(
             for file in files:
                 name, ext = os.path.splitext(file)
                 # Collect active and rotated log files from the default log locations.
-                pattern_rotated = os.path.join(dir, "{0}*{1}".format(name, ext))
+                pattern_rotated = os.path.join(dir, f"{name}*{ext}")
                 for std_log_file in glob.glob(pattern_rotated):
                     add_file_collection_task(std_log_file)
 
                 # Collect archived log files from the default log locations.
-                pattern_archived = os.path.join(dir, "{0}*{1}.gz".format(name, ext))
+                pattern_archived = os.path.join(dir, f"{name}*{ext}.gz")
                 for std_log_file in glob.glob(pattern_archived):
                     add_file_collection_task(std_log_file)
 
@@ -474,9 +474,7 @@ def make_collect_logs_tasks(
         name, ext = os.path.splitext(log_file_name)
 
         # Lookup SG log files inside the parent directory, including rotated log files.
-        rotated_logs_pattern = os.path.join(
-            log_file_parent_dir, "{0}*{1}".format(name, ext)
-        )
+        rotated_logs_pattern = os.path.join(log_file_parent_dir, f"{name}*{ext}")
         for log_file_item_name in glob.iglob(rotated_logs_pattern):
             log_file_item_path = os.path.join(log_file_parent_dir, log_file_item_name)
             add_file_collection_task(log_file_item_path)
@@ -495,7 +493,7 @@ def make_collect_logs_tasks(
             # iterate over all log files, including those with a rotation timestamp
             # e.g: sg_info-2018-12-31T13-33-41.055.log
             name, ext = os.path.splitext(log_file_name)
-            log_file_pattern = "{0}*{1}".format(name, ext)
+            log_file_pattern = f"{name}*{ext}"
             rotated_logs_pattern = os.path.join(log_file_path, log_file_pattern)
 
             for log_file_item_name in glob.iglob(rotated_logs_pattern):
@@ -504,7 +502,7 @@ def make_collect_logs_tasks(
 
             # try gzipped logs too
             # e.g: sg_info-2018-12-31T13-33-41.055.log.gz
-            log_file_pattern = "{0}*{1}.gz".format(name, ext)
+            log_file_pattern = f"{name}*{ext}.gz"
             rotated_logs_pattern = os.path.join(log_file_path, log_file_pattern)
 
             for log_file_item_name in glob.iglob(rotated_logs_pattern):
@@ -516,7 +514,7 @@ def make_collect_logs_tasks(
 
 def get_db_list(sg_url: str, auth_headers: dict[str, str]) -> list[str]:
     # build url to _all_dbs
-    all_dbs_url = "{0}/_all_dbs".format(sg_url)
+    all_dbs_url = f"{sg_url}/_all_dbs"
     data: list[str] = []
 
     # get content and parse into json
@@ -537,11 +535,11 @@ def get_db_list(sg_url: str, auth_headers: dict[str, str]) -> list[str]:
 #   Server config
 #   Each DB config
 def make_config_tasks(
-    sg_config_path: Optional[str],
+    sg_config_path: str | None,
     sg_url: str,
     auth_headers: dict[str, str],
     should_redact: bool,
-) -> List[PythonTask]:
+) -> list[PythonTask]:
     """
     Return a list of tasks suitable for collecting configuration information.
 
@@ -557,8 +555,8 @@ def make_config_tasks(
     sg_config_files = [
         "/home/sync_gateway/sync_gateway.json",  # linux sync gateway
         "/opt/sync_gateway/etc/sync_gateway.json",  # amazon linux AMI sync gateway
-        "/Users/sync_gateway/sync_gateway.json"  # OSX sync gateway
-        R"C:\Program Files (x86)\Couchbase\serviceconfig.json"  # Windows (Pre-2.0) sync gateway
+        "/Users/sync_gateway/sync_gateway.json",  # OSX sync gateway
+        R"C:\Program Files (x86)\Couchbase\serviceconfig.json",  # Windows (Pre-2.0) sync gateway
         R"C:\Program Files\Couchbase\Sync Gateway\serviceconfig.json",  # Windows (Post-2.0) sync gateway
     ]
     sg_config_files = [x for x in sg_config_files if os.path.exists(x)]
@@ -587,7 +585,7 @@ def make_config_tasks(
         collect_config_tasks.append(task)
 
     # Get server config
-    server_config_url = "{0}/_config".format(sg_url)
+    server_config_url = f"{sg_url}/_config"
 
     config_task = make_curl_task(
         name="Collect server config",
@@ -599,7 +597,7 @@ def make_config_tasks(
     collect_config_tasks.append(config_task)
 
     # Get server config with runtime defaults and runtime dbconfigs
-    server_runtime_config_url = "{0}/_config?include_runtime=true".format(sg_url)
+    server_runtime_config_url = f"{sg_url}/_config?include_runtime=true"
     runtime_config_task = make_curl_task(
         name="Collect runtime config",
         auth_headers=auth_headers,
@@ -612,9 +610,9 @@ def make_config_tasks(
     # Get persisted dbconfigs
     dbs = get_db_list(sg_url, auth_headers)
     for db in dbs:
-        db_config_url = "{0}/{1}/_config".format(sg_url, db)
+        db_config_url = f"{sg_url}/{db}/_config"
         db_config_task = make_curl_task(
-            name="Collect {0} database config".format(db),
+            name=f"Collect {db} database config",
             auth_headers=auth_headers,
             url=db_config_url,
             log_file="sync_gateway.log",
@@ -623,7 +621,7 @@ def make_config_tasks(
         collect_config_tasks.append(db_config_task)
 
     # Get cluster information
-    cluster_info_url = "{0}/_cluster_info".format(sg_url)
+    cluster_info_url = f"{sg_url}/_cluster_info"
     cluster_info_task = make_curl_task(
         name="Collect SG cluster info",
         auth_headers=auth_headers,
@@ -636,7 +634,7 @@ def make_config_tasks(
     return collect_config_tasks
 
 
-def get_config_path_from_cmdline(cmdline_args: list[str]) -> Optional[str]:
+def get_config_path_from_cmdline(cmdline_args: list[str]) -> str | None:
     """
     Parse command line arguments to find the configuration file path and return an absolute path. May return None if the path doesn't exist.
 
@@ -656,7 +654,7 @@ def get_config_path_from_cmdline(cmdline_args: list[str]) -> Optional[str]:
 
 def get_paths_from_expvars(
     sg_url: str, auth_headers: dict[str, str]
-) -> tuple[Optional[str], Optional[str]]:
+) -> tuple[str | None, str | None]:
     """
     Get the Sync Gateway binary and configuration file path from /_expvar endpoint.
     """
@@ -707,19 +705,17 @@ def make_sg_tasks(
     *,
     sg_url: str,
     auth_headers: dict[str, str],
-    sync_gateway_config_path_option: Optional[str],
-    sync_gateway_executable_path: Optional[str],
+    sync_gateway_config_path_option: str | None,
+    sync_gateway_executable_path: str | None,
     should_redact: bool,
-) -> List[PythonTask]:
+) -> list[PythonTask]:
     # Get path to sg binary (reliable) and config (not reliable)
     sg_binary_path, sg_config_path = get_paths_from_expvars(
         sg_url,
         auth_headers=auth_headers,
     )
     print(
-        "Discovered from expvars: sg_binary_path={0} sg_config_path={1}".format(
-            sg_binary_path, sg_config_path
-        )
+        f"Discovered from expvars: sg_binary_path={sg_binary_path} sg_config_path={sg_config_path}"
     )
 
     # If user passed in a specific path to the SG binary, then use it
@@ -728,10 +724,8 @@ def make_sg_tasks(
         and len(sync_gateway_executable_path) > 0
     ):
         if not os.path.exists(sync_gateway_executable_path):
-            raise Exception(
-                "Path to sync gateway executable passed in does not exist: {0}".format(
-                    sync_gateway_executable_path
-                )
+            raise Exception(  # noqa: TRY002
+                f"Path to sync gateway executable passed in does not exist: {sync_gateway_executable_path}"
             )
         sg_binary_path = sync_gateway_executable_path
 
@@ -770,7 +764,7 @@ def make_sg_tasks(
     status_tasks = make_curl_task(
         name="Collect server status",
         auth_headers=auth_headers,
-        url="{0}/_status".format(sg_url),
+        url=f"{sg_url}/_status",
         log_file="sync_gateway.log",
         content_postprocessors=[password_remover.pretty_print_json],
     )
@@ -791,7 +785,7 @@ def make_sg_tasks(
 
 def discover_sg_binary_path(
     options: optparse.Values,
-    sg_url: Optional[str],
+    sg_url: str | None,
     auth_headers: dict[str, str],
 ) -> str:
     """
@@ -803,10 +797,8 @@ def discover_sg_binary_path(
     """
     if options.sync_gateway_executable:
         if not os.path.exists(options.sync_gateway_executable):
-            raise Exception(
-                "Path to sync gateway executable passed in does not exist: {0}".format(
-                    options.sync_gateway_executable
-                )
+            raise Exception(  # noqa: TRY002
+                f"Path to sync gateway executable passed in does not exist: {options.sync_gateway_executable}"
             )
         return options.sync_gateway_executable
     if sg_url:
@@ -855,7 +847,7 @@ def main() -> NoReturn:
         zip_filename = zip_filename + ".zip"
     zip_dir = os.path.dirname(os.path.abspath(zip_filename))
     if not os.access(zip_dir, os.W_OK | os.X_OK):
-        print("do not have write access to the directory %s" % (zip_dir))
+        print(f"do not have write access to the directory {zip_dir}")
         sys.exit(1)
 
     if options.redact_level != "none" and options.redact_level != "partial":
@@ -913,7 +905,7 @@ def main() -> NoReturn:
 
         # Output the Python version if verbosity was enabled
         if options.verbosity:
-            log("Python version: %s" % sys.version)
+            log(f"Python version: {sys.version}")
 
         # Find path to sg binary
         sg_binary_path = discover_sg_binary_path(options, sg_url, auth_headers)
@@ -945,7 +937,7 @@ def main() -> NoReturn:
 
         # Build redacted zip file
         if should_redact:
-            log("Redacting log files to level: %s" % options.redact_level)
+            log(f"Redacting log files to level: {options.redact_level}")
             runner.redact_and_zip(
                 redact_zip_file, "sgcollect_info", options.salt_value, platform.node()
             )
@@ -955,9 +947,9 @@ def main() -> NoReturn:
             runner.zip(zip_filename, "sgcollect_info", platform.node())
 
             if options.redact_level != "none":
-                print("Zipfile built: {0}".format(redact_zip_file))
+                print(f"Zipfile built: {redact_zip_file}")
 
-            print("Zipfile built: {0}".format(zip_filename))
+            print(f"Zipfile built: {zip_filename}")
 
             if not upload_url:
                 sys.exit(0)
@@ -976,11 +968,11 @@ def main() -> NoReturn:
 def ud(value, should_redact=True):
     if not should_redact:
         return value
-    return "<ud>{0}</ud>".format(value)
+    return f"<ud>{value}</ud>"
 
 
 def get_sgcollect_info_options_task(
-    options: optparse.Values, args: List[str]
+    options: optparse.Values, args: list[str]
 ) -> AllOsTask:
     """
     Create a task that returns all the options used to run sgcollect_info.
@@ -988,7 +980,7 @@ def get_sgcollect_info_options_task(
     should_redact = should_redact_from_options(options)
     return AllOsTask(
         "Echo sgcollect_info cmd line args",
-        "echo options: {0} args: {1}".format(
+        "echo options: {} args: {}".format(
             {
                 k: ud(v, should_redact)
                 for k, v in list(options.__dict__.items())
@@ -1017,7 +1009,7 @@ def get_sg_url(options: optparse.Values, auth_headers: dict[str, str]) -> str:
     2. http://127.0.0.1:4985
     3. https://127.0.0.1:4985
     """
-    possible_urls: List[str] = []
+    possible_urls: list[str] = []
     if options.sync_gateway_url:
         if "://" in options.sync_gateway_url:
             possible_urls.append(options.sync_gateway_url)
@@ -1045,7 +1037,7 @@ def can_connect_to_sg_url(sg_url: str, auth_headers: dict[str, str]) -> bool:
     try:
         response = urlopen(url=sg_url, auth_headers=auth_headers)
         json.load(response)
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         print(f"Failed to communicate with: {sg_url} {e}")
         return False
     return True
@@ -1076,7 +1068,5 @@ def get_basic_authorization_header(username: str, password: str) -> str:
     """
     Return the value for the Authorization header for basic auth.
     """
-    base64string = base64.b64encode((f"{username}:{password}").encode("utf-8")).decode(
-        "utf-8"
-    )
+    base64string = base64.b64encode((f"{username}:{password}").encode()).decode("utf-8")
     return f"Basic {base64string}"

--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 Copyright 2016-Present Couchbase, Inc.
 
@@ -28,12 +26,13 @@ import types
 import urllib.error
 import urllib.parse
 import urllib.request
+from collections.abc import Callable
 from copy import copy
-from typing import Callable, List, Optional, Union
+from datetime import UTC
 
 
 class LogRedactor:
-    def __init__(self, salt: str, tmpdir: Union[str, pathlib.Path]):
+    def __init__(self, salt: str, tmpdir: str | pathlib.Path):
         self.target_dir = os.path.join(tmpdir, "redacted")
         os.makedirs(self.target_dir)
 
@@ -42,20 +41,22 @@ class LogRedactor:
 
     def _process_file(self, ifile, ofile, processor):
         try:
-            with get_open_fn(ifile)(
-                ifile,
-                "rb",
-            ) as inp:
-                with get_open_fn(ofile)(
+            with (
+                get_open_fn(ifile)(
+                    ifile,
+                    "rb",
+                ) as inp,
+                get_open_fn(ofile)(
                     ofile,
                     "wb+",
-                ) as out:
-                    # Write redaction header
-                    out.write(self.couchbase_log.do(b"RedactLevel"))
-                    for line in inp:
-                        out.write(processor.do(line))
-        except IOError as e:
-            log("I/O error(%s): %s" % (e.errno, e.strerror))
+                ) as out,
+            ):
+                # Write redaction header
+                out.write(self.couchbase_log.do(b"RedactLevel"))
+                for line in inp:
+                    out.write(processor.do(line))
+        except OSError as e:
+            log(f"I/O error({e.errno}): {e.strerror}")
 
     def redact_file(self, name, ifile):
         _, filename = os.path.split(name)
@@ -116,7 +117,7 @@ def log(message, end="\n"):
     sys.stderr.flush()
 
 
-class Task(object):
+class Task:
     privileged = False
     no_header = False
     num_samples = 1
@@ -158,7 +159,7 @@ class Task(object):
             # setting non-zero status code. It's might also
             # automatically handle things like "failed to fork due
             # to some system limit".
-            fp.write(f"Failed to execute {self.command}: {e}".encode("utf-8"))
+            fp.write(f"Failed to execute {self.command}: {e}".encode())
             return 127
         p.stdin.close()
 
@@ -191,9 +192,7 @@ class Task(object):
                 # message
                 if timer_fired.isSet():
                     fp.write(
-                        f"`{self.command}` timed out after {self.timeout} seconds".encode(
-                            "utf-8"
-                        )
+                        f"`{self.command}` timed out after {self.timeout} seconds".encode()
                     )
 
         return p.wait()
@@ -203,7 +202,7 @@ class Task(object):
         return sys.platform.startswith(tuple(self.platforms))
 
 
-class PythonTask(object):
+class PythonTask:
     """
     A task that takes a python function as an argument rather than an OS command.
     These will run on any platform.
@@ -226,7 +225,7 @@ class PythonTask(object):
 
     def execute(self, fp):
         """Run the task"""
-        print("log_file: {0}. ".format(self.log_file))
+        print(f"log_file: {self.log_file}. ")
         try:
             result = self.callable()
             try:
@@ -234,9 +233,9 @@ class PythonTask(object):
             except (UnicodeEncodeError, AttributeError):
                 fp.write(result)
             return 0
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             if self.log_exception:
-                print("Exception executing python task: {0}".format(e))
+                print(f"Exception executing python task: {e}")
             return 1
 
     def will_run(self):
@@ -244,7 +243,7 @@ class PythonTask(object):
         return True
 
 
-class TaskRunner(object):
+class TaskRunner:
     """
     TaskRunner manages running tasks and collecting their output into files. Use as a context manager to cleanup the
     temporary files when finished.
@@ -265,7 +264,7 @@ class TaskRunner(object):
         try:
             self.tmpdir = tempfile.mkdtemp(dir=tmp_dir, prefix="sgcollect")
         except OSError as e:
-            print("Could not use temporary dir {0}: {1}".format(tmp_dir, e))
+            print(f"Could not use temporary dir {tmp_dir}: {e}")
             sys.exit(1)
 
         # If a dir wasn't passed by --tmp-dir, check if the env var was set and if we were able to use it
@@ -274,17 +273,17 @@ class TaskRunner(object):
             and os.getenv("TMPDIR")
             and os.path.split(self.tmpdir)[0] != os.getenv("TMPDIR")
         ):
-            log("Could not use TMPDIR {0}".format(os.getenv("TMPDIR")))
-            log("Using temporary dir {0}".format(os.path.split(self.tmpdir)[0]))
+            log("Could not use TMPDIR {}".format(os.getenv("TMPDIR")))
+            log(f"Using temporary dir {os.path.split(self.tmpdir)[0]}")
 
     def __enter__(self):
         return self
 
     def __exit__(
         self,
-        exc_type: Optional[type[BaseException]],
-        exc_value: Optional[type[BaseException]],
-        traceback: Optional[types.TracebackType],
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: types.TracebackType | None,
     ):
         self.close_all_files()
         shutil.rmtree(self.tmpdir, ignore_errors=True)
@@ -295,15 +294,15 @@ class TaskRunner(object):
         filename - Absolute path to file to collect.
         """
         if filename not in self.files:
-            self.files[filename] = open(filename, "r")
+            self.files[filename] = open(filename, "r")  # noqa: SIM115
         else:
-            log("Unable to collect file '{0}' - already collected.".format(filename))
+            log(f"Unable to collect file '{filename}' - already collected.")
 
     def get_file(self, filename):
         if filename in self.files:
             fp = self.files[filename]
         else:
-            fp = open(os.path.join(self.tmpdir, filename), "wb+")
+            fp = open(os.path.join(self.tmpdir, filename), "wb+")  # noqa: SIM115
             self.files[filename] = fp
 
         return fp
@@ -317,13 +316,13 @@ class TaskRunner(object):
         if result == 0:
             log("OK")
         else:
-            log("Exit code %d" % result)
+            log(f"Exit code {result:d}")
 
     def run(self, task):
         """Run a task with a file descriptor corresponding to its log file"""
         command_to_print = getattr(task, "command_to_print", task.command)
         if task.will_run():
-            log("%s (%s) - " % (task.description, command_to_print), end="")
+            log(f"{task.description} ({command_to_print}) - ", end="")
             if task.privileged and os.getuid() != 0:
                 log("skipped (needs root privs)")
                 return
@@ -340,7 +339,7 @@ class TaskRunner(object):
             for i in range(task.num_samples):
                 if i > 0:
                     log(
-                        "Taking sample %d after %f seconds - " % (i + 1, task.interval),
+                        f"Taking sample {i + 1:d} after {task.interval:f} seconds - ",
                         end="",
                     )
                     time.sleep(task.interval)
@@ -350,8 +349,7 @@ class TaskRunner(object):
 
         elif self.verbosity >= 2:
             log(
-                'Skipping "%s" (%s): not for platform %s'
-                % (task.description, command_to_print, sys.platform)
+                f'Skipping "{task.description}" ({command_to_print}): not for platform {sys.platform}'
             )
 
     def redact_and_zip(self, filename: str, log_type: str, salt: str, node: str):
@@ -381,7 +379,7 @@ class TaskRunner(object):
         self.__make_zip(prefix, filename, files)
 
     def close_all_files(self):
-        for name, fp in self.files.items():
+        for fp in self.files.values():
             fp.close()
 
     @staticmethod
@@ -399,15 +397,15 @@ class TaskRunner(object):
 
 
 class LinuxTask(Task):
-    platforms = ["linux"]
+    platforms: tuple[str, ...] = ("linux",)
 
 
 class WindowsTask(Task):
-    platforms = ["win32", "cygwin"]
+    platforms: tuple[str, ...] = ("win32", "cygwin")
 
 
 class MacOSXTask(Task):
-    platforms = ["darwin"]
+    platforms: tuple[str, ...] = ("darwin",)
 
 
 class UnixTask(LinuxTask, MacOSXTask):
@@ -422,7 +420,7 @@ def make_curl_task(
     name: str,
     url: str,
     auth_headers: dict[str, str],
-    content_postprocessors: Optional[List[Callable]] = None,
+    content_postprocessors: list[Callable] | None = None,
     timeout=60,
     log_file="python_curl.log",
     **kwargs,
@@ -446,14 +444,14 @@ def make_curl_task(
 
     """
 
-    def python_curl_task() -> Union[bytes, str]:
+    def python_curl_task() -> bytes | str:
         """
         Return the output from the request after post processing.
         """
         try:
             response_file_handle = urlopen(url, auth_headers)
         except urllib.error.URLError as e:
-            print("WARNING: Error connecting to url {0}: {1}".format(url, e))
+            print(f"WARNING: Error connecting to url {url}: {e}")
             return b""
 
         response_string: bytes = response_file_handle.read()
@@ -468,9 +466,9 @@ def make_curl_task(
 
 
 def add_file_task(
-    sourcefile_path: Union[pathlib.Path, str],
-    output_path: Union[pathlib.Path, str],
-    content_postprocessors: Optional[List[Callable]] = None,
+    sourcefile_path: pathlib.Path | str,
+    output_path: pathlib.Path | str,
+    content_postprocessors: list[Callable] | None = None,
 ):
     """
     Adds the contents of a file to the output zip
@@ -487,7 +485,7 @@ def add_file_task(
             return contents
 
     task = PythonTask(
-        description="Contents of {0}".format(sourcefile_path),
+        description=f"Contents of {sourcefile_path}",
         callable=python_add_file_task,
         log_file=output_path,
         log_exception=False,
@@ -501,7 +499,7 @@ def make_event_log_task():
 
     # I found that wmic ntevent can be extremely slow; so limiting the output
     # to approximately last month
-    limit = datetime.today() - timedelta(days=31)
+    limit = datetime.now(UTC) - timedelta(days=31)
     limit = limit.strftime("%Y%m%d000000.000000-000")
 
     return WindowsTask(
@@ -509,10 +507,10 @@ def make_event_log_task():
         "wmic ntevent where "
         '"'
         "(LogFile='application' or LogFile='system') and "
-        "EventType<3 and TimeGenerated>'%(limit)s'"
+        "EventType<3 and TimeGenerated>'{limit}'"
         '" '
         "get TimeGenerated,LogFile,SourceName,EventType,Message,InsertionStrings "
-        "/FORMAT:list" % locals(),
+        "/FORMAT:list".format(**locals()),
     )
 
 
@@ -521,7 +519,7 @@ def make_event_log_task_sg_info():
 
     # I found that wmic ntevent can be extremely slow; so limiting the output
     # to approximately last month
-    limit = datetime.today() - timedelta(days=31)
+    limit = datetime.now(UTC) - timedelta(days=31)
     limit = limit.strftime("%Y%m%d000000.000000-000")
 
     return WindowsTask(
@@ -529,10 +527,10 @@ def make_event_log_task_sg_info():
         "wmic ntevent where "
         '"'
         "SourceName='SyncGateway' and "
-        "TimeGenerated>'%(limit)s'"
+        "TimeGenerated>'{limit}'"
         '" '
         "get TimeGenerated,LogFile,SourceName,EventType,InsertionStrings "
-        "/FORMAT:list" % locals(),
+        "/FORMAT:list".format(**locals()),
     )
 
 
@@ -585,8 +583,9 @@ def make_os_tasks(processes):
         UnixTask("sysctl settings", "sysctl -a"),
         LinuxTask(
             "Relevant lsof output",
-            "echo %(programs)s | xargs -n1 pgrep | xargs -n1 -r -- lsof -n -p"
-            % locals(),
+            "echo {programs} | xargs -n1 pgrep | xargs -n1 -r -- lsof -n -p".format(
+                **locals()
+            ),
         ),
         LinuxTask("LVM info", "lvdisplay"),
         LinuxTask("LVM info", "vgdisplay"),
@@ -662,9 +661,10 @@ def make_os_tasks(processes):
         ),
         LinuxTask(
             "Relevant proc data",
-            "echo %(programs)s | "
-            "xargs -n1 pgrep | xargs -n1 -- sh -c 'echo $1; cat /proc/$1/status; cat /proc/$1/limits; cat /proc/$1/smaps; cat /proc/$1/numa_maps; cat /proc/$1/task/*/sched; echo' --"
-            % locals(),
+            "echo {programs} | "
+            "xargs -n1 pgrep | xargs -n1 -- sh -c 'echo $1; cat /proc/$1/status; cat /proc/$1/limits; cat /proc/$1/smaps; cat /proc/$1/numa_maps; cat /proc/$1/task/*/sched; echo' --".format(
+                **locals()
+            ),
         ),
         LinuxTask("NUMA data", "numactl --hardware"),
         LinuxTask("NUMA data", "numactl --show"),
@@ -708,8 +708,7 @@ def iter_flatten(iterable):
     it = iter(iterable)
     for e in it:
         if isinstance(e, (list, tuple)):
-            for f in iter_flatten(e):
-                yield f
+            yield from iter_flatten(e)
         else:
             yield e
 
@@ -732,7 +731,7 @@ def do_upload(path, url, proxy):
 
         opener = urllib.request.build_opener(proxy_handler)
         request = urllib.request.Request(url, data=f, method="PUT")
-        request.add_header(str("Content-Type"), str("application/zip"))
+        request.add_header("Content-Type", "application/zip")
         request.add_header("Content-Length", os.fstat(f.fileno()).st_size)
 
         try:
@@ -740,12 +739,10 @@ def do_upload(path, url, proxy):
             if url.getcode() == 200:
                 log("Done uploading")
             else:
-                raise Exception(
-                    "Error uploading, expected status code 200, got status code: {0}".format(
-                        url.getcode()
-                    )
+                raise Exception(  # noqa: TRY002
+                    f"Error uploading, expected status code 200, got status code: {url.getcode()}"
                 )
-        except Exception:
+        except Exception:  # noqa: BLE001
             log(traceback.format_exc())
             return 1
 
@@ -771,12 +768,12 @@ def generate_upload_url(parser, options, zip_filename):
         customer = urllib.parse.quote(options.upload_customer)
         fname = urllib.parse.quote(os.path.basename(zip_filename))
         if options.upload_ticket:
-            full_path = "%s/%s/%d/%s" % (path, customer, options.upload_ticket, fname)
+            full_path = f"{path}/{customer}/{options.upload_ticket:d}/{fname}"
         else:
-            full_path = "%s/%s/%s" % (path, customer, fname)
+            full_path = f"{path}/{customer}/{fname}"
 
         upload_url = urllib.parse.urlunsplit((scheme, netloc, full_path, "", ""))
-        log("Will upload collected .zip file into %s" % upload_url)
+        log(f"Will upload collected .zip file into {upload_url}")
     return upload_url
 
 
@@ -785,7 +782,7 @@ def check_ticket(option, opt, value):
         return int(value)
     else:
         raise optparse.OptionValueError(
-            "option %s: invalid ticket number: %r" % (opt, value)
+            f"option {opt}: invalid ticket number: {value!r}"
         )
 
 
@@ -795,7 +792,7 @@ class CbcollectInfoOptions(optparse.Option):
     TYPE_CHECKER["ticket"] = check_ticket
 
 
-def redactable_file(filename: Union[pathlib.Path, str]) -> bool:
+def redactable_file(filename: pathlib.Path | str) -> bool:
     """
     Return True if the file should be redacted, otherwise False.
     """
@@ -805,7 +802,7 @@ def redactable_file(filename: Union[pathlib.Path, str]) -> bool:
     return filename.stem != "sync_gateway"
 
 
-def get_open_fn(path: Union[pathlib.Path, str]) -> Callable:
+def get_open_fn(path: pathlib.Path | str) -> Callable:
     """
     Return open function for path. gzip.open if suffixed with .gz, else open.
     """


### PR DESCRIPTION
CBG-5409

Unclean cherry pick of #8315 to 3.3.8
- `auth/session_test.go` — this branch's sg-bucket `KVStore.Set` has no `context.Context` param; dropped `ctx` from the two new `dataStore.Set` calls added by this commit.

This PR also carries two preceding CI-fix commits, neither of which has a backport ticket. Every GitHub Actions job on this branch was failing before them, so no PR against `release/3.3.8` could go green:

- **CBG-5675: pin GitHub Actions to commit SHAs** — the org policy requires actions pinned to a full-length SHA. Reference: [#8555](https://github.com/couchbase/sync_gateway/pull/8555) did the equivalent on `main`; that commit doesn't apply here (this branch has 4 fewer workflow files and `ci.yml` has diverged substantially), so each action actually used on this branch was pinned in place at its current tag, no version bumps.
- **CBG-5640: fix Python lint under ruff 0.16** — `ruff-action` installs the latest ruff because this branch declares no ruff version, and ruff 0.16 widened its default rule set, producing 193 findings across 7 files. The job had simply never run here before, being blocked by the policy above. Reference: [#8481](https://github.com/couchbase/sync_gateway/pull/8481) did the equivalent on `main`; cherry-picking it isn't viable (conflicts across 6 files, and it bundles an unrelated mypy→ty migration), so its resolutions were used as a reference — the resulting `noqa` set matches main's exactly. Two changes affect behaviour, both matching main: missing commas restored in `sg_config_files` (they were silently concatenating the macOS and Windows paths into one nonsense path), and `datetime.today()` → `datetime.now(UTC)` for the wmic event-log cutoff.

🤖 Opened with the `sync-gateway-backport` skill in [Claude Code](https://claude.com/claude-code)
