### PR TITLE
[4.0.8 Backport] CBG-5775: Failed to release sequence after 404 error on getAvailable1xRev inside recalculateSyncFnForActiveRev

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -2551,15 +2551,17 @@ func (db *DatabaseCollectionWithUser) addAttachments(ctx context.Context, newAtt
 }
 
 // assignSequence assigns a global sequence number from database.
-func (c *DatabaseCollectionWithUser) assignSequence(ctx context.Context, docSequence uint64, doc *Document, unusedSequences []uint64) ([]uint64, error) {
+func (c *DatabaseCollectionWithUser) assignSequence(ctx context.Context, docSequence uint64, doc *Document, unusedSequences []uint64) (uint64, []uint64, error) {
 	return c.dbCtx.assignSequence(ctx, docSequence, doc, unusedSequences)
 }
 
 // Sequence processing :
-// Assigns provided sequence to the document
+// Assigns provided sequence to the document, and returns it so the caller can release it if the write doesn't
+// complete.  Returns zero if no sequence is held by the caller - on error, any incoming sequence has already been
+// moved to unusedSequences.
 // Update unusedSequences in the event that there is a conflict and we have to provide a new sequence number
 // Update and prune RecentSequences
-func (db *DatabaseContext) assignSequence(ctx context.Context, docSequence uint64, doc *Document, unusedSequences []uint64) ([]uint64, error) {
+func (db *DatabaseContext) assignSequence(ctx context.Context, docSequence uint64, doc *Document, unusedSequences []uint64) (uint64, []uint64, error) {
 
 	// Assign the next sequence number, for _changes feed.
 	// Be careful not to request a second sequence # on a retry if we don't need one.
@@ -2575,7 +2577,7 @@ func (db *DatabaseContext) assignSequence(ctx context.Context, docSequence uint6
 
 		var err error
 		if docSequence, err = db.sequences.nextSequence(ctx); err != nil {
-			return unusedSequences, err
+			return 0, unusedSequences, err
 		}
 		firstAllocatedSequence := docSequence
 
@@ -2588,7 +2590,7 @@ func (db *DatabaseContext) assignSequence(ctx context.Context, docSequence uint6
 			var releasedSequenceCount uint64
 			docSequence, releasedSequenceCount, err = db.sequences.nextSequenceGreaterThan(ctx, doc.Sequence)
 			if err != nil {
-				return unusedSequences, err
+				return 0, unusedSequences, err
 			}
 			if releasedSequenceCount > unusedSequenceWarningThreshold {
 				base.WarnfCtx(ctx, "Doc %s / %s had an existing sequence %d that is higher than the next db sequence value %d, resulting in the release of %d unused sequences. This may indicate documents being migrated between databases by an external process.", base.UD(doc.ID), doc.GetRevTreeID(), doc.Sequence, firstAllocatedSequence, releasedSequenceCount)
@@ -2645,7 +2647,7 @@ func (db *DatabaseContext) assignSequence(ctx context.Context, docSequence uint6
 		base.SortedUint64Slice(doc.RecentSequences).Sort()
 	}
 
-	return unusedSequences, nil
+	return docSequence, unusedSequences, nil
 }
 
 func (doc *Document) updateExpiry(syncExpiry, updatedExpiry *uint32, expiry *uint32) (finalExp *uint32) {
@@ -2735,11 +2737,19 @@ func (col *DatabaseCollectionWithUser) documentUpdateFunc(
 	retNewRevID string,
 	retStoredDoc *Document,
 	retOldBodyJSON string,
+	retDocSequence uint64,
 	retUnusedSequences []uint64,
 	changedAccessPrincipals []string,
 	changedRoleAccessUsers []string,
 	createNewRevIDSkipped bool,
 	err error) {
+
+	// Seed the sequences held by this write attempt, so that every path (including the naked early returns below)
+	// hands them back for the caller to release if the write doesn't complete.  assignSequence overwrites both -
+	// with the newly allocated sequence, or with zero if allocation failed, in which case it has already moved the
+	// incoming sequence to unusedSequences.
+	retDocSequence = previousDocSequenceIn
+	retUnusedSequences = unusedSequences
 
 	err = validateExistingDoc(doc, allowImport, docExists)
 	if err != nil {
@@ -2825,7 +2835,7 @@ func (col *DatabaseCollectionWithUser) documentUpdateFunc(
 
 	col.backupAncestorRevs(ctx, doc, newDoc.RevID, oldChannels)
 
-	unusedSequences, err = col.assignSequence(ctx, previousDocSequenceIn, doc, unusedSequences)
+	retDocSequence, retUnusedSequences, err = col.assignSequence(ctx, previousDocSequenceIn, doc, retUnusedSequences)
 	if err != nil {
 		if errors.Is(err, base.ErrMaxSequenceReleasedExceeded) {
 			base.ErrorfCtx(ctx, "Doc %s / %s had a much larger sequence (%d) than the current sequence number. Document update will be cancelled, since we don't want to allocate sequences to fill a gap this large. This may indicate document metadata being migrated between databases where it should've been stripped and re-imported.", base.UD(newDoc.ID), prevCurrentRev, doc.Sequence)
@@ -2876,7 +2886,7 @@ func (col *DatabaseCollectionWithUser) documentUpdateFunc(
 
 	doc.ClusterUUID = col.serverUUID()
 	doc.TimeSaved = time.Now()
-	return updatedExpiry, newRevID, newDoc, oldBodyJSON, unusedSequences, changedAccessPrincipals, changedRoleAccessUsers, createNewRevIDSkipped, err
+	return updatedExpiry, newRevID, newDoc, oldBodyJSON, retDocSequence, retUnusedSequences, changedAccessPrincipals, changedRoleAccessUsers, createNewRevIDSkipped, err
 }
 
 // Function type for the callback passed into updateAndReturnDoc
@@ -2948,7 +2958,7 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 			}
 
 			isNewDocCreation = currentValue == nil
-			updatedDoc.Expiry, newRevID, storedDoc, oldBodyJSON, unusedSequences, changedAccessPrincipals, changedRoleAccessUsers, createNewRevIDSkipped, err = db.documentUpdateFunc(ctx, !isNewDocCreation, doc, allowImport, docSequence, unusedSequences, callback, expiry, docUpdateEvent)
+			updatedDoc.Expiry, newRevID, storedDoc, oldBodyJSON, docSequence, unusedSequences, changedAccessPrincipals, changedRoleAccessUsers, createNewRevIDSkipped, err = db.documentUpdateFunc(ctx, !isNewDocCreation, doc, allowImport, docSequence, unusedSequences, callback, expiry, docUpdateEvent)
 			if err != nil {
 				return
 			}
@@ -2956,7 +2966,6 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 			if db.dataStore.IsSupported(sgbucket.BucketStoreFeaturePreserveExpiry) && updatedDoc.Expiry != nil {
 				opts.PreserveExpiry = false
 			}
-			docSequence = doc.Sequence
 			inConflict = doc.hasFlag(channels.Conflict)
 			currentRevFromHistory, ok := doc.History[doc.GetRevTreeID()]
 			if !ok {
@@ -3055,16 +3064,9 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 		// For timeout errors, the write may or may not have succeeded so we cannot release the sequence as unused
 		if !base.IsTimeoutError(err) {
 			if docSequence > 0 {
-				if seqErr := db.sequences().releaseSequence(ctx, docSequence); seqErr != nil {
-					base.WarnfCtx(ctx, "Error returned when releasing sequence %d. Falling back to skipped sequence handling.  Error:%v", docSequence, seqErr)
-				}
-
+				unusedSequences = append(unusedSequences, docSequence)
 			}
-			for _, sequence := range unusedSequences {
-				if seqErr := db.sequences().releaseSequence(ctx, sequence); seqErr != nil {
-					base.WarnfCtx(ctx, "Error returned when releasing sequence %d. Falling back to skipped sequence handling.  Error:%v", sequence, seqErr)
-				}
-			}
+			db.releaseSequences(ctx, unusedSequences)
 		}
 	}
 

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1676,6 +1676,93 @@ func TestReleaseSequenceOnDocWriteFailure(t *testing.T) {
 	}, time.Second*10, time.Millisecond*100)
 }
 
+// TestReleaseSequenceOnRecalculateSyncFnFailure verifies that a sequence allocated by documentUpdateFunc is
+// released when the update subsequently fails - here by rejecting the sync function recalculation performed for a
+// newly winning revision (CBG-5763).
+func TestReleaseSequenceOnRecalculateSyncFnFailure(t *testing.T) {
+	defer SuspendSequenceBatching()()
+
+	db, ctx := SetupTestDBWithOptions(t, DatabaseContextOptions{AllowConflicts: base.Ptr(true)})
+	defer db.Close(ctx)
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+
+	//    1-a
+	//   /   \
+	// 2-a   2-b
+	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", Body{"key1": "value1"}, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
+	require.NoError(t, err, "add 1-a")
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", Body{"recalculated": true}, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
+	require.NoError(t, err, "add 2-a")
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", Body{"key1": "value1"}, []string{"2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
+	require.NoError(t, err, "add 2-b")
+
+	// Reject 2-a's body, but not the tombstone written below
+	_, err = collection.UpdateSyncFun(ctx, `function(doc){if (doc.recalculated) {throw({forbidden: "rejected"})} channel("chan");}`)
+	require.NoError(t, err)
+
+	startReleasedSequenceCount := db.DbStats.Database().SequenceReleasedCount.Value()
+
+	// Tombstoning the winning branch makes 2-a current again, so the sync function is recalculated against 2-a's
+	// body and rejects.  The update fails after a sequence has been allocated for the tombstone.
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", Body{BodyDeleted: true}, []string{"3-b", "2-b"}, false, ExistingVersionWithUpdateToHLV)
+	require.ErrorContains(t, err, "rejected")
+
+	releasedSequenceCount := db.DbStats.Database().SequenceReleasedCount.Value() - startReleasedSequenceCount
+	require.Equal(t, int64(1), releasedSequenceCount)
+}
+
+// TestReleaseSequencesAcrossCASRetries verifies that sequences allocated on earlier CAS retries are still
+// released when a later attempt fails before allocating a sequence of its own.
+func TestReleaseSequencesAcrossCASRetries(t *testing.T) {
+	defer SuspendSequenceBatching()()
+
+	const docID = "doc1"
+	var collection *DatabaseCollectionWithUser
+	var collectionCtx context.Context
+
+	// Competing writes to force two CAS retries of the 3-a write below.  The first only bumps the doc's sequence,
+	// the second moves the winning revision away from 2-a so the third attempt is rejected as a conflict.
+	forceCASRetries := false
+	casRetries := 0
+	updateCallback := func(key string) {
+		if key != docID || !forceCASRetries || casRetries >= 2 {
+			return
+		}
+		forceCASRetries = false
+		defer func() { forceCASRetries = true }()
+		casRetries++
+
+		history := []string{"2-0", "1-a"} // loses to 2-a, so 2-a remains the parent of the pending 3-a write
+		if casRetries == 2 {
+			history = []string{"3-z", "2-a", "1-a"} // beats 3-a, leaving 2-a as a non-winning parent
+		}
+		_, _, err := collection.PutExistingRevWithBody(collectionCtx, docID, Body{"competing": casRetries}, history, false, ExistingVersionWithUpdateToHLV)
+		require.NoError(t, err)
+	}
+
+	bucket := base.NewLeakyBucket(base.GetTestBucket(t), base.LeakyBucketConfig{UpdateCallback: updateCallback})
+	db, ctx := SetupTestDBForBucketWithOptions(t, bucket, DatabaseContextOptions{AllowConflicts: base.Ptr(true)})
+	defer db.Close(ctx)
+	collection, collectionCtx = GetSingleDatabaseCollectionWithUser(ctx, t, db)
+
+	_, _, err := collection.PutExistingRevWithBody(collectionCtx, docID, Body{"key1": "value1"}, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
+	require.NoError(t, err, "add 1-a")
+	_, _, err = collection.PutExistingRevWithBody(collectionCtx, docID, Body{"key1": "value1"}, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
+	require.NoError(t, err, "add 2-a")
+
+	startReleasedSequenceCount := db.DbStats.Database().SequenceReleasedCount.Value()
+
+	// The first two attempts each allocate a sequence, the third is rejected before it reaches assignSequence -
+	// both the sequence accumulated in unusedSequences and the one held by the failing attempt must be released.
+	forceCASRetries = true
+	_, _, err = collection.PutExistingRevWithBody(collectionCtx, docID, Body{"key1": "value2"}, []string{"3-a", "2-a", "1-a"}, true, ExistingVersionWithUpdateToHLV)
+	require.ErrorContains(t, err, "conflict")
+	require.Equal(t, 2, casRetries)
+
+	releasedSequenceCount := db.DbStats.Database().SequenceReleasedCount.Value() - startReleasedSequenceCount
+	require.Equal(t, int64(2), releasedSequenceCount)
+}
+
 func TestDocUpdateCorruptSequence(t *testing.T) {
 	if !base.TestUseXattrs() {
 		t.Skip("This test only works with XATTRS enabled")

--- a/db/database.go
+++ b/db/database.go
@@ -1802,7 +1802,9 @@ func (db *DatabaseCollectionWithUser) getResyncedDocument(ctx context.Context, d
 
 		if rev.ID == doc.GetRevTreeID() {
 			if regenerateSequences {
-				updatedUnusedSequences, err = db.assignSequence(ctx, 0, doc, unusedSequences)
+				// TODO(CBG-5801): each CAS retry allocates a new sequence and drops the previous one, and the
+				// allocated sequence isn't returned to the caller for release if the write fails.
+				_, updatedUnusedSequences, err = db.assignSequence(ctx, 0, doc, unusedSequences)
 				if err != nil {
 					base.WarnfCtx(ctx, "Unable to assign a sequence number: %v", err)
 				}


### PR DESCRIPTION
CBG-5775

Unclean cherry pick of #8711 to 4.0.8

- `db/database.go`: `getResyncedDocument` uses the outer `unusedSequences` on
  this branch, so no local declaration was added.
- `db/database.go`: the `TODO(CBG-5801)` comment for `ResyncDocument` is not
  applied. `ResyncDocument` on this branch still has the non-xattr branch that
  `main` dropped, and it does not call `releaseSequences`, so the comment has no
  anchor. The upstream change there is a comment only, with no functional part.
- `db/crud_test.go`: changed two assertions from `uint64` to `int64`, because
  `SequenceReleasedCount` is an `SgwIntStat` on this branch.

`db/crud.go` applied unchanged from upstream.

The two new tests fail on this branch without the production change, with a
released sequence count of 0 instead of 1 and 1 instead of 2. They pass with it.

Stacked on #8720.

🤖 Opened with the `sync-gateway-backport` skill in [Claude Code](https://claude.com/claude-code)
