### PR TITLE
CBG-5738: Rename CB Server 8.1 to 8.5

### DIFF
--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -314,11 +314,14 @@ func TestClusterVersion(t testing.TB) *ComparableBuildVersion {
 	return &version
 }
 
-// RequireServerVersionForTest skips the test unless the Couchbase Server backing the test bucket pool
-// is at least the minimum version required for its release train. Pass one minimum version per release
-// train the feature shipped in, e.g. RequireServerVersionForTest(t, "7.6.12", "8.0.3", "8.5.0"). This
-// is a no-op when not running against Couchbase Server, since those tests are gated separately.
-func RequireServerVersionForTest(t testing.TB, minReleaseVersions ...string) {
+// RequireAtLeastServerVersionForTest skips the test unless the Couchbase Server backing the test bucket
+// pool meets the minimum version for its release train, matched on major.minor. Pass one minimum per
+// train that needs a floor, e.g. RequireAtLeastServerVersionForTest(t, "7.6.12", "8.0.3") for a feature
+// backported to those patch releases. Trains newer than every minimum given qualify automatically, so
+// the newest train needs listing only to exclude some of its builds - and doing so raises the bar for
+// every unlisted train. Trains older than all the minimums never qualify. This is a no-op when not
+// running against Couchbase Server, since those tests are gated separately.
+func RequireAtLeastServerVersionForTest(t testing.TB, minReleaseVersions ...string) {
 	if !sgtest.TestUseCouchbaseServer() {
 		return
 	}

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -316,7 +316,7 @@ func TestClusterVersion(t testing.TB) *ComparableBuildVersion {
 
 // RequireServerVersionForTest skips the test unless the Couchbase Server backing the test bucket pool
 // is at least the minimum version required for its release train. Pass one minimum version per release
-// train the feature shipped in, e.g. RequireServerVersionForTest(t, "7.6.12", "8.0.3", "8.1.0"). This
+// train the feature shipped in, e.g. RequireServerVersionForTest(t, "7.6.12", "8.0.3", "8.5.0"). This
 // is a no-op when not running against Couchbase Server, since those tests are gated separately.
 func RequireServerVersionForTest(t testing.TB, minReleaseVersions ...string) {
 	if !sgtest.TestUseCouchbaseServer() {

--- a/base/version_comparable_build.go
+++ b/base/version_comparable_build.go
@@ -170,13 +170,15 @@ func (pv *ComparableBuildVersion) AtLeastMinorVersion(major, minor uint8) bool {
 
 // AtLeastReleaseVersion reports whether pv is at least the minimum version applicable to its
 // release train, given one minimum version per train. This is for features shipped (or backported)
-// across several release trains at different patch levels - e.g. a feature available in 7.6.12,
-// 8.0.3, and 8.5.0. The rule per train (matched on major.minor):
+// across several release trains at different patch levels - e.g. a feature backported to 7.6.12 and
+// 8.0.3. Given those two minimums, the rule per train (matched on major.minor):
 //   - 7.6.x qualifies only if >= 7.6.12
 //   - 8.0.x qualifies only if >= 8.0.3
-//   - 8.5.x qualifies (>= 8.5.0, i.e. any 8.5 build)
-//   - anything newer than every listed minimum (e.g. 8.6.0) qualifies
-//   - anything in an older, unlisted train does not qualify
+//   - anything newer than every listed minimum (e.g. 8.1.0, 8.5.0) qualifies without being listed
+//   - anything in an older, unlisted train (e.g. 7.2.0) does not qualify
+//
+// Listing a train's minimum is therefore only needed to hold that train to a floor - and note that
+// the newest minimum listed also becomes the floor for every unlisted train.
 //
 // Returns false if pv is nil or no minimum versions are provided.
 func (pv *ComparableBuildVersion) AtLeastReleaseVersion(minVersions ...*ComparableBuildVersion) bool {

--- a/base/version_comparable_build.go
+++ b/base/version_comparable_build.go
@@ -171,11 +171,11 @@ func (pv *ComparableBuildVersion) AtLeastMinorVersion(major, minor uint8) bool {
 // AtLeastReleaseVersion reports whether pv is at least the minimum version applicable to its
 // release train, given one minimum version per train. This is for features shipped (or backported)
 // across several release trains at different patch levels - e.g. a feature available in 7.6.12,
-// 8.0.3, and 8.1.0. The rule per train (matched on major.minor):
+// 8.0.3, and 8.5.0. The rule per train (matched on major.minor):
 //   - 7.6.x qualifies only if >= 7.6.12
 //   - 8.0.x qualifies only if >= 8.0.3
-//   - 8.1.x qualifies (>= 8.1.0, i.e. any 8.1 build)
-//   - anything newer than every listed minimum (e.g. 8.2.0) qualifies
+//   - 8.5.x qualifies (>= 8.5.0, i.e. any 8.5 build)
+//   - anything newer than every listed minimum (e.g. 8.6.0) qualifies
 //   - anything in an older, unlisted train does not qualify
 //
 // Returns false if pv is nil or no minimum versions are provided.

--- a/base/version_comparable_build_test.go
+++ b/base/version_comparable_build_test.go
@@ -259,40 +259,83 @@ func TestAtLeastMinorDowngradeVersion(t *testing.T) {
 }
 
 func TestAtLeastReleaseVersion(t *testing.T) {
-	// Feature shipped across three release trains at different patch levels.
-	minVersions := []string{"7.6.12", "8.0.3", "8.5.0"}
-	testCases := []struct {
-		version   string
-		qualifies bool
+	tests := []struct {
+		name        string
+		minVersions []string
+		versions    map[string]bool
 	}{
-		{version: "7.6.11", qualifies: false},
-		{version: "7.6.12", qualifies: true},
-		{version: "7.6.13", qualifies: true},
-		{version: "8.0.2", qualifies: false},
-		{version: "8.0.3", qualifies: true},
-		{version: "8.0.4", qualifies: true},
-		{version: "8.5.0", qualifies: true},
-		{version: "8.5.5", qualifies: true},
-		{version: "8.6.0", qualifies: true},
-		{version: "9.0.0", qualifies: true},
-		{version: "7.6.0", qualifies: false},
-		{version: "7.2.0", qualifies: false},
+		{
+			name:        "backported to two trains",
+			minVersions: []string{"7.6.12", "8.0.3"},
+			versions: map[string]bool{
+				"7.2.0":  false,
+				"7.6.0":  false,
+				"7.6.11": false,
+				"7.6.12": true,
+				"7.6.13": true,
+				"8.0.2":  false,
+				"8.0.3":  true,
+				"8.0.4":  true,
+				// unlisted trains newer than every minimum qualify without being listed
+				"8.1.0": true,
+				"8.5.0": true,
+				"9.0.0": true,
+			},
+		},
+		{
+			name: "newest train listed, holding unlisted trains to its floor",
+			// listing 8.5.0 raises the bar for unlisted trains, so 8.1.x no longer qualifies
+			minVersions: []string{"7.6.12", "8.0.3", "8.5.0"},
+			versions: map[string]bool{
+				"8.0.3": true,
+				"8.1.0": false,
+				"8.5.0": true,
+				"8.5.5": true,
+				"8.6.0": true,
+			},
+		},
+		{
+			name:        "build-numbered minimum",
+			minVersions: []string{"7.6.0", "8.0.4", "8.1.0@2674"},
+			versions: map[string]bool{
+				"7.6.0":      true,
+				"8.0.3":      false,
+				"8.0.4":      true,
+				"8.1.0@2673": false,
+				"8.1.0@2674": true,
+				"8.1.1":      true,
+				"8.5.0":      true,
+			},
+		},
 	}
 
-	mins := make([]*ComparableBuildVersion, 0, len(minVersions))
-	for _, v := range minVersions {
-		parsed, err := NewComparableBuildVersionFromString(v)
-		require.NoError(t, err)
-		mins = append(mins, parsed)
-	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mins := make([]*ComparableBuildVersion, 0, len(test.minVersions))
+			for _, v := range test.minVersions {
+				parsed, err := NewComparableBuildVersionFromString(v)
+				require.NoError(t, err)
+				mins = append(mins, parsed)
+			}
 
-	for _, test := range testCases {
-		t.Run(test.version, func(t *testing.T) {
-			version, err := NewComparableBuildVersionFromString(test.version)
-			require.NoError(t, err)
-			require.Equal(t, test.qualifies, version.AtLeastReleaseVersion(mins...))
+			for versionStr, qualifies := range test.versions {
+				t.Run(versionStr, func(t *testing.T) {
+					version, err := NewComparableBuildVersionFromString(versionStr)
+					require.NoError(t, err)
+					require.Equal(t, qualifies, version.AtLeastReleaseVersion(mins...))
+				})
+			}
 		})
 	}
+}
+
+func TestAtLeastReleaseVersionNoMinimums(t *testing.T) {
+	version, err := NewComparableBuildVersionFromString("8.5.0")
+	require.NoError(t, err)
+	require.False(t, version.AtLeastReleaseVersion())
+
+	var nilVersion *ComparableBuildVersion
+	require.False(t, nilVersion.AtLeastReleaseVersion(version))
 }
 
 func BenchmarkComparableBuildVersion(b *testing.B) {

--- a/base/version_comparable_build_test.go
+++ b/base/version_comparable_build_test.go
@@ -260,7 +260,7 @@ func TestAtLeastMinorDowngradeVersion(t *testing.T) {
 
 func TestAtLeastReleaseVersion(t *testing.T) {
 	// Feature shipped across three release trains at different patch levels.
-	minVersions := []string{"7.6.12", "8.0.3", "8.1.0"}
+	minVersions := []string{"7.6.12", "8.0.3", "8.5.0"}
 	testCases := []struct {
 		version   string
 		qualifies bool
@@ -271,9 +271,9 @@ func TestAtLeastReleaseVersion(t *testing.T) {
 		{version: "8.0.2", qualifies: false},
 		{version: "8.0.3", qualifies: true},
 		{version: "8.0.4", qualifies: true},
-		{version: "8.1.0", qualifies: true},
-		{version: "8.1.5", qualifies: true},
-		{version: "8.2.0", qualifies: true},
+		{version: "8.5.0", qualifies: true},
+		{version: "8.5.5", qualifies: true},
+		{version: "8.6.0", qualifies: true},
 		{version: "9.0.0", qualifies: true},
 		{version: "7.6.0", qualifies: false},
 		{version: "7.2.0", qualifies: false},

--- a/integration-test/start_cbs.py
+++ b/integration-test/start_cbs.py
@@ -200,7 +200,7 @@ def main() -> None:
         services = ", ".join(s.strip() for s in opts.services.split(",") if s.strip())
 
         # A version containing '/' is a full docker image reference (e.g.
-        # ghcr.io/cb-vanilla/server:8.1.0), not a plain version string - pull it directly via
+        # ghcr.io/cb-vanilla/server:8.5.0), not a plain version string - pull it directly via
         # docker.image instead of letting cbdinocluster resolve 'version' against its registries.
         # 'version' is still set to the same raw string in this case: cbdinocluster's node
         # deployment (getImagesForNodeGrps) skips version resolution entirely whenever

--- a/rest/fleet_manager_reporter_test.go
+++ b/rest/fleet_manager_reporter_test.go
@@ -29,7 +29,7 @@ func TestSendingMetricsToNsServerCollector(t *testing.T) {
 	if !sgtest.TestUseCouchbaseServer() {
 		t.Skip("Fleet Manager Collector only works on CBS")
 	}
-	base.RequireServerVersionForTest(t, "7.6.12", "8.0.3", "8.5.0")
+	base.RequireAtLeastServerVersionForTest(t, "7.6.12", "8.0.3")
 	rt := NewRestTesterPersistentConfig(t)
 	defer rt.Close()
 	ctx := rt.Context()
@@ -60,7 +60,7 @@ func TestSendingMetricsToNsServerCollectorAsMobileSyncGatewayRole(t *testing.T) 
 	if !sgtest.TestUseCouchbaseServer() {
 		t.Skip("Fleet Manager Collector only works on CBS")
 	}
-	base.RequireServerVersionForTest(t, "7.6.12", "8.0.3", "8.5.0")
+	base.RequireAtLeastServerVersionForTest(t, "7.6.12", "8.0.3")
 	rt := NewRestTesterPersistentConfig(t)
 	defer rt.Close()
 	ctx := rt.Context()
@@ -89,7 +89,7 @@ func TestSendingMetricsWhenCollectorDisabled(t *testing.T) {
 	if !sgtest.TestUseCouchbaseServer() {
 		t.Skip("Fleet Manager Collector only works on CBS")
 	}
-	base.RequireServerVersionForTest(t, "7.6.12", "8.0.3", "8.5.0")
+	base.RequireAtLeastServerVersionForTest(t, "7.6.12", "8.0.3")
 
 	rt := NewRestTesterPersistentConfig(t)
 	defer rt.Close()
@@ -131,7 +131,7 @@ func TestNoContentResponseForCollector(t *testing.T) {
 	if !sgtest.TestUseCouchbaseServer() {
 		t.Skip("Fleet Manager Collector only works on CBS")
 	}
-	base.RequireServerVersionForTest(t, "7.6.12", "8.0.3", "8.5.0")
+	base.RequireAtLeastServerVersionForTest(t, "7.6.12", "8.0.3")
 	rt := NewRestTesterPersistentConfig(t)
 	defer rt.Close()
 
@@ -154,7 +154,7 @@ func TestGetCollectorSettings(t *testing.T) {
 	if !sgtest.TestUseCouchbaseServer() {
 		t.Skip("Fleet Manager Collector only works on CBS")
 	}
-	base.RequireServerVersionForTest(t, "7.6.12", "8.0.3", "8.5.0")
+	base.RequireAtLeastServerVersionForTest(t, "7.6.12", "8.0.3")
 	rt := NewRestTesterPersistentConfig(t)
 	defer rt.Close()
 	ctx := rt.Context()

--- a/rest/fleet_manager_reporter_test.go
+++ b/rest/fleet_manager_reporter_test.go
@@ -29,7 +29,7 @@ func TestSendingMetricsToNsServerCollector(t *testing.T) {
 	if !sgtest.TestUseCouchbaseServer() {
 		t.Skip("Fleet Manager Collector only works on CBS")
 	}
-	base.RequireServerVersionForTest(t, "7.6.12", "8.0.3", "8.1.0")
+	base.RequireServerVersionForTest(t, "7.6.12", "8.0.3", "8.5.0")
 	rt := NewRestTesterPersistentConfig(t)
 	defer rt.Close()
 	ctx := rt.Context()
@@ -60,7 +60,7 @@ func TestSendingMetricsToNsServerCollectorAsMobileSyncGatewayRole(t *testing.T) 
 	if !sgtest.TestUseCouchbaseServer() {
 		t.Skip("Fleet Manager Collector only works on CBS")
 	}
-	base.RequireServerVersionForTest(t, "7.6.12", "8.0.3", "8.1.0")
+	base.RequireServerVersionForTest(t, "7.6.12", "8.0.3", "8.5.0")
 	rt := NewRestTesterPersistentConfig(t)
 	defer rt.Close()
 	ctx := rt.Context()
@@ -89,7 +89,7 @@ func TestSendingMetricsWhenCollectorDisabled(t *testing.T) {
 	if !sgtest.TestUseCouchbaseServer() {
 		t.Skip("Fleet Manager Collector only works on CBS")
 	}
-	base.RequireServerVersionForTest(t, "7.6.12", "8.0.3", "8.1.0")
+	base.RequireServerVersionForTest(t, "7.6.12", "8.0.3", "8.5.0")
 
 	rt := NewRestTesterPersistentConfig(t)
 	defer rt.Close()
@@ -131,7 +131,7 @@ func TestNoContentResponseForCollector(t *testing.T) {
 	if !sgtest.TestUseCouchbaseServer() {
 		t.Skip("Fleet Manager Collector only works on CBS")
 	}
-	base.RequireServerVersionForTest(t, "7.6.12", "8.0.3", "8.1.0")
+	base.RequireServerVersionForTest(t, "7.6.12", "8.0.3", "8.5.0")
 	rt := NewRestTesterPersistentConfig(t)
 	defer rt.Close()
 
@@ -154,7 +154,7 @@ func TestGetCollectorSettings(t *testing.T) {
 	if !sgtest.TestUseCouchbaseServer() {
 		t.Skip("Fleet Manager Collector only works on CBS")
 	}
-	base.RequireServerVersionForTest(t, "7.6.12", "8.0.3", "8.1.0")
+	base.RequireServerVersionForTest(t, "7.6.12", "8.0.3", "8.5.0")
 	rt := NewRestTesterPersistentConfig(t)
 	defer rt.Close()
 	ctx := rt.Context()

--- a/rest/manualbucketpooltest/metadata_migration_no_default_test.go
+++ b/rest/manualbucketpooltest/metadata_migration_no_default_test.go
@@ -329,7 +329,7 @@ func TestMigrationThenDropDefaultCollectionTwoDatabases(t *testing.T) {
 
 	// MB-73113: a deferred index build never finishes on any collection once _default._default has been dropped.
 	// Fixed in 8.0.4, 8.1.0@2674, and all 8.5.0+ builds. 7.6.x is unaffected, hence the 7.6.0 minimum.
-	base.RequireServerVersionForTest(t, "7.6.0", "8.0.4", "8.1.0@2674")
+	base.RequireAtLeastServerVersionForTest(t, "7.6.0", "8.0.4", "8.1.0@2674")
 
 	ctx := base.TestCtx(t)
 

--- a/rest/manualbucketpooltest/metadata_migration_no_default_test.go
+++ b/rest/manualbucketpooltest/metadata_migration_no_default_test.go
@@ -328,8 +328,8 @@ func TestMigrationThenDropDefaultCollectionTwoDatabases(t *testing.T) {
 	base.TestRequiresCollections(t)
 
 	// MB-73113: a deferred index build never finishes on any collection once _default._default has been dropped.
-	// Fixed in 8.1.0@2674. There is no 8.0.x backport yet, so the 8.0 minimum stays at a build no release will reach.
-	base.RequireServerVersionForTest(t, "7.6.0", "8.0.99", "8.1.0@2674")
+	// Fixed in 8.0.4, 8.1.0@2674, and all 8.5.0+ builds. 7.6.x is unaffected, hence the 7.6.0 minimum.
+	base.RequireServerVersionForTest(t, "7.6.0", "8.0.4", "8.1.0@2674")
 
 	ctx := base.TestCtx(t)
 


### PR DESCRIPTION
CBG-5738

- Rename CB Server 8.1 to 8.5
- `TestMigrationThenDropDefaultCollectionTwoDatabases` retains its 8.1.0@2674 fix version just in case we decide to go back and re-run against older server builds. Included 8.0.4 as a fix version and 8.5.0 is implicitly enabled and not skipped with the version helper.
- Rename/improve comments on `RequireServerVersionForTest` helper for clarity

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] 8.0.2 https://jenkins.sgwdev.com/job/SyncGatewayIntegration/1126/

<!--
Automated review runs on every non-draft PR raised from this repo (forks are not reviewed automatically).
  - Re-run it, or ask a follow-up, by commenting `@droid <question>`
  - Suppress it with the `droid-skip` label, or `WIP`/`DO NOT MERGE` in the title
-->
