### PR TITLE
[3.3.8 Backport] CBG-5216: add deterministic node UID

### DIFF
--- a/base/node_uid.go
+++ b/base/node_uid.go
@@ -1,0 +1,101 @@
+//  Copyright 2012-Present Couchbase, Inc.
+//
+//  Use of this software is governed by the Business Source License included
+//  in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+//  in that file, in accordance with the Business Source License, use of this
+//  software will be governed by the Apache License, Version 2.0, included in
+//  the file licenses/APL2.txt.
+
+package base
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"hash"
+	"net"
+	"os"
+	"sort"
+)
+
+// nodeUIDLength is the expected length of a valid node UID (128-bit value encoded as a 32-character lowercase hex string)
+const nodeUIDLength = 32
+
+// GenerateNodeUID derives a stable 32-character hex node UID from a fingerprint of the SG's process and its host.
+// Components: hostname + NIC MAC addresses + API listen addresses.
+// The same SG instance on the same hardware produces the same UID across restarts without any persistent state.
+//
+// Only if no fingerprint inputs can be collected do we fall back to a random ID.
+func GenerateNodeUID(ctx context.Context, listenAddrs ...string) (string, error) {
+	hostname, macs := nodeFingerprint(ctx)
+	if hostname == "" && len(macs) == 0 && len(listenAddrs) == 0 {
+		WarnfCtx(ctx, "Could not collect hostname, interface MACs, or listen addresses for deterministic node UID — falling back to random node UID")
+		return GenerateRandomID()
+	}
+
+	return deterministicNodeUID(hostname, macs, listenAddrs), nil
+}
+
+// nodeFingerprint reads the hostname and non-empty hardware addresses of all network interfaces.
+// Either component may be empty if the system call fails; both empty means we cannot fingerprint the host.
+func nodeFingerprint(ctx context.Context) (hostname string, macs []string) {
+	hostname, err := os.Hostname()
+	if err != nil {
+		WarnfCtx(ctx, "Could not read hostname for node UID fingerprint: %v", err)
+	}
+
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		WarnfCtx(ctx, "Could not enumerate network interfaces for node UID fingerprint: %v", err)
+		return hostname, nil
+	}
+
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		if mac := iface.HardwareAddr.String(); mac != "" {
+			macs = append(macs, mac)
+		}
+	}
+
+	return hostname, macs
+}
+
+// deterministicNodeUID produces a 32-char lowercase hex digest for the given:
+//  1. hostname
+//  2. All network interface MACs
+//  3. SG REST API listen addresses
+//
+// This ensures that we can calculate a unique identifier for a given Sync Gateway process even under these conditions:
+//  1. Different hostnames but same listen addresses (common case)
+//  2. Same host shared across multiple listen addresses (uncommon but often test setups ... '2-node' on ports 4984 and 5984 for example)
+//  3. Same hostname different physical hardware (uncommon but default/unconfigured hostname setups may cause this)
+func deterministicNodeUID(hostname string, macs []string, listenAddrs []string) string {
+	sortedMACs := append([]string(nil), macs...)
+	sort.Strings(sortedMACs)
+	sortedAddrs := append([]string(nil), listenAddrs...)
+	sort.Strings(sortedAddrs)
+
+	h := sha256.New()
+	writeLengthPrefixed(h, hostname)
+	for _, mac := range sortedMACs {
+		writeLengthPrefixed(h, mac)
+	}
+	for _, addr := range sortedAddrs {
+		writeLengthPrefixed(h, addr)
+	}
+	sum := h.Sum(nil)
+	return hex.EncodeToString(sum[:nodeUIDLength/2])
+}
+
+// writeLengthPrefixed writes a uint32 little-endian length followed by the bytes of s,
+// so that adjacent components in the hash input cannot run together regardless of their
+// contents.
+func writeLengthPrefixed(h hash.Hash, s string) {
+	var lenBuf [4]byte
+	binary.LittleEndian.PutUint32(lenBuf[:], uint32(len(s)))
+	_, _ = h.Write(lenBuf[:])
+	_, _ = h.Write([]byte(s))
+}

--- a/base/node_uid_test.go
+++ b/base/node_uid_test.go
@@ -1,0 +1,101 @@
+//  Copyright 2012-Present Couchbase, Inc.
+//
+//  Use of this software is governed by the Business Source License included
+//  in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+//  in that file, in accordance with the Business Source License, use of this
+//  software will be governed by the Apache License, Version 2.0, included in
+//  the file licenses/APL2.txt.
+
+package base
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// assertValidNodeUID asserts that id is a 32-character lowercase hex string
+// (the format produced by GenerateNodeUID and GenerateRandomID).
+func assertValidNodeUID(t *testing.T, id string) {
+	t.Helper()
+	require.Lenf(t, id, nodeUIDLength, "expected %d-char node UID, got %q", nodeUIDLength, id)
+	for _, c := range id {
+		require.Truef(t, (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'), "invalid char %q in node UID %q", c, id)
+	}
+}
+
+func TestGenerateNodeUID(t *testing.T) {
+	ctx := TestCtx(t)
+
+	id1, err := GenerateNodeUID(ctx, "127.0.0.1:4984", "127.0.0.1:4985")
+	require.NoError(t, err)
+	assertValidNodeUID(t, id1)
+
+	id2, err := GenerateNodeUID(ctx, "127.0.0.1:4984", "127.0.0.1:4985")
+	require.NoError(t, err)
+	assert.Equal(t, id1, id2, "expected deterministic UID across calls on the same host with same listen addresses")
+
+	id3, err := GenerateNodeUID(ctx, "127.0.0.1:5984", "127.0.0.1:5985")
+	require.NoError(t, err)
+	assert.NotEqual(t, id1, id3, "different listen addresses on the same host should produce different UIDs")
+}
+
+func TestDeterministicNodeUID(t *testing.T) {
+	const hostA = "alpha"
+	const hostB = "beta"
+	macs1 := []string{"02:42:ac:11:00:02", "02:42:ac:11:00:03"}
+	macs2 := []string{"02:42:ac:11:00:04"}
+	addrs1 := []string{"0.0.0.0:4984", "0.0.0.0:4985"}
+	addrs2 := []string{"0.0.0.0:5984", "0.0.0.0:5985"}
+
+	t.Run("same inputs produce same output", func(t *testing.T) {
+		a := deterministicNodeUID(hostA, macs1, addrs1)
+		b := deterministicNodeUID(hostA, macs1, addrs1)
+		assert.Equal(t, a, b)
+		assertValidNodeUID(t, a)
+	})
+
+	t.Run("different hostnames with identical MACs differ", func(t *testing.T) {
+		a := deterministicNodeUID(hostA, macs1, addrs1)
+		b := deterministicNodeUID(hostB, macs1, addrs1)
+		assert.NotEqual(t, a, b, "hostname should affect the UID")
+	})
+
+	t.Run("identical hostnames with different MACs differ", func(t *testing.T) {
+		a := deterministicNodeUID(hostA, macs1, addrs1)
+		b := deterministicNodeUID(hostA, macs2, addrs1)
+		assert.NotEqual(t, a, b, "MAC set should disambiguate colliding hostnames")
+	})
+
+	t.Run("MAC ordering does not affect output", func(t *testing.T) {
+		a := deterministicNodeUID(hostA, []string{"aa:aa:aa:aa:aa:aa", "bb:bb:bb:bb:bb:bb"}, addrs1)
+		b := deterministicNodeUID(hostA, []string{"bb:bb:bb:bb:bb:bb", "aa:aa:aa:aa:aa:aa"}, addrs1)
+		assert.Equal(t, a, b)
+	})
+
+	t.Run("listen address ordering does not affect output", func(t *testing.T) {
+		a := deterministicNodeUID(hostA, macs1, []string{"0.0.0.0:4984", "0.0.0.0:4985"})
+		b := deterministicNodeUID(hostA, macs1, []string{"0.0.0.0:4985", "0.0.0.0:4984"})
+		assert.Equal(t, a, b)
+	})
+
+	t.Run("identical hostnames and MACs but different listen addresses differ", func(t *testing.T) {
+		a := deterministicNodeUID(hostA, macs1, addrs1)
+		b := deterministicNodeUID(hostA, macs1, addrs2)
+		assert.NotEqual(t, a, b, "listen addresses should disambiguate two SG processes on the same host")
+	})
+
+	t.Run("empty MAC list and listen addresses with hostname still produces valid UID", func(t *testing.T) {
+		id := deterministicNodeUID(hostA, nil, nil)
+		assertValidNodeUID(t, id)
+	})
+
+	t.Run("component boundaries are unambiguous", func(t *testing.T) {
+		// If components were concatenated without length-prefixing, these two inputs would
+		// hash to the same value. With length-prefixing they must differ.
+		a := deterministicNodeUID("foobar", nil, nil)
+		b := deterministicNodeUID("foo", []string{"bar"}, nil)
+		assert.NotEqual(t, a, b, "shifting bytes between components must change the UID")
+	})
+}

--- a/rest/config.go
+++ b/rest/config.go
@@ -1617,6 +1617,12 @@ func SetupServerContext(ctx context.Context, config *StartupConfig, persistentCo
 
 	sc := NewServerContext(ctx, config, persistentConfig)
 
+	nodeUID, err := base.GenerateNodeUID(ctx, sc.Config.API.PublicInterface, sc.Config.API.AdminInterface)
+	if err != nil {
+		return nil, err
+	}
+	sc.NodeUID = nodeUID
+
 	if !base.ServerIsWalrus(sc.Config.Bootstrap.Server) {
 		err := sc.initializeGocbAdminConnection(ctx)
 		if err != nil {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -93,6 +93,7 @@ type ServerContext struct {
 	ActiveReplicationsCounter
 	invalidDatabaseConfigTracking invalidDatabaseConfigs
 	SGCollect                     *sgCollect // singleton instance for this server's sgcollect_info process
+	NodeUID                       string     // Stable identifier for this SG node, derived deterministically from host fingerprint
 }
 
 type ActiveReplicationsCounter struct {


### PR DESCRIPTION
CBG-5216

Clean cherry pick of #8692 to 3.3.8

Prerequisite for the CBG-5809 phone home backport stacked on top of this. No backport ticket of its own - happy to create the clone if you want one.

Taken from the 4.0.8 backport rather than main, since #8692 had already cut #8190 down to just the node UID, which is the minimum CBG-5809 needs - `base/node_uid.go`, `base/node_uid_test.go`, the `ServerContext.NodeUID` field and its assignment in `SetupServerContext`.

Deliberately left out: the rest of ClusterCompatVersion phase 1 - the cluster compat manager, bucket node registry, `node_uid` in the admin and public API responses, the OpenAPI schema additions, and the new dependency. Nothing else on 3.3.8 reads `NodeUID`, so this layer is inert until the reporter uses it.

🤖 Opened with the `sync-gateway-backport` skill in [Claude Code](https://claude.com/claude-code)
