### PR TITLE
[4.0.8 Backport] CBG-5772: fix channel loss on isgr v4 write

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -1648,7 +1648,7 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 						return nil, nil, false, nil, err
 					}
 
-					_, err = doc.addNewerRevisionsToRevTreeHistory(ctx, opts.NewDoc, currentRevIndex, parent, opts.RevTreeHistory)
+					err = doc.addNewerRevisionsToRevTreeHistory(ctx, opts.NewDoc, currentRevIndex, parent, opts.RevTreeHistory)
 					if err != nil {
 						return nil, nil, false, nil, err
 					}
@@ -4107,20 +4107,16 @@ func (doc *Document) alignRevTreeHistoryForHLVWrite(ctx context.Context, db *Dat
 		}
 	}
 
-	newRev, err := doc.addNewerRevisionsToRevTreeHistory(ctx, newDoc, currentRevIndex, parent, revTreeHistory)
-	if err != nil {
-		return err
-	}
-	// If we are skipping history check we are either allowing conflicting tombstones or we are aligning a rev tree post
-	// conflict resolution. In both cases we do not want to update the current rev here on the document.
-	if !skipHistoryCheck {
-		doc.SetRevTreeID(newRev)
-	}
-	return nil
+	// Note that the document's current rev is deliberately not set here. documentUpdateFunc calls
+	// updateWinningRevAndSetDocFlags once this callback returns, which selects the winning revision of the
+	// rev tree - including the incoming revisions added below - and makes it the document's current rev.
+	// Setting the current rev here as well makes the pre-update rev captured by documentUpdateFunc identical
+	// to the new rev, which suppresses the channel and access update for the incoming revision.
+	return doc.addNewerRevisionsToRevTreeHistory(ctx, newDoc, currentRevIndex, parent, revTreeHistory)
 }
 
 // addNewerRevisionsToRevTreeHistory will add any newer rev tree id's to the local document history
-func (doc *Document) addNewerRevisionsToRevTreeHistory(ctx context.Context, newDoc *Document, currentRevIndex int, parent string, docHistory []string) (string, error) {
+func (doc *Document) addNewerRevisionsToRevTreeHistory(ctx context.Context, newDoc *Document, currentRevIndex int, parent string, docHistory []string) error {
 	// currentRevIndex here is the index of the incoming rev tree list to start from.
 	for i := currentRevIndex - 1; i >= 0; i-- {
 		err := doc.History.addRevision(ctx, newDoc.ID,
@@ -4130,12 +4126,11 @@ func (doc *Document) addNewerRevisionsToRevTreeHistory(ctx context.Context, newD
 				Deleted: i == 0 && newDoc.Deleted})
 
 		if err != nil {
-			return "", err
+			return err
 		}
 		parent = docHistory[i]
 	}
-	// return last element added from docHistory, this will be the doc's new current rev for writes that are aligning rev tree
-	return parent, nil
+	return nil
 }
 
 const (

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -2283,3 +2283,204 @@ func TestSyncDataCVEqual(t *testing.T) {
 		})
 	}
 }
+
+// TestPutExistingCurrentVersionISGRNewDocChannels reproduces the case where a brand-new document arriving over an
+// ISGR pull replication is written without its channels being persisted (channel_set: null), making it invisible to
+// the changes feed. See https://www.couchbase.com/forums/t/41307
+func TestPutExistingCurrentVersionISGRNewDocChannels(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
+
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+
+	const (
+		docID    = "isgrDoc"
+		chanName = "event-123"
+		revID    = "1-abc"
+	)
+
+	// simulate a brand-new doc arriving from another Sync Gateway over ISGR - the sending SGW provides its rev tree
+	// history alongside the HLV
+	newDoc := CreateTestDocument(docID, "", Body{"channels": []string{chanName}}, false, 0)
+	opts := PutDocOptions{
+		NewDoc:         newDoc,
+		NewDocHLV:      &HybridLogicalVector{SourceID: "remoteSource", Version: 1234},
+		RevTreeHistory: []string{revID},
+		ISGRWrite:      true,
+		ExistingDoc:    &sgbucket.BucketDocument{},
+	}
+	_, _, _, err := collection.PutExistingCurrentVersion(ctx, opts)
+	require.NoError(t, err)
+
+	doc, err := collection.GetDocument(ctx, docID, DocUnmarshalAll)
+	require.NoError(t, err)
+	require.Equal(t, revID, doc.GetRevTreeID())
+	require.NotZero(t, doc.Sequence)
+	// ChannelMap values are nil for channels the doc is currently in, so check for key presence
+	_, inChannel := doc.Channels[chanName]
+	require.True(t, inChannel, "sync function channel not persisted for ISGR-written doc, channels=%v", doc.Channels)
+}
+
+const isgrScopeSyncFn = `function(doc){ if (doc.channels) { channel(doc.channels); access("bob", doc.channels); } }`
+
+// TestPutExistingCurrentVersionISGRAccessGrant verifies access() grants from the sync function are persisted
+// for a new document arriving over ISGR. See https://www.couchbase.com/forums/t/41307
+func TestPutExistingCurrentVersionISGRAccessGrant(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, isgrScopeSyncFn, db.Options.JavascriptTimeout)
+
+	newDoc := CreateTestDocument("accessDoc", "", Body{"channels": []string{"chanA"}}, false, 0)
+	_, _, _, err := collection.PutExistingCurrentVersion(ctx, PutDocOptions{
+		NewDoc:         newDoc,
+		NewDocHLV:      &HybridLogicalVector{SourceID: "remote", Version: 1234},
+		RevTreeHistory: []string{"1-abc"},
+		ISGRWrite:      true,
+		ExistingDoc:    &sgbucket.BucketDocument{},
+	})
+	require.NoError(t, err)
+
+	doc, err := collection.GetDocument(ctx, "accessDoc", DocUnmarshalAll)
+	require.NoError(t, err)
+	t.Logf("channels=%v access=%v", doc.Channels, doc.Access)
+	require.NotEmpty(t, doc.Access, "access() grant dropped on ISGR write")
+}
+
+// TestPutExistingCurrentVersionISGRTombstoneChannelRemoval verifies an ISGR tombstone for a live local document
+// records the channel removals, rather than leaving the doc in its previous channels.
+func TestPutExistingCurrentVersionISGRTombstoneChannelRemoval(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+
+	// local live doc with correct channel metadata
+	rev, _, err := collection.Put(ctx, "tombDoc", Body{"channels": []string{"chanA"}})
+	require.NoError(t, err)
+	local, err := collection.GetDocument(ctx, "tombDoc", DocUnmarshalAll)
+	require.NoError(t, err)
+	_, hasA := local.Channels["chanA"]
+	require.True(t, hasA, "precondition: local write sets chanA, channels=%v", local.Channels)
+	t.Logf("before tombstone: rev=%s channels=%v", rev, local.Channels)
+
+	// incoming ISGR tombstone that dominates the local version
+	incomingHLV := local.HLV.Copy()
+	incomingHLV.PreviousVersions = HLVVersions{incomingHLV.SourceID: incomingHLV.Version}
+	incomingHLV.SourceID = "remote"
+	incomingHLV.Version = local.HLV.Version + 1000
+
+	tombstone := CreateTestDocument("tombDoc", "", Body{}, true, 0)
+	_, _, _, err = collection.PutExistingCurrentVersion(ctx, PutDocOptions{
+		NewDoc:                         tombstone,
+		NewDocHLV:                      incomingHLV,
+		RevTreeHistory:                 []string{"2-def", rev},
+		ISGRWrite:                      true,
+		ForceAllowConflictingTombstone: true,
+	})
+	require.NoError(t, err)
+
+	doc, err := collection.GetDocument(ctx, "tombDoc", DocUnmarshalAll)
+	require.NoError(t, err)
+	t.Logf("after ISGR tombstone: deleted=%v channels=%v", doc.IsDeleted(), doc.Channels)
+	require.NotNil(t, doc.Channels["chanA"], "chanA not marked removed by ISGR tombstone, channels=%v", doc.Channels)
+}
+
+// TestPutExistingCurrentVersionISGRLegacyDocChannels verifies an ISGR write onto a pre-upgrade document (rev tree,
+// no HLV) persists the channels calculated by the sync function, rather than leaving the legacy channel set in place.
+func TestPutExistingCurrentVersionISGRLegacyDocChannels(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+
+	// pre-upgrade doc: rev tree, no HLV
+	rev1, _ := collection.CreateDocNoHLV(t, ctx, "legacyDoc", Body{"channels": []string{"chanA"}})
+	legacyDoc, err := collection.GetDocument(ctx, "legacyDoc", DocUnmarshalAll)
+	require.NoError(t, err)
+	require.Nil(t, legacyDoc.HLV, "precondition: doc must have no HLV")
+	_, hasA := legacyDoc.Channels["chanA"]
+	require.True(t, hasA, "precondition: legacy write sets chanA, channels=%v", legacyDoc.Channels)
+
+	// ISGR write moving the doc from chanA to chanB, carrying rev tree history
+	newDoc := CreateTestDocument("legacyDoc", "", Body{"channels": []string{"chanB"}}, false, 0)
+	_, _, _, err = collection.PutExistingCurrentVersion(ctx, PutDocOptions{
+		NewDoc:         newDoc,
+		NewDocHLV:      &HybridLogicalVector{SourceID: "remote", Version: 123456789},
+		RevTreeHistory: []string{"2-def", rev1},
+		ISGRWrite:      true,
+	})
+	require.NoError(t, err)
+
+	doc, err := collection.GetDocument(ctx, "legacyDoc", DocUnmarshalAll)
+	require.NoError(t, err)
+	_, inB := doc.Channels["chanB"]
+	require.True(t, inB, "chanB not persisted on ISGR write to legacy doc, channels=%v", doc.Channels)
+}
+
+// TestPutExistingCurrentVersionISGROldRevBackup verifies an ISGR write backs up the superseded revision body in the
+// same way a local write does.
+//
+// documentUpdateFunc captures the document's pre-update rev after the update callback has run, and that one value
+// drives both the channel/access update and storeOldBodyInRevTreeAndUpdateCurrent. A callback that sets the current
+// rev itself makes the captured rev identical to the incoming rev, which silently disables both - so this asserts the
+// second consequence alongside the channel coverage above. See https://www.couchbase.com/forums/t/41307
+//
+// Note the backup is only written when delta sync is off and legacy rev tree data is stored - with delta sync enabled
+// postWriteUpdateHLV writes a CV-keyed backup instead. Both are the defaults for a test database.
+func TestPutExistingCurrentVersionISGROldRevBackup(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+
+	require.False(t, collection.deltaSyncEnabled(), "precondition: delta sync off, so the rev tree ID keyed backup is used")
+	require.True(t, collection.storeLegacyRevTreeData(), "precondition: legacy rev tree data is stored")
+
+	const (
+		rev1Body = `{"channels":["chanA"],"value":"one"}`
+		rev2Body = `{"channels":["chanB"],"value":"two"}`
+	)
+
+	// a locally updated document, for comparison - every write path other than ISGR backs the superseded body up
+	localRev1, _, err := collection.Put(ctx, "localDoc", unmarshalBody(t, rev1Body))
+	require.NoError(t, err)
+	localRev2Body := unmarshalBody(t, rev2Body)
+	localRev2Body[BodyRev] = localRev1
+	_, _, err = collection.Put(ctx, "localDoc", localRev2Body)
+	require.NoError(t, err)
+
+	// the same update arriving over ISGR
+	isgrRev1, _, err := collection.Put(ctx, "isgrDoc", unmarshalBody(t, rev1Body))
+	require.NoError(t, err)
+	localDoc, err := collection.GetDocument(ctx, "isgrDoc", DocUnmarshalAll)
+	require.NoError(t, err)
+
+	incomingHLV := localDoc.HLV.Copy()
+	incomingHLV.PreviousVersions = HLVVersions{incomingHLV.SourceID: incomingHLV.Version}
+	incomingHLV.SourceID = "remote"
+	incomingHLV.Version = localDoc.HLV.Version + 1000
+
+	_, _, _, err = collection.PutExistingCurrentVersion(ctx, PutDocOptions{
+		NewDoc:         CreateTestDocument("isgrDoc", "", unmarshalBody(t, rev2Body), false, 0),
+		NewDocHLV:      incomingHLV,
+		RevTreeHistory: []string{"2-def", isgrRev1},
+		ISGRWrite:      true,
+	})
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		docID         string
+		supersededRev string
+	}{
+		{docID: "localDoc", supersededRev: localRev1},
+		{docID: "isgrDoc", supersededRev: isgrRev1},
+	} {
+		t.Run(tc.docID, func(t *testing.T) {
+			backup, _, _, err := collection.getOldRevisionJSON(ctx, tc.docID, tc.supersededRev)
+			require.NoError(t, err, "superseded revision %s of %s was not backed up", tc.supersededRev, tc.docID)
+			require.JSONEq(t, rev1Body, string(backup))
+		})
+	}
+}

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -766,6 +766,9 @@ func TestAlignRevTreeHistory(t *testing.T) {
 			require.NoError(t, err)
 			base.RequireKeysEqual(t, tc.expectedRevTree, doc.History)
 
+			// alignRevTreeHistoryForHLVWrite doesn't set the current rev - documentUpdateFunc calls
+			// updateWinningRevAndSetDocFlags after the update callback
+			doc.updateWinningRevAndSetDocFlags(ctx)
 			assert.Equal(t, tc.expectedActive, doc.GetRevTreeID())
 			if tc.expectedTombstone != "" {
 				assert.True(t, doc.History[tc.expectedTombstone].Deleted)

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -2070,15 +2070,11 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.Run(func(t *testing.T) {
 
-		rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
-		remoteURL, err := url.Parse(remoteURLString)
-		require.NoError(t, err)
+		rt1, rt2, _ := sgrRunner.SetupSGRPeers(t)
 
-		const (
-			// test url encoding of username/password with these
-			username = "AL_1c.e-@"
-			password = rest.RestTesterDefaultUserPassword
-		)
+		// Replicating as this user below is what exercises URL encoding of the credentials
+		const username = "AL_1c.e-@"
+		rt2.CreateUser(username, []string{username})
 
 		docID := rest.SafeDocumentName(t, t.Name()) + "rt2doc1"
 		version := rt2.PutDoc(docID, `{"source":"rt2","channels":["`+username+`"]}`)
@@ -2093,7 +2089,7 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 		ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
 			ID:          replicationID,
 			Direction:   db.ActiveReplicatorTypePull,
-			RemoteDBURL: remoteURL,
+			RemoteDBURL: userDBURL(rt2, username),
 			ActiveDB: &db.Database{
 				DatabaseContext: rt1.GetDatabase(),
 			},
@@ -2121,6 +2117,11 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 		body, err := doc.GetDeepMutableBody()
 		require.NoError(t, err)
 		assert.Equal(t, "rt2", body["source"])
+
+		// the receiving peer must run its own sync function and persist the resulting channels - ChannelMap values
+		// are nil for channels the doc is currently in, so check for key presence
+		_, inChannel := doc.Channels[username]
+		assert.True(t, inChannel, "channels not persisted on pulled doc, channels=%v", doc.Channels)
 
 		// replication status updates just after the document has been written in a blip handler callback, so the
 		// document can exist before stat is updated
@@ -3238,6 +3239,11 @@ func TestActiveReplicatorPushBasic(t *testing.T) {
 		body, err := doc.GetDeepMutableBody()
 		require.NoError(t, err)
 		assert.Equal(t, "rt1", body["source"])
+
+		// the receiving peer must run its own sync function and persist the resulting channels - ChannelMap values
+		// are nil for channels the doc is currently in, so check for key presence
+		_, inChannel := doc.Channels[username]
+		assert.True(t, inChannel, "channels not persisted on pushed doc, channels=%v", doc.Channels)
 
 		assert.Equal(t, strconv.FormatUint(localDoc.Sequence, 10), ar.GetStatus(ctx1).LastSeqPush)
 	})
@@ -8238,4 +8244,177 @@ func TestISGRRunAsNonExistentUserReplicationConfigInDbConfig(t *testing.T) {
 
 	resp := passiveRT.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/"+docID, "")
 	require.Equal(t, http.StatusNotFound, resp.Code, "expected secret doc to not be pushed with invalid run_as user")
+}
+
+// TestActiveReplicatorPullNewDocChannels reproduces a new document pulled over ISGR being written without its
+// channels (channel_set: null), leaving it absent from the authenticated changes feed on the receiving Sync Gateway.
+// See https://www.couchbase.com/forums/t/41307
+func TestActiveReplicatorPullNewDocChannels(t *testing.T) {
+	base.RequireNumTestBuckets(t, 2)
+
+	const (
+		username = "bob"
+		chanName = "event-123"
+	)
+
+	sgrRunner := rest.NewSGRTestRunner(t)
+	sgrRunner.Run(func(t *testing.T) {
+		activeRT, passiveRT, remoteURLString := sgrRunner.SetupSGRPeers(t)
+		remoteURL, err := url.Parse(remoteURLString)
+		require.NoError(t, err)
+
+		// user on the receiving (active) side with access to the channel the sync function will assign
+		activeRT.CreateUser(username, []string{chanName})
+
+		ctx1 := activeRT.Context()
+		ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+			ID:          rest.SafeDocumentName(t, t.Name()),
+			Direction:   db.ActiveReplicatorTypePull,
+			RemoteDBURL: remoteURL,
+			ActiveDB: &db.Database{
+				DatabaseContext: activeRT.GetDatabase(),
+			},
+			ChangesBatchSize:       200,
+			Continuous:             true,
+			ReplicationStatsMap:    dbReplicatorStats(t),
+			CollectionsEnabled:     !activeRT.GetDatabase().OnlyDefaultCollection(),
+			SupportedBLIPProtocols: sgrRunner.SupportedSubprotocols,
+		})
+		require.NoError(t, err)
+		defer func() { assert.NoError(t, ar.Stop()) }()
+		require.NoError(t, ar.Start(ctx1))
+
+		// brand new document created on the remote, assigned to chanName by the sync function
+		docID := rest.SafeDocumentName(t, t.Name()) + "rt2doc1"
+		version := passiveRT.PutDoc(docID, `{"source":"rt2","channels":["`+chanName+`"]}`)
+
+		sgrRunner.WaitForVersion(docID, activeRT, version)
+
+		rt1collection, rt1ctx := activeRT.GetSingleTestDatabaseCollection()
+		doc, err := rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
+		require.NoError(t, err)
+		require.NotZero(t, doc.Sequence)
+		// ChannelMap values are nil for channels the doc is currently in, so check for key presence
+		_, inChannel := doc.Channels[chanName]
+		require.True(t, inChannel, "channel not persisted on pulled doc, channels=%v", doc.Channels)
+
+		// _user/bob doc is also in the feed, hence 2
+		changes := activeRT.WaitForChanges(2, "/{{.keyspace}}/_changes", username, false)
+		require.Equal(t, docID, changes.Results[1].ID)
+	})
+}
+
+// TestActiveReplicatorPushNewDocChannels is the push equivalent of TestActiveReplicatorPullNewDocChannels - a new
+// document pushed over ISGR must have its channels persisted on the receiving (passive) peer.
+func TestActiveReplicatorPushNewDocChannels(t *testing.T) {
+	base.RequireNumTestBuckets(t, 2)
+
+	const (
+		username = "alice"
+		chanName = "event-123"
+	)
+
+	sgrRunner := rest.NewSGRTestRunner(t)
+	sgrRunner.Run(func(t *testing.T) {
+		activeRT, passiveRT, _ := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+			UserChannelAccess: []string{chanName},
+		})
+		ctx1 := activeRT.Context()
+
+		ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+			ID:          rest.SafeDocumentName(t, t.Name()),
+			Direction:   db.ActiveReplicatorTypePush,
+			RemoteDBURL: userDBURL(passiveRT, username),
+			ActiveDB: &db.Database{
+				DatabaseContext: activeRT.GetDatabase(),
+			},
+			ChangesBatchSize:       200,
+			Continuous:             true,
+			ReplicationStatsMap:    dbReplicatorStats(t),
+			CollectionsEnabled:     !activeRT.GetDatabase().OnlyDefaultCollection(),
+			SupportedBLIPProtocols: sgrRunner.SupportedSubprotocols,
+		})
+		require.NoError(t, err)
+		defer func() { assert.NoError(t, ar.Stop()) }()
+		require.NoError(t, ar.Start(ctx1))
+
+		// brand new document created on the active peer, assigned to chanName by the sync function
+		docID := rest.SafeDocumentName(t, t.Name()) + "rt1doc1"
+		version := activeRT.PutDoc(docID, `{"source":"rt1","channels":["`+chanName+`"]}`)
+
+		sgrRunner.WaitForVersion(docID, passiveRT, version)
+
+		passiveRTCollection, passiveRTCtx := passiveRT.GetSingleTestDatabaseCollection()
+		doc, err := passiveRTCollection.GetDocument(passiveRTCtx, docID, db.DocUnmarshalAll)
+		require.NoError(t, err)
+		require.NotZero(t, doc.Sequence)
+		// ChannelMap values are nil for channels the doc is currently in, so check for key presence
+		_, inChannel := doc.Channels[chanName]
+		require.True(t, inChannel, "channel not persisted on pushed doc, channels=%v", doc.Channels)
+
+		// _user/alice doc is also in the feed, hence 2
+		changes := passiveRT.WaitForChanges(2, "/{{.keyspace}}/_changes", username, false)
+		require.Equal(t, docID, changes.Results[1].ID)
+	})
+}
+
+// TestActiveReplicatorPullUpdatedDocChannels verifies that an ISGR update which changes a document's channels is
+// reflected in the receiving peer's channel metadata - the doc must be added to the new channel and removed from the
+// old one, rather than retaining a stale channel set.
+func TestActiveReplicatorPullUpdatedDocChannels(t *testing.T) {
+	base.RequireNumTestBuckets(t, 2)
+
+	const (
+		username = "alice"
+		chanA    = "chanA"
+		chanB    = "chanB"
+	)
+
+	sgrRunner := rest.NewSGRTestRunner(t)
+	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
+		activeRT, passiveRT, _ := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+			UserChannelAccess: []string{chanA, chanB},
+		})
+		ctx1 := activeRT.Context()
+
+		ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+			ID:          rest.SafeDocumentName(t, t.Name()),
+			Direction:   db.ActiveReplicatorTypePushAndPull,
+			RemoteDBURL: userDBURL(passiveRT, username),
+			ActiveDB: &db.Database{
+				DatabaseContext: activeRT.GetDatabase(),
+			},
+			ChangesBatchSize:       200,
+			Continuous:             true,
+			ReplicationStatsMap:    dbReplicatorStats(t),
+			CollectionsEnabled:     !activeRT.GetDatabase().OnlyDefaultCollection(),
+			SupportedBLIPProtocols: sgrRunner.SupportedSubprotocols,
+		})
+		require.NoError(t, err)
+		defer func() { assert.NoError(t, ar.Stop()) }()
+		require.NoError(t, ar.Start(ctx1))
+
+		// doc originates LOCALLY on active, so active's channel metadata starts out correct
+		docID := rest.SafeDocumentName(t, t.Name()) + "doc1"
+		v1 := activeRT.PutDoc(docID, `{"channels":["`+chanA+`"]}`)
+		activeRTCollection, activeRTCtx := activeRT.GetSingleTestDatabaseCollection()
+		localDoc, err := activeRTCollection.GetDocument(activeRTCtx, docID, db.DocUnmarshalAll)
+		require.NoError(t, err)
+		_, hasA := localDoc.Channels[chanA]
+		require.True(t, hasA, "precondition: local write should set chanA, channels=%v", localDoc.Channels)
+
+		sgrRunner.WaitForVersion(docID, passiveRT, v1)
+
+		// now update the doc on rt2, moving it from chanA to chanB, and let it replicate back to rt1
+		v2 := passiveRT.UpdateDoc(docID, v1, `{"channels":["`+chanB+`"]}`)
+		sgrRunner.WaitForVersion(docID, activeRT, v2)
+
+		doc, err := activeRTCollection.GetDocument(activeRTCtx, docID, db.DocUnmarshalAll)
+		require.NoError(t, err)
+		t.Logf("active channels after ISGR update: %+v", doc.Channels)
+		_, inB := doc.Channels[chanB]
+		assert.True(t, inB, "chanB (added by the ISGR update) not persisted, channels=%v", doc.Channels)
+		removalA := doc.Channels[chanA]
+		assert.NotNil(t, removalA, "chanA should be marked removed after the ISGR update, channels=%v", doc.Channels)
+	})
 }


### PR DESCRIPTION
CBG-5772

Unclean cherry pick of #8724 to 4.0.8
Changes from main commit:
- `db/crud_test.go` — the cherry-pick's merge base carries `TestProposedRev` (added on main by #7875), which isn't on 4.0.8, so it appeared on the upstream side of the conflict; only the 5 tests this commit actually adds were applied
- `rest/replicatortest/replicator_test.go` — `SetupSGRPeers`/`SetupSGRPeersWithOptions` return a tuple on 4.0.8 rather than `*TestISGRPeers` (CBG-4625, #8659, isn't on this branch); the 4 call sites were converted back to tuple destructuring
- `rest/replicatortest/replicator_test.go` — `dbReplicatorStats` takes only `*testing.T` on 4.0.8, so the `*db.DatabaseContext` argument was dropped from the 3 new calls

`db/crud.go` and `db/document_test.go` are upstream-identical. All eight tests the commit adds or extends are applied in full.

Rebased onto current `release/4.0.8`. This depends on CBG-5814 (#8736), which carries the `TestAlignRevTreeHistory` fix: CBG-5771 stops `alignRevTreeHistoryForHLVWrite` setting the current rev, so `updateWinningRevAndSetDocFlags` picks the winner from the rev tree, and the pre-#8736 test built its local tree newest-first — `gap in histories, local larger` then resolved to `10-abc` instead of `3-abc`.

🤖 Opened with the `sync-gateway-backport` skill in [Claude Code](https://claude.com/claude-code)
