### PR TITLE
[4.0.8 Backport] CBG-5768: ISGR RunAs does not ensure the given username exists at replication creation or run time

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -746,12 +746,6 @@ func waitForBGTCompletion(ctx context.Context, waitTimeMax time.Duration, tasks 
 	}
 }
 
-func (context *DatabaseContext) IsClosed() bool {
-	context.BucketLock.RLock()
-	defer context.BucketLock.RUnlock()
-	return context.Bucket == nil
-}
-
 // For testing only!
 func (context *DatabaseContext) RestartListener(ctx context.Context) error {
 	context.mutationListener.Stop(ctx)
@@ -880,10 +874,9 @@ func (db *Database) TakeDbOffline(nonContextStruct base.NonCancellableContext, r
 	return db.DatabaseContext.TakeDbOffline(nonContextStruct.Ctx, reason)
 }
 
+// Authenticator returns an authenticator for this database context. The authenticator is stateless, so it's safe to
+// return a new instance on each call.
 func (context *DatabaseContext) Authenticator(ctx context.Context) *auth.Authenticator {
-	context.BucketLock.RLock()
-	defer context.BucketLock.RUnlock()
-
 	sessionCookieName := auth.DefaultCookieName
 	if context.Options.SessionCookieName != "" {
 		sessionCookieName = context.Options.SessionCookieName

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -540,6 +540,7 @@ func (m *sgReplicateManager) StartReplications(ctx context.Context) error {
 			activeReplicator, err := m.InitializeReplication(replicationCfg)
 			if err != nil {
 				base.WarnfCtx(m.loggingCtx, "Error initializing replication %s: %v", replicationID, err)
+				m.saveInitializationError(replicationCfg, err)
 				continue
 			}
 			m.activeReplicatorsLock.Lock()
@@ -567,6 +568,9 @@ func (m *sgReplicateManager) NewActiveReplicatorConfig(config *ReplicationCfg) (
 		user, err := m.dbContext.Authenticator(m.loggingCtx).GetUser(config.RunAs)
 		if err != nil {
 			return nil, err
+		}
+		if user == nil {
+			return nil, base.RedactErrorf("run_as user %s not found", base.UD(config.RunAs))
 		}
 		activeDB.SetUser(user)
 	}
@@ -733,6 +737,29 @@ func (m *sgReplicateManager) replicationComplete(replicationID string) {
 	}
 }
 
+// saveInitializationError persists an error status for a replication that failed to initialise,
+// so that GetReplicationStatus returns ReplicationStateError instead of the target state.
+func (m *sgReplicateManager) saveInitializationError(config *ReplicationCfg, initErr error) {
+	status := &ReplicationStatus{
+		ID:           config.ID,
+		Status:       ReplicationStateError,
+		ErrorMessage: initErr.Error(),
+	}
+	expirySecs := int(m.dbContext.Options.LocalDocExpirySecs)
+	if config.Direction == ActiveReplicatorTypePush || config.Direction == ActiveReplicatorTypePushAndPull {
+		pushKey := m.dbContext.MetadataKeys.ReplicationStatusKey(PushCheckpointID(config.ID))
+		if err := setLocalStatus(m.loggingCtx, m.dbContext.MetadataStore, pushKey, status, expirySecs); err != nil {
+			base.WarnfCtx(m.loggingCtx, "Unable to persist error status for replication %s: %v", base.UD(config.ID), err)
+		}
+	}
+	if config.Direction == ActiveReplicatorTypePull || config.Direction == ActiveReplicatorTypePushAndPull {
+		pullKey := m.dbContext.MetadataKeys.ReplicationStatusKey(PullCheckpointID(config.ID))
+		if err := setLocalStatus(m.loggingCtx, m.dbContext.MetadataStore, pullKey, status, expirySecs); err != nil {
+			base.WarnfCtx(m.loggingCtx, "Unable to persist error status for replication %s: %v", base.UD(config.ID), err)
+		}
+	}
+}
+
 func (m *sgReplicateManager) Stop() {
 
 	// Close subscribe terminator first to stop subscribing/responding to cluster config changes prior to
@@ -802,6 +829,7 @@ func (m *sgReplicateManager) RefreshReplicationCfg(ctx context.Context) error {
 				replicator, initError := m.InitializeReplication(replicationCfg)
 				if initError != nil {
 					base.WarnfCtx(m.loggingCtx, "Error initializing upserted replication %s: %v", replicationID, initError)
+					m.saveInitializationError(replicationCfg, initError)
 				} else {
 					m.activeReplicators[replicationID] = replicator
 					activeReplicator = replicator
@@ -831,6 +859,7 @@ func (m *sgReplicateManager) RefreshReplicationCfg(ctx context.Context) error {
 				replicator, initError := m.InitializeReplication(replicationCfg)
 				if initError != nil {
 					base.WarnfCtx(m.loggingCtx, "Error initializing replication %s: %v", replicationID, initError)
+					m.saveInitializationError(replicationCfg, initError)
 					continue
 				}
 				m.activeReplicators[replicationID] = replicator

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -1528,6 +1528,8 @@ func TestRequireReplicatorStoppedBeforeUpsert(t *testing.T) {
 	const username = "alice"
 	rt.CreateUser("alice", []string{})
 
+	collectionsEnabled := strconv.FormatBool(!rt.GetDatabase().OnlyDefaultCollection())
+
 	DBURL := userDBURL(rt, username)
 
 	replicationConfig := fmt.Sprintf(`{
@@ -1536,8 +1538,9 @@ func TestRequireReplicatorStoppedBeforeUpsert(t *testing.T) {
 		"direction": "pushAndPull",
 		"conflict_resolution_type":"default",
 		"max_backoff":100,
+		"collections_enabled": %s,
         "continuous":true
-	}`, DBURL.String())
+	}`, DBURL.String(), collectionsEnabled)
 
 	response := rt.SendAdminRequest("PUT", "/{{.db}}/_replication/replication1", replicationConfig)
 	rest.RequireStatus(t, response, http.StatusCreated)
@@ -1545,11 +1548,7 @@ func TestRequireReplicatorStoppedBeforeUpsert(t *testing.T) {
 	response = rt.SendAdminRequest("GET", "/{{.db}}/_replicationStatus/", "")
 	rest.RequireStatus(t, response, http.StatusOK)
 
-	var body []map[string]interface{}
-	err := base.JSONUnmarshal(response.BodyBytes(), &body)
-	fmt.Println(string(response.BodyBytes()))
-	assert.NoError(t, err)
-	assert.Equal(t, "running", body[0]["status"])
+	rt.WaitForReplicationStatus("replication1", db.ReplicationStateRunning)
 
 	replicationConfigUpdate := fmt.Sprintf(`{
 		"replication_id": "replication1",
@@ -8044,4 +8043,199 @@ func TestReplicationConfigUpdatedAt(t *testing.T) {
 		base.AssertTimeGreaterThan(t, *configResponse.UpdatedAt, *currTime)
 		assert.Equal(t, configResponse.CreatedAt.UnixNano(), createdAtTime.UnixNano())
 	})
+}
+
+func TestISGRRunAsNonExistentUserPushesAsAdmin(t *testing.T) {
+	base.LongRunningTest(t)
+	base.RequireNumTestBuckets(t, 2)
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyReplicate, base.KeyHTTP, base.KeyAccess, base.KeyChanges)
+
+	const (
+		repl1Name      = "repl"
+		repl2Name      = "repl2"
+		repl3Name      = "repl3"
+		runAsMissing   = "missinguser"
+		privateChannel = "secret"
+	)
+
+	// Both peers use the default channels-from-doc sync function.
+	rtConfig := &rest.RestTesterConfig{
+		SyncFn: `function(doc) { channel(doc.channels); }`,
+	}
+
+	// Passive peer — receives docs. Needs an alice for remote auth.
+	passiveRT := rest.NewRestTester(t, rtConfig)
+	defer passiveRT.Close()
+
+	publicSrv := httptest.NewServer(passiveRT.TestPublicHandler())
+	defer publicSrv.Close()
+
+	// Active peer
+	activeRTConfig := &rest.RestTesterConfig{
+		SyncFn:             rtConfig.SyncFn,
+		SgReplicateEnabled: true,
+	}
+	activeRT := rest.NewRestTester(t, activeRTConfig)
+	defer activeRT.Close()
+
+	passiveRT.CreateUser("alice", []string{"*"})
+
+	// Admin-authored private document on active, in a channel that would
+	// never match a scoped run_as user's access (because no such user
+	// exists to grant access to).
+	docID := "private_doc_" + rest.SafeDocumentName(t, t.Name())
+	version := activeRT.PutDoc(docID, `{"channels":["`+privateChannel+`"],"content":"secret"}`)
+	activeRT.WaitForPendingChanges()
+
+	// One-shot (non-continuous) push with run_as: <non-existent user>.
+	// One-shot is used instead of continuous so the replicator reaches a
+	// terminal state on its own — a continuous replication holds the cbgt
+	// cluster-config subscription open and can deadlock on test teardown.
+	collectionsEnabled := strconv.FormatBool(!activeRT.GetDatabase().OnlyDefaultCollection())
+	replConf := fmt.Sprintf(`{
+        "replication_id": "%s",
+        "remote": "%s/%s",
+        "direction": "push",
+        "continuous": false,
+        "run_as": "%s",
+        "remote_username": "alice",
+        "remote_password": "%s",
+		"initial_state": "stopped",
+        "collections_enabled": %s
+    }`, repl1Name, publicSrv.URL, passiveRT.GetDatabase().Name,
+		runAsMissing, rest.RestTesterDefaultUserPassword, collectionsEnabled)
+
+	configResp := activeRT.SendAdminRequest(http.MethodPut,
+		"/{{.db}}/_replication/"+repl1Name, replConf)
+	rest.RequireStatus(t, configResp, http.StatusCreated)
+
+	// StartReplications will error initialising the replicator but will not return an error
+	require.NoError(t, activeRT.GetDatabase().SGReplicateMgr.StartReplications(activeRT.Context()))
+
+	activeRT.WaitForReplicationStatus(repl1Name, db.ReplicationStateError)
+
+	resp := passiveRT.SendAdminRequest(http.MethodGet,
+		"/{{.keyspace}}/"+docID, "")
+	require.Equal(t, http.StatusNotFound, resp.Code, "expected secret doc to not be pushed")
+
+	// create a replication with the same config but without the run_as field, this should push the doc successfully as admin
+	replConfNoRunAs := fmt.Sprintf(`{
+		 "replication_id": "%s",
+        "remote": "%s/%s",
+        "direction": "push",
+        "continuous": false,
+        "remote_username": "alice",
+        "remote_password": "%s",
+        "collections_enabled": %s
+		}`, repl2Name, publicSrv.URL, passiveRT.GetDatabase().Name, rest.RestTesterDefaultUserPassword, collectionsEnabled)
+
+	configResp = activeRT.SendAdminRequest(http.MethodPut,
+		"/{{.db}}/_replication/"+repl2Name, replConfNoRunAs)
+	rest.RequireStatus(t, configResp, http.StatusCreated)
+
+	// doc should be pushed successfully with the second replication that doesn't have run_as set
+	passiveRT.WaitForVersion(docID, version)
+	activeRT.WaitForReplicationStatus(repl2Name, db.ReplicationStateStopped)
+
+	// purge doc on passive
+	passiveRT.PurgeDoc(docID)
+
+	// now create a replication with the bad run_as user again, but this time don't specify initial state so the replication starts straight away
+	replConf = fmt.Sprintf(`{
+        "replication_id": "%s",
+        "remote": "%s/%s",
+        "direction": "push",
+        "continuous": false,
+        "run_as": "%s",
+        "remote_username": "alice",
+        "remote_password": "%s",
+        "collections_enabled": %s
+    }`, repl3Name, publicSrv.URL, passiveRT.GetDatabase().Name,
+		runAsMissing, rest.RestTesterDefaultUserPassword, collectionsEnabled)
+
+	configResp = activeRT.SendAdminRequest(http.MethodPut,
+		"/{{.db}}/_replication/"+repl3Name, replConf)
+	rest.RequireStatus(t, configResp, http.StatusCreated)
+
+	// assert that the replication doesn't start
+	activeRT.WaitForReplicationStatus(repl3Name, db.ReplicationStateError)
+
+	resp = passiveRT.SendAdminRequest(http.MethodGet,
+		"/{{.keyspace}}/"+docID, "")
+	require.Equal(t, http.StatusNotFound, resp.Code, "expected secret doc to not be pushed")
+}
+
+// TestISGRRunAsNonExistentUserLegacyConfig verifies that a replication with a non-existent
+// run_as user defined inline in the database config (legacy file-based config style, via
+// RestTesterConfig.DatabaseConfig.Replications) enters the error state and does not push
+// any documents.
+func TestISGRRunAsNonExistentUserReplicationConfigInDbConfig(t *testing.T) {
+	base.LongRunningTest(t)
+	base.RequireNumTestBuckets(t, 2)
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyReplicate, base.KeyHTTP, base.KeyAccess, base.KeyChanges)
+
+	const (
+		replName       = "repl-legacy"
+		runAsMissing   = "missinguser"
+		privateChannel = "secret"
+		aliceUser      = "alice"
+	)
+
+	syncFn := `function(doc) { channel(doc.channels); }`
+
+	// Passive peer — receives docs; provides alice for remote auth.
+	passiveRT := rest.NewRestTester(t, &rest.RestTesterConfig{
+		SyncFn: syncFn,
+	})
+	defer passiveRT.Close()
+
+	publicSrv := httptest.NewServer(passiveRT.TestPublicHandler())
+	defer publicSrv.Close()
+
+	passiveRT.CreateUser(aliceUser, []string{"*"})
+
+	// collectionsEnabled mirrors !OnlyDefaultCollection() for the passive RT.
+	// Both RTs share the same test environment so the topology is identical.
+	collectionsEnabled := !passiveRT.GetDatabase().OnlyDefaultCollection()
+
+	// Define the replication inline in the DatabaseConfig
+	// rather than creating it through the admin REST API.
+	// initial_state "stopped" prevents it from running before we call
+	// StartReplications, while still exercising the initialisation path that
+	// validates run_as.
+	activeRT := rest.NewRestTester(t, &rest.RestTesterConfig{
+		SyncFn:             syncFn,
+		SgReplicateEnabled: true,
+		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+			Replications: map[string]*db.ReplicationConfig{
+				replName: {
+					ID:                 replName,
+					Remote:             fmt.Sprintf("%s/%s", publicSrv.URL, passiveRT.GetDatabase().Name),
+					Direction:          db.ActiveReplicatorTypePush,
+					Continuous:         false,
+					RunAs:              runAsMissing,
+					RemoteUsername:     aliceUser,
+					RemotePassword:     rest.RestTesterDefaultUserPassword,
+					InitialState:       db.ReplicationStateStopped,
+					CollectionsEnabled: collectionsEnabled,
+				},
+			},
+		}},
+	})
+	defer activeRT.Close()
+
+	// Admin-authored private document; a non-existent run_as user can never
+	// be granted access to this channel.
+	docID := "private_doc_" + rest.SafeDocumentName(t, t.Name())
+	activeRT.PutDoc(docID, `{"channels":["`+privateChannel+`"],"content":"secret"}`)
+	activeRT.WaitForPendingChanges()
+
+	// StartReplications initialises the replicator; it errors on the missing
+	// run_as user but does not surface an error to the caller.
+	require.NoError(t, activeRT.GetDatabase().SGReplicateMgr.StartReplications(activeRT.Context()))
+
+	activeRT.WaitForReplicationStatus(replName, db.ReplicationStateError)
+
+	resp := passiveRT.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/"+docID, "")
+	require.Equal(t, http.StatusNotFound, resp.Code, "expected secret doc to not be pushed with invalid run_as user")
 }


### PR DESCRIPTION
CBG-5768

Unclean cherry pick of #8205 to 4.0.8

- `rest/replicatortest/replicator_test.go`: this branch declared
  `var body []map[string]interface{}`. Upstream already changed it to `any`, so
  the deleted block did not match. The resolution takes the upstream
  replacement, `rt.WaitForReplicationStatus`. The production change in
  `db/sg_replicate_cfg.go` is identical to upstream.

## Why this PR includes CBG-5337 (#8204)

The first commit backports #8204. That commit removes `DatabaseContext.BucketLock`
from `Authenticator()`. It has no backport ticket. Without it, this backport
deadlocks.

🤖 Opened with the `sync-gateway-backport` skill in [Claude Code](https://claude.com/claude-code)
