### PR TITLE
[4.0.8 Backport] CBG-5819: split purge role from delete role to avoid an abandoned sequence

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -736,10 +736,13 @@ func (auth *Authenticator) DeleteUser(user User) error {
 	return auth.datastore.Delete(user.DocID())
 }
 
-func (auth *Authenticator) DeleteRole(role Role, purge bool, deleteSeq uint64) error {
-	if purge {
-		return auth.datastore.Delete(role.DocID())
-	}
+// PurgeRole removes the role document from the bucket.
+func (auth *Authenticator) PurgeRole(role Role) error {
+	return auth.datastore.Delete(role.DocID())
+}
+
+// DeleteRole deletes the role. This invalidates the role at deleteSeq
+func (auth *Authenticator) DeleteRole(role Role, deleteSeq uint64) error {
 	return auth.casUpdatePrincipal(role, func(p Principal) (updatedPrincipal Principal, err error) {
 		if p == nil || p.IsDeleted() {
 			return p, base.ErrUpdateCancel

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -2672,11 +2672,11 @@ func TestRoleSoftDelete(t *testing.T) {
 	assert.True(t, role.Channels().Contains("channel"))
 
 	// Delete role
-	err = auth.DeleteRole(role, false, 2)
+	err = auth.DeleteRole(role, 2)
 	assert.NoError(t, err)
 
 	// Delete again
-	err = auth.DeleteRole(role, false, 2)
+	err = auth.DeleteRole(role, 2)
 	assert.NoError(t, err)
 
 	expectedChannelHistory := GrantHistorySequencePair{StartSeq: 1, EndSeq: 2}
@@ -2730,7 +2730,7 @@ func TestObtainChannelsForDeletedRole(t *testing.T) {
 			assert.NoError(t, err)
 
 			// Role deleted
-			err = auth.DeleteRole(role, true, 2)
+			err = auth.PurgeRole(role)
 			assert.NoError(t, err)
 
 			// Successfully able to get inherited channels even though role is missing
@@ -2743,7 +2743,7 @@ func TestObtainChannelsForDeletedRole(t *testing.T) {
 			"DeleteThenGetUser",
 			func(auth *Authenticator, role Role, t *testing.T) {
 				// Role deleted
-				err := auth.DeleteRole(role, true, 2)
+				err := auth.PurgeRole(role)
 				assert.NoError(t, err)
 
 				// Get user

--- a/db/users.go
+++ b/db/users.go
@@ -33,14 +33,17 @@ func (db *DatabaseContext) DeleteRole(ctx context.Context, name string, purge bo
 		return base.ErrNotFound
 	}
 
-	// CBG-5789: a purge is a true deletion of the role document and ignores this sequence, so it is
-	// neither written nor released - leaving a permanent gap in the sequence range.
+	// A purge deletes the role document outright, so there is no tombstone to write a sequence to.
+	if purge {
+		return authenticator.PurgeRole(role)
+	}
+
 	seq, err := db.sequences.nextSequence(ctx)
 	if err != nil {
 		return err
 	}
 
-	return authenticator.DeleteRole(role, purge, seq)
+	return authenticator.DeleteRole(role, seq)
 }
 
 // UpdatePrincipal updates or creates a principal from a PrincipalConfig structure.

--- a/db/users_test.go
+++ b/db/users_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2026-Present Couchbase, Inc.
+
+Use of this software is governed by the Business Source License included in
+the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+file, in accordance with the Business Source License, use of this software will
+be governed by the Apache License, Version 2.0, included in the file
+licenses/APL2.txt.
+*/
+
+package db
+
+import (
+	"testing"
+
+	"github.com/couchbase/sync_gateway/channels"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDeleteRoleSequenceAllocation asserts that a soft delete allocates the sequence it writes to the
+// role tombstone, and that a purge allocates nothing - an unwritten sequence would leave a permanent
+// gap in the sequence range.
+func TestDeleteRoleSequenceAllocation(t *testing.T) {
+	testCases := []struct {
+		name          string
+		purge         bool
+		allocatedSeqs int64
+	}{
+		{name: "soft delete", purge: false, allocatedSeqs: 1},
+		{name: "purge", purge: true, allocatedSeqs: 0},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			db, ctx := setupTestDB(t)
+			defer db.Close(ctx)
+
+			authenticator := db.Authenticator(ctx)
+			roleName := uuid.NewString()
+			role, err := authenticator.NewRole(roleName, channels.BaseSetOf(t, "chan1"))
+			require.NoError(t, err)
+			require.NoError(t, authenticator.Save(role))
+
+			assignedBefore := db.DbStats.Database().SequenceAssignedCount.Value()
+			require.NoError(t, db.DeleteRole(ctx, roleName, testCase.purge))
+			assigned := db.DbStats.Database().SequenceAssignedCount.Value() - assignedBefore
+			require.Equal(t, testCase.allocatedSeqs, assigned)
+		})
+	}
+}

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -4078,8 +4078,7 @@ func TestBlipPullReplicationRolePurge(t *testing.T) {
 		require.True(t, db.WaitForUserWaiterChange(userWaiter))
 
 		// Changes are sent in sequence order, so once afterPurgeAllowed arrives, afterPurgeRevoked would
-		// already have arrived if the revoked channel were still being served.  The purge leaks a
-		// sequence (CBG-5789), so afterPurgeRevoked isn't visible until CachePendingSeqMaxWait elapses.
+		// already have arrived if the revoked channel were still being served.
 		revoked := rt.PutDoc("afterPurgeRevoked", `{"channels":["`+roleChannel+`"]}`)
 		allowed := rt.PutDoc("afterPurgeAllowed", `{"channels":["`+userChannel+`"]}`)
 		btcRunner.WaitForVersion(client.id, "afterPurgeAllowed", allowed)

--- a/rest/changes_test.go
+++ b/rest/changes_test.go
@@ -779,8 +779,7 @@ func TestContinuousChangesRolePurge(t *testing.T) {
 	require.True(t, db.WaitForUserWaiterChange(userWaiter))
 
 	// The feed sends in sequence order, so a feed still serving the revoked channel would send
-	// afterPurgeRevoked first.  The purge leaks a sequence (CBG-5789), so afterPurgeRevoked isn't
-	// visible until CachePendingSeqMaxWait elapses.
+	// afterPurgeRevoked first.
 	rt.PutDoc("afterPurgeRevoked", `{"channels":["`+roleChannel+`"]}`)
 	rt.PutDoc("afterPurgeAllowed", `{"channels":["`+userChannel+`"]}`)
 

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -1619,7 +1619,7 @@ func TestDeletedRoleChanHistory(t *testing.T) {
 			assert.True(t, channels.Contains("channel"))
 
 			// Delete role
-			err = a.DeleteRole(role, false, 2)
+			err = a.DeleteRole(role, 2)
 			assert.NoError(t, err)
 
 			// get deleted role and assert channel is in channel history


### PR DESCRIPTION
CBG-5819

Unclean cherry pick of #8737 to 4.0.8
Changes from main commit:
- `auth/auth.go` — conflict: `datastore.Delete` takes no context argument on this branch, so `PurgeRole` calls `auth.datastore.Delete(role.DocID())`
- `db/users_test.go` — release branch predates the `testing/require` wrappers; imports renamed back to `github.com/stretchr/testify/require`, and `allocatedSeqs` is `int64` because `SgwIntStat.Value` returns `int64` here

🤖 Opened with the `sync-gateway-backport` skill in [Claude Code](https://claude.com/claude-code)
