### PR TITLE
[3.3.8 Backport] CBG-5798: notify change listener on principal deletions

### DIFF
--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -176,16 +176,17 @@ func (listener *changeListener) ProcessFeedEvent(event sgbucket.FeedEvent) bool 
 		return true
 	}
 
-	if event.Opcode != sgbucket.FeedOpMutation {
-		// nothing more to handle and this point if the event is not a mutation
-		return true
-	}
-
+	// Notify for principal mutations *and* deletions to wake changes feeds.
 	docType := listener.DocumentType(event.Key)
 	if docType == DocTypeUser || docType == DocTypeRole {
 		// defer to notify after callback completion
 		key := channels.NewID(string(event.Key), principalDocCollectionIDForChannelID)
 		defer listener.notifyKey(listener.ctx, key)
+	}
+
+	if event.Opcode != sgbucket.FeedOpMutation {
+		// nothing more to handle at this point if the event is not a mutation
+		return true
 	}
 
 	listener.OnDocChanged(event, docType)

--- a/db/change_listener_test.go
+++ b/db/change_listener_test.go
@@ -133,3 +133,69 @@ func TestUserWaiterForRoleChange(t *testing.T) {
 	// Wait for user notification of updated role
 	require.True(t, WaitForUserWaiterChange(userWaiter))
 }
+
+// TestUserWaiterForUserDelete ensures that deleting a user notifies the change listener.  A deletion
+// that isn't notified leaves running feeds serving a user that no longer exists.
+func TestUserWaiterForUserDelete(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
+
+	const username = "bob"
+	authenticator := db.Authenticator(ctx)
+	user, err := authenticator.NewUser(username, "letmein", channels.BaseSetOf(t, "ABC"))
+	require.NoError(t, err, "Error creating new user")
+
+	// Create the waiter before the save, so the save's notification can't land before the waiter
+	// takes its baseline count
+	userDb, err := GetDatabase(db.DatabaseContext, user)
+	require.NoError(t, err)
+	userWaiter := userDb.NewUserWaiter()
+
+	require.NoError(t, authenticator.Save(user), "Error saving user")
+
+	// Wait for notify from the save, so the next wait can only be satisfied by the delete
+	require.True(t, WaitForUserWaiterChange(userWaiter))
+
+	require.NoError(t, authenticator.DeleteUser(user), "Error deleting user")
+	require.True(t, WaitForUserWaiterChange(userWaiter))
+}
+
+// TestUserWaiterForRolePurge ensures that a purged role notifies the change listener.  A non-purge
+// role delete writes a tombstone (a mutation), but purge is a true deletion.
+func TestUserWaiterForRolePurge(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
+
+	const roleName = "good_egg"
+	authenticator := db.Authenticator(ctx)
+	role, err := authenticator.NewRole(roleName, channels.BaseSetOf(t, "ABC"))
+	require.NoError(t, err, "Error creating new role")
+	require.NoError(t, authenticator.Save(role))
+
+	const username = "bob"
+	user, err := authenticator.NewUser(username, "letmein", nil)
+	require.NoError(t, err, "Error creating new user")
+	user.SetExplicitRoles(channels.AtSequence(base.SetOf(roleName), 1), 1)
+
+	// Create the waiter before the save, so the save's notification can't land before the waiter
+	// takes its baseline count
+	userDb, err := GetDatabase(db.DatabaseContext, user)
+	require.NoError(t, err)
+	userWaiter := userDb.NewUserWaiter()
+
+	require.NoError(t, authenticator.Save(user), "Error saving user")
+	require.True(t, WaitForUserWaiterChange(userWaiter))
+
+	// Retrieving the user moves ExplicitRoles->roles, which is another user write to wait out
+	user, err = authenticator.GetUser(username)
+	require.NoError(t, err, "Error retrieving user")
+	require.True(t, user.RoleNames().Contains(roleName))
+	require.True(t, WaitForUserWaiterChange(userWaiter))
+
+	// Add the role to the waiter's keys.  RefreshUserKeys re-baselines the count, so the next wait
+	// can only be satisfied by the purge.
+	userWaiter.RefreshUserKeys(user, db.MetadataKeys)
+
+	require.NoError(t, db.DeleteRole(ctx, roleName, true), "Error purging role")
+	require.True(t, WaitForUserWaiterChange(userWaiter))
+}

--- a/db/users.go
+++ b/db/users.go
@@ -33,6 +33,8 @@ func (db *DatabaseContext) DeleteRole(ctx context.Context, name string, purge bo
 		return base.ErrNotFound
 	}
 
+	// CBG-5789: a purge is a true deletion of the role document and ignores this sequence, so it is
+	// neither written nor released - leaving a permanent gap in the sequence range.
 	seq, err := db.sequences.nextSequence(ctx)
 	if err != nil {
 		return err

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -2918,21 +2918,11 @@ func TestRequestPlusPullDbConfig(t *testing.T) {
 	})
 }
 
-// TestBlipRefreshUser makes sure there is no panic if a user gets deleted during a replication
-func TestBlipRefreshUser(t *testing.T) {
-
-	t.Skip("CBG-3512 known test flake")
-	/*
-		This probably happens because:
-
-		1. The unsubChanges comes in before the delete mutation arrives over the caching DCP feed. This fails the test (doesn’t return 503)
-
-		2. The delete mutation arrives over the caching feed, notifies the changes feed, and the changes feed errors out before the unsubChanges call is made. The test passes in this case
-
-		3. The delete mutation arrives over the caching feed, and the unsubChanges call is made before the changes feed is notified/errors out. The test also passes in this case
-
-			The problem is that adding a doc after the DELETE happens means that it might be guaranteed to hit (2) and never hit (3). I don't see how to make the test as is guarantee to catch this panic.
-	*/
+// TestBlipMessageAfterUserDelete ensures a blip message on a connection whose user has since been
+// deleted fails with CBLReconnectErrorCode, CBL's cue to reconnect and re-authenticate.  Uses a
+// one-shot pull so no continuous changes feed is running, which would tear down the connection and
+// race with the message below - TestBlipPullReplicationUserDeleted covers that teardown.
+func TestBlipMessageAfterUserDelete(t *testing.T) {
 	rtConfig := RestTesterConfig{
 		SyncFn: channels.DocChannelsSyncFunction,
 	}
@@ -2944,45 +2934,33 @@ func TestBlipRefreshUser(t *testing.T) {
 		defer rt.Close()
 
 		const username = "bernard"
-		// Initialize blip tester client (will create user)
-		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
-			Username:               "bernard",
-			Channels:               []string{"chan1"},
+		rt.CreateUser(username, []string{"chan1"})
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
+			Username:               username,
 			SupportedBLIPProtocols: SupportedBLIPProtocols,
 		})
-		defer btc.Close()
-
-		// add chan1 explicitly
-		rt.CreateUser(username, []string{"chan1"})
+		defer client.Close()
 
 		version := rt.PutDoc(docID, `{"channels":["chan1"]}`)
 
-		// Start a regular one-shot pull
-		btcRunner.StartPullSince(btc.id, BlipTesterPullOptions{Continuous: true, Since: "0"})
-
-		_ = btcRunner.WaitForDoc(btc.id, docID)
-
-		_, ok := btcRunner.GetVersion(btc.id, docID, version)
-		require.True(t, ok)
-
-		// delete user with an active blip connection
-		response := rt.SendAdminRequest(http.MethodDelete, "/{{.db}}/_user/"+username, "")
-		RequireStatus(t, response, http.StatusOK)
-
+		// A one-shot pull only sends what the cache has already seen
 		rt.WaitForPendingChanges()
 
-		// further requests will 500, but shouldn't panic
+		btcRunner.StartOneshotPull(client.id)
+		btcRunner.WaitForVersion(client.id, docID, version)
+
+		// refreshUser only reloads once the deletion has been notified over the caching feed
+		userWaiter := rt.NewUserWaiter(username)
+		rt.DeleteUser(username)
+		require.True(t, db.WaitForUserWaiterChange(userWaiter))
+
 		unsubChangesRequest := blip.NewRequest()
 		unsubChangesRequest.SetProfile(db.MessageUnsubChanges)
-		btc.addCollectionProperty(unsubChangesRequest)
+		client.addCollectionProperty(unsubChangesRequest)
+		client.pullReplication.sendMsg(unsubChangesRequest)
 
-		btc.pullReplication.sendMsg(unsubChangesRequest)
-
-		testResponse := unsubChangesRequest.Response()
-		require.Equal(t, strconv.Itoa(db.CBLReconnectErrorCode), testResponse.Properties[db.BlipErrorCode])
-		body, err := testResponse.Body()
-		require.NoError(t, err)
-		require.NotContains(t, string(body), "Panic:")
+		response := unsubChangesRequest.Response()
+		require.Equal(t, strconv.Itoa(db.CBLReconnectErrorCode), response.Properties[db.BlipErrorCode])
 	})
 }
 
@@ -3267,4 +3245,94 @@ func TestBlipPushRevOnResurrection(t *testing.T) {
 			})
 		})
 	}
+}
+
+// TestBlipPullReplicationUserDeleted ensures that deleting a user terminates a running BLIP pull
+// replication for that user.  Unlike the HTTP _changes tests, a changes feed error here tears down the
+// whole websocket connection.
+func TestBlipPullReplicationUserDeleted(t *testing.T) {
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
+		defer rt.Close()
+
+		const (
+			username = "alice"
+			channel  = "chan1"
+		)
+		rt.CreateUser(username, []string{channel})
+
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{Username: username, SupportedBLIPProtocols: SupportedBLIPProtocols})
+		defer client.Close()
+		btcRunner.StartPull(client.id)
+
+		pullStats := rt.GetDatabase().DbStats.CBLReplicationPull()
+		dbStats := rt.GetDatabase().DbStats.Database()
+
+		// Replicate a doc to the client, so we know the continuous changes feed is running
+		beforeDelete := rt.PutDoc("beforeDelete", `{"channels":["`+channel+`"]}`)
+		btcRunner.WaitForVersion(client.id, "beforeDelete", beforeDelete)
+		require.Equal(t, int64(1), pullStats.NumPullReplActiveContinuous.Value())
+
+		// BlipTesterClient opens separate websockets for pull and push, so only one is torn down here
+		replicationsBeforeDelete := dbStats.NumReplicationsActive.Value()
+
+		rt.DeleteUser(username)
+
+		// The changes feed ends...
+		base.RequireWaitForStat(t, pullStats.NumPullReplActiveContinuous.Value, 0)
+		// ...and takes the whole blip connection with it
+		base.RequireWaitForStat(t, dbStats.NumReplicationsActive.Value, replicationsBeforeDelete-1)
+
+		// A doc written in the deleted user's channel afterwards isn't replicated, and no new
+		// subChanges is started
+		rt.PutDoc("afterDelete", `{"channels":["`+channel+`"]}`)
+		rt.WaitForPendingChanges()
+		require.Equal(t, int64(0), pullStats.NumPullReplActiveContinuous.Value())
+		require.Equal(t, int64(1), pullStats.NumPullReplTotalContinuous.Value())
+	})
+}
+
+// TestBlipPullReplicationRolePurge ensures that purging a role revokes the role's channels from a
+// running BLIP pull replication for a user who holds that role.
+func TestBlipPullReplicationRolePurge(t *testing.T) {
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
+		defer rt.Close()
+
+		const (
+			username = "alice"
+			roleName = "chan1-role"
+			// roleChannel is granted only via the role, userChannel is granted directly
+			roleChannel = "chan1"
+			userChannel = "chan2"
+		)
+		rt.CreateRole(roleName, []string{roleChannel})
+		rt.CreateUser(username, []string{userChannel}, roleName)
+
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{Username: username, SupportedBLIPProtocols: SupportedBLIPProtocols})
+		defer client.Close()
+		btcRunner.StartPull(client.id)
+
+		// Prove the role grant is in effect before the purge
+		beforePurge := rt.PutDoc("beforePurge", `{"channels":["`+roleChannel+`"]}`)
+		btcRunner.WaitForVersion(client.id, "beforePurge", beforePurge)
+
+		// The purge has to be notified before the writes below, otherwise the replication wakes on the
+		// document notification alone and is still holding the stale channel set.
+		userWaiter := rt.NewUserWaiter(username)
+		RequireStatus(t, rt.SendAdminRequest(http.MethodDelete, "/{{.db}}/_role/"+roleName+"?purge=true", ""), http.StatusOK)
+		require.True(t, db.WaitForUserWaiterChange(userWaiter))
+
+		// Changes are sent in sequence order, so once afterPurgeAllowed arrives, afterPurgeRevoked would
+		// already have arrived if the revoked channel were still being served.  The purge leaks a
+		// sequence (CBG-5789), so afterPurgeRevoked isn't visible until CachePendingSeqMaxWait elapses.
+		revoked := rt.PutDoc("afterPurgeRevoked", `{"channels":["`+roleChannel+`"]}`)
+		allowed := rt.PutDoc("afterPurgeAllowed", `{"channels":["`+userChannel+`"]}`)
+		btcRunner.WaitForVersion(client.id, "afterPurgeAllowed", allowed)
+
+		_, found := btcRunner.GetVersion(client.id, "afterPurgeRevoked", revoked)
+		require.False(t, found, "document in the purged role's channel was replicated to the client")
+	})
 }

--- a/rest/changes_test.go
+++ b/rest/changes_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -390,4 +391,118 @@ func TestJumpInSequencesAtAllocatorRangeInPending(t *testing.T) {
 	changes := rt.WaitForChanges(2, "/{{.keyspace}}/_changes", "", true)
 	changes.RequireDocIDs(t, []string{"doc1", "doc"})
 	changes.RequireRevID(t, []string{docVrs.RevID, doc1Vrs.RevID})
+}
+
+// TestContinuousChangesUserDeleted ensures that deleting a user terminates a continuous _changes feed
+// running for that user.
+func TestContinuousChangesUserDeleted(t *testing.T) {
+	rt := NewRestTester(t, &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
+	defer rt.Close()
+
+	const (
+		username = "alice"
+		channel  = "chan1"
+	)
+	rt.CreateUser(username, []string{channel})
+	rt.PutDoc("beforeDelete", `{"channels":["`+channel+`"]}`)
+
+	rt.WaitForPendingChanges()
+
+	caughtUpCount := rt.GetDatabase().DbStats.CBLReplicationPull().NumPullReplCaughtUp.Value()
+	feed := rt.StartContinuousChanges("/{{.keyspace}}/_changes?feed=continuous&since=0", username)
+
+	require.NoError(t, rt.GetDatabase().WaitForCaughtUp(caughtUpCount+1))
+
+	rt.DeleteUser(username)
+	RequireStatus(t, rt.SendUserRequest(http.MethodGet, "/{{.keyspace}}/_changes", "", username), http.StatusUnauthorized)
+
+	changes := feed.RequireEnded()
+	base.RequireWaitForStat(t, rt.GetDatabase().DbStats.Database().NumReplicationsActive.Value, 0)
+
+	require.Len(t, changes, 2)
+	require.Equal(t, "_user/"+username, changes[0].ID)
+	require.Equal(t, "beforeDelete", changes[1].ID)
+}
+
+// TestLongpollChangesUserDeleted is the longpoll counterpart to TestContinuousChangesUserDeleted.
+func TestLongpollChangesUserDeleted(t *testing.T) {
+	rt := NewRestTester(t, &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
+	defer rt.Close()
+
+	const (
+		username = "alice"
+		channel  = "chan1"
+	)
+	rt.CreateUser(username, []string{channel})
+
+	rt.WaitForPendingChanges()
+	since := rt.GetChanges("/{{.keyspace}}/_changes", username).Last_Seq
+	caughtUpCount := rt.GetDatabase().DbStats.CBLReplicationPull().NumPullReplCaughtUp.Value()
+
+	var changes ChangesResults
+	feedDone := make(chan struct{})
+	go func() {
+		defer close(feedDone)
+		changes = rt.PostChanges("/{{.keyspace}}/_changes", fmt.Sprintf(`{"since":"%s", "feed":"longpoll"}`, since), username)
+	}()
+
+	require.NoError(t, rt.GetDatabase().WaitForCaughtUp(caughtUpCount+1))
+
+	rt.DeleteUser(username)
+
+	select {
+	case <-feedDone:
+	case <-time.After(30 * time.Second):
+		require.Fail(t, "longpoll changes feed still running after user delete")
+	}
+
+	require.Empty(t, changes.Results)
+}
+
+// TestContinuousChangesRolePurge ensures that purging a role revokes the role's channels from a
+// continuous _changes feed already running for a user who holds that role.  limit=1 terminates the feed
+// after the next change it sends, so the test can assert on which document that was.
+func TestContinuousChangesRolePurge(t *testing.T) {
+	rt := NewRestTester(t, &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
+	defer rt.Close()
+
+	const (
+		username = "alice"
+		roleName = "chan1-role"
+		// roleChannel is granted only via the role, userChannel is granted directly
+		roleChannel = "chan1"
+		userChannel = "chan2"
+	)
+	rt.CreateRole(roleName, []string{roleChannel})
+	rt.CreateUser(username, []string{userChannel}, roleName)
+
+	// Prove the role grant is in effect before the purge
+	rt.PutDoc("beforePurge", `{"channels":["`+roleChannel+`"]}`)
+	changes := rt.WaitForChanges(2, "/{{.keyspace}}/_changes?since=0", username, false)
+	require.Equal(t, "beforePurge", changes.Results[len(changes.Results)-1].ID)
+
+	// Start the feed at the current sequence, so the only entry it can send is one of the documents
+	// written after the purge below
+	rt.WaitForPendingChanges()
+	since := rt.GetChanges("/{{.keyspace}}/_changes", username).Last_Seq
+	caughtUpCount := rt.GetDatabase().DbStats.CBLReplicationPull().NumPullReplCaughtUp.Value()
+	feed := rt.StartContinuousChanges(fmt.Sprintf("/{{.keyspace}}/_changes?feed=continuous&limit=1&since=%s", since), username)
+
+	require.NoError(t, rt.GetDatabase().WaitForCaughtUp(caughtUpCount+1))
+
+	// The purge has to be notified before the writes below, otherwise the feed wakes on the document
+	// notification alone and is still holding the stale channel set.
+	userWaiter := rt.NewUserWaiter(username)
+	RequireStatus(t, rt.SendAdminRequest(http.MethodDelete, "/{{.db}}/_role/"+roleName+"?purge=true", ""), http.StatusOK)
+	require.True(t, db.WaitForUserWaiterChange(userWaiter))
+
+	// The feed sends in sequence order, so a feed still serving the revoked channel would send
+	// afterPurgeRevoked first.  The purge leaks a sequence (CBG-5789), so afterPurgeRevoked isn't
+	// visible until CachePendingSeqMaxWait elapses.
+	rt.PutDoc("afterPurgeRevoked", `{"channels":["`+roleChannel+`"]}`)
+	rt.PutDoc("afterPurgeAllowed", `{"channels":["`+userChannel+`"]}`)
+
+	feedChanges := feed.RequireEnded()
+	require.Len(t, feedChanges, 1)
+	require.Equal(t, "afterPurgeAllowed", feedChanges[0].ID)
 }

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -551,6 +551,34 @@ func (rt *RestTester) CreateUser(username string, channels []string, roles ...st
 	RequireStatus(rt.TB(), response, http.StatusCreated)
 }
 
+// DeleteUser deletes the given user via the admin API.
+func (rt *RestTester) DeleteUser(username string) {
+	rt.TB().Helper()
+	var response *TestResponse
+	if rt.AdminInterfaceAuthentication {
+		response = rt.SendAdminRequestWithAuth(http.MethodDelete, "/{{.db}}/_user/"+username, "", base.TestClusterUsername(), base.TestClusterPassword())
+	} else {
+		response = rt.SendAdminRequest(http.MethodDelete, "/{{.db}}/_user/"+username, "")
+	}
+	RequireStatus(rt.TB(), response, http.StatusOK)
+}
+
+// NewUserWaiter returns a db.ChangeWaiter for the given user, notified when the user document or any
+// of the user's role documents is written or deleted.  Create the waiter before making the change,
+// then call db.WaitForUserWaiterChange to wait for that change to be notified.
+func (rt *RestTester) NewUserWaiter(username string) *db.ChangeWaiter {
+	rt.TB().Helper()
+	// Catch up on the principal docs written so far, so the waiter can only be satisfied by a
+	// subsequent change
+	rt.WaitForPendingChanges()
+	user, err := rt.GetDatabase().Authenticator(rt.Context()).GetUser(username)
+	require.NoError(rt.TB(), err)
+	require.NotNil(rt.TB(), user, "user %q not found", username)
+	userDB, err := db.GetDatabase(rt.GetDatabase(), user)
+	require.NoError(rt.TB(), err)
+	return userDB.NewUserWaiter()
+}
+
 // CreateRole creates a role with channels scoped to a single test collection.
 func (rt *RestTester) CreateRole(rolename string, channels []string) {
 	var response *TestResponse
@@ -2616,6 +2644,47 @@ func (rt *RestTester) ReadContinuousChanges(response *TestResponse) ([]db.Change
 
 	}
 	return changes, nil
+}
+
+// ContinuousChangesFeed is a continuous _changes feed running in the background.  See
+// RestTester.StartContinuousChanges.
+type ContinuousChangesFeed struct {
+	rt       *RestTester
+	done     chan struct{}
+	response *TestResponse
+}
+
+// StartContinuousChanges runs a continuous _changes feed for the given user in the background.  The
+// feed is given no timeout, so only Sync Gateway terminates it and tests can assert on what ended it -
+// see ContinuousChangesFeed.RequireEnded.  rt.Context is cancelled on test cleanup, so a feed Sync
+// Gateway never ends doesn't outlive the test.
+func (rt *RestTester) StartContinuousChanges(uri, username string) *ContinuousChangesFeed {
+	rt.TB().Helper()
+	ctx := rt.Context()
+	// initialize the public handler before the goroutine sends on it
+	_ = rt.TestPublicHandler()
+	request := RequestByUser(http.MethodGet, rt.mustTemplateResource(uri), "", username).WithContext(ctx)
+	feed := &ContinuousChangesFeed{rt: rt, done: make(chan struct{})}
+	go func() {
+		defer close(feed.done)
+		feed.response = rt.Send(request)
+	}()
+	return feed
+}
+
+// RequireEnded waits for the feed to be terminated by Sync Gateway and returns the changes it sent,
+// failing the test if the feed is still running.
+func (f *ContinuousChangesFeed) RequireEnded() []db.ChangeEntry {
+	t := f.rt.TB()
+	t.Helper()
+	select {
+	case <-f.done:
+	case <-time.After(30 * time.Second):
+		require.Fail(t, "continuous changes feed still running")
+	}
+	changes, err := f.rt.ReadContinuousChanges(f.response)
+	require.NoError(t, err)
+	return changes
 }
 
 // RequireContinuousFeedChangesCount Calls a changes feed on every collection and asserts that the nth expected change is


### PR DESCRIPTION
CBG-5798

Unclean cherry pick of #8707 to 3.3.8
Changes from main commit:
- `rest/utilities_testing.go`, `rest/changes_test.go` — `base.RequireChanClosed` and `base.TestChanTimeout` do not exist on this branch (added upstream by #8175, a DCP change not worth backporting here), so both feed waits use the `select`/`time.After`/`require.Fail` idiom the surrounding tests already use.
- `rest/utilities_testing.go` — `RestTester.ReadContinuousChanges` returns `([]db.ChangeEntry, error)` on this branch, so `RequireEnded` asserts on the error.
- `db/change_listener_test.go`, `rest/blip_api_crud_test.go`, `rest/changes_test.go` — `db.WaitForUserWaiterChange` returns a bool here rather than failing the test itself (changed upstream by #8088), so the 8 call sites are wrapped in `require.True`, matching the branch's existing callers.
- `rest/blip_api_crud_test.go` — the `btcRunner.Run` callback still takes `SupportedBLIPProtocols` on this branch, so the two new tests take it and pass it through to `BlipTesterClientOpts`.
- `rest/blip_api_crud_test.go` — `TestBlipMessageAfterUserDelete` keeps `addCollectionProperty` + `pullReplication.sendMsg`; the collection client has no `sendPullMsg` on this branch. This replaces the branch's `TestBlipRefreshUser`, which was skipped for the CBG-3512 flake — the new deterministic `NewUserWaiter` wait is what makes it runnable, and it passes here.

🤖 Opened with the `sync-gateway-backport` skill in [Claude Code](https://claude.com/claude-code)
