### PR TITLE
[3.3.8 Backport] CBG-5809: collect and send phone home records to collector

### DIFF
--- a/base/collection.go
+++ b/base/collection.go
@@ -509,7 +509,7 @@ func (b *GocbV2Bucket) MgmtRequest(ctx context.Context, method, uri, contentType
 		username, password, _ = b.Spec.Auth.GetCredentials()
 	}
 
-	respBytes, statusCode, err := MgmtRequest(b.HttpClient(ctx), mgmtEp, method, uri, contentType, username, password, body)
+	respBytes, statusCode, err := MgmtRequest(ctx, b.HttpClient(ctx), mgmtEp, method, uri, contentType, username, password, body)
 	if err != nil {
 		return nil, statusCode, err
 	}

--- a/base/fleet_manager_collector.go
+++ b/base/fleet_manager_collector.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2026-Present Couchbase, Inc.
+
+Use of this software is governed by the Business Source License included in
+the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+file, in accordance with the Business Source License, use of this software will
+be governed by the Apache License, Version 2.0, included in the file
+licenses/APL2.txt.
+*/
+
+package base
+
+import (
+	"context"
+	"os"
+	"runtime"
+	"strconv"
+
+	"github.com/KimMachineGun/automemlimit/memlimit"
+	"github.com/elastic/gosigar"
+	"github.com/shirou/gopsutil/mem"
+)
+
+const ProductInfoName = "sync_gateway"
+
+type SyncGatewayFleetManagerMetrics struct {
+	InstanceID    string                  `json:"instanceId"`
+	CpuCores      int                     `json:"cpuCores"`
+	RamBytesTotal string                  `json:"ramBytesTotal"`
+	RamBytesUsed  string                  `json:"ramBytesUsed"`
+	ProductInfo   FleetManagerProductInfo `json:"product"`
+	OSVersion     string                  `json:"osVersion"`
+	Hostname      string                  `json:"hostname"`
+	UptimeSeconds int64                   `json:"uptimeSeconds"`
+}
+
+type FleetManagerProductInfo struct {
+	Edition string `json:"edition"`
+	Version string `json:"version"`
+	Name    string `json:"name"`
+}
+
+type FleetManagerCollectorSettings struct {
+	ReportingInterval int  `json:"reportIntervalHours"`
+	Enabled           bool `json:"enabled"`
+}
+
+func CollectSGWFleetManagerMetrics(ctx context.Context, nodeUID, hostname string) SyncGatewayFleetManagerMetrics {
+	edition := "Enterprise"
+	if !IsEnterpriseEdition() {
+		edition = "Community"
+	}
+	productInfo := FleetManagerProductInfo{
+		Edition: edition,
+		Version: ProductVersion.ReleaseVersionString(),
+		Name:    ProductInfoName,
+	}
+
+	sysInfo := getSystemInfo(ctx)
+
+	return SyncGatewayFleetManagerMetrics{
+		InstanceID:    nodeUID,
+		CpuCores:      sysInfo.cpuCores,
+		RamBytesTotal: sysInfo.ramBytesTotal,
+		RamBytesUsed:  sysInfo.ramBytesUsed,
+		ProductInfo:   productInfo,
+		OSVersion:     sysInfo.osVersion,
+		Hostname:      hostname,
+		UptimeSeconds: sysInfo.uptimeSeconds,
+	}
+}
+
+type systemInfo struct {
+	cpuCores      int
+	ramBytesTotal string
+	ramBytesUsed  string
+	osVersion     string
+	uptimeSeconds int64
+}
+
+func getSystemInfo(ctx context.Context) systemInfo {
+	var residentBytes int64
+
+	// Sample process/system memory directly here rather than reading the ResourceUtilizationStats
+	// expvars: those are only populated by the stats-logger ticker, so at startup (before its first
+	// tick) and whenever the stats logger is disabled they would still read zero when this report is
+	// sent, yielding a phone-home record with ramBytesUsed/ramBytesTotal of 0.
+	procMem := gosigar.ProcMem{}
+	if err := procMem.Get(os.Getpid()); err != nil {
+		WarnfCtx(ctx, "Could not read process memory for fleet manager metrics: %v", err)
+	} else {
+		residentBytes = int64(procMem.Resident)
+	}
+
+	totalRam := GetTotalMemory(ctx, false)
+	return systemInfo{
+		uptimeSeconds: SyncGatewayStats.GlobalStats.ResourceUtilizationStats().Uptime.ToSeconds(),
+		cpuCores:      runtime.NumCPU(),
+		ramBytesUsed:  strconv.FormatInt(residentBytes, 10),
+		ramBytesTotal: strconv.FormatInt(int64(totalRam), 10),
+		osVersion:     runtime.GOOS + "-" + runtime.GOARCH,
+	}
+}
+
+// getTotalMemory returns the total memory available on the system. If a cgroup is detected, it will use the cgroup memory max.
+func GetTotalMemory(ctx context.Context, virtualMem bool) uint64 {
+	memoryTotal, err := memlimit.FromCgroup()
+	if err == nil {
+		return memoryTotal
+	}
+	TracefCtx(ctx, KeyAll, "Did not detect a cgroup for a memory limit")
+	var totalRam uint64
+	if virtualMem {
+		memory, err := mem.VirtualMemory()
+		if err != nil {
+			WarnfCtx(ctx, "Error getting total memory from gopsutil: %v", err)
+			return 0
+		}
+		totalRam = memory.Total
+	} else {
+		sysMem := gosigar.Mem{}
+		if err := sysMem.Get(); err != nil {
+			WarnfCtx(ctx, "Error getting total memory from gosigar: %v", err)
+		} else {
+			totalRam = sysMem.Total
+		}
+	}
+	return totalRam
+}

--- a/base/gocb_utils.go
+++ b/base/gocb_utils.go
@@ -166,8 +166,8 @@ func getRootCAs(ctx context.Context, caCertPath string) (*x509.CertPool, error) 
 
 // MgmtRequest makes a request to the http couchbase management api. This function will read the entire contents of
 // the response and return the output bytes, the status code, and an error.
-func MgmtRequest(client *http.Client, mgmtEp, method, uri, contentType, username, password string, body io.Reader) ([]byte, int, error) {
-	req, err := http.NewRequest(method, mgmtEp+uri, body)
+func MgmtRequest(ctx context.Context, client *http.Client, mgmtEp, method, uri, contentType, username, password string, body io.Reader) ([]byte, int, error) {
+	req, err := http.NewRequestWithContext(ctx, method, mgmtEp+uri, body)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -521,7 +521,9 @@ func (tbp *TestBucketPool) createTestBuckets(ctx context.Context, numBuckets, bu
 			}
 
 			bucket, err := tbp.cluster.openTestBucket(ctx, tbpBucketName(bucketName), waitForReadyBucketTimeout)
-			if err != nil {
+			if ctx.Err() != nil {
+				return
+			} else if err != nil {
 				tbp.Fatalf(ctx, "Timed out trying to open new bucket: %v", err)
 			}
 
@@ -596,11 +598,11 @@ loop:
 
 				start := time.Now()
 				b, err := tbp.cluster.openTestBucket(ctx, testBucketName, waitForReadyBucketTimeout)
-				ctx = KeyspaceLogCtx(ctx, b.GetName(), "", "")
 				if err != nil {
 					tbp.Logf(ctx, "Couldn't open bucket to get ready, got error: %v", err)
 					return
 				}
+				ctx = KeyspaceLogCtx(ctx, b.GetName(), "", "")
 
 				err, _ = RetryLoop(ctx, b.GetName()+"bucketReadierRetry", func() (bool, error, interface{}) {
 					tbp.Logf(ctx, "Running bucket through readier function")

--- a/base/stats.go
+++ b/base/stats.go
@@ -1211,6 +1211,10 @@ func (s *SgwDurStat) String() string {
 	return strconv.Itoa(int(time.Since(s.StartTime).Nanoseconds()))
 }
 
+func (s *SgwDurStat) ToSeconds() int64 {
+	return int64(time.Since(s.StartTime).Seconds())
+}
+
 type QueryStat struct {
 	QueryCount      *SgwIntStat
 	QueryErrorCount *SgwIntStat

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -284,6 +284,43 @@ func TestUseCouchbaseServer() bool {
 	return strings.EqualFold(backingStore, TestEnvBackingStoreCouchbase)
 }
 
+// TestClusterVersion returns the Couchbase Server version backing the test bucket pool. It fails the
+// test if there is no cluster connection (i.e. not running against Couchbase Server).
+func TestClusterVersion(t testing.TB) *ComparableBuildVersion {
+	require.NotNil(t, GTestBucketPool, "GTestBucketPool is not initialized")
+	require.NotNil(t, GTestBucketPool.cluster, "no cluster connection available - not running against Couchbase Server")
+	// cluster.version is the raw x.y.z-build-edition node metadata string; convert it to the
+	// x.y.z@build form ComparableBuildVersion parses.
+	components := strings.Split(GTestBucketPool.cluster.version, "-")
+	vrs := components[0]
+	if len(components) > 1 {
+		vrs += "@" + components[1]
+	}
+	version, err := NewComparableBuildVersionFromString(vrs)
+	require.NoError(t, err, "couldn't parse cluster version %q", GTestBucketPool.cluster.version)
+	return version
+}
+
+// RequireServerVersionForTest skips the test unless the Couchbase Server backing the test bucket pool
+// is at least the minimum version required for its release train. Pass one minimum version per release
+// train the feature shipped in, e.g. RequireServerVersionForTest(t, "7.6.12", "8.0.3", "8.1.0"). This
+// is a no-op when not running against Couchbase Server, since those tests are gated separately.
+func RequireServerVersionForTest(t testing.TB, minReleaseVersions ...string) {
+	if !TestUseCouchbaseServer() {
+		return
+	}
+	minVersions := make([]*ComparableBuildVersion, 0, len(minReleaseVersions))
+	for _, v := range minReleaseVersions {
+		parsed, err := NewComparableBuildVersionFromString(v)
+		require.NoError(t, err, "couldn't parse minimum version %q", v)
+		minVersions = append(minVersions, parsed)
+	}
+	serverVersion := TestClusterVersion(t)
+	if !serverVersion.AtLeastReleaseVersion(minVersions...) {
+		t.Skipf("Test requires Couchbase Server %v, but running against %v", minReleaseVersions, serverVersion)
+	}
+}
+
 func TestUseWalrus() bool {
 	backingStore := os.Getenv(TestEnvSyncGatewayBackingStore)
 	return strings.EqualFold(backingStore, TestEnvBackingStoreWalrus)

--- a/base/version_comparable_build.go
+++ b/base/version_comparable_build.go
@@ -137,6 +137,38 @@ func (a *ComparableBuildVersion) Less(b *ComparableBuildVersion) bool {
 	return false
 }
 
+// AtLeastReleaseVersion reports whether pv is at least the minimum version applicable to its
+// release train, given one minimum version per train. This is for features shipped (or backported)
+// across several release trains at different patch levels - e.g. a feature available in 7.6.12,
+// 8.0.3, and 8.1.0. The rule per train (matched on major.minor):
+//   - 7.6.x qualifies only if >= 7.6.12
+//   - 8.0.x qualifies only if >= 8.0.3
+//   - 8.1.x qualifies (>= 8.1.0, i.e. any 8.1 build)
+//   - anything newer than every listed minimum (e.g. 8.2.0) qualifies
+//   - anything in an older, unlisted train does not qualify
+//
+// Returns false if pv is nil or no minimum versions are provided.
+func (pv *ComparableBuildVersion) AtLeastReleaseVersion(minVersions ...*ComparableBuildVersion) bool {
+	if pv == nil {
+		return false
+	}
+	var newest *ComparableBuildVersion
+	for _, min := range minVersions {
+		if min == nil {
+			continue
+		}
+		if newest == nil || newest.Less(min) {
+			newest = min
+		}
+		// Same release train as this minimum (matched on major.minor): pv must meet it.
+		if pv.major == min.major && pv.minor == min.minor {
+			return !pv.Less(min)
+		}
+	}
+	// pv isn't in any listed train: it only qualifies if it's newer than all of them.
+	return newest != nil && !pv.Less(newest)
+}
+
 // AtLeastMinorDowngrade returns true there is a major or minor downgrade from a to b.
 func (a *ComparableBuildVersion) AtLeastMinorDowngrade(b *ComparableBuildVersion) bool {
 	if a.epoch != b.epoch {
@@ -152,6 +184,25 @@ func (a *ComparableBuildVersion) AtLeastMinorDowngrade(b *ComparableBuildVersion
 // e.g. "1:22-3-25@33-EE"
 func (pv ComparableBuildVersion) String() string {
 	return pv.str
+}
+
+// ReleaseVersionString returns the major.minor.patch[.other] release version, omitting epoch,
+// build number, and edition. The optional 4th (other) component is included only when non-zero.
+// e.g. "4.1.0", "4.0.6", or "4.1.0.1"
+func (pv *ComparableBuildVersion) ReleaseVersionString() string {
+	if pv == nil {
+		return "0.0.0"
+	}
+	releaseStr := strconv.FormatUint(uint64(pv.major), 10) +
+		string(comparableBuildVersionSep) +
+		strconv.FormatUint(uint64(pv.minor), 10) +
+		string(comparableBuildVersionSep) +
+		strconv.FormatUint(uint64(pv.patch), 10)
+	if pv.other > 0 {
+		releaseStr += string(comparableBuildVersionSep) +
+			strconv.FormatUint(uint64(pv.other), 10)
+	}
+	return releaseStr
 }
 
 // MarshalJSON implements json.Marshaler for ComparableBuildVersion. The JSON representation is the version string.

--- a/base/version_comparable_build_test.go
+++ b/base/version_comparable_build_test.go
@@ -134,6 +134,30 @@ func TestComparableBuildVersionEmptyStringJSON(t *testing.T) {
 	require.Equal(t, "0.0.0", version.String())
 }
 
+func TestReleaseVersionString(t *testing.T) {
+	testCases := []struct {
+		version  string
+		expected string
+	}{
+		{version: "4.1.0", expected: "4.1.0"},            // 4th component is 0 → omitted
+		{version: "4.0.6", expected: "4.0.6"},            // patch release
+		{version: "4.1.0.1", expected: "4.1.0.1"},        // 4th component present
+		{version: "4.1.0@123-EE", expected: "4.1.0"},     // build and edition stripped
+		{version: "4.1.0.1@123-CE", expected: "4.1.0.1"}, // build and edition stripped, other kept
+	}
+	for _, test := range testCases {
+		t.Run(test.version, func(t *testing.T) {
+			version, err := NewComparableBuildVersionFromString(test.version)
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, version.ReleaseVersionString())
+		})
+	}
+
+	// nil receiver is safe and yields the zero version.
+	var nilVersion *ComparableBuildVersion
+	assert.Equal(t, "0.0.0", nilVersion.ReleaseVersionString())
+}
+
 func TestAtLeastMinorDowngradeVersion(t *testing.T) {
 	testCases := []struct {
 		versionA       string
@@ -230,6 +254,43 @@ func TestAtLeastMinorDowngradeVersion(t *testing.T) {
 			versionB, err := NewComparableBuildVersionFromString(test.versionB)
 			require.NoError(t, err)
 			require.Equal(t, test.minorDowngrade, versionA.AtLeastMinorDowngrade(versionB))
+		})
+	}
+}
+
+func TestAtLeastReleaseVersion(t *testing.T) {
+	// Feature shipped across three release trains at different patch levels.
+	minVersions := []string{"7.6.12", "8.0.3", "8.1.0"}
+	testCases := []struct {
+		version   string
+		qualifies bool
+	}{
+		{version: "7.6.11", qualifies: false},
+		{version: "7.6.12", qualifies: true},
+		{version: "7.6.13", qualifies: true},
+		{version: "8.0.2", qualifies: false},
+		{version: "8.0.3", qualifies: true},
+		{version: "8.0.4", qualifies: true},
+		{version: "8.1.0", qualifies: true},
+		{version: "8.1.5", qualifies: true},
+		{version: "8.2.0", qualifies: true},
+		{version: "9.0.0", qualifies: true},
+		{version: "7.6.0", qualifies: false},
+		{version: "7.2.0", qualifies: false},
+	}
+
+	mins := make([]*ComparableBuildVersion, 0, len(minVersions))
+	for _, v := range minVersions {
+		parsed, err := NewComparableBuildVersionFromString(v)
+		require.NoError(t, err)
+		mins = append(mins, parsed)
+	}
+
+	for _, test := range testCases {
+		t.Run(test.version, func(t *testing.T) {
+			version, err := NewComparableBuildVersionFromString(test.version)
+			require.NoError(t, err)
+			require.Equal(t, test.qualifies, version.AtLeastReleaseVersion(mins...))
 		})
 	}
 }

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -764,7 +764,7 @@ func GetIndexPartitionCount(t testing.TB, bucket *base.GocbV2Bucket, dsName sgbu
 	}
 	ctx := base.TestCtx(t)
 	uri := "/getIndexStatus"
-	respBytes, statusCode, err := base.MgmtRequest(bucket.HttpClient(ctx), gsiEps[0], http.MethodGet, uri, "application/json", username, password, nil)
+	respBytes, statusCode, err := base.MgmtRequest(ctx, bucket.HttpClient(ctx), gsiEps[0], http.MethodGet, uri, "application/json", username, password, nil)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, statusCode, "unexpected status code for %s", respBytes)
 	var output struct {

--- a/rest/config.go
+++ b/rest/config.go
@@ -1633,6 +1633,15 @@ func SetupServerContext(ctx context.Context, config *StartupConfig, persistentCo
 		return nil, err
 	}
 
+	// Fleet manager metrics are reported to the Couchbase Server management API, which isn't
+	// available when running against Walrus/Rosmar. Whether the connected server actually supports
+	// the collector endpoint is not gated here: reportFleetManagerMetrics attempts the report each
+	// interval and treats an unavailable endpoint as a benign skip, so reporting starts automatically
+	// once the server is upgraded to a supporting version.
+	if !base.ServerIsWalrus(sc.Config.Bootstrap.Server) {
+		sc.reportFleetManagerMetrics(sc.serverCtx)
+	}
+
 	// On successful server context creation, generate startup audit event
 	base.Audit(ctx, base.AuditIDSyncGatewayStartup, sc.StartupAuditFields())
 

--- a/rest/fleet_manager_reporter.go
+++ b/rest/fleet_manager_reporter.go
@@ -1,0 +1,90 @@
+// Copyright 2026-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package rest
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/couchbase/sync_gateway/base"
+)
+
+const fleetManagerMetricsInterval = 1 * time.Hour // todo: CBG-5525 make this configurable
+
+func (sc *ServerContext) reportFleetManagerMetrics(ctx context.Context) {
+	hostname, err := os.Hostname()
+	if err != nil {
+		base.WarnfCtx(ctx, "Could not read hostname for fleet manager metrics: %v", err)
+	}
+
+	report := func() {
+		metrics := base.CollectSGWFleetManagerMetrics(ctx, sc.NodeUID, hostname)
+		if err := sc.sendFleetManagerMetrics(ctx, metrics); err != nil {
+			base.WarnfCtx(ctx, "Could not report fleet manager metrics: %v", err)
+		}
+	}
+
+	ticker := time.NewTicker(fleetManagerMetricsInterval)
+	go func() {
+		defer ticker.Stop()
+		// Report once on startup rather than waiting a full interval for the first tick.
+		report()
+		for {
+			select {
+			case <-ticker.C:
+				report()
+			case <-ctx.Done():
+				base.InfofCtx(ctx, base.KeyAll, "Stopping fleet manager metrics reporting: %v", context.Cause(ctx))
+				return
+			}
+		}
+	}()
+	base.InfofCtx(ctx, base.KeyAll, "Starting fleet manager metrics reporting")
+}
+
+// sendFleetManagerMetrics POSTs the collected metrics to the ns_server fleet manager collector
+// ingest endpoint on the Couchbase Server management API. A 404 means the connected server predates
+// the collector endpoint (or it has been removed); this is treated as a benign skip so reporting
+// starts automatically once the server is upgraded, rather than a hard error.
+func (sc *ServerContext) sendFleetManagerMetrics(ctx context.Context, metrics base.SyncGatewayFleetManagerMetrics) error {
+	endpoints, httpClient, err := sc.ObtainManagementEndpointsAndHTTPClient()
+	if err != nil {
+		return fmt.Errorf("could not obtain management endpoints: %w", err)
+	}
+	if len(endpoints) == 0 {
+		return fmt.Errorf("no management endpoints available")
+	}
+
+	metricsJSON, err := base.JSONMarshal(metrics)
+	if err != nil {
+		return fmt.Errorf("could not marshal fleet manager metrics: %w", err)
+	}
+
+	uri := fmt.Sprintf("/_telemetryCollector/ingest?product_name=%s&instance_id=%s", base.ProductInfoName, url.QueryEscape(metrics.InstanceID))
+	statusCode, _, err := doHTTPAuthRequest(ctx, httpClient, sc.Config.Bootstrap.Username, sc.Config.Bootstrap.Password, http.MethodPost, uri, "application/json", endpoints, metricsJSON)
+	if err != nil {
+		return err
+	}
+	switch statusCode {
+	case http.StatusNoContent:
+		// success
+		return nil
+	case http.StatusNotFound:
+		// Server doesn't expose the collector endpoint (too old, or collector removed). Skip quietly
+		// and retry on the next interval.
+		base.DebugfCtx(ctx, base.KeyAll, "Fleet manager collector endpoint unavailable (status %d); will retry next interval", statusCode)
+		return nil
+	default:
+		return fmt.Errorf("unexpected status %d from fleet manager collector", statusCode)
+	}
+}

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -1128,7 +1128,7 @@ func (h *handler) checkAdminAuthenticationOnly() (bool, error) {
 		return false, ErrLoginRequired
 	}
 
-	statusCode, _, err := doHTTPAuthRequest(h.ctx(), httpClient, username, password, "POST", "/pools/default/checkPermissions", managementEndpoints, nil)
+	statusCode, _, err := doHTTPAuthRequest(h.ctx(), httpClient, username, password, "POST", "/pools/default/checkPermissions", "", managementEndpoints, nil)
 	if err != nil {
 		return false, base.HTTPErrorf(http.StatusInternalServerError, "Error performing HTTP auth request: %v", err)
 	}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -28,15 +28,12 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/KimMachineGun/automemlimit/memlimit"
-	"github.com/couchbase/sync_gateway/auth"
-	"github.com/couchbase/sync_gateway/db/functions"
-	"github.com/shirou/gopsutil/mem"
-
 	"github.com/couchbase/gocbcore/v10"
 	sgbucket "github.com/couchbase/sg-bucket"
+	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
+	"github.com/couchbase/sync_gateway/db/functions"
 )
 
 const kDefaultSlowQueryWarningThreshold uint32 = 500 // ms
@@ -73,6 +70,12 @@ type ServerContext struct {
 	_dbConfigs          map[string]*RuntimeDatabaseConfig // _dbConfigs is a map of db name to the RuntimeDatabaseConfig
 	_databases          map[string]*db.DatabaseContext    // _databases is a map of dbname to db.DatabaseContext
 	_databasesLock      sync.RWMutex                      // Lock for _databases and other db-specific maps above
+
+	// serverCtx is cancelled by Close() to broadcast server shutdown to background goroutines
+	// that outlive a single request. Currently the fleet manager metrics reporter is its only
+	// consumer.
+	serverCtx       context.Context
+	serverCtxCancel context.CancelCauseFunc
 
 	statsContext      *statsContext
 	BootstrapContext  *bootstrapContext
@@ -157,7 +160,7 @@ func (sc *ServerContext) CloseCpuPprofFile(ctx context.Context) (filename string
 }
 
 func NewServerContext(ctx context.Context, config *StartupConfig, persistentConfig bool) *ServerContext {
-
+	serverCtx, serverCtxCancel := context.WithCancelCause(context.Background())
 	sc := &ServerContext{
 		Config:              config,
 		persistentConfig:    persistentConfig,
@@ -172,6 +175,8 @@ func NewServerContext(ctx context.Context, config *StartupConfig, persistentConf
 		hasStarted:          make(chan struct{}),
 		_httpServers:        map[serverType]*serverInfo{},
 		SGCollect:           newSGCollect(ctx),
+		serverCtx:           serverCtx,
+		serverCtxCancel:     serverCtxCancel,
 	}
 	sc.invalidDatabaseConfigTracking = invalidDatabaseConfigs{
 		dbNames: map[string]*invalidConfigInfo{},
@@ -192,7 +197,7 @@ func NewServerContext(ctx context.Context, config *StartupConfig, persistentConf
 	if config.HeapProfileCollectionThreshold != nil {
 		sc.statsContext.heapProfileCollectionThreshold = *config.HeapProfileCollectionThreshold
 	} else {
-		memoryTotal := getTotalMemory(ctx)
+		memoryTotal := base.GetTotalMemory(ctx, true)
 		if memoryTotal != 0 {
 			sc.statsContext.heapProfileCollectionThreshold = uint64(float64(memoryTotal) * 0.85)
 		} else {
@@ -262,6 +267,10 @@ func (sc *ServerContext) PostStartup() {
 const serverContextStopMaxWait = 30 * time.Second
 
 func (sc *ServerContext) Close(ctx context.Context) {
+	// Cancel the server's lifetime context first so background goroutines watching
+	// serverCtx.Done() stop promptly rather than working against a server tearing down.
+	sc.serverCtxCancel(errors.New("server context is closing"))
+
 	// stop HTTP servers - prevents any further requests from coming in before we continue with tearing down everything else
 	sc.stopHTTPServers(ctx)
 
@@ -2033,7 +2042,7 @@ func (sc *ServerContext) ObtainManagementEndpointsAndHTTPClient() ([]string, *ht
 func CheckPermissions(ctx context.Context, httpClient *http.Client, managementEndpoints []string, bucketName, username, password string, accessPermissions []Permission, responsePermissions []Permission) (statusCode int, permissionResults map[string]bool, err error) {
 	combinedPermissions := append(accessPermissions, responsePermissions...)
 	body := []byte(strings.Join(FormatPermissionNames(combinedPermissions, bucketName), ","))
-	statusCode, bodyResponse, err := doHTTPAuthRequest(ctx, httpClient, username, password, "POST", "/pools/default/checkPermissions", managementEndpoints, body)
+	statusCode, bodyResponse, err := doHTTPAuthRequest(ctx, httpClient, username, password, "POST", "/pools/default/checkPermissions", "", managementEndpoints, body)
 	if err != nil {
 		return http.StatusInternalServerError, nil, err
 	}
@@ -2087,7 +2096,7 @@ type WhoAmIResponse struct {
 }
 
 func cbRBACWhoAmI(ctx context.Context, httpClient *http.Client, managementEndpoints []string, username, password string) (response *WhoAmIResponse, statusCode int, err error) {
-	statusCode, bodyResponse, err := doHTTPAuthRequest(ctx, httpClient, username, password, "GET", "/whoami", managementEndpoints, nil)
+	statusCode, bodyResponse, err := doHTTPAuthRequest(ctx, httpClient, username, password, "GET", "/whoami", "", managementEndpoints, nil)
 	if err != nil {
 		return nil, http.StatusInternalServerError, err
 	}
@@ -2128,12 +2137,12 @@ func CheckRoles(ctx context.Context, httpClient *http.Client, managementEndpoint
 	return http.StatusForbidden, nil
 }
 
-func doHTTPAuthRequest(ctx context.Context, httpClient *http.Client, username, password, method, path string, endpoints []string, requestBody []byte) (statusCode int, responseBody []byte, err error) {
+func doHTTPAuthRequest(ctx context.Context, httpClient *http.Client, username, password, method, path, contentType string, endpoints []string, requestBody []byte) (statusCode int, responseBody []byte, err error) {
 	retryCount := 0
 
 	worker := func() (shouldRetry bool, err error, value interface{}) {
 		endpointIdx := retryCount % len(endpoints)
-		responseBody, statusCode, err = base.MgmtRequest(httpClient, endpoints[endpointIdx], method, path, "", username, password, bytes.NewBuffer(requestBody))
+		responseBody, statusCode, err = base.MgmtRequest(ctx, httpClient, endpoints[endpointIdx], method, path, contentType, username, password, bytes.NewBuffer(requestBody))
 
 		if err, ok := err.(net.Error); ok && err.Timeout() {
 			retryCount++
@@ -2255,21 +2264,6 @@ func (sc *ServerContext) SetContextLogID(parent context.Context, id string) cont
 	return parent
 }
 
-// getTotalMemory returns the total memory available on the system. If a cgroup is detected, it will use the cgroup memory max.
-func getTotalMemory(ctx context.Context) uint64 {
-	memoryTotal, err := memlimit.FromCgroup()
-	if err == nil {
-		return memoryTotal
-	}
-	base.TracefCtx(ctx, base.KeyAll, "Did not detect a cgroup for a memory limit")
-	memory, err := mem.VirtualMemory()
-	if err != nil {
-		base.WarnfCtx(ctx, "Error getting total memory from gopsutil: %v", err)
-		return 0
-	}
-	return memory.Total
-}
-
 // getClusterUUID returns the cluster UUID. rosmar does not have a ClusterUUID, so this will return an empty cluster UUID and no error in this case.
 func (sc *ServerContext) getClusterUUID(ctx context.Context) (string, error) {
 	allDbNames := sc.AllDatabaseNames()
@@ -2289,7 +2283,7 @@ func (sc *ServerContext) getClusterUUID(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	statusCode, output, err := doHTTPAuthRequest(ctx, client, sc.Config.Bootstrap.Username, sc.Config.Bootstrap.Password, http.MethodGet, "/pools", eps, nil)
+	statusCode, output, err := doHTTPAuthRequest(ctx, client, sc.Config.Bootstrap.Username, sc.Config.Bootstrap.Password, http.MethodGet, "/pools", "", eps, nil)
 	if err != nil {
 		return "", err
 	}

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -897,7 +897,7 @@ func TestCompactIntervalFromConfig(t *testing.T) {
 }
 
 func TestHeapProfileValuesPopulated(t *testing.T) {
-	totalMemory := uint64(float64(getTotalMemory(base.TestCtx(t))) * 0.85)
+	totalMemory := uint64(float64(base.GetTotalMemory(base.TestCtx(t), true)) * 0.85)
 	testCases := []struct {
 		name                           string
 		startupConfig                  *StartupConfig
@@ -1049,4 +1049,149 @@ func TestDatabaseCollectionDeletedErrorState(t *testing.T) {
 
 	allDbs = rt.ServerContext().allDatabaseSummaries()
 	require.Len(t, allDbs, 1)
+}
+
+func TestSendingMetricsToNsServerCollector(t *testing.T) {
+	if !base.TestUseCouchbaseServer() {
+		t.Skip("Fleet Manager Collector only works on CBS")
+	}
+	base.RequireServerVersionForTest(t, "7.6.12", "8.0.3", "8.1.0")
+	rt := NewRestTesterPersistentConfig(t)
+	defer rt.Close()
+	ctx := rt.Context()
+	bucket := rt.Bucket()
+
+	gocbV2Bucket, err := base.AsGocbV2Bucket(bucket)
+	require.NoError(t, err)
+
+	uri := "/internal/settings/telemetry"
+	respBytes, _, err := gocbV2Bucket.MgmtRequest(ctx, http.MethodGet, uri, "application/json", nil)
+	require.NoError(t, err)
+	var settings base.FleetManagerCollectorSettings
+	require.NoError(t, base.JSONUnmarshal(respBytes, &settings))
+	assert.True(t, settings.Enabled) // enabled by default
+	assert.NotEmpty(t, settings.ReportingInterval)
+
+	// Exercise the production send path rather than re-implementing the POST here.
+	metrics := base.CollectSGWFleetManagerMetrics(ctx, "someNodeID", "myHost")
+	require.NoError(t, rt.ServerContext().sendFleetManagerMetrics(ctx, metrics))
+}
+
+// TestSendingMetricsToNsServerCollectorAsMobileSyncGatewayRole verifies that a user holding only the
+// role Sync Gateway is bootstrapped with (mobile_sync_gateway on Enterprise, bucket_full_access on
+// Community) is authorized to POST to the ns_server collector endpoint. Operators are expected to
+// bootstrap Sync Gateway with such a user, so we point the server's bootstrap credentials at a
+// freshly-created user with that role and run the production send path as it.
+func TestSendingMetricsToNsServerCollectorAsMobileSyncGatewayRole(t *testing.T) {
+	if !base.TestUseCouchbaseServer() {
+		t.Skip("Fleet Manager Collector only works on CBS")
+	}
+	base.RequireServerVersionForTest(t, "7.6.12", "8.0.3", "8.1.0")
+	rt := NewRestTesterPersistentConfig(t)
+	defer rt.Close()
+	ctx := rt.Context()
+	sc := rt.ServerContext()
+
+	eps, httpClient, err := sc.ObtainManagementEndpointsAndHTTPClient()
+	require.NoError(t, err)
+
+	roleName := MobileSyncGatewayRole.RoleName
+	if base.TestsUseServerCE() {
+		roleName = BucketFullAccessRole.RoleName
+	}
+
+	const username, password = "MobileSyncGatewayUser", "password"
+	role := fmt.Sprintf("%s[%s]", roleName, rt.Bucket().GetName())
+	MakeUser(t, httpClient, eps[0], username, password, []string{role})
+	defer DeleteUser(t, httpClient, eps[0], username)
+
+	// Redirect the send path's authentication to the scoped user for the test;
+	// sendFleetManagerMetrics reads these credentials at call time.
+	sc.Config.Bootstrap.Username, sc.Config.Bootstrap.Password = username, password
+
+	metrics := base.CollectSGWFleetManagerMetrics(ctx, "someNodeID", "myHost")
+	require.NoError(t, sc.sendFleetManagerMetrics(ctx, metrics))
+}
+
+func TestSendingMetricsWhenCollectorDisabled(t *testing.T) {
+	if !base.TestUseCouchbaseServer() {
+		t.Skip("Fleet Manager Collector only works on CBS")
+	}
+	base.RequireServerVersionForTest(t, "7.6.12", "8.0.3", "8.1.0")
+
+	rt := NewRestTesterPersistentConfig(t)
+	defer rt.Close()
+	ctx := rt.Context()
+	bucket := rt.Bucket()
+
+	gocbV2Bucket, err := base.AsGocbV2Bucket(bucket)
+	require.NoError(t, err)
+
+	uri := "/internal/settings/telemetry"
+	disableBody := []byte(`{"enabled": false}`)
+	respBytes, statusCode, err := gocbV2Bucket.MgmtRequest(ctx, http.MethodPost, uri, "application/json", bytes.NewReader(disableBody))
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, statusCode, "unexpected response: %s code: %d", string(respBytes), statusCode)
+
+	// Re-enable the cluster-wide collector via defer so we don't leak the disabled state to other
+	// tests on the shared cluster if an assertion below fails before we get to flip it back.
+	defer func() {
+		enableBody := []byte(`{"enabled": true}`)
+		respBytes, statusCode, err := gocbV2Bucket.MgmtRequest(ctx, http.MethodPost, uri, "application/json", bytes.NewReader(enableBody))
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, statusCode)
+
+		// verify enabled is true now
+		settings := base.FleetManagerCollectorSettings{}
+		require.NoError(t, base.JSONUnmarshal(respBytes, &settings))
+		assert.True(t, settings.Enabled)
+	}()
+
+	var settings base.FleetManagerCollectorSettings
+	require.NoError(t, base.JSONUnmarshal(respBytes, &settings))
+	assert.False(t, settings.Enabled)
+
+	metrics := base.CollectSGWFleetManagerMetrics(ctx, "someNodeID", "myHost")
+	require.NoError(t, rt.ServerContext().sendFleetManagerMetrics(ctx, metrics))
+}
+
+func TestNoContentResponseForCollector(t *testing.T) {
+	if !base.TestUseCouchbaseServer() {
+		t.Skip("Fleet Manager Collector only works on CBS")
+	}
+	base.RequireServerVersionForTest(t, "7.6.12", "8.0.3", "8.1.0")
+	rt := NewRestTesterPersistentConfig(t)
+	defer rt.Close()
+
+	gocbV2Bucket, err := base.AsGocbV2Bucket(rt.Bucket())
+	require.NoError(t, err)
+
+	metrics := base.CollectSGWFleetManagerMetrics(base.TestCtx(t), "someNodeID", "myHost")
+	uri := fmt.Sprintf("/_telemetryCollector/ingest?product_name=%s&instance_id=%s", base.ProductInfoName, "someID")
+	metricsBytes, err := base.JSONMarshal(metrics)
+	require.NoError(t, err)
+	respBytes, statusCode, err := gocbV2Bucket.MgmtRequest(rt.Context(), http.MethodPost, uri, "application/json", bytes.NewReader(metricsBytes))
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, statusCode)
+	assert.Empty(t, respBytes)
+}
+
+func TestAllFleetManagerMetricsPopulated(t *testing.T) {
+	rt := NewRestTesterPersistentConfig(t)
+	defer rt.Close()
+	ctx := rt.Context()
+
+	metrics := base.CollectSGWFleetManagerMetrics(ctx, "someNodeID", "myHost")
+	assert.NotEmpty(t, metrics.InstanceID)
+	assert.NotZero(t, metrics.CpuCores)
+	// RAM values are sampled directly at collection time, so they must be populated even before the
+	// stats-logger ticker has run (a "0" string passes NotEmpty, which is why we check for non-zero).
+	assert.NotEqual(t, "0", metrics.RamBytesTotal)
+	assert.NotEqual(t, "0", metrics.RamBytesUsed)
+	assert.NotEmpty(t, metrics.OSVersion)
+	assert.NotEmpty(t, metrics.Hostname)
+	assert.GreaterOrEqual(t, metrics.UptimeSeconds, int64(0))
+	assert.NotEmpty(t, metrics.ProductInfo.Edition)
+	assert.NotEmpty(t, metrics.ProductInfo.Version)
+	assert.NotEmpty(t, metrics.ProductInfo.Name)
 }


### PR DESCRIPTION
CBG-5809

Unclean cherry pick of #8693 to 3.3.8
Stacked on #8750 (CBG-5216 node UID prerequisite).

Taken from the 4.0.8 backport rather than main (#8422) - #8693 had already adapted it heavily for a pre-4.1 codebase, and 12 of the 14 files land byte-identical here.

Changes from the 4.0.8 commit:
- `base/main_test_cluster.go` - hunk dropped. #8693 adds `context.Background()` to two `base.MgmtRequest` callers in that file, but on 3.3.8 the test cluster still uses the gocb v2 `Cluster` API and calls `MgmtRequest` nowhere, so the new ctx arg has no target there. The three package-level callers 3.3.8 does have (`base/collection.go`, `db/util_testing.go`, `rest/server_context.go`) all applied clean, and no test loses coverage.
- `base/util_testing.go` - `TestClusterVersion` parses `GTestBucketPool.cluster.version` before returning it. On 4.0.8 that field is already a `ComparableBuildVersion`, whilst 3.3.8 stores the raw `x.y.z-build-edition` node metadata string, so the helper does the same conversion 4.0.8 does in `GetCouchbaseServerVersion`.
- `base/main_test_bucket_pool.go` - not touched by #8693, but making `MgmtRequest` honour ctx cancellation exposes two existing faults in the pool that 4.0.8 can't hit, because on 4.0.8 `openTestBucket` sets `supportsHLV` directly and makes no management request at all. On 3.3.8 it still goes through `queryHLVBucketSetting`, so a cancelled pool ctx now fails the open:
  - `bucketInit` turned that into `tbp.Fatalf`, with no `ctx.Err()` guard, unlike the `insertBucket` call directly above it.
  - `bucketReadierWorker` read `b.GetName()` for the log ctx before checking the open error, so a failed open panicked on a nil bucket.

  Without these, any focused integration run against CBS fails - reproduced 3/3, and confirmed as the cause by reverting `http.NewRequestWithContext` alone (3/3 pass with ctx ignored). Full package runs pass either way, so CI wouldn't have caught it.

Testing: run against 7.6.12-8946-enterprise in Docker, which is exactly the 7.6 minimum this gates on, so the collector tests execute rather than skip. All five pass - `TestSendingMetricsToNsServerCollector`, `TestSendingMetricsToNsServerCollectorAsMobileSyncGatewayRole`, `TestSendingMetricsWhenCollectorDisabled`, `TestNoContentResponseForCollector` and `TestAllFleetManagerMetricsPopulated`. Also green: full `./base/` and `./xdcr/`, plus `TestAdminAuth`, `TestCheckPermissions`, `TestDisablePermissionCheck`, `TestNewlyCreateSGWPermissions`, `TestShouldCheckAdminRBAC` and `TestObtainManagementEndpoints*`, that last group being the production path for the ctx threading.

Two gaps worth knowing about. The CE branch of `TestSendingMetricsToNsServerCollectorAsMobileSyncGatewayRole` (`BucketFullAccessRole` rather than `MobileSyncGatewayRole`) is unexercised - `TestsUseServerCE` keys off the server edition, and the newest community images are 7.6.2 and 8.0.2, both below this gate, so no public CE image can reach it. The 8.0.3 train can't be tested here either: 3.3.8's bucket pool still creates design documents and CBS 8.0 has dropped views, so bucket init dies with `no_ddocs_service`. That's pre-existing and nothing to do with this PR - `origin/release/3.3.8` fails the same way on 8.0.3.

🤖 Opened with the `sync-gateway-backport` skill in [Claude Code](https://claude.com/claude-code)
