### PR TITLE
[4.1.2 Backport] CBG-5714: Corrupt history built when legacy revision supplied in rev message history

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -1491,7 +1491,7 @@ func (db *DatabaseCollectionWithUser) Put(ctx context.Context, docid string, bod
 
 		newRev := CreateRevIDWithBytes(generation, matchRev, canonicalBytesForRevID)
 
-		if err := doc.History.addRevision(newDoc.ID, RevInfo{ID: newRev, Parent: matchRev, Deleted: deleted}); err != nil {
+		if err := doc.History.addRevision(ctx, newDoc.ID, RevInfo{ID: newRev, Parent: matchRev, Deleted: deleted}); err != nil {
 			base.InfofCtx(ctx, base.KeyCRUD, "Failed to add revision ID: %s, for doc: %s, error: %v", newRev, base.UD(docid), err)
 			return nil, nil, false, nil, base.ErrRevTreeAddRevFailure
 		}
@@ -1627,6 +1627,10 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 				// the new document has a dominating hlv, so we can just update local revtree with incoming revtree
 				if !opts.ISGRWrite {
 					previousRevTreeID = doc.GetRevTreeID()
+					// The new revision is parented to the local current rev rather than the incoming
+					// history, so its generation has to be recomputed from that parent.
+					prevGeneration, _ = ParseRevID(ctx, previousRevTreeID)
+					newGeneration = prevGeneration + 1
 				} else {
 					// align rev tree here for ISGR replications
 					alignErr := doc.alignRevTreeHistoryForHLVWrite(ctx, db, opts.NewDoc, opts.RevTreeHistory, false)
@@ -1648,7 +1652,7 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 						return nil, nil, false, nil, err
 					}
 
-					_, err = doc.addNewerRevisionsToRevTreeHistory(opts.NewDoc, currentRevIndex, parent, opts.RevTreeHistory)
+					_, err = doc.addNewerRevisionsToRevTreeHistory(ctx, opts.NewDoc, currentRevIndex, parent, opts.RevTreeHistory)
 					if err != nil {
 						return nil, nil, false, nil, err
 					}
@@ -1709,7 +1713,7 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 				return nil, nil, false, nil, err
 			}
 			newRev = CreateRevIDWithBytes(newGeneration, previousRevTreeID, encoding)
-			if err := doc.History.addRevision(opts.NewDoc.ID, RevInfo{ID: newRev, Parent: previousRevTreeID, Deleted: opts.NewDoc.Deleted}); err != nil {
+			if err := doc.History.addRevision(ctx, opts.NewDoc.ID, RevInfo{ID: newRev, Parent: previousRevTreeID, Deleted: opts.NewDoc.Deleted}); err != nil {
 				base.InfofCtx(ctx, base.KeyCRUD, "Failed to add revision ID: %s, for doc: %s, error: %v", newRev, base.UD(opts.NewDoc.ID), err)
 				return nil, nil, false, nil, base.ErrRevTreeAddRevFailure
 			}
@@ -1850,7 +1854,7 @@ func (db *DatabaseCollectionWithUser) PutExistingRevWithConflictResolution(ctx c
 
 		// Add all the new-to-me revisions to the rev tree:
 		for i := currentRevIndex - 1; i >= 0; i-- {
-			err := doc.History.addRevision(newDoc.ID,
+			err := doc.History.addRevision(ctx, newDoc.ID,
 				RevInfo{
 					ID:      docHistory[i],
 					Parent:  parent,
@@ -2363,7 +2367,7 @@ func (db *DatabaseCollectionWithUser) tombstoneActiveRevision(ctx context.Contex
 	// Create tombstone
 	newGeneration := genOfRevID(ctx, revID) + 1
 	newRevID := CreateRevIDWithBytes(newGeneration, revID, []byte(DeletedDocument))
-	err = doc.History.addRevision(doc.ID,
+	err = doc.History.addRevision(ctx, doc.ID,
 		RevInfo{
 			ID:      newRevID,
 			Parent:  revID,
@@ -4131,7 +4135,7 @@ func (doc *Document) alignRevTreeHistoryForHLVWrite(ctx context.Context, db *Dat
 		}
 	}
 
-	newRev, err := doc.addNewerRevisionsToRevTreeHistory(newDoc, currentRevIndex, parent, revTreeHistory)
+	newRev, err := doc.addNewerRevisionsToRevTreeHistory(ctx, newDoc, currentRevIndex, parent, revTreeHistory)
 	if err != nil {
 		return err
 	}
@@ -4144,10 +4148,10 @@ func (doc *Document) alignRevTreeHistoryForHLVWrite(ctx context.Context, db *Dat
 }
 
 // addNewerRevisionsToRevTreeHistory will add any newer rev tree id's to the local document history
-func (doc *Document) addNewerRevisionsToRevTreeHistory(newDoc *Document, currentRevIndex int, parent string, docHistory []string) (string, error) {
+func (doc *Document) addNewerRevisionsToRevTreeHistory(ctx context.Context, newDoc *Document, currentRevIndex int, parent string, docHistory []string) (string, error) {
 	// currentRevIndex here is the index of the incoming rev tree list to start from.
 	for i := currentRevIndex - 1; i >= 0; i-- {
-		err := doc.History.addRevision(newDoc.ID,
+		err := doc.History.addRevision(ctx, newDoc.ID,
 			RevInfo{
 				ID:      docHistory[i],
 				Parent:  parent, // set the parent of this revision to the element of docHistory from the last iteration

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -4992,12 +4992,14 @@ func TestRevTreeConflictCheck(t *testing.T) {
 			lenLocalHistory := len(testCase.localHistory)
 
 			parent := ""
-			for i, revID := range testCase.localHistory {
-				err := doc.History.addRevision(revID,
+			// localHistory is newest-first (as on the wire), so build the tree oldest-first
+			for i := lenLocalHistory - 1; i >= 0; i-- {
+				revID := testCase.localHistory[i]
+				err := doc.History.addRevision(ctx, doc.ID,
 					RevInfo{
 						ID:      revID,
 						Parent:  parent, // set the parent of this revision to the element of docHistory from the last iteration
-						Deleted: i == lenLocalHistory-1 && testCase.localDelete})
+						Deleted: i == 0 && testCase.localDelete})
 				require.NoError(t, err)
 				parent = revID
 			}

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -695,10 +695,10 @@ func TestAlignRevTreeHistory(t *testing.T) {
 		{
 			name:            "gap in histories, incoming larger",
 			currentRev:      "3-abc",
-			localRevTree:    []string{"1-abc", "2-abc", "3-abc"},
-			incomingRevTree: []string{"12-abc", "10-abc", "11-abc"},
+			localRevTree:    []string{"3-abc", "2-abc", "1-abc"},
+			incomingRevTree: []string{"12-abc", "11-abc", "10-abc"},
 			// rev 4- is new rev created for tombstone here, 12-abc is the active rev
-			expectedRevTree:   []string{"12-abc", "10-abc", "11-abc", "4-cc0337d9d38c8e5fc930ae3deda62bf8", "3-abc", "2-abc", "1-abc"},
+			expectedRevTree:   []string{"12-abc", "11-abc", "10-abc", "4-cc0337d9d38c8e5fc930ae3deda62bf8", "3-abc", "2-abc", "1-abc"},
 			expectedActive:    "12-abc",
 			expectedTombstone: "4-cc0337d9d38c8e5fc930ae3deda62bf8",
 		},
@@ -752,8 +752,9 @@ func TestAlignRevTreeHistory(t *testing.T) {
 			var parent string
 			doc := NewDocument("doc")
 			doc.SetRevTreeID(tc.currentRev)
-			for i := range tc.localRevTree {
-				err := doc.History.addRevision("doc", RevInfo{
+			// localRevTree is newest-first (as on the wire), so build the tree oldest-first
+			for i := len(tc.localRevTree) - 1; i >= 0; i-- {
+				err := doc.History.addRevision(ctx, "doc", RevInfo{
 					ID:     tc.localRevTree[i],
 					Parent: parent,
 				})

--- a/db/import.go
+++ b/db/import.go
@@ -302,7 +302,7 @@ func (db *DatabaseCollectionWithUser) importDoc(ctx context.Context, docid strin
 			base.DebugfCtx(ctx, base.KeyImport, "Created new rev ID for doc %q / %q", base.UD(newDoc.ID), newRev)
 			// body[BodyRev] = newRev
 			newDoc.RevID = newRev
-			err := doc.History.addRevision(newDoc.ID, RevInfo{ID: newRev, Parent: parentRev, Deleted: isDelete})
+			err := doc.History.addRevision(ctx, newDoc.ID, RevInfo{ID: newRev, Parent: parentRev, Deleted: isDelete})
 			if err != nil {
 				base.InfofCtx(ctx, base.KeyImport, "Error adding new rev ID for doc %q / %q, Error: %v", base.UD(newDoc.ID), newRev, err)
 			}

--- a/db/revtree.go
+++ b/db/revtree.go
@@ -395,7 +395,7 @@ func (tree RevTree) findAncestorFromSet(revid string, ancestors []string) string
 }
 
 // Records a revision in a RevTree.
-func (tree RevTree) addRevision(docid string, info RevInfo) error {
+func (tree RevTree) addRevision(ctx context.Context, docid string, info RevInfo) error {
 	revid := info.ID
 	if revid == "" {
 		return fmt.Errorf("doc: %v, RevTree addRevision, empty revid is illegal", docid)
@@ -407,6 +407,14 @@ func (tree RevTree) addRevision(docid string, info RevInfo) error {
 		parent, ok := tree[p]
 		if !ok {
 			return fmt.Errorf("doc: %v, RevTree addRevision, parent id %q is missing", docid, p)
+		}
+		// A revision must be at least one generation higher than its parent. If it isn't, the branch can
+		// no longer be encoded as a _revisions list (splitRevisionList requires start >= len(ids)), which
+		// makes the document unreplicatable to pre-4.0 clients. See CBG-5713.
+		if generation, _, err := parseRevID(revid); err == nil {
+			if parentGeneration, _, parentErr := parseRevID(p); parentErr == nil && generation <= parentGeneration {
+				return base.RedactErrorf("doc: %s, RevTree addRevision, revision %q is not a higher generation than its parent %q", base.UD(docid), revid, p)
+			}
 		}
 		// we're adding a new child, so strip the channels from the parent - they're now superseded
 		parent.Channels = nil

--- a/db/revtree_test.go
+++ b/db/revtree_test.go
@@ -172,7 +172,7 @@ func getMultiBranchTestRevtree1(ctx context.Context, unconflictedBranchNumRevs, 
 					Parent:  parentRevId,
 					Deleted: true,
 				}
-				err := revTree.addRevision("testdoc", revInfo)
+				err := revTree.addRevision(ctx, "testdoc", revInfo)
 				if err != nil {
 					panic(fmt.Sprintf("Error: %v", err))
 				}
@@ -255,7 +255,7 @@ func TestRevTreeUnmarshalOldFormatNonWinningRev(t *testing.T) {
 	ri.Channels = nil
 
 	// non-winning revisions do retain channel information, so populate this for the expected expected
-	err = expected.addRevision("", RevInfo{
+	err = expected.addRevision(base.TestCtx(t), "", RevInfo{
 		ID:       "3-drei",
 		Parent:   "2-two",
 		Body:     []byte(`{"foo":"buzz"}`),
@@ -341,7 +341,7 @@ func TestRevTreeAddRevision(t *testing.T) {
 	tempmap := testmap.copy()
 	assert.Equal(t, testmap, tempmap)
 
-	err := tempmap.addRevision("testdoc", RevInfo{ID: "4-four", Parent: "3-three"})
+	err := tempmap.addRevision(base.TestCtx(t), "testdoc", RevInfo{ID: "4-four", Parent: "3-three"})
 	require.NoError(t, err)
 	assert.Equal(t, "3-three", tempmap.getParent("4-four"))
 }
@@ -350,7 +350,7 @@ func TestRevTreeAddRevisionWithEmptyID(t *testing.T) {
 	tempmap := testmap.copy()
 	assert.Equal(t, testmap, tempmap)
 
-	err := tempmap.addRevision("testdoc", RevInfo{Parent: "3-three"})
+	err := tempmap.addRevision(base.TestCtx(t), "testdoc", RevInfo{Parent: "3-three"})
 	assert.Equal(t, fmt.Sprintf("doc: %v, RevTree addRevision, empty revid is illegal", "testdoc"), err.Error())
 }
 
@@ -358,7 +358,7 @@ func TestRevTreeAddDuplicateRevID(t *testing.T) {
 	tempmap := testmap.copy()
 	assert.Equal(t, testmap, tempmap)
 
-	err := tempmap.addRevision("testdoc", RevInfo{ID: "2-two", Parent: "1-one"})
+	err := tempmap.addRevision(base.TestCtx(t), "testdoc", RevInfo{ID: "2-two", Parent: "1-one"})
 	assert.Equal(t, fmt.Sprintf("doc: %v, RevTree addRevision, already contains rev %q", "testdoc", "2-two"), err.Error())
 }
 
@@ -366,7 +366,7 @@ func TestRevTreeAddRevisionWithMissingParent(t *testing.T) {
 	tempmap := testmap.copy()
 	assert.Equal(t, testmap, tempmap)
 
-	err := tempmap.addRevision("testdoc", RevInfo{ID: "5-five", Parent: "4-four"})
+	err := tempmap.addRevision(base.TestCtx(t), "testdoc", RevInfo{ID: "5-five", Parent: "4-four"})
 	assert.Equal(t, fmt.Sprintf("doc: %v, RevTree addRevision, parent id %q is missing", "testdoc", "4-four"), err.Error())
 }
 
@@ -398,7 +398,7 @@ func TestRevTreeChannelMapLeafOnly(t *testing.T) {
 	// but let's force it to ensure we're not storing old revs in ChannelsMap
 	ri.Channels = base.SetOf("EN")
 
-	err = tree.addRevision(t.Name(), RevInfo{
+	err = tree.addRevision(base.TestCtx(t), t.Name(), RevInfo{
 		ID:       "4-four",
 		Parent:   "3-three",
 		Channels: nil, // we don't store channels for winning revs
@@ -435,13 +435,13 @@ func TestRevTreeWinningRev(t *testing.T) {
 	assert.Equal(t, "3-three", winner)
 	assert.True(t, branched)
 	assert.True(t, conflict)
-	err := tempmap.addRevision("testdoc", RevInfo{ID: "4-four", Parent: "3-three"})
+	err := tempmap.addRevision(ctx, "testdoc", RevInfo{ID: "4-four", Parent: "3-three"})
 	require.NoError(t, err)
 	winner, branched, conflict = tempmap.winningRevision(ctx)
 	assert.Equal(t, "4-four", winner)
 	assert.True(t, branched)
 	assert.True(t, conflict)
-	err = tempmap.addRevision("testdoc", RevInfo{ID: "5-five", Parent: "4-four", Deleted: true})
+	err = tempmap.addRevision(ctx, "testdoc", RevInfo{ID: "5-five", Parent: "4-four", Deleted: true})
 	require.NoError(t, err)
 	winner, branched, conflict = tempmap.winningRevision(ctx)
 	assert.Equal(t, "3-drei", winner)
@@ -1074,7 +1074,7 @@ func TestRevisionPruningLoop(t *testing.T) {
 func addAndGet(t *testing.T, revTree RevTree, revID string, parentRevID string, isTombstone bool) error {
 
 	revBody := []byte(`{"foo":"bar"}`)
-	err := revTree.addRevision("foobar", RevInfo{
+	err := revTree.addRevision(base.TestCtx(t), "foobar", RevInfo{
 		ID:      revID,
 		Parent:  parentRevID,
 		Body:    revBody,
@@ -1125,7 +1125,7 @@ func TestPruneRevisionsWithDisconnected(t *testing.T) {
 }
 
 func addPruneAndGet(ctx context.Context, revTree RevTree, revID string, parentRevID string, revBody []byte, revsLimit uint32, tombstone bool) (numPruned int, err error) {
-	_ = revTree.addRevision("doc", RevInfo{
+	_ = revTree.addRevision(ctx, "doc", RevInfo{
 		ID:      revID,
 		Parent:  parentRevID,
 		Body:    revBody,
@@ -1251,7 +1251,7 @@ func addRevs(ctx context.Context, revTree RevTree, startingParentRevId string, n
 			Deleted:  false,
 			Channels: channels,
 		}
-		_ = revTree.addRevision("testdoc", revInfo)
+		_ = revTree.addRevision(ctx, "testdoc", revInfo)
 
 		generation += 1
 

--- a/db/utilities_hlv_testing.go
+++ b/db/utilities_hlv_testing.go
@@ -262,7 +262,7 @@ func (db *DatabaseCollectionWithUser) CreateDocNoHLV(t testing.TB, ctx context.C
 
 		newRev := CreateRevIDWithBytes(generation, matchRev, canonicalBytesForRevID)
 
-		if err := doc.History.addRevision(newDoc.ID, RevInfo{ID: newRev, Parent: matchRev, Deleted: deleted}); err != nil {
+		if err := doc.History.addRevision(ctx, newDoc.ID, RevInfo{ID: newRev, Parent: matchRev, Deleted: deleted}); err != nil {
 			base.InfofCtx(ctx, base.KeyCRUD, "Failed to add revision ID: %s, for doc: %s, error: %v", newRev, base.UD(docid), err)
 			return nil, nil, false, nil, base.ErrRevTreeAddRevFailure
 		}

--- a/rest/blip_legacy_revid_test.go
+++ b/rest/blip_legacy_revid_test.go
@@ -12,7 +12,9 @@ package rest
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -1371,4 +1373,64 @@ func removeHLV(rt *RestTester, docID string) {
 		base.SyncXattrName: base.MustJSONMarshal(rt.TB(), syncData),
 	}, db.DefaultMutateInOpts())
 	require.NoError(rt.TB(), err)
+}
+
+func TestLegacyHistoryPushCreatesDuplicateGenerationRevs(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeySGTest, base.KeyCRUD, base.KeySync, base.KeySyncMsg)
+
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[RevtreeSubtestName] = true
+
+	btcRunner.Run(func(t *testing.T) {
+		rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
+		defer rt.Close()
+
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
+		defer client.Close()
+
+		docID := SafeDocumentName(t, t.Name())
+
+		// SGW holds a pre-upgrade document - rev tree only, no HLV - and the client holds the same
+		// pre-upgrade revision.
+		legacyDoc := rt.CreateDocNoHLV(docID, db.Body{"v": 0})
+		legacyRev := legacyDoc.GetRevTreeID()
+		clientVersion := btcRunner.AddRevTreeRev(client.id, docID, legacyRev, EmptyDocVersion(), []byte(`{"v": 0}`))
+
+		btcRunner.StartPush(client.id)
+		defer btcRunner.StopPush(client.id)
+
+		// Four post-upgrade updates from the client.
+		for i := 1; i <= 4; i++ {
+			clientVersion = btcRunner.AddRev(client.id, docID, &clientVersion, fmt.Appendf(nil, `{"v": %d}`, i))
+			rt.WaitForVersion(docID, clientVersion)
+		}
+
+		collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
+		bucketDoc, _, err := collection.GetDocWithXattrs(ctx, docID, db.DocUnmarshalAll)
+		require.NoError(t, err)
+
+		// Walk the rev tree from the current rev back to the root.
+		var chain []string
+		for revID := bucketDoc.GetRevTreeID(); revID != ""; {
+			revInfo, ok := bucketDoc.History[revID]
+			require.True(t, ok, "rev %q missing from rev tree", revID)
+			chain = append(chain, revID)
+			revID = revInfo.Parent
+		}
+		slices.Reverse(chain)
+
+		generations := make([]int, 0, len(chain))
+		for _, revID := range chain {
+			generation, _ := db.ParseRevID(ctx, revID)
+			require.Greater(t, generation, 0)
+			generations = append(generations, generation)
+		}
+		t.Logf("rev tree root -> leaf: %v (generations %v)", chain, generations)
+
+		// Every revision must be at least one generation higher than its parent.
+		for i := 1; i < len(chain); i++ {
+			require.Greater(t, generations[i], generations[i-1],
+				"revision %q is not a higher generation than its parent %q", chain[i], chain[i-1])
+		}
+	})
 }

--- a/rest/replicatortest/replicator_conflict_test.go
+++ b/rest/replicatortest/replicator_conflict_test.go
@@ -176,6 +176,8 @@ func TestActiveReplicatorHLVConflictRemoteAndLocalWins(t *testing.T) {
 					rest.AssertRevTreeAfterHLVConflictResolution(t, rt1Doc, localWinsVersion.RevTreeID, rt1Version.RevTreeID)
 				}
 
+				// Conflict resolution must not leave a revision at or below its parent's generation.
+				rest.RequireStrictlyIncreasingRevTreeGenerations(t, rt1ctx, rt1Doc)
 			})
 		}
 	})

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2799,6 +2799,31 @@ func AssertRevTreeAfterHLVConflictResolution(t *testing.T, doc *db.Document, exp
 	require.Equal(t, 1, activeLeafCount)
 }
 
+// RequireStrictlyIncreasingRevTreeGenerations walks every branch of a document's rev tree from leaf to
+// root and requires each revision to be at least one generation higher than its parent.
+func RequireStrictlyIncreasingRevTreeGenerations(t *testing.T, ctx context.Context, doc *db.Document) {
+	t.Helper()
+	for _, leafRevID := range doc.History.GetLeaves() {
+		var branch []string
+		for revID := leafRevID; revID != ""; {
+			revInfo, ok := doc.History[revID]
+			require.True(t, ok, "rev %q missing from rev tree for doc %q", revID, doc.ID)
+			branch = append(branch, revID)
+			revID = revInfo.Parent
+		}
+		// branch runs leaf -> root, so generations must strictly decrease as we walk it.
+		for i := 1; i < len(branch); i++ {
+			childGeneration, _ := db.ParseRevID(ctx, branch[i-1])
+			parentGeneration, _ := db.ParseRevID(ctx, branch[i])
+			require.Greater(t, childGeneration, 0)
+			require.Greater(t, parentGeneration, 0)
+			require.Greater(t, childGeneration, parentGeneration,
+				"doc %q: revision %q is not a higher generation than its parent %q (branch from leaf: %v)",
+				doc.ID, branch[i-1], branch[i], branch)
+		}
+	}
+}
+
 // ClearServerContextLoggingGlobals clears the global variables related to logging in ServerContext and allows testing initialization of a server context's logging parameters.
 func ClearServerContextLoggingGlobals(t *testing.T) {
 	// the end of the test must clean up global logging


### PR DESCRIPTION
CBG-5714

Clean cherry pick of #8591 to 4.1.2

🤖 Opened with the `sync-gateway-backport` skill in [Claude Code](https://claude.com/claude-code)
