### PR TITLE
[4.1.2 Backport] CBG-5813: Auto-repair corrupt non-increasing generations in revtree

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -95,6 +95,7 @@ const (
 	StatAddedVersion3dot3dot0     = "3.3.0"
 	StatAddedVersion4dot0dot0     = "4.0.0"
 	StatAddedVersion4dot1dot0     = "4.1.0"
+	StatAddedVersion4dot1dot2     = "4.1.2"
 
 	StatDeprecatedVersionNotDeprecated = ""
 	StatDeprecatedVersion3dot2dot0     = "3.2.0"
@@ -644,6 +645,8 @@ type DatabaseStats struct {
 	HighSeqFeed *SgwUint64Stat `json:"high_seq_feed"`
 	// The total number of document writes where the Sync Gateway-generated HLV version exceeded the document CAS and required a corrective re-stamp. A non-zero value indicates clock skew between Sync Gateway and Couchbase Server.
 	HLVVersionCASRetryCount *SgwIntStat `json:"hlv_version_cas_retry_count"`
+	// The total number of times a document's revision tree was found to be invalid.
+	InvalidRevTreeCount *SgwIntStat `json:"invalid_rev_tree_count"`
 	// The number of attachments compacted
 	NumAttachmentsCompacted *SgwIntStat `json:"num_attachments_compacted"`
 	// The total number of documents read via Couchbase Lite 2.x replication since Sync Gateway node startup.
@@ -1890,6 +1893,10 @@ func (d *DbStats) initDatabaseStats() error {
 	if err != nil {
 		return err
 	}
+	resUtil.InvalidRevTreeCount, err = NewIntStat(SubsystemDatabaseKey, "invalid_rev_tree_count", StatUnitNoUnits, InvalidRevTreeCountDesc, StatAddedVersion4dot1dot2, StatDeprecatedVersionNotDeprecated, StatStabilityInternal, labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
 	resUtil.PublicRestBytesWritten, err = NewIntStat(SubsystemDatabaseKey, "http_bytes_written", StatUnitBytes, PublicRestBytesWrittenDesc, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityVolatile, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
@@ -2070,6 +2077,7 @@ func (d *DbStats) unregisterDatabaseStats() {
 	prometheus.Unregister(d.DatabaseStats.DocWritesXattrBytes)
 	prometheus.Unregister(d.DatabaseStats.HighSeqFeed)
 	prometheus.Unregister(d.DatabaseStats.HLVVersionCASRetryCount)
+	prometheus.Unregister(d.DatabaseStats.InvalidRevTreeCount)
 	prometheus.Unregister(d.DatabaseStats.DocWritesBytesBlip)
 	prometheus.Unregister(d.DatabaseStats.NumAttachmentsCompacted)
 	prometheus.Unregister(d.DatabaseStats.NumDocReadsBlip)

--- a/base/stats_descriptions.go
+++ b/base/stats_descriptions.go
@@ -271,6 +271,8 @@ const (
 
 	HLVVersionCASRetryCountDesc = "The total number of document writes where the Sync Gateway-generated HLV version exceeded the document CAS and required a corrective re-stamp. A non-zero value indicates clock skew between Sync Gateway and Couchbase Server."
 
+	InvalidRevTreeCountDesc = "The total number of times a document's revision tree was found to be invalid at read or write time."
+
 	NumAttachmentsCompactedDesc = "The number of attachments compacted import_feed"
 
 	ImportFeedDesc = "Contains low level dcp stats: (a). dcp_backfill_expected - the expected number of sequences in backfill (b). dcp_backfill_completed - the number of backfill items processed (c). dcp_rollback_count - the number of DCP rollbacks"

--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -1808,3 +1808,121 @@ func rawDocWithInlineSyncMetaAndAttachment() []byte {
 }
 `)
 }
+
+// TestRepairDoesNotDropPre4dot0Attachments covers a rev tree repair on a document carrying pre-4.0 style
+// attachment metadata, i.e. in _sync.attachments rather than _globalSync.attachments_meta.
+//
+// The repair re-persists _sync from the in-memory document, and unmarshal has by then moved the metadata
+// out of SyncData.AttachmentsPre4dot0 and into _globalSync - so the repair has to write _globalSync as
+// well, or the attachment metadata exists in neither xattr afterwards.
+func TestRepairDoesNotDropPre4dot0Attachments(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD)
+	dbCtx, ctx := setupTestDB(t)
+	defer dbCtx.Close(ctx)
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, dbCtx)
+
+	const docID = "corruptWithPre4dot0Attachment"
+	const attName = "hello.txt"
+	expectedAttachment := DocAttachment{
+		Data:   []byte("hello world"),
+		Digest: "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=",
+		Length: 11,
+		Revpos: 1,
+	}
+
+	// write a real attachment, so its body is stored and its metadata is persisted to _globalSync, then
+	// replace the rev tree with one whose generations do not increase
+	var body Body
+	require.NoError(t, base.JSONUnmarshal([]byte(`{"planted":true,"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`), &body))
+	PlantRevTreeForTest(t, ctx, collection, docID, body,
+		map[string]string{"1-abc": "", "2-abc": "1-abc", "2-def": "2-abc"}, "2-def")
+
+	// turn it into a pre-4.0 document: move the metadata from _globalSync.attachments_meta into
+	// _sync.attachments and drop _globalSync. Macro-expanded so _sync.cas still matches the document CAS
+	// and this does not read as an SDK write needing an import.
+	value, _, err := collection.dataStore.GetRaw(ctx, docID)
+	require.NoError(t, err)
+	MoveAttachmentXattrFromGlobalToSync(t, collection.dataStore, docID, value, true)
+	dbCtx.FlushRevisionCacheForTest()
+
+	// precondition: the metadata really is in _sync and _globalSync really is gone
+	rawBefore, _, err := collection.dataStore.GetXattrs(ctx, docID, []string{base.SyncXattrName, base.GlobalXattrName})
+	require.NoError(t, err)
+	require.Contains(t, string(rawBefore[base.SyncXattrName]), `"attachments"`, "the attachment metadata should be in _sync")
+	require.Empty(t, rawBefore[base.GlobalXattrName], "_globalSync should be gone, as it is on a pre-4.0 document")
+
+	// precondition: the attachment is readable before the repair
+	gotBody, err := collection.Get1xRevBody(ctx, docID, "", false, []string{})
+	require.NoError(t, err)
+	require.Equal(t, AttachmentMap{attName: expectedAttachment}, GetAttachmentsFrom1xBody(t, gotBody))
+
+	// this load repairs the rev tree, and the repair re-persists _sync
+	repaired, err := collection.GetDocument(ctx, docID, DocUnmarshalAll)
+	require.NoError(t, err)
+	require.Equal(t, "3-def", repaired.GetRevTreeID(), "precondition: the repair should have run")
+
+	rawAfter, _, err := collection.dataStore.GetXattrs(ctx, docID, []string{base.SyncXattrName, base.GlobalXattrName})
+	require.NoError(t, err)
+
+	// the repair migrates the metadata to 4.0 style as a side effect: out of _sync, into _globalSync
+	assert.NotContains(t, string(rawAfter[base.SyncXattrName]), `"attachments"`)
+	assert.Contains(t, string(rawAfter[base.GlobalXattrName]), expectedAttachment.Digest,
+		"the repair dropped the document's attachment metadata")
+
+	dbCtx.FlushRevisionCacheForTest()
+	after, _, err := collection.GetDocWithXattrs(ctx, docID, DocUnmarshalAll)
+	require.NoError(t, err)
+	_, okAfter := after.Attachments()[attName]
+	assert.True(t, okAfter, "the repair dropped the document's attachment metadata")
+
+	// and the attachment is still usable, body and all
+	dbCtx.FlushRevisionCacheForTest()
+	gotBody, err = collection.Get1xRevBody(ctx, docID, "", false, []string{})
+	require.NoError(t, err)
+	assert.Equal(t, AttachmentMap{attName: expectedAttachment}, GetAttachmentsFrom1xBody(t, gotBody),
+		"the attachment is not readable after the repair")
+}
+
+func TestRepairPreservesPost4Dot0Attachment(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD)
+	dbCtx, ctx := setupTestDB(t)
+	defer dbCtx.Close(ctx)
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, dbCtx)
+
+	const docID = "corruptWithRealAttachment"
+	var body Body
+	require.NoError(t, base.JSONUnmarshal([]byte(`{"planted":true,"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`), &body))
+
+	// PlantRevTreeForTest does the initial Put, so the attachment is stored and its metadata lands in
+	// _globalSync exactly as a 4.0-native document's would, then the rev tree is replaced.
+	PlantRevTreeForTest(t, ctx, collection, docID, body,
+		map[string]string{"1-abc": "", "2-abc": "1-abc", "2-def": "2-abc"}, "2-def")
+	dbCtx.FlushRevisionCacheForTest()
+
+	globalBefore, _, err := collection.dataStore.GetXattrs(ctx, docID, []string{base.GlobalXattrName})
+	require.NoError(t, err)
+	require.NotEmpty(t, globalBefore[base.GlobalXattrName], "precondition: attachment metadata is in _globalSync")
+
+	repaired, err := collection.GetDocument(ctx, docID, DocUnmarshalAll)
+	require.NoError(t, err)
+	require.Equal(t, "3-def", repaired.GetRevTreeID(), "precondition: the repair should have run")
+
+	globalAfter, _, err := collection.dataStore.GetXattrs(ctx, docID, []string{base.GlobalXattrName})
+	require.NoError(t, err)
+	assert.JSONEq(t, string(globalBefore[base.GlobalXattrName]), string(globalAfter[base.GlobalXattrName]),
+		"the repair changed _globalSync")
+
+	// the attachment is still readable, body and all
+	dbCtx.FlushRevisionCacheForTest()
+	gotBody, err := collection.Get1xRevBody(ctx, docID, "", false, []string{})
+	require.NoError(t, err)
+	atts := GetAttachmentsFrom1xBody(t, gotBody)
+	assert.Equal(t, AttachmentMap{
+		"hello.txt": DocAttachment{
+			Data:   []byte("hello world"),
+			Digest: "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=",
+			Length: 11,
+			Revpos: 1,
+		},
+	}, atts, "the attachment is not readable after the repair")
+}

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -849,6 +849,10 @@ func (bsc *BlipSyncContext) sendRevision(ctx context.Context, sender *blip.Sende
 		var err error
 		revTreeHistory, err = toHistory(docRev.History, knownRevs, maxHistory)
 		if err != nil {
+			// The only way toHistory fails is an encoded history splitRevisionList rejects, which means
+			// the document's rev tree could not be expressed on the wire - a metadata problem with the
+			// document rather than a replication problem.
+			handleChangesResponseCollection.dbStats().Database().InvalidRevTreeCount.Add(1)
 			err := base.RedactErrorf("Could not get rev tree history for %s %s: %w, sending a noRev to skip this revision for replication at sequence %s.", base.UD(docID), revID, err, seq)
 			base.WarnfCtx(ctx, "%s", err)
 			return bsc.sendNoRev(sender, docID, revID, collectionIdx, seq, err)

--- a/db/crud.go
+++ b/db/crud.go
@@ -61,6 +61,28 @@ func (c *DatabaseCollection) getRevSeqNo(ctx context.Context, docID string) (rev
 	return revSeqNo, cas, err
 }
 
+// getMetadataOnlyUpdateInputs fetches everything computeMetadataOnlyUpdate needs to stamp _mou for a
+// metadata-only write - the document's revSeqNo, its existing _mou, and the cas all three were read at.
+//
+// mou is nil when the document has no _mou, which is the correct input for a document whose current cas
+// is a body mutation - it makes computeMetadataOnlyUpdate start a new chain.
+func (c *DatabaseCollection) getMetadataOnlyUpdateInputs(ctx context.Context, docID string) (revSeqNo uint64, mou *MetadataOnlyUpdate, cas uint64, err error) {
+	xattrs, cas, err := c.dataStore.GetXattrs(ctx, docID, []string{base.VirtualXattrRevSeqNo, base.MouXattrName})
+	if err != nil {
+		return 0, nil, 0, err
+	}
+	revSeqNo, err = unmarshalRevSeqNo(xattrs[base.VirtualXattrRevSeqNo])
+	if err != nil {
+		return 0, nil, 0, err
+	}
+	if rawMou, ok := xattrs[base.MouXattrName]; ok && len(rawMou) > 0 {
+		if err := base.JSONUnmarshal(rawMou, &mou); err != nil {
+			return 0, nil, 0, base.RedactErrorf("failed to unmarshal _mou for doc %s: %w", base.UD(docID), err)
+		}
+	}
+	return revSeqNo, mou, cas, nil
+}
+
 // GetDocument with raw returns the document from the bucket. This may perform an on-demand import.
 func (c *DatabaseCollection) GetDocument(ctx context.Context, docid string, unmarshalLevel DocumentUnmarshalLevel) (doc *Document, err error) {
 	doc, _, err = c.GetDocumentWithRaw(ctx, docid, unmarshalLevel)
@@ -130,6 +152,16 @@ func (c *DatabaseCollection) GetDocumentWithRaw(ctx context.Context, docid strin
 			Body: rawDoc,
 			Cas:  cas,
 		}
+	}
+
+	// Repair a rev tree whose generations don't increase before the document is used - see
+	// repairInvalidRevTreeForGet. Does nothing for the overwhelming majority of documents.
+	//
+	// Only run with the whole of sync data in hand, or the repair writes back a document missing the
+	// parts that weren't unmarshalled. DocUnmarshalHistory is the one to watch - it populates History, so
+	// detection would fire, but zeroes the rest of SyncData.
+	if unmarshalLevel == DocUnmarshalAll || unmarshalLevel == DocUnmarshalSync {
+		doc = c.repairInvalidRevTreeForGet(ctx, doc, doc.Cas)
 	}
 
 	return doc, rawBucketDoc, nil
@@ -1402,6 +1434,14 @@ func (db *DatabaseCollectionWithUser) Put(ctx context.Context, docid string, bod
 			}
 		}
 
+		// Repair an invalid rev tree before it is used for conflict detection - see
+		// repairInvalidRevTreeForWrite. Must follow the import above, never precede it.
+		if doc != nil {
+			if err := db.repairInvalidRevTreeForWrite(ctx, newDoc.ID, doc); err != nil {
+				return nil, nil, false, nil, err
+			}
+		}
+
 		var conflictErr error
 
 		// OCC check of matchCV against CV on the doc
@@ -1535,6 +1575,14 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 		if doc != nil && !isSgWrite && db.UseXattrs() {
 			err := db.OnDemandImportForWrite(ctx, opts.NewDoc.ID, doc, opts.NewDoc.Deleted)
 			if err != nil {
+				return nil, nil, false, nil, err
+			}
+		}
+
+		// Repair an invalid rev tree before it is used for conflict detection - see
+		// repairInvalidRevTreeForWrite. Must follow the import above, never precede it.
+		if doc != nil {
+			if err := db.repairInvalidRevTreeForWrite(ctx, opts.NewDoc.ID, doc); err != nil {
 				return nil, nil, false, nil, err
 			}
 		}
@@ -1800,6 +1848,14 @@ func (db *DatabaseCollectionWithUser) PutExistingRevWithConflictResolution(ctx c
 		if doc != nil && !isSgWrite && db.UseXattrs() {
 			err := db.OnDemandImportForWrite(ctx, newDoc.ID, doc, newDoc.Deleted)
 			if err != nil {
+				return nil, nil, false, nil, err
+			}
+		}
+
+		// Repair an invalid rev tree before it is used for conflict detection - see
+		// repairInvalidRevTreeForWrite. Must follow the import above, never precede it.
+		if doc != nil {
+			if err := db.repairInvalidRevTreeForWrite(ctx, newDoc.ID, doc); err != nil {
 				return nil, nil, false, nil, err
 			}
 		}
@@ -3377,6 +3433,202 @@ func (db *DatabaseCollectionWithUser) restampVersionCAS(ctx context.Context, key
 		base.VvXattrName:   vvXattr,
 		base.MouXattrName:  rawMouXattr,
 	}, opts)
+}
+
+// repairInvalidRevTreeForGet repairs a document whose revision tree contains a revision that does not
+// exceed its parent's generation, and returns the document to use, mirroring OnDemandImportForGet. It is
+// called from GetDocumentWithRaw, so it runs once per load from the bucket rather than once per revision
+// cache hit.
+//
+// A caller that asked for a specific revision the repair renamed gets ErrMissing (404), which
+// sendRevision turns into a replacement rev or a norev; either way the client sees the repaired revision.
+//
+// A failed repair does not fail the load - the document is served corrupt, as it was before.
+func (c *DatabaseCollection) repairInvalidRevTreeForGet(ctx context.Context, doc *Document, cas uint64) *Document {
+	if !doc.History.hasNonIncreasingGenerations(ctx, doc.GetRevTreeID()) {
+		return doc
+	}
+	// The read that loaded this document did not fetch _mou or the revSeqNo virtual xattr - they are not
+	// in syncGlobalSyncAndUserXattrKeys - so fetch them now. Only corrupt documents get this far, so
+	// healthy reads pay nothing for it.
+	revSeqNo, mou, fetchedCas, err := c.getMetadataOnlyUpdateInputs(ctx, doc.ID)
+	if err != nil {
+		// Best-effort, as below: don't fail the caller's read because we couldn't stamp _mou correctly.
+		base.DebugfCtx(ctx, base.KeyCRUD, "Unable to read the metadata needed to repair the invalid rev tree of doc %s, skipping the repair: %v", base.UD(doc.ID), err)
+		return doc
+	}
+	if fetchedCas != cas {
+		// The document moved between the load and now, so the tree in hand is already stale. Bail before
+		// renumbering it or allocating a sequence - the CAS-guarded write would only fail anyway.
+		base.DebugfCtx(ctx, base.KeyCRUD, "Doc %s was written while preparing to repair its invalid rev tree - a later read or write will repair it.", base.UD(doc.ID))
+		return doc
+	}
+	c.repairInvalidRevTree(ctx, doc, cas, revSeqNo, mou)
+	return doc
+}
+
+// repairInvalidRevTreeForWrite repairs an invalid rev tree from inside a write callback, mirroring
+// OnDemandImportForWrite - including its staleness guard, because the repair is a CAS-guarded write and
+// the document in hand may already have been superseded (most obviously by an on-demand import earlier in
+// the same callback).
+//
+// Like the import, the caller's document is left to the retry rather than being made current here: the
+// repair bumps the CAS, so the write this callback is building is guaranteed to fail with a CAS mismatch
+// and the callback re-runs against a freshly read, repaired document. The conflict check therefore always
+// reaches its final answer against the repaired tree.
+func (db *DatabaseCollectionWithUser) repairInvalidRevTreeForWrite(ctx context.Context, docid string, doc *Document) error {
+	// Gate on the in-memory check for corruption before going to the bucket for the CAS.
+	if !doc.History.hasNonIncreasingGenerations(ctx, doc.GetRevTreeID()) {
+		return nil
+	}
+	// Same fetch as the read path. The write path's own load does include _mou, but not the revSeqNo
+	// virtual xattr, and it already paid for a fetch here to get the CAS - so reading all three together
+	// costs nothing extra and keeps both paths stamping _mou from identical inputs.
+	revSeqNo, mou, cas, err := db.getMetadataOnlyUpdateInputs(ctx, docid)
+	if err != nil {
+		// Unlike an import, a repair is best-effort: the write is valid without it, so don't fail the
+		// caller's write because we couldn't check whether a repair was safe.
+		base.DebugfCtx(ctx, base.KeyCRUD, "Unable to read the metadata needed to repair the invalid rev tree of doc %s, skipping the repair: %v", base.UD(docid), err)
+		return nil
+	}
+	if cas != doc.Cas {
+		return base.ErrCasFailureShouldRetry
+	}
+	db.repairInvalidRevTree(ctx, doc, doc.Cas, revSeqNo, mou)
+	return nil
+}
+
+// repairInvalidRevTree is the shared detect/report/repair used by both the read and write paths. The
+// document is repaired in place; whether the caller uses the repaired document or discards it in favour
+// of a re-read is the caller's business - see the two wrappers above. Detection must be run before
+// calling, and revSeqNo/mou must come from a fetch at the supplied cas
+func (c *DatabaseCollection) repairInvalidRevTree(ctx context.Context, doc *Document, cas uint64, revSeqNo uint64, mou *MetadataOnlyUpdate) {
+	c.dbStats().Database().InvalidRevTreeCount.Add(1)
+
+	previousRev := doc.GetRevTreeID()
+	if err := c.repairRevTreeGenerations(ctx, doc, cas, revSeqNo, mou); err != nil {
+		if base.IsCasMismatch(err) {
+			// Someone else wrote the document while we were repairing it, so the tree we repaired is
+			// already stale.
+			base.DebugfCtx(ctx, base.KeyCRUD, "Repair of invalid rev tree for doc %s rev %s lost a CAS race with a concurrent write - a later read or write will repair it.", base.UD(doc.ID), base.MD(previousRev))
+			return
+		}
+		base.WarnfCtx(ctx, "Invalid rev tree for doc %s rev %s - a revision does not exceed the generation of its parent, and the repair failed, so its revision history cannot be replicated accurately to pre-4.0 clients: %v", base.UD(doc.ID), base.MD(previousRev), err)
+		return
+	}
+	base.DebugfCtx(ctx, base.KeyCRUD, "Repaired invalid rev tree for doc %s - a revision did not exceed the generation of its parent. Current revision %s is now %s.", base.UD(doc.ID), base.MD(previousRev), base.MD(doc.GetRevTreeID()))
+}
+
+// repairRevTreeGenerations renumbers the document's rev tree so every revision exceeds its parent's
+// generation, and writes the result back as a metadata-only update guarded on the supplied CAS. The
+// document body is untouched.
+//
+// A new sequence is allocated so the repaired revision is delivered on the changes feed - without one,
+// clients that were already told about the pre-repair revision would never hear about the repair.
+//
+// _mou is stamped from revSeqNo and mou rather than from the document, because neither is guaranteed to
+// have been loaded onto it.
+func (c *DatabaseCollection) repairRevTreeGenerations(ctx context.Context, doc *Document, cas uint64, revSeqNo uint64, mou *MetadataOnlyUpdate) error {
+	previousRev := doc.GetRevTreeID()
+
+	// Snapshot everything the repair mutates. repairGenerations renumbers the tree in place, and
+	// assignSequence advances the document's sequence, so a repair that fails after this point would
+	// otherwise leave the caller holding a document that was never written - which the read path then
+	// serves and caches. rollback puts it back.
+	//
+	// maps.Clone is enough for the tree: repairGenerations copies each RevInfo rather than mutating it,
+	// so the entries this snapshot holds still carry their original IDs and parents.
+	preRepairHistory := maps.Clone(doc.History)
+	preRepairSequence := doc.Sequence
+	preRepairRecentSequences := slices.Clone(doc.RecentSequences)
+	preRepairUnusedSequences := slices.Clone(doc.UnusedSequences)
+	preRepairMou := doc.MetadataOnlyUpdate
+	rollback := func(err error) error {
+		// Release the sequence assignSequence allocated, as updateAndReturnDoc does for its own write -
+		// an allocated sequence that is never written and never released is a permanent gap in the
+		// numbering. Not on a timeout, where the write may have landed after all.
+		if doc.Sequence != preRepairSequence && !base.IsTimeoutError(err) {
+			if seqErr := c.sequences().releaseSequence(ctx, doc.Sequence); seqErr != nil {
+				base.WarnfCtx(ctx, "Error returned when releasing sequence %d allocated for an abandoned rev tree repair. Falling back to skipped sequence handling.  Error:%v", doc.Sequence, seqErr)
+			}
+		}
+		doc.History = preRepairHistory
+		doc.SetRevTreeID(previousRev)
+		doc.Sequence = preRepairSequence
+		doc.RecentSequences = preRepairRecentSequences
+		doc.UnusedSequences = preRepairUnusedSequences
+		doc.MetadataOnlyUpdate = preRepairMou
+		return err
+	}
+
+	newCurrentRev, renamed, err := doc.History.repairGenerations(previousRev)
+	if err != nil {
+		return err
+	}
+	if len(renamed) == 0 {
+		// hasNonIncreasingGenerations said otherwise, so the two disagree - fail rather than write nothing
+		return base.RedactErrorf("rev tree for doc %s was reported invalid but the repair renamed no revisions", base.UD(doc.ID))
+	}
+	// repairGenerations keeps the winner winning, so this only fires for a document whose current
+	// revision was already off the winning branch. Leaving it corrupt beats moving it onto another
+	// branch, which every other caller would read as the document changing on its own.
+	if winner, _, _ := doc.History.winningRevision(ctx); winner != newCurrentRev {
+		return rollback(base.RedactErrorf("repaired rev tree for doc %s would leave current revision %s off the winning branch, %s", base.UD(doc.ID), base.MD(newCurrentRev), base.MD(winner)))
+	}
+	doc.SetRevTreeID(newCurrentRev)
+
+	collectionWithUser := &DatabaseCollectionWithUser{DatabaseCollection: c}
+	// No unused sequences to release alongside the allocated one - assignSequence only returns those for
+	// a caller that came in holding a sequence, and this one always allocates fresh.
+	if _, _, err = collectionWithUser.assignSequence(ctx, 0, doc, nil); err != nil {
+		return rollback(err)
+	}
+	doc.MetadataOnlyUpdate = computeMetadataOnlyUpdate(cas, revSeqNo, mou)
+
+	_, syncXattr, _, mouXattr, globalXattr, err := doc.MarshalWithXattrs()
+	if err != nil {
+		return rollback(err)
+	}
+
+	opts := &sgbucket.MutateInOptions{
+		MacroExpansion: []sgbucket.MacroExpansionSpec{
+			sgbucket.NewMacroExpansionSpec(xattrCasPath(base.SyncXattrName), sgbucket.MacroCas),
+			sgbucket.NewMacroExpansionSpec(XattrMouCasPath(), sgbucket.MacroCas),
+		},
+		PreserveExpiry: true,
+	}
+	// CAS-guarded: a concurrent write means the tree we repaired is already stale, so fail rather than
+	// clobber it. The caller serves the document unrepaired and a later read will try again.
+	xattrsToUpdate := map[string][]byte{
+		base.SyncXattrName: syncXattr,
+		base.MouXattrName:  mouXattr,
+	}
+	if len(globalXattr) > 0 {
+		xattrsToUpdate[base.GlobalXattrName] = globalXattr
+	}
+	casOut, err := c.dataStore.UpdateXattrs(ctx, realDocID(doc.ID), 0, cas, xattrsToUpdate, opts)
+	if err != nil {
+		return rollback(err)
+	}
+
+	// Bring the in-memory document into line with the values the server macro-expanded, as
+	// updateAndReturnDoc does after its own write.
+	doc.Cas = casOut
+	doc.SyncData.Cas = base.CasToString(casOut)
+	if doc.MetadataOnlyUpdate != nil && doc.MetadataOnlyUpdate.HexCAS == expandMacroCASValueString {
+		doc.MetadataOnlyUpdate.HexCAS = base.CasToString(casOut)
+	}
+
+	// Drop any pre-repair entries. A write with insert-on-write can have cached one, and so can an
+	// earlier CV read whose own repair failed - a CV load caches the document even when its history
+	// can't be encoded. The repair leaves the HLV alone, so the CV key is unchanged and this removes
+	// the entry rather than orphaning it.
+	c.revisionCache.Remove(ctx, doc.ID, previousRev)
+	if doc.HLV != nil {
+		c.revisionCache.Remove(ctx, doc.ID, doc.HLV.GetCurrentVersionString())
+	}
+
+	return nil
 }
 
 // getAttachmentIDsForLeafRevisions returns a map of attachment docids with values of attachment names.

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -18,6 +18,9 @@ import (
 	"testing"
 	"time"
 
+	"fmt"
+	"sync"
+
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
@@ -2890,4 +2893,124 @@ func TestPutExistingCurrentVersionISGROldRevBackup(t *testing.T) {
 			require.JSONEq(t, rev1Body, string(backup))
 		})
 	}
+}
+
+func TestRepairFailureDoesNotLeakSequence(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD)
+
+	defer SuspendSequenceBatching()()
+
+	const docID = "corruptRacedRepairSequence"
+	tb := base.GetTestBucket(t)
+	var raceOnce sync.Once
+	lb := base.NewLeakyBucket(tb, base.LeakyBucketConfig{
+		// fires before the real UpdateXattrs, so the repair's CAS is stale by the time it lands.
+		// Written through the underlying bucket to avoid re-entering this callback.
+		UpdateXattrsCallback: func(key string) {
+			if key != docID {
+				return
+			}
+			raceOnce.Do(func() {
+				ctx := base.TestCtx(t)
+				var body []byte
+				_, err := tb.GetSingleDataStore().Get(ctx, key, &body)
+				require.NoError(t, err)
+				require.NoError(t, tb.GetSingleDataStore().Set(ctx, key, 0, nil, body))
+			})
+		},
+		IgnoreClose: true,
+	})
+
+	defer tb.Close(base.TestCtx(t)) // IgnoreClose means dbCtx.Close leaves the underlying bucket open
+	dbCtx, ctx := setupTestDBForBucket(t, lb)
+	defer dbCtx.Close(ctx)
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, dbCtx)
+
+	// a document whose rev tree the repair will want to renumber
+	PlantRevTreeForTest(t, ctx, collection, docID, Body{"planted": true},
+		map[string]string{"1-abc": "", "2-abc": "1-abc", "2-def": "2-abc"}, "2-def")
+	dbCtx.FlushRevisionCacheForTest()
+
+	// before: the committed state, and how far the sequence allocator has got
+	before, err := collection.GetDocSyncData(ctx, docID)
+	require.NoError(t, err)
+	highSeqBefore, err := dbCtx.sequences.lastSequence(ctx)
+	require.NoError(t, err)
+	releasedBefore := dbCtx.DbStats.Database().SequenceReleasedCount.Value()
+
+	// the read that triggers the repair. The repair renumbers the tree, takes a sequence, and then its
+	// CAS-guarded write loses the injected race - so none of it reaches the bucket.
+	doc, err := collection.GetDocument(ctx, docID, DocUnmarshalAll)
+	require.NoError(t, err)
+
+	after, err := collection.GetDocSyncData(ctx, docID)
+	require.NoError(t, err)
+	highSeqAfter, err := dbCtx.sequences.lastSequence(ctx)
+	require.NoError(t, err)
+	releasedCount := dbCtx.DbStats.Database().SequenceReleasedCount.Value() - releasedBefore
+
+	t.Logf("sequence allocator: %d -> %d, released %d", highSeqBefore, highSeqAfter, releasedCount)
+	t.Logf("committed rev %q seq %d -> rev %q seq %d; returned doc.Sequence=%d",
+		before.GetRevTreeID(), before.Sequence, after.GetRevTreeID(), after.Sequence, doc.Sequence)
+
+	// precondition: the repair lost the race, so nothing about it was committed
+	require.Equal(t, before.GetRevTreeID(), after.GetRevTreeID(), "the repair should have written nothing")
+	require.Equal(t, before.Sequence, after.Sequence, "the repair should not have committed a sequence")
+
+	// precondition: it did take a sequence on the way, though - exactly one, batching is off
+	require.Equal(t, highSeqBefore+1, highSeqAfter, "the repair should have allocated exactly one sequence")
+	abandonedSequence := highSeqAfter
+
+	// the abandoned sequence is given back...
+	assert.Equal(t, uint64(1), releasedCount, "sequence %d was allocated and never released", abandonedSequence)
+
+	// ...as an unused-sequence document, which is what stops the change cache waiting on the gap
+	unusedSeqKey := fmt.Sprintf("%s%d", dbCtx.MetadataKeys.UnusedSeqPrefix(), abandonedSequence)
+	exists, err := dbCtx.MetadataStore.Exists(ctx, unusedSeqKey)
+	require.NoError(t, err)
+	assert.True(t, exists, "no unused-sequence document %q for abandoned sequence %d", unusedSeqKey, abandonedSequence)
+
+	// ...and the document handed back to the caller does not claim it
+	assert.Equal(t, before.Sequence, doc.Sequence, "the returned document claims uncommitted sequence %d", doc.Sequence)
+}
+
+func TestWritePathRepairMouChain(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD, base.KeyImport)
+	dbCtx, ctx := setupTestDB(t)
+	defer dbCtx.Close(ctx)
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, dbCtx)
+
+	const docID = "corruptWritePathMouChain"
+	PlantRevTreeForTest(t, ctx, collection, docID, Body{"planted": true},
+		map[string]string{"1-abc": "", "2-abc": "1-abc", "2-def": "2-abc"}, "2-def")
+
+	// the SDK write is the last real body mutation
+	require.NoError(t, collection.dataStore.Set(ctx, docID, 0, nil, []byte(`{"sdk":true}`)))
+	_, sdkWriteCas, err := collection.dataStore.GetRaw(ctx, docID)
+	require.NoError(t, err)
+	dbCtx.FlushRevisionCacheForTest()
+
+	// a write on top: the callback imports, bails to a CAS retry, then repairs on the retry
+	_, _, err = collection.Put(ctx, docID, Body{"fromSG": true})
+	require.Error(t, err, "a Put with no matching rev against an existing document is a conflict")
+
+	_, casAfterRepair, err := collection.dataStore.GetRaw(ctx, docID)
+	require.NoError(t, err)
+	_, mouAfterRepair, _ := getSyncAndMou(t, collection, docID)
+
+	require.Equal(t, base.CasToString(casAfterRepair), mouAfterRepair.HexCAS,
+		"precondition: the repair should be the current metadata-only update")
+
+	// this is the claim under test
+	assert.Equal(t, base.CasToString(sdkWriteCas), mouAfterRepair.PreviousHexCAS,
+		"write-path _mou.pCas should have chained back to the SDK write, not restarted at the import")
+
+	// _mou.pRev is the revSeqNo before the repair's own mutation. The repair is the last write here (the
+	// caller's write was rejected), so that is one less than the document's current revSeqNo - and never
+	// zero, which is what the write path stamped before it stopped discarding the revSeqNo it fetches.
+	revSeqNoAfterRepair, _, err := collection.getRevSeqNo(ctx, docID)
+	require.NoError(t, err)
+	require.NotZero(t, revSeqNoAfterRepair)
+	assert.Equal(t, revSeqNoAfterRepair-1, mouAfterRepair.PreviousRevSeqNo,
+		"write-path _mou.pRev should be the revSeqNo immediately before the repair (current revSeqNo %d)", revSeqNoAfterRepair)
 }

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -1656,6 +1656,94 @@ func getBucketDocument(t *testing.T, collection *DatabaseCollection, docID strin
 	}
 }
 
+// TestWritePathRepairForcesCasRetryAfterImport:
+// Tests that repair is committed against post import version of the doc on write
+func TestWritePathRepairForcesCasRetryAfterImport(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD, base.KeyImport)
+	dbCtx, ctx := setupTestDB(t)
+	defer dbCtx.Close(ctx)
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, dbCtx)
+
+	const docID = "corruptThenSDKWriteThenPut"
+	PlantRevTreeForTest(t, ctx, collection, docID, Body{"planted": true},
+		map[string]string{"1-abc": "", "2-abc": "1-abc", "2-def": "2-abc"}, "2-def")
+	require.NoError(t, collection.dataStore.Set(ctx, docID, 0, nil, []byte(`{"sdk":true}`)))
+	dbCtx.FlushRevisionCacheForTest()
+
+	// the write callback imports, then the repair must see a stale doc.Cas and force a retry rather than
+	// repairing against the pre-import document
+	base.AssertLogContains(t, "Repaired invalid rev tree for doc <ud>"+docID+"</ud>", func() {
+		_, _, err := collection.Put(ctx, docID, Body{"fromSG": true})
+		require.Error(t, err, "a Put with no matching rev against an existing document is a conflict")
+	})
+
+	// whatever happened to the caller's write, the repair itself committed against the post-import
+	// document - so the tree left behind is valid and internally consistent
+	currentRev, tree := revTreeState(t, ctx, collection, docID)
+	t.Logf("after the write: currentRev=%q tree=%v", currentRev, tree)
+
+	// the import added its revision under 2-def at generation 3; the repair then renumbered 2-def to
+	// 3-def and re-pointed the import's revision onto its renamed parent at generation 4
+	gen, digest := ParseRevID(ctx, currentRev)
+	require.Equal(t, 4, gen, "import created generation 3, the repair should have renumbered it to 4")
+	assert.Equal(t, map[string]string{
+		"1-abc":       "",
+		"2-abc":       "1-abc",
+		"3-def":       "2-abc",
+		"4-" + digest: "3-def",
+	}, tree, "unexpected rev tree after import + repair")
+
+	syncData, _, _ := getSyncAndMou(t, collection, docID)
+	require.NoError(t, syncData.History.verifyIncreasingGenerations(),
+		"the write path left the document with a non-increasing generation")
+	_, inTree := syncData.History[currentRev]
+	assert.True(t, inTree, "current revision %q is not in the rev tree", currentRev)
+	_, renamedStillPresent := tree["2-def"]
+	assert.False(t, renamedStillPresent, "the renamed revision 2-def should be gone from the tree")
+}
+
+// TestGetPathDoesNotRepairJustImportedDoc:
+// Asserts that on demand import triggered in get path and repair is done in one pass of Get
+func TestGetPathDoesNotRepairJustImportedDoc(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD, base.KeyImport)
+	dbCtx, ctx := setupTestDB(t)
+	defer dbCtx.Close(ctx)
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, dbCtx)
+
+	const docID = "corruptThenSDKWriteRepairOnRead"
+	PlantRevTreeForTest(t, ctx, collection, docID, Body{"planted": true},
+		map[string]string{"1-abc": "", "2-abc": "1-abc", "2-def": "2-abc"}, "2-def")
+	require.NoError(t, collection.dataStore.Set(ctx, docID, 0, nil, []byte(`{"sdk":true}`)))
+	dbCtx.FlushRevisionCacheForTest()
+
+	doc, err := collection.GetDocument(ctx, docID, DocUnmarshalAll)
+	require.NoError(t, err)
+	// the import committed, so the document the repair was handed carries the post-import CAS
+	require.NotZero(t, doc.Cas)
+
+	currentRev, tree := revTreeState(t, ctx, collection, docID)
+	t.Logf("after one read: bucket currentRev=%q tree=%v", currentRev, tree)
+
+	// one read did both: the import added its revision under 2-def at generation 3, then the repair
+	// renumbered 2-def to 3-def and re-pointed the import's revision onto it at generation 4
+	gen, digest := ParseRevID(ctx, currentRev)
+	require.Equal(t, 4, gen, "import created generation 3, the repair should have renumbered it to 4")
+	assert.Equal(t, map[string]string{
+		"1-abc":       "",
+		"2-abc":       "1-abc",
+		"3-def":       "2-abc",
+		"4-" + digest: "3-def",
+	}, tree, "unexpected rev tree after import + repair")
+	_, renamedStillPresent := tree["2-def"]
+	assert.False(t, renamedStillPresent, "the renamed revision 2-def should be gone from the tree")
+
+	// the document the caller was handed matches what was committed, tree and all
+	assert.Equal(t, currentRev, doc.GetRevTreeID(), "the returned document disagrees with the bucket")
+	assert.Equal(t, tree, revTreeParents(doc.History), "the returned document's tree disagrees with the bucket")
+	assert.NoError(t, doc.History.verifyIncreasingGenerations(),
+		"the read left the document unrepaired in the bucket")
+}
+
 // TestImportTombstoneAttachmentMetadata records the attachment metadata an import leaves on a tombstone,
 // which is not what a Sync Gateway delete leaves.
 //

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -3525,3 +3525,237 @@ func TestRevisionCacheInvalidRevisionError(t *testing.T) {
 		assert.ErrorContains(t, err, "missing DocID")
 	})
 }
+
+// TestInvalidRevTreeRevisionCacheHandling covers what the revision cache is left holding across a
+// repair. None of this is visible from the document itself, and each case has a different key involved:
+//
+//   - a pre-repair CV-keyed entry left by an earlier write must be evicted. This is the dangerous one:
+//     the repair deliberately does not change cv, so the key stays exactly the one a 4.0+ client asks
+//     for while the revID and history it holds go stale. TestInvalidRevTreeCVEntryCachedByFailedRepair
+//     covers the other way that entry gets there.
+//   - a corrupt revision must never be cached. The load that would have cached it repairs the document
+//     first, so the revision asked for no longer exists and the load fails - and a failed load is
+//     discarded (removeValueForFailedLoad).
+//   - loading the active revision must cache the repaired one. GetActive keys on the rev tree ID of the
+//     document it just loaded, which is post-repair. So must ensure post-repair history is cached.
+func TestInvalidRevTreeRevisionCacheHandling(t *testing.T) {
+	if base.TestDisableRevCache() {
+		t.Skip("Test asserts on revision cache contents")
+	}
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD)
+
+	dbCtx, ctx := SetupTestDBWithOptions(t, DatabaseContextOptions{
+		RevisionCacheOptions: &RevisionCacheOptions{
+			// MaxItemCount must be set - a zero value silently selects the bypass cache, which stores
+			// nothing, and every "should not be cached" assertion below would pass vacuously
+			MaxItemCount:  DefaultRevisionCacheSize,
+			ShardCount:    DefaultRevisionCacheShardCount,
+			InsertOnWrite: true,
+		},
+	})
+	defer dbCtx.Close(ctx)
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, dbCtx)
+	revisionCache := collection.revisionCache
+
+	const docID = "revCacheDoc"
+	PlantRevTreeForTest(t, ctx, collection, docID, Body{"planted": true},
+		map[string]string{"1-abc": "", "2-abc": "1-abc", "2-def": "2-abc"}, "2-def")
+	dbCtx.FlushRevisionCacheForTest()
+
+	// read cv straight from _vv - every path that returns a Document repairs on the way, and the cache
+	// has to be seeded with the pre-repair state
+	xattrs, _, err := collection.dataStore.GetXattrs(ctx, docID, []string{base.VvXattrName})
+	require.NoError(t, err)
+	var preRepairHLV HybridLogicalVector
+	require.NoError(t, base.JSONUnmarshal(xattrs[base.VvXattrName], &preRepairHLV))
+	preRepairVersion := preRepairHLV.ExtractCurrentVersionFromHLV()
+	preRepairCV := preRepairHLV.GetCurrentVersionString()
+
+	syncData, err := collection.GetDocSyncData(ctx, docID)
+	require.NoError(t, err)
+	require.Equal(t, "2-def", syncData.GetRevTreeID(), "the cache must be seeded before anything repairs the document")
+
+	// seed the entry an InsertOnWrite write would have left behind. Put keys on cv only, so this is the
+	// CV-keyed entry - a revID-keyed entry can only be created by a revID load, which would repair first.
+	require.NoError(t, revisionCache.Put(ctx, DocumentRevision{
+		DocID:      docID,
+		RevID:      "2-def",
+		BodyBytes:  []byte(`{"planted":true}`),
+		History:    encodeRevisions(ctx, docID, []string{"2-def", "2-abc", "1-abc"}),
+		Channels:   syncData.getCurrentChannels(),
+		CV:         preRepairVersion,
+		HlvHistory: preRepairHLV.ToHistoryForHLV(),
+	}))
+	seeded, found := revisionCache.Peek(ctx, docID, preRepairCV)
+	require.True(t, found, "failed to seed the cache under %q", preRepairCV)
+	require.Equal(t, "2-def", seeded.RevID)
+
+	// the repair, triggered by a load exactly as production triggers it
+	repaired, err := collection.GetDocument(ctx, docID, DocUnmarshalAll)
+	require.NoError(t, err)
+	require.Equal(t, "3-def", repaired.GetRevTreeID())
+	require.Equal(t, preRepairCV, repaired.HLV.GetCurrentVersionString(), "the repair must not change cv")
+
+	t.Run("stale pre-repair CV entry is evicted by the repair", func(t *testing.T) {
+		_, found := revisionCache.Peek(ctx, docID, preRepairCV)
+		assert.False(t, found, "the pre-repair CV entry should have been removed by the repair")
+	})
+
+	t.Run("a corrupt revision is never cached", func(t *testing.T) {
+		_, err := collection.GetRev(ctx, docID, "2-def", true, nil)
+		require.Error(t, err)
+		require.True(t, base.IsDocNotFoundError(err), "expected a 404-shaped error, got %v", err)
+
+		_, found := revisionCache.Peek(ctx, docID, "2-def")
+		assert.False(t, found, "a failed load must not leave an entry in the cache")
+	})
+
+	t.Run("loading the active revision caches the repaired revision", func(t *testing.T) {
+		rev, err := collection.GetRev(ctx, docID, "", true, nil)
+		require.NoError(t, err)
+		require.Equal(t, "3-def", rev.RevID)
+
+		// GetActive keys on the rev tree ID of the document it loaded, which is the repaired one
+		cached, found := revisionCache.Peek(ctx, docID, "3-def")
+		require.True(t, found, "the active revision should have been cached under the repaired rev ID")
+		assert.Equal(t, "3-def", cached.RevID)
+		assert.Equal(t, 3, cached.History[RevisionsStart], "cached history should be the repaired branch")
+		assert.Equal(t, []string{"def", "abc", "abc"}, cached.History[RevisionsIds].([]string))
+
+		_, found = revisionCache.Peek(ctx, docID, "2-def")
+		assert.False(t, found, "nothing should be cached under the pre-repair rev ID")
+	})
+
+	t.Run("a CV load repopulates the CV key with the repaired revision", func(t *testing.T) {
+		docRev, err := revisionCache.Get(ctx, docID, preRepairCV, RevCacheDontLoadBackupRev)
+		require.NoError(t, err)
+		assert.Equal(t, "3-def", docRev.RevID, "the CV key must now resolve to the repaired revision")
+		assert.Equal(t, 3, docRev.History[RevisionsStart])
+	})
+
+	// The subtests above all run against a document something has already repaired. This one is the case
+	// that actually matters for caching: the active-revision load is itself the thing that triggers the
+	// repair, so the repair has to happen before the cache value is built. GetActive keys on the rev tree
+	// ID of the document it loaded, so a repair applied any later would cache the corrupt revision, with its corrupt
+	// history, under the pre-repair key.
+	t.Run("an active revision load repairs and caches the repaired revision in one step", func(t *testing.T) {
+		const unrepairedDocID = "revCacheUnrepairedDoc"
+		invalidRevTreeCount := dbCtx.DbStats.Database().InvalidRevTreeCount
+		countBefore := invalidRevTreeCount.Value()
+
+		PlantRevTreeForTest(t, ctx, collection, unrepairedDocID, Body{"planted": true},
+			map[string]string{"1-abc": "", "2-abc": "1-abc", "2-def": "2-abc"}, "2-def")
+		dbCtx.FlushRevisionCacheForTest()
+
+		// nothing has read this document, so it is still corrupt and nothing is cached for it
+		currentRev, _ := revTreeState(t, ctx, collection, unrepairedDocID)
+		require.Equal(t, "2-def", currentRev)
+		_, found := revisionCache.Peek(ctx, unrepairedDocID, "2-def")
+		require.False(t, found)
+
+		// the active-revision load is the first thing to touch it
+		rev, err := collection.GetRev(ctx, unrepairedDocID, "", true, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "3-def", rev.RevID, "the active revision load should have returned the repaired revision")
+		assert.Equal(t, countBefore+1, invalidRevTreeCount.Value(), "the active revision load should have triggered the repair")
+
+		// what it cached is the repaired revision, under the repaired key
+		cached, found := revisionCache.Peek(ctx, unrepairedDocID, "3-def")
+		require.True(t, found, "the repaired revision should have been cached")
+		assert.Equal(t, "3-def", cached.RevID)
+		assert.Equal(t, 3, cached.History[RevisionsStart])
+		assert.Equal(t, []string{"def", "abc", "abc"}, cached.History[RevisionsIds].([]string))
+
+		// ...and nothing was cached under the corrupt revision on the way there
+		_, found = revisionCache.Peek(ctx, unrepairedDocID, "2-def")
+		assert.False(t, found, "the corrupt revision must never have been cached")
+
+		currentRev, tree := revTreeState(t, ctx, collection, unrepairedDocID)
+		assert.Equal(t, "3-def", currentRev)
+		assert.Equal(t, map[string]string{"1-abc": "", "2-abc": "1-abc", "3-def": "2-abc"}, tree)
+	})
+}
+
+// TestInvalidRevTreeCVEntryCachedByFailedRepair covers a stale CV entry that no write put there. A CV
+// load caches the document even when its history cannot be encoded, so a read whose repair loses a CAS
+// race leaves a pre-repair entry under the CV key - with no InsertOnWrite involved. The repair that
+// eventually succeeds has to evict it, otherwise every later CV lookup keeps serving the pre-repair
+// revision and its unencodable history, and a pre-4.0 pull keeps getting a norev.
+func TestInvalidRevTreeCVEntryCachedByFailedRepair(t *testing.T) {
+	if base.TestDisableRevCache() {
+		t.Skip("Test asserts on revision cache contents")
+	}
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD)
+
+	const docID = "cvCachedCorruptDoc"
+	tb := base.GetTestBucket(t)
+	var raceOnce sync.Once
+	lb := base.NewLeakyBucket(tb, base.LeakyBucketConfig{
+		// fires before the real UpdateXattrs, so the first repair's CAS is stale by the time it lands.
+		// Written through the underlying bucket to avoid re-entering this callback.
+		UpdateXattrsCallback: func(key string) {
+			if key != docID {
+				return
+			}
+			raceOnce.Do(func() {
+				ctx := base.TestCtx(t)
+				var body []byte
+				_, err := tb.GetSingleDataStore().Get(ctx, key, &body)
+				require.NoError(t, err)
+				require.NoError(t, tb.GetSingleDataStore().Set(ctx, key, 0, nil, body))
+			})
+		},
+		IgnoreClose: true,
+	})
+	defer tb.Close(base.TestCtx(t)) // IgnoreClose means dbCtx.Close leaves the underlying bucket open
+
+	dbCtx, ctx := SetupTestDBForBucketWithOptions(t, lb, DatabaseContextOptions{
+		CacheOptions: base.Ptr(DefaultCacheOptions()),
+		RevisionCacheOptions: &RevisionCacheOptions{
+			// MaxItemCount must be set - a zero value silently selects the bypass cache, which stores
+			// nothing. InsertOnWrite is deliberately off: the entry under test comes from a read.
+			MaxItemCount: DefaultRevisionCacheSize,
+			ShardCount:   DefaultRevisionCacheShardCount,
+		},
+	})
+	defer dbCtx.Close(ctx)
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, dbCtx)
+
+	PlantRevTreeForTest(t, ctx, collection, docID, Body{"planted": true},
+		map[string]string{"1-abc": "", "2-abc": "1-abc", "2-def": "2-abc"}, "2-def")
+	dbCtx.FlushRevisionCacheForTest()
+
+	syncData, hlv, err := collection.GetDocSyncDataNoImport(ctx, docID, DocUnmarshalSync)
+	require.NoError(t, err)
+	require.Equal(t, "2-def", syncData.GetRevTreeID(), "the document must still be corrupt at this point")
+	cvString := hlv.GetCurrentVersionString()
+
+	// a CV lookup whose repair loses the injected CAS race - the corrupt revision gets cached
+	first, err := collection.GetRev(ctx, docID, cvString, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, "2-def", first.RevID, "precondition: the first repair should have lost the race")
+	cached, found := collection.revisionCache.Peek(ctx, docID, cvString)
+	require.True(t, found, "precondition: the failed repair should have left a CV entry behind")
+	require.Equal(t, "2-def", cached.RevID)
+	_, err = toHistory(cached.History, map[string]bool{}, 0)
+	require.Error(t, err, "precondition: the cached history should be the unencodable corrupt one")
+
+	// the next read repairs the document for real
+	repaired, err := collection.GetDocument(ctx, docID, DocUnmarshalAll)
+	require.NoError(t, err)
+	require.Equal(t, "3-def", repaired.GetRevTreeID())
+	require.Equal(t, cvString, repaired.HLV.GetCurrentVersionString(), "the repair must not change cv")
+	bucketRev, _ := revTreeState(t, ctx, collection, docID)
+	require.Equal(t, "3-def", bucketRev)
+
+	_, found = collection.revisionCache.Peek(ctx, docID, cvString)
+	assert.False(t, found, "the repair should have evicted the pre-repair CV entry")
+
+	// the same CV lookup now reloads, and serves the repaired revision with encodable history
+	second, err := collection.GetRev(ctx, docID, cvString, true, nil)
+	require.NoError(t, err)
+	assert.Equal(t, bucketRev, second.RevID, "the CV lookup should serve the repaired revision")
+	history, err := toHistory(second.History, map[string]bool{}, 0)
+	require.NoError(t, err, "the repaired history must encode, so a pre-4.0 pull gets the revision")
+	assert.Equal(t, []string{"2-abc", "1-abc"}, history, "history is the repaired branch, minus the revision itself")
+}

--- a/db/revtree.go
+++ b/db/revtree.go
@@ -267,6 +267,235 @@ func (node RevInfo) ParentGenGTENodeGen(ctx context.Context) bool {
 	return genOfRevID(ctx, node.Parent) >= genOfRevID(ctx, node.ID)
 }
 
+// hasNonIncreasingGenerations reports whether the branch ending at currentRev contains a revision whose
+// generation does not exceed its parent's.
+//
+// That invariant has two distinct failure modes on the wire, and this checks for the underlying cause
+// rather than either symptom:
+//
+//   - If the branch is long relative to its leaf generation, encodeRevisions produces a _revisions list
+//     that splitRevisionList rejects (it requires start >= len(ids)), so the document is unreplicatable
+//     to pre-4.0 (BLIP v3) clients and gets skipped with a noRev. This is the loud case.
+//   - Otherwise the list encodes, but since _revisions can only express start, start-1, start-2 ...,
+//     every ancestor after the duplicate is sent under the wrong rev ID. This is the quiet case, and it
+//     is what a corrupt document looks like once pruning has shortened the branch.
+//
+// It would be cheaper to test the loud case alone - gen(leaf) < len(branch) is exactly the noRev
+// condition, and len(tree) bounds any single branch, so gen(leaf) >= len(tree) would rule it out.
+// That test is sound but not complete: a generation gap that inflates gen(leaf) enough to hide a backwards step (1-abc -> 11-abc -> 10-abc passes it
+// while being plainly invalid).
+func (tree RevTree) hasNonIncreasingGenerations(ctx context.Context, currentRev string) bool {
+	childGen, _, err := parseRevID(currentRev)
+	if err != nil {
+		return false
+	}
+	// The walk is self-terminating even on a cyclic tree: it only continues while the generation
+	// strictly decreases, so a revision can never be reached twice.
+	revid := currentRev
+	for {
+		info, ok := tree[revid]
+		if !ok || info.Parent == "" {
+			return false
+		}
+		parentGen, _, err := parseRevID(info.Parent)
+		if err != nil {
+			return false
+		}
+		if childGen <= parentGen {
+			base.DebugfCtx(ctx, base.KeyCRUD, "revision %q does not exceed the generation of its parent %q", revid, info.Parent)
+			return true
+		}
+		// Step up to the parent and keep walking.
+		childGen = parentGen
+		revid = info.Parent
+	}
+}
+
+// verifyIncreasingGenerations returns an error if any revision in the tree fails to exceed its parent's
+// generation. Unlike hasNonIncreasingGenerations this covers every branch, and is used to check the
+// result of a repair rather than to detect the replication symptom.
+func (tree RevTree) verifyIncreasingGenerations() error {
+	for revid, info := range tree {
+		if info.Parent == "" {
+			continue
+		}
+		if _, ok := tree[info.Parent]; !ok {
+			// Dangling parent - serialized as a root, see MarshalJSON and SG issue #2847.
+			continue
+		}
+		gen, _, err := parseRevID(revid)
+		if err != nil {
+			return err
+		}
+		parentGen, _, err := parseRevID(info.Parent)
+		if err != nil {
+			return err
+		}
+		if gen <= parentGen {
+			return fmt.Errorf("revision %q does not exceed the generation of its parent %q", revid, info.Parent)
+		}
+	}
+	return nil
+}
+
+// repairGenerations renumbers every revision whose generation does not exceed its parent's, keeping the
+// revision's digest so the repaired revision remains recognisable:
+//
+//	1-abc, 2-abc, 2-def, 2-ghi  ->  1-abc, 2-abc, 3-def, 4-ghi
+//
+// It returns the current revision's ID after repair and a map of old ID -> new ID for every revision that
+// moved.
+//
+// The whole tree is renumbered, not just the winning branch. Renaming a revision raises the generation
+// its children must exceed, so a conflict branch hanging off a renamed revision can be pushed into
+// violation by the repair itself; renumbering breadth-first from the roots resolves that in one pass.
+// It also means every child of a renamed revision is re-pointed - a dangling parent would silently
+// detach the branch, since MarshalJSON writes a parent index of -1 for one (SG issue #2847).
+func (tree RevTree) repairGenerations(currentRev string) (newCurrentRev string, renamed map[string]string, err error) {
+	// Index children so the tree can be walked root -> leaf.
+	children := make(map[string][]string, len(tree))
+	roots := make([]string, 0, 1)
+	for revid, info := range tree {
+		_, parentInTree := tree[info.Parent]
+		// A revision with a dangling parent is a root as far as serialization is concerned.
+		isRoot := info.Parent == "" || !parentInTree
+		if isRoot {
+			roots = append(roots, revid)
+			continue
+		}
+		children[info.Parent] = append(children[info.Parent], revid)
+	}
+
+	// Breadth-first from the roots, so a revision's parent is always renumbered before it is.
+	newGen := make(map[string]int, len(tree))
+	queue := make([]string, 0, len(tree))
+	for _, revid := range roots {
+		gen, _, parseErr := parseRevID(revid)
+		if parseErr != nil {
+			return "", nil, fmt.Errorf("cannot repair rev tree, unparseable root revision: %w", parseErr)
+		}
+		newGen[revid] = gen
+		queue = append(queue, revid)
+	}
+	// Note the queue grows as children are appended, so this walks the whole tree, not just the roots.
+	for i := 0; i < len(queue); i++ {
+		parentID := queue[i]
+		parentGen := newGen[parentID]
+		for _, childID := range children[parentID] {
+			childGen, digest, parseErr := parseRevID(childID)
+			if parseErr != nil {
+				return "", nil, fmt.Errorf("cannot repair rev tree, unparseable revision: %w", parseErr)
+			}
+			if childGen <= parentGen {
+				childGen = parentGen + 1
+				if renamed == nil {
+					renamed = make(map[string]string)
+				}
+				renamed[childID] = fmt.Sprintf("%d-%s", childGen, digest)
+			}
+			newGen[childID] = childGen
+			queue = append(queue, childID)
+		}
+	}
+
+	// Every revision has at most one parent, so each is enqueued exactly once. Anything left over is
+	// unreachable from a root, which means the tree contains a cycle - refuse rather than repair blind.
+	if len(queue) != len(tree) {
+		return "", nil, fmt.Errorf("cannot repair rev tree, %d revisions are unreachable from any root (cycle?)", len(tree)-len(queue))
+	}
+
+	if len(renamed) == 0 {
+		return currentRev, nil, nil
+	}
+
+	// Renumbering only ever raises generations, so a losing branch carrying more violations than the
+	// winning one can be lifted past it. Raise the current revision to keep it winning, otherwise the
+	// caller persists _sync.rev as a revision winningRevision no longer selects.
+	if raised := tree.raisedCurrentRevToKeepWinning(currentRev, children, newGen); raised != "" {
+		renamed[currentRev] = raised
+	}
+
+	repaired := make(RevTree, len(tree))
+	for oldID, info := range tree {
+		newInfo := *info
+		if newID, ok := renamed[oldID]; ok {
+			newInfo.ID = newID
+		}
+		if newParent, ok := renamed[info.Parent]; ok {
+			newInfo.Parent = newParent
+		}
+		if _, collision := repaired[newInfo.ID]; collision {
+			return "", nil, fmt.Errorf("cannot repair rev tree, renumbering would produce duplicate revision %q", newInfo.ID)
+		}
+		repaired[newInfo.ID] = &newInfo
+	}
+
+	newCurrentRev = currentRev
+	if newID, ok := renamed[currentRev]; ok {
+		newCurrentRev = newID
+	}
+	if _, ok := repaired[newCurrentRev]; !ok {
+		return "", nil, fmt.Errorf("cannot repair rev tree, current revision %q is missing from the repaired tree", newCurrentRev)
+	}
+
+	// Never hand back a tree that is still invalid: that would let a caller repair, write, re-detect and
+	// repair again forever.
+	if verifyErr := repaired.verifyIncreasingGenerations(); verifyErr != nil {
+		return "", nil, fmt.Errorf("rev tree still invalid after repair: %w", verifyErr)
+	}
+
+	clear(tree)
+	for revid, info := range repaired {
+		tree[revid] = info
+	}
+	return newCurrentRev, renamed, nil
+}
+
+// raisedCurrentRevToKeepWinning returns the ID the current revision must take so that winningRevision
+// still selects it once the tree has been renumbered to the generations in newGen, or "" if it needs no
+// further raising.
+//
+// The current revision is only raised if it was the winner to begin with - promoting one that was
+// already losing would move the document just as silently, in the other direction.
+func (tree RevTree) raisedCurrentRevToKeepWinning(currentRev string, children map[string][]string, newGen map[string]int) string {
+	currentInfo, ok := tree[currentRev]
+	if !ok || len(children[currentRev]) > 0 {
+		// Not a leaf, so winningRevision never selected it, and raising it would push its descendants
+		// back into violation.
+		return ""
+	}
+	currentOldGen, currentDigest, err := parseRevID(currentRev)
+	if err != nil {
+		return ""
+	}
+	raiseTo := 0
+	for revid, info := range tree {
+		if revid == currentRev || len(children[revid]) > 0 {
+			continue
+		}
+		if info.Deleted != currentInfo.Deleted {
+			if !info.Deleted {
+				return "" // a live leaf always beats a tombstone, so the current revision was already losing
+			}
+			continue
+		}
+		oldGen, digest, err := parseRevID(revid)
+		if err != nil {
+			return ""
+		}
+		if oldGen > currentOldGen || (oldGen == currentOldGen && digest > currentDigest) {
+			return "" // already losing before the repair, so keep it that way
+		}
+		if gen := newGen[revid]; gen > newGen[currentRev] || (gen == newGen[currentRev] && digest > currentDigest) {
+			raiseTo = max(raiseTo, gen+1)
+		}
+	}
+	if raiseTo == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%d-%s", raiseTo, currentDigest)
+}
+
 // Returns true if the RevTree has an entry for this revid.
 func (tree RevTree) contains(revid string) bool {
 	_, exists := tree[revid]

--- a/db/revtree_test.go
+++ b/db/revtree_test.go
@@ -12,12 +12,16 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"maps"
 	"os"
+	"slices"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1315,4 +1319,1169 @@ func createBodyContentAsMapWithSize(docSizeBytes int) map[string]string {
 		body[key] = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	}
 	return body
+}
+
+// buildRevTree constructs a RevTree from a parent -> child spec, without going via addRevision (which
+// deliberately rejects the non-increasing generations these tests need to build).
+func buildRevTree(t *testing.T, revs map[string]string) RevTree {
+	t.Helper()
+	tree := make(RevTree, len(revs))
+	for revid, parent := range revs {
+		tree[revid] = &RevInfo{ID: revid, Parent: parent}
+	}
+	for revid, info := range tree {
+		if info.Parent == "" {
+			continue
+		}
+		_, ok := tree[info.Parent]
+		require.True(t, ok, "test fixture for %q references parent %q that isn't in the tree", revid, info.Parent)
+	}
+	return tree
+}
+
+// revTreeDigest is a realistic 32-character digest. Rev IDs are map keys and are parsed per step, so
+// digest length affects the cost of the walks BenchmarkRevTreeGenerations measures.
+const revTreeDigest = "d6a4d4a2e0ba7dbc4dbc0c0dcbe0f6a3"
+
+// linearRevTree returns a clean chain of n revisions, and the leaf rev ID.
+func linearRevTree(n int) (RevTree, string) {
+	tree := make(RevTree, n)
+	parent, leaf := "", ""
+	for i := 1; i <= n; i++ {
+		id := fmt.Sprintf("%d-%s", i, revTreeDigest)
+		tree[id] = &RevInfo{ID: id, Parent: parent}
+		parent, leaf = id, id
+	}
+	return tree, leaf
+}
+
+// corruptRevTree returns a chain of n revisions where the last dupes of them all share the top
+// generation.
+func corruptRevTree(n, dupes int) (RevTree, string) {
+	tree, leaf := linearRevTree(n - dupes)
+	parent := leaf
+	topGen := n - dupes
+	for i := range dupes {
+		id := fmt.Sprintf("%d-%032x", topGen, i)
+		tree[id] = &RevInfo{ID: id, Parent: parent}
+		parent, leaf = id, id
+	}
+	return tree, leaf
+}
+
+func TestHasNonIncreasingGenerations(t *testing.T) {
+	ctx := base.TestCtx(t)
+	testCases := []struct {
+		name       string
+		revs       map[string]string // revID -> parentID
+		currentRev string
+		expected   bool
+	}{
+		{
+			name:       "clean linear tree",
+			revs:       map[string]string{"1-abc": "", "2-abc": "1-abc", "3-abc": "2-abc"},
+			currentRev: "3-abc",
+		},
+		{
+			name:       "single root revision",
+			revs:       map[string]string{"1-abc": ""},
+			currentRev: "1-abc",
+		},
+		{
+			// gaps push the leaf generation up, so they must not trip the predicate
+			name:       "clean tree with generation gaps",
+			revs:       map[string]string{"1-abc": "", "5-abc": "1-abc", "12-abc": "5-abc"},
+			currentRev: "12-abc",
+		},
+		{
+			// a pruned tree is rooted above generation 1
+			name:       "clean pruned tree",
+			revs:       map[string]string{"8-abc": "", "9-abc": "8-abc", "10-abc": "9-abc"},
+			currentRev: "10-abc",
+		},
+		{
+			name:       "duplicate generation at the leaf",
+			revs:       map[string]string{"1-abc": "", "2-abc": "1-abc", "2-def": "2-abc"},
+			currentRev: "2-def",
+			expected:   true,
+		},
+		{
+			name:       "duplicate generation mid-branch",
+			revs:       map[string]string{"1-abc": "", "2-abc": "1-abc", "2-def": "2-abc", "3-ghi": "2-def"},
+			currentRev: "3-ghi",
+			expected:   true,
+		},
+		{
+			name: "run of duplicate generations",
+			revs: map[string]string{
+				"1-abc": "", "2-abc": "1-abc", "2-def": "2-abc", "2-ghi": "2-def", "2-jkl": "2-ghi",
+			},
+			currentRev: "2-jkl",
+			expected:   true,
+		},
+		{
+			// The gap from 1-abc to 11-abc inflates the leaf generation enough that the branch still
+			// encodes as a _revisions list, so this replicates (with wrong ancestor rev IDs) rather
+			// than producing a noRev. It is still a violation and must be reported.
+			name:       "parent generation higher than child, masked by a gap",
+			revs:       map[string]string{"1-abc": "", "11-abc": "1-abc", "10-abc": "11-abc"},
+			currentRev: "10-abc",
+			expected:   true,
+		},
+		{
+			// Once pruning shortens the branch, gen(leaf) exceeds the branch length and the corruption
+			// stops producing a noRev - the quiet case. Checking the invariant still catches it.
+			name:       "duplicate generation in a pruned tree",
+			revs:       map[string]string{"8-abc": "", "9-abc": "8-abc", "9-def": "9-abc"},
+			currentRev: "9-def",
+			expected:   true,
+		},
+		{
+			// corruption on a branch that isn't the one being asked about
+			name: "corruption confined to another branch",
+			revs: map[string]string{
+				"1-abc": "", "2-abc": "1-abc", "3-abc": "2-abc",
+				"2-xxx": "1-abc", "2-yyy": "2-xxx",
+			},
+			currentRev: "3-abc",
+		},
+		{
+			name:       "malformed current rev is not flagged",
+			revs:       map[string]string{"1-abc": ""},
+			currentRev: "not-a-rev",
+		},
+		{
+			name:       "current rev absent from tree is not flagged",
+			revs:       map[string]string{"1-abc": ""},
+			currentRev: "2-abc",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := buildRevTree(t, tc.revs)
+			assert.Equal(t, tc.expected, tree.hasNonIncreasingGenerations(ctx, tc.currentRev))
+		})
+	}
+}
+
+// TestHasNonIncreasingGenerationsCleanTrees asserts no false positives on clean branches of any length -
+// this runs on every write, so a false positive would repair documents that don't need it.
+func TestHasNonIncreasingGenerationsCleanTrees(t *testing.T) {
+	ctx := base.TestCtx(t)
+	for _, n := range []int{1, 2, 50, 500} {
+		tree, leaf := linearRevTree(n)
+		assert.False(t, tree.hasNonIncreasingGenerations(ctx, leaf), "clean linear tree of %d revs", n)
+	}
+}
+
+// TestHasNonIncreasingGenerationsPrunedIsStillDetected pruning shortens the branch while the leaf generation keeps
+// climbing, so the documents that have been corrupt longest are exactly the ones it would skip.
+func TestHasNonIncreasingGenerationsPrunedIsStillDetected(t *testing.T) {
+	ctx := base.TestCtx(t)
+
+	// a corrupt branch pruned to 10 revisions, with 4 revisions sharing generation 196
+	tree := make(RevTree, 10)
+	parent := ""
+	for gen := 190; gen <= 195; gen++ {
+		id := fmt.Sprintf("%d-abc", gen)
+		tree[id] = &RevInfo{ID: id, Parent: parent}
+		parent = id
+	}
+	leaf := ""
+	for i := range 4 {
+		id := fmt.Sprintf("196-dup%d", i)
+		tree[id] = &RevInfo{ID: id, Parent: parent}
+		parent, leaf = id, id
+	}
+
+	leafGen, _, err := parseRevID(leaf)
+	require.NoError(t, err)
+	require.Greater(t, leafGen, len(tree), "fixture must defeat the gen(leaf) >= len(tree) rule-out")
+
+	assert.True(t, tree.hasNonIncreasingGenerations(ctx, leaf))
+	require.Error(t, tree.verifyIncreasingGenerations())
+}
+
+func TestRepairGenerations(t *testing.T) {
+	ctx := base.TestCtx(t)
+	testCases := []struct {
+		name              string
+		revs              map[string]string // revID -> parentID
+		currentRev        string
+		expectedCurrent   string
+		expectedRenames   map[string]string
+		expectedRevTree   map[string]string // full expected tree after repair, revID -> parentID
+		expectedErrSubstr string
+	}{
+		{
+			name:            "no repair needed leaves the tree untouched",
+			revs:            map[string]string{"1-abc": "", "2-abc": "1-abc", "3-abc": "2-abc"},
+			currentRev:      "3-abc",
+			expectedCurrent: "3-abc",
+			expectedRevTree: map[string]string{"1-abc": "", "2-abc": "1-abc", "3-abc": "2-abc"},
+		},
+		{
+			name:            "run of duplicate generations is renumbered, digests kept",
+			revs:            map[string]string{"1-abc": "", "2-abc": "1-abc", "2-def": "2-abc", "2-ghi": "2-def"},
+			currentRev:      "2-ghi",
+			expectedCurrent: "4-ghi",
+			expectedRenames: map[string]string{"2-def": "3-def", "2-ghi": "4-ghi"},
+			expectedRevTree: map[string]string{"1-abc": "", "2-abc": "1-abc", "3-def": "2-abc", "4-ghi": "3-def"},
+		},
+		{
+			// One duplicate mid-chain, with a well-formed run below it: 1,2,2,3,4,5 -> 1,2,3,4,5,6.
+			// Every revision after the duplicate is individually fine against its original parent, so
+			// nothing below 2-def is corrupt on its own - but renaming 2-def to 3-def raises the
+			// generation its child must exceed, which cascades to the leaf.
+			name: "duplicate mid-tree cascades to every descendant",
+			revs: map[string]string{
+				"1-abc": "", "2-abc": "1-abc", "2-def": "2-abc", "3-ghi": "2-def",
+				"4-jkl": "3-ghi", "5-mno": "4-jkl",
+			},
+			currentRev:      "5-mno",
+			expectedCurrent: "6-mno",
+			expectedRenames: map[string]string{
+				"2-def": "3-def", "3-ghi": "4-ghi", "4-jkl": "5-jkl", "5-mno": "6-mno",
+			},
+			expectedRevTree: map[string]string{
+				"1-abc": "", "2-abc": "1-abc", "3-def": "2-abc", "4-ghi": "3-def",
+				"5-jkl": "4-ghi", "6-mno": "5-jkl",
+			},
+		},
+		{
+			name:            "parent generation higher than child",
+			revs:            map[string]string{"1-abc": "", "11-abc": "1-abc", "10-abc": "11-abc"},
+			currentRev:      "10-abc",
+			expectedCurrent: "12-abc",
+			expectedRenames: map[string]string{"10-abc": "12-abc"},
+			expectedRevTree: map[string]string{"1-abc": "", "11-abc": "1-abc", "12-abc": "11-abc"},
+		},
+		{
+			name:            "generation gaps are preserved, not normalised",
+			revs:            map[string]string{"1-abc": "", "9-abc": "1-abc", "9-def": "9-abc"},
+			currentRev:      "9-def",
+			expectedCurrent: "10-def",
+			expectedRenames: map[string]string{"9-def": "10-def"},
+			expectedRevTree: map[string]string{"1-abc": "", "9-abc": "1-abc", "10-def": "9-abc"},
+		},
+		{
+			// a conflict branch hanging off the corruption must come with it
+			name: "branched tree, conflict branch re-pointed",
+			revs: map[string]string{
+				"1-abc": "", "2-abc": "1-abc", "2-def": "2-abc", "2-ghi": "2-def",
+				"3-xxx": "2-def",
+			},
+			currentRev:      "3-xxx",
+			expectedCurrent: "4-xxx",
+			expectedRenames: map[string]string{"2-def": "3-def", "2-ghi": "4-ghi", "3-xxx": "4-xxx"},
+			expectedRevTree: map[string]string{
+				"1-abc": "", "2-abc": "1-abc", "3-def": "2-abc", "4-ghi": "3-def",
+				"4-xxx": "3-def",
+			},
+		},
+		{
+			// a conflict branch that doesn't descend from a renamed revision must not move. The winning
+			// branch starts at generation 5 so it stays the winner without being raised - see
+			// "losing branch renumbered past the winner" for what happens when it doesn't.
+			name: "branched tree, untouched branch is left alone",
+			revs: map[string]string{
+				"1-abc": "", "5-abc": "1-abc", "5-def": "5-abc",
+				"2-xxx": "1-abc", "3-xxx": "2-xxx",
+			},
+			currentRev:      "5-def",
+			expectedCurrent: "6-def",
+			expectedRenames: map[string]string{"5-def": "6-def"},
+			expectedRevTree: map[string]string{
+				"1-abc": "", "5-abc": "1-abc", "6-def": "5-abc",
+				"2-xxx": "1-abc", "3-xxx": "2-xxx",
+			},
+		},
+		{
+			// corruption on a non-winning branch is still repaired - the whole tree is renumbered
+			name: "corruption on a non-winning branch is repaired",
+			revs: map[string]string{
+				"1-abc": "", "2-abc": "1-abc", "3-abc": "2-abc",
+				"2-xxx": "1-abc", "2-aaa": "2-xxx",
+			},
+			currentRev:      "3-abc",
+			expectedCurrent: "3-abc",
+			expectedRenames: map[string]string{"2-aaa": "3-aaa"},
+			expectedRevTree: map[string]string{
+				"1-abc": "", "2-abc": "1-abc", "3-abc": "2-abc",
+				"2-xxx": "1-abc", "3-aaa": "2-xxx",
+			},
+		},
+		{
+			// A wide tree with two independent corruption points, exercising the breadth-first walk
+			// across forks rather than down a single chain:
+			//
+			//	1-aaa
+			//	├── 2-bbb                     clean
+			//	│   ├── 2-ccc  -> 3-ccc       dup at a fork: both children follow
+			//	│   │   ├── 3-ddd -> 4-ddd
+			//	│   │   └── 3-eee -> 4-eee
+			//	│   └── 3-fff                 clean, sibling of the corruption, must not move
+			//	│       └── 3-ggg -> 4-ggg    second, independent violation
+			//	└── 2-hhh                     clean
+			//	    ├── 3-iii                 clean
+			//	    └── 2-jjj -> 3-jjj
+			//	        └── 4-kkk             child of a renamed rev that still clears it: stays put
+			//
+			// 4-kkk is the case worth naming: its parent moves 2-jjj -> 3-jjj, but 4 already exceeds 3,
+			// so it must be re-pointed without being renumbered. Renaming it anyway would be a silent
+			// generation inflation on every write that follows.
+			name: "highly branched tree, multiple independent violations",
+			revs: map[string]string{
+				"1-aaa": "",
+				"2-bbb": "1-aaa", "2-hhh": "1-aaa",
+				"2-ccc": "2-bbb", "3-fff": "2-bbb",
+				"3-ddd": "2-ccc", "3-eee": "2-ccc",
+				"3-ggg": "3-fff",
+				"3-iii": "2-hhh", "2-jjj": "2-hhh",
+				"4-kkk": "2-jjj",
+			},
+			currentRev:      "4-kkk",
+			expectedCurrent: "4-kkk",
+			expectedRenames: map[string]string{
+				"2-ccc": "3-ccc", "2-jjj": "3-jjj",
+				"3-ddd": "4-ddd", "3-eee": "4-eee", "3-ggg": "4-ggg",
+			},
+			expectedRevTree: map[string]string{
+				"1-aaa": "",
+				"2-bbb": "1-aaa", "2-hhh": "1-aaa",
+				"3-ccc": "2-bbb", "3-fff": "2-bbb",
+				"4-ddd": "3-ccc", "4-eee": "3-ccc",
+				"4-ggg": "3-fff",
+				"3-iii": "2-hhh", "3-jjj": "2-hhh",
+				"4-kkk": "3-jjj",
+			},
+		},
+		{
+			// The losing branch carries more violations than the winning one, so renumbering lifts its
+			// leaf past the winner. The current revision has to be raised again to stay the winner:
+			//
+			//	1-aaa
+			//	├── 2-bbb
+			//	│   └── 2-zzz -> 5-zzz        current, one violation, raised past 4-ccc
+			//	└── 2-ppp
+			//	    └── 2-qqq -> 3-qqq        two violations on the losing branch
+			//	        └── 2-ccc -> 4-ccc
+			name: "losing branch renumbered past the winner does not take over",
+			revs: map[string]string{
+				"1-aaa": "",
+				"2-bbb": "1-aaa", "2-zzz": "2-bbb",
+				"2-ppp": "1-aaa", "2-qqq": "2-ppp", "2-ccc": "2-qqq",
+			},
+			currentRev:      "2-zzz",
+			expectedCurrent: "5-zzz",
+			expectedRenames: map[string]string{"2-zzz": "5-zzz", "2-qqq": "3-qqq", "2-ccc": "4-ccc"},
+			expectedRevTree: map[string]string{
+				"1-aaa": "",
+				"2-bbb": "1-aaa", "5-zzz": "2-bbb",
+				"2-ppp": "1-aaa", "3-qqq": "2-ppp", "4-ccc": "3-qqq",
+			},
+		},
+		{
+			// renumbering 2-def to 3-def would collide with the existing sibling
+			//
+			name:              "renumbering that would collide is refused",
+			revs:              map[string]string{"1-abc": "", "2-abc": "1-abc", "2-def": "2-abc", "3-def": "2-abc"},
+			currentRev:        "2-def",
+			expectedErrSubstr: "duplicate revision",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := buildRevTree(t, tc.revs)
+			newCurrentRev, renamed, err := tree.repairGenerations(tc.currentRev)
+
+			if tc.expectedErrSubstr != "" {
+				require.ErrorContains(t, err, tc.expectedErrSubstr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedCurrent, newCurrentRev)
+			assert.Equal(t, tc.expectedRenames, renamed)
+
+			actual := make(map[string]string, len(tree))
+			for revid, info := range tree {
+				assert.Equal(t, revid, info.ID, "RevInfo.ID must match its key")
+				actual[revid] = info.Parent
+			}
+			assert.Equal(t, tc.expectedRevTree, actual)
+
+			// the repaired tree must satisfy the invariant on every branch, and be free of the
+			// replication symptom on the winning branch
+			require.NoError(t, tree.verifyIncreasingGenerations())
+			assert.False(t, tree.hasNonIncreasingGenerations(ctx, newCurrentRev))
+
+			// renumbering must not move the document onto another branch - _sync.rev is assumed to be
+			// the tree's winner everywhere else in Sync Gateway
+			winner, _, _ := tree.winningRevision(ctx)
+			assert.Equal(t, newCurrentRev, winner, "the repair left the current revision off the winning branch")
+		})
+	}
+}
+
+// TestRepairGenerationsDoesNotPromoteALosingCurrentRev asserts the repair never raises a current
+// revision that was off the winning branch to begin with - that would move the document just as silently
+// as leaving it behind one. The caller abandons the repair instead, see
+// TestInvalidRevTreeRepairAbandonedWhenCurrentRevIsNotWinner.
+func TestRepairGenerationsDoesNotPromoteALosingCurrentRev(t *testing.T) {
+	ctx := base.TestCtx(t)
+	tree := buildRevTree(t, map[string]string{"1-rrr": "", "2-bbb": "1-rrr", "2-aaa": "2-bbb", "3-xxx": "1-rrr"})
+
+	newCurrentRev, _, err := tree.repairGenerations("2-aaa")
+	require.NoError(t, err)
+	assert.Equal(t, "3-aaa", newCurrentRev)
+	winner, _, _ := tree.winningRevision(ctx)
+	assert.Equal(t, "3-xxx", winner, "the repair promoted a current revision that was already losing")
+}
+
+// TestRepairGenerationsIgnoresTombstonedRivals asserts a tombstone renumbered past the current revision
+// does not cause it to be raised - winningRevision prefers any live leaf, so the tombstone was never a
+// rival for the win.
+func TestRepairGenerationsIgnoresTombstonedRivals(t *testing.T) {
+	ctx := base.TestCtx(t)
+	tree := RevTree{
+		"1-aaa": &RevInfo{ID: "1-aaa"},
+		"2-bbb": &RevInfo{ID: "2-bbb", Parent: "1-aaa"},
+		"2-zzz": &RevInfo{ID: "2-zzz", Parent: "2-bbb"},
+		"2-ppp": &RevInfo{ID: "2-ppp", Parent: "1-aaa"},
+		"2-qqq": &RevInfo{ID: "2-qqq", Parent: "2-ppp"},
+		"2-ccc": &RevInfo{ID: "2-ccc", Parent: "2-qqq", Deleted: true},
+	}
+
+	// the tombstone renumbers to 4-ccc, which outranks 3-zzz on generation but not on being alive
+	newCurrentRev, _, err := tree.repairGenerations("2-zzz")
+	require.NoError(t, err)
+	assert.Equal(t, "3-zzz", newCurrentRev, "the current revision was raised past a tombstone that could never win")
+	winner, _, _ := tree.winningRevision(ctx)
+	assert.Equal(t, newCurrentRev, winner)
+}
+
+// TestRepairGenerationsPreservesRevInfo asserts the repair only rewrites IDs and parent pointers - a
+// renamed revision keeps its body, tombstone flag, channels and attachment marker.
+func TestRepairGenerationsPreservesRevInfo(t *testing.T) {
+	tree := RevTree{
+		"1-abc": &RevInfo{ID: "1-abc"},
+		"2-abc": &RevInfo{ID: "2-abc", Parent: "1-abc"},
+		"2-def": &RevInfo{ID: "2-def", Parent: "2-abc", Body: []byte(`{"foo":"bar"}`), HasAttachments: true},
+		"2-ghi": &RevInfo{ID: "2-ghi", Parent: "2-def", Deleted: true, Channels: base.SetOf("ABC"), BodyKey: "_sync:rb:key"},
+	}
+
+	newCurrentRev, renamed, err := tree.repairGenerations("2-ghi")
+	require.NoError(t, err)
+	require.Equal(t, "4-ghi", newCurrentRev)
+	require.Equal(t, map[string]string{"2-def": "3-def", "2-ghi": "4-ghi"}, renamed)
+
+	moved := tree["3-def"]
+	require.NotNil(t, moved)
+	assert.Equal(t, []byte(`{"foo":"bar"}`), moved.Body)
+	assert.True(t, moved.HasAttachments)
+
+	leaf := tree["4-ghi"]
+	require.NotNil(t, leaf)
+	assert.True(t, leaf.Deleted)
+	assert.Equal(t, base.SetOf("ABC"), leaf.Channels)
+	assert.Equal(t, "_sync:rb:key", leaf.BodyKey)
+}
+
+// TestRepairGenerationsSurvivesMarshalling guards the dangling-parent hazard: MarshalJSON writes a
+// parent index of -1 for a parent that isn't in the tree (SG issue #2847), so a missed re-point would
+// silently detach a branch rather than fail.
+func TestRepairGenerationsSurvivesMarshalling(t *testing.T) {
+	ctx := base.TestCtx(t)
+	tree := buildRevTree(t, map[string]string{
+		"1-abc": "", "2-abc": "1-abc", "2-def": "2-abc", "2-ghi": "2-def",
+		"3-xxx": "2-def",
+	})
+
+	newCurrentRev, _, err := tree.repairGenerations("2-ghi")
+	require.NoError(t, err)
+
+	marshalled, err := tree.MarshalJSON()
+	require.NoError(t, err)
+	roundTripped := RevTree{}
+	require.NoError(t, roundTripped.UnmarshalJSON(marshalled))
+
+	require.NoError(t, roundTripped.verifyIncreasingGenerations())
+	assert.False(t, roundTripped.hasNonIncreasingGenerations(ctx, newCurrentRev))
+	assert.Len(t, roundTripped, len(tree))
+	// 1-abc is the only root; any dropped re-point would show up as a second one
+	for revid, info := range roundTripped {
+		if revid != "1-abc" {
+			assert.NotEmpty(t, info.Parent, "revision %q became a root", revid)
+		}
+	}
+}
+
+// TestRepairGenerationsRefusesCycle asserts the repair bails on a tree containing a cycle rather than
+// renumbering a tree it cannot fully walk.
+func TestRepairGenerationsRefusesCycle(t *testing.T) {
+	tree := RevTree{
+		"1-abc": &RevInfo{ID: "1-abc"},
+		"2-abc": &RevInfo{ID: "2-abc", Parent: "1-abc"},
+		// 3-abc and 4-abc point at each other, so neither is reachable from the root
+		"3-abc": &RevInfo{ID: "3-abc", Parent: "4-abc"},
+		"4-abc": &RevInfo{ID: "4-abc", Parent: "3-abc"},
+	}
+	_, _, err := tree.repairGenerations("2-abc")
+	require.ErrorContains(t, err, "unreachable from any root")
+}
+
+// TestRepairGenerationsDanglingParent asserts a revision whose parent is absent is treated as a root,
+// matching how MarshalJSON serializes it, rather than being reported as a cycle.
+func TestRepairGenerationsDanglingParent(t *testing.T) {
+	tree := RevTree{
+		"5-abc": &RevInfo{ID: "5-abc", Parent: "4-missing"},
+		"5-def": &RevInfo{ID: "5-def", Parent: "5-abc"},
+	}
+	newCurrentRev, renamed, err := tree.repairGenerations("5-def")
+	require.NoError(t, err)
+	assert.Equal(t, "6-def", newCurrentRev)
+	assert.Equal(t, map[string]string{"5-def": "6-def"}, renamed)
+	assert.Equal(t, "4-missing", tree["5-abc"].Parent, "dangling parent should be left as-is")
+}
+
+// BenchmarkRevTreeGenerations sizes the generation checks against winningRevision, which
+// documentUpdateFunc already runs unconditionally on every write.
+// hasNonIncreasingGenerations is intended to run in the same place, so that ratio is the number that
+// matters - see the rationale on hasNonIncreasingGenerations for why the O(1) rule-out was dropped in
+// favour of always walking the branch.
+func BenchmarkRevTreeGenerations(b *testing.B) {
+	ctx := base.TestCtx(b)
+	const dupes = 4
+
+	for _, n := range []int{50, 100} {
+		clean, cleanLeaf := linearRevTree(n)
+		corrupt, corruptLeaf := corruptRevTree(n, dupes)
+
+		b.Run(fmt.Sprintf("detect/clean/n=%d", n), func(b *testing.B) {
+			for b.Loop() {
+				_ = clean.hasNonIncreasingGenerations(ctx, cleanLeaf)
+			}
+		})
+
+		b.Run(fmt.Sprintf("detect/corrupt/n=%d", n), func(b *testing.B) {
+			for b.Loop() {
+				_ = corrupt.hasNonIncreasingGenerations(ctx, corruptLeaf)
+			}
+		})
+
+		// what every write already pays, for comparison
+		b.Run(fmt.Sprintf("baseline/winningRevision/n=%d", n), func(b *testing.B) {
+			for b.Loop() {
+				_, _, _ = clean.winningRevision(ctx)
+			}
+		})
+
+		// only ever runs on a document that is already corrupt
+		b.Run(fmt.Sprintf("repair/n=%d", n), func(b *testing.B) {
+			for b.Loop() {
+				b.StopTimer()
+				tree, leaf := corruptRevTree(n, dupes)
+				b.StartTimer()
+
+				if _, _, err := tree.repairGenerations(leaf); err != nil {
+					b.Fatalf("repairGenerations: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// TestNonIncreasingGenerationsHistoryEncoding ties hasNonIncreasingGenerations to the wire behaviour it
+// reasons about, by running the pipeline sendRevision actually uses to build a rev message:
+// getHistory -> encodeRevisions -> toHistory. It pins down which trees produce the loud failure (an
+// error, which sendRevision turns into a noRev) and which encode "successfully" but hand the client
+// ancestors under rev IDs that don't exist in the tree.
+func TestNonIncreasingGenerationsHistoryEncoding(t *testing.T) {
+	ctx := base.TestCtx(t)
+	testCases := []struct {
+		name string
+		revs map[string]string // revID -> parentID
+		// currentRev is the rev being sent
+		currentRev string
+		// detected is what hasNonIncreasingGenerations reports
+		detected bool
+		// noRev is true when toHistory errors, which sendRevision turns into a noRev
+		noRev bool
+		// ancestorsOnWire is the ancestor list the client receives, which is not necessarily the
+		// ancestor list in the tree - nil when noRev is true
+		ancestorsOnWire []string
+		// ancestorsInTree is the truth, for comparison
+		ancestorsInTree []string
+		// collidesWithRealRevision is true when a mis-stated ancestor reuses a rev ID that genuinely
+		// exists elsewhere in the tree. That is the worst of the quiet cases: the client is handed a
+		// revision it may well hold, positioned wrongly in the ancestry, so nothing looks amiss.
+		collidesWithRealRevision bool
+	}{
+		{
+			name:            "clean tree replicates accurately",
+			revs:            map[string]string{"1-abc": "", "2-abc": "1-abc", "3-abc": "2-abc"},
+			currentRev:      "3-abc",
+			detected:        false,
+			ancestorsOnWire: []string{"2-abc", "1-abc"},
+			ancestorsInTree: []string{"2-abc", "1-abc"},
+		},
+		{
+			// the loud case: 3 revisions but the leaf is only at generation 2, so splitRevisionList
+			// rejects the encoding and the document is skipped for replication entirely
+			name:            "duplicate generation short-circuits to a noRev",
+			revs:            map[string]string{"1-abc": "", "2-abc": "1-abc", "2-def": "2-abc"},
+			currentRev:      "2-def",
+			detected:        true,
+			noRev:           true,
+			ancestorsInTree: []string{"2-abc", "1-abc"},
+		},
+		{
+			// the quiet case: the gap lifts the leaf generation clear of the branch length, so this
+			// encodes - and every ancestor arrives renamed
+			name:            "violation masked by a gap replicates with wrong ancestor IDs",
+			revs:            map[string]string{"1-abc": "", "11-abc": "1-abc", "10-abc": "11-abc"},
+			currentRev:      "10-abc",
+			detected:        true,
+			ancestorsOnWire: []string{"9-abc", "8-abc"},
+			ancestorsInTree: []string{"11-abc", "1-abc"},
+		},
+		{
+			// same shape as a corrupt document that has since been pruned. Note 8-abc is a real
+			// revision here, sent as the parent of 9-def when it is actually its grandparent.
+			name:                     "duplicate generation in a pruned tree replicates with wrong ancestor IDs",
+			revs:                     map[string]string{"8-abc": "", "9-abc": "8-abc", "9-def": "9-abc"},
+			currentRev:               "9-def",
+			detected:                 true,
+			ancestorsOnWire:          []string{"8-abc", "7-abc"},
+			ancestorsInTree:          []string{"9-abc", "8-abc"},
+			collidesWithRealRevision: true,
+		},
+		{
+			// control: no violation at all, but gaps still mis-state the ancestors
+			name:            "clean tree with gaps also replicates with wrong ancestor IDs",
+			revs:            map[string]string{"1-abc": "", "5-abc": "1-abc", "12-abc": "5-abc"},
+			currentRev:      "12-abc",
+			detected:        false,
+			ancestorsOnWire: []string{"11-abc", "10-abc"},
+			ancestorsInTree: []string{"5-abc", "1-abc"},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := buildRevTree(t, tc.revs)
+
+			require.Equal(t, tc.detected, tree.hasNonIncreasingGenerations(ctx, tc.currentRev),
+				"hasNonIncreasingGenerations disagrees with the documented behaviour for this tree")
+
+			// the pipeline sendRevision uses to build the rev message history
+			revHistory, err := tree.getHistory(tc.currentRev)
+			require.NoError(t, err)
+			require.Equal(t, append([]string{tc.currentRev}, tc.ancestorsInTree...), revHistory)
+
+			ancestors, err := toHistory(encodeRevisions(ctx, "doc", revHistory), map[string]bool{}, 0)
+			if tc.noRev {
+				// blip_sync_context.sendRevision turns this into sendNoRev
+				require.ErrorContains(t, err, "invalid revision history")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.ancestorsOnWire, ancestors)
+
+			// every case that isn't a noRev still replicates - the question is only whether what it
+			// sends is true, and whether the client has any way to tell
+			require.Len(t, ancestors, len(tc.ancestorsInTree))
+			collides := false
+			for i, rev := range ancestors {
+				if rev != tc.ancestorsInTree[i] && tree.contains(rev) {
+					collides = true
+				}
+			}
+			assert.Equal(t, tc.collidesWithRealRevision, collides)
+		})
+	}
+}
+
+// TestInvalidRevTreeRepairedOnLoad covers the read-path repair: a document whose rev tree contains a
+// revision that does not exceed its parent's generation is reported and repaired when it is loaded from
+// the bucket, under a new sequence so the repaired revision reaches clients on the changes feed.
+//
+// The requested revision then no longer exists, which is what turns into a norev for a pre-4.0 client -
+// see TestInvalidRevTreePullRepairsAndRedelivers for that end of it.
+func TestInvalidRevTreeRepairedOnLoad(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD)
+	dbCtx, ctx := setupTestDB(t)
+	defer dbCtx.Close(ctx)
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, dbCtx)
+
+	invalidRevTreeCount := dbCtx.DbStats.Database().InvalidRevTreeCount
+
+	// a clean tree is neither reported nor touched
+	PlantRevTreeForTest(t, ctx, collection, "cleanDoc", Body{"planted": true},
+		map[string]string{"1-abc": "", "2-abc": "1-abc", "3-abc": "2-abc"}, "3-abc")
+	dbCtx.FlushRevisionCacheForTest()
+	_, err := collection.GetRev(ctx, "cleanDoc", "3-abc", true, nil)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), invalidRevTreeCount.Value())
+	clean, err := collection.GetDocument(ctx, "cleanDoc", DocUnmarshalAll)
+	require.NoError(t, err)
+	require.Equal(t, "3-abc", clean.GetRevTreeID())
+	require.Len(t, clean.RecentSequences, 3, "a clean document should not have been written")
+
+	// 3 revisions with a leaf at generation 2 - the loud case, see TestNonIncreasingGenerationsHistoryEncoding
+	PlantRevTreeForTest(t, ctx, collection, "corruptDoc", Body{"planted": true},
+		map[string]string{"1-abc": "", "2-abc": "1-abc", "2-def": "2-abc"}, "2-def")
+	dbCtx.FlushRevisionCacheForTest()
+
+	// the requested revision is renumbered out from under the caller, so the load fails - and that is
+	// deliberate, it is what produces the norev rather than a revision with mis-stated ancestors
+	base.AssertLogContains(t, "Repaired invalid rev tree for doc <ud>corruptDoc</ud>", func() {
+		_, err = collection.GetRev(ctx, "corruptDoc", "2-def", true, nil)
+		require.Error(t, err, "the pre-repair revision should no longer be available")
+		require.True(t, base.IsDocNotFoundError(err), "expected a 404-shaped error, got %v", err)
+	})
+	require.Equal(t, int64(1), invalidRevTreeCount.Value(), "corrupt rev tree was not reported")
+
+	repaired, err := collection.GetDocument(ctx, "corruptDoc", DocUnmarshalAll)
+	require.NoError(t, err)
+	assert.Equal(t, "3-def", repaired.GetRevTreeID(), "2-def should have been renumbered to 3-def")
+	assert.NotContains(t, slices.Collect(maps.Keys(repaired.History)), "2-def")
+	require.NoError(t, repaired.History.verifyIncreasingGenerations())
+
+	// the repair allocated a sequence, so the repaired revision is delivered on the changes feed
+	require.Len(t, repaired.RecentSequences, 4)
+	assert.Equal(t, repaired.RecentSequences[3], repaired.Sequence)
+	assert.IsIncreasing(t, repaired.RecentSequences)
+
+	// _mou is stamped so the import feed does not re-import the repair - it is the _mou.cas == doc.cas
+	// match that marks the write as ours.
+	xattrs, cas, err := collection.dataStore.GetXattrs(ctx, "corruptDoc", []string{base.MouXattrName})
+	require.NoError(t, err)
+	rawXattr, ok := xattrs[base.MouXattrName]
+	require.True(t, ok)
+	var mou MetadataOnlyUpdate
+	require.NoError(t, base.JSONUnmarshal(rawXattr, &mou))
+	assert.Equal(t, cas, mou.CAS(), "_mou.cas should match the document CAS, otherwise the import feed re-imports the repair")
+
+	// _mou.pRev is the document's revSeqNo before the repair's own mutation. The repair is the last write
+	// to the document, so that is one less than its current revSeqNo - and never zero, which is what it
+	// would be if the repair stamped _mou without reading the revSeqNo virtual xattr.
+	revSeqNo, _, err := collection.getRevSeqNo(ctx, "corruptDoc")
+	require.NoError(t, err)
+	require.NotZero(t, revSeqNo)
+	assert.Equal(t, revSeqNo-1, mou.PreviousRevSeqNo,
+		"_mou.pRev should be the revSeqNo immediately before the repair (current revSeqNo %d)", revSeqNo)
+
+	// the repaired current revision loads normally, and nothing is reported a second time
+	_, err = collection.GetRev(ctx, "corruptDoc", "3-def", true, nil)
+	require.NoError(t, err)
+	dbCtx.FlushRevisionCacheForTest()
+	_, err = collection.GetRev(ctx, "corruptDoc", "3-def", true, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), invalidRevTreeCount.Value(), "a repaired document should not be reported again")
+}
+
+// TestInvalidRevTreeGetReturnsRepairedDoc covers the read path's contract in detail: the load that
+// triggers the repair returns the *repaired* document, not the corrupt one it read from the bucket, and
+// the document it returns is internally consistent with what was committed.
+//
+// The renamed-revision case is the reason the read path can return a document rather than an error - a
+// caller that asked for a revision the repair renumbered gets a 404 out of the existing code, which is
+// what sendRevision turns into a replacement rev or a norev.
+func TestInvalidRevTreeGetReturnsRepairedDoc(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD)
+	dbCtx, ctx := setupTestDB(t)
+	defer dbCtx.Close(ctx)
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, dbCtx)
+
+	// 2-def sits at the same generation as its parent, so the repair renumbers it to 3-def
+	const docID = "getPathwayDoc"
+	PlantRevTreeForTest(t, ctx, collection, docID, Body{"planted": true},
+		map[string]string{"1-abc": "", "2-abc": "1-abc", "2-def": "2-abc"}, "2-def")
+	dbCtx.FlushRevisionCacheForTest()
+
+	// Capture the version before the repair, via a read that does not repair. The repair is a
+	// metadata-only update and must leave the document's version alone, so these are what the assertions
+	// below compare against.
+	_, preRepairHLV, err := collection.GetDocSyncDataNoImport(ctx, docID, DocUnmarshalAll)
+	require.NoError(t, err)
+	require.NotNil(t, preRepairHLV)
+
+	// the load that triggers the repair must hand back the repaired document
+	repaired, err := collection.GetDocument(ctx, docID, DocUnmarshalAll)
+	require.NoError(t, err)
+	require.Equal(t, "3-def", repaired.GetRevTreeID(), "GetDocument returned the pre-repair current revision")
+
+	// assert the whole tree, not just the current revision - a renumbering that dropped or re-parented
+	// anything else would still leave the current revision looking right
+	assert.Equal(t, map[string]string{"1-abc": "", "2-abc": "1-abc", "3-def": "2-abc"}, revTreeParents(repaired.History))
+	assert.Equal(t, []string{"3-def"}, repaired.History.GetLeaves())
+	require.NoError(t, repaired.History.verifyIncreasingGenerations())
+
+	// the returned document must describe the state that was actually committed, not the macro
+	// placeholders the write was built from - revCacheLoaderForDocument stores doc.HLV by pointer, so a
+	// placeholder here is cached and served
+	assert.Equal(t, base.CasToString(repaired.Cas), repaired.SyncData.Cas)
+	require.NotNil(t, repaired.MetadataOnlyUpdate)
+	assert.Equal(t, repaired.Cas, repaired.MetadataOnlyUpdate.CAS(),
+		"_mou.cas must equal the committed CAS - it is what stops updateHLV treating the repair as an import")
+
+	// Only the rev IDs changed, so the version must be untouched: cv identical, and cvCAS deliberately
+	// left behind the new CAS rather than re-stamped to it.
+	require.NotNil(t, repaired.HLV)
+	assert.Equal(t, preRepairHLV.GetCurrentVersionString(), repaired.HLV.GetCurrentVersionString(), "the repair changed the document's version")
+	assert.Equal(t, preRepairHLV.CurrentVersionCAS, repaired.HLV.CurrentVersionCAS, "the repair re-stamped cvCAS")
+
+	// ...and re-reading it from the bucket must produce the same thing, which is what proves the
+	// in-memory fixups above match what was persisted rather than merely looking plausible
+	dbCtx.FlushRevisionCacheForTest()
+	reread, err := collection.GetDocument(ctx, docID, DocUnmarshalAll)
+	require.NoError(t, err)
+	assert.Equal(t, repaired.GetRevTreeID(), reread.GetRevTreeID())
+	assert.Equal(t, revTreeParents(repaired.History), revTreeParents(reread.History))
+	assert.Equal(t, repaired.Cas, reread.Cas, "the repair should not have been applied a second time")
+	assert.Equal(t, repaired.HLV.CurrentVersionCAS, reread.HLV.CurrentVersionCAS)
+	assert.Equal(t, repaired.SyncData.Cas, reread.SyncData.Cas)
+
+	t.Run("requested revision renamed by the repair returns 404", func(t *testing.T) {
+		dbCtx.FlushRevisionCacheForTest()
+		_, err := collection.GetRev(ctx, docID, "2-def", true, nil)
+		require.Error(t, err, "2-def no longer exists in the repaired tree")
+		assert.True(t, base.IsDocNotFoundError(err), "expected a 404-shaped error so sendRevision sends a replacement rev or a norev, got %v", err)
+	})
+
+	t.Run("repaired revision is retrievable with the repaired history", func(t *testing.T) {
+		dbCtx.FlushRevisionCacheForTest()
+		rev, err := collection.GetRev(ctx, docID, "3-def", true, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "3-def", rev.RevID)
+		// history is the encoded {start, ids} form - start must be the repaired generation, and the
+		// digests the repaired branch, so a pre-4.0 client is told a history that exists
+		require.NotNil(t, rev.History)
+		revisions, ok := rev.History[RevisionsStart].(int)
+		require.True(t, ok, "history start missing: %v", rev.History)
+		assert.Equal(t, 3, revisions)
+		assert.Equal(t, []string{"def", "abc", "abc"}, rev.History[RevisionsIds].([]string))
+	})
+
+	t.Run("current revision requested by empty revID returns the repaired revision", func(t *testing.T) {
+		dbCtx.FlushRevisionCacheForTest()
+		rev, err := collection.GetRev(ctx, docID, "", true, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "3-def", rev.RevID)
+	})
+}
+
+// TestInvalidRevTreePushWithFabricatedHistory covers a client pushing back the fabricated ancestry it
+// was given for a quietly-corrupt document. A corrupt-but-encodable tree is sent under ancestor rev IDs
+// that do not exist (see TestNonIncreasingGenerationsHistoryEncoding), and nothing on the write path
+// checks that an incoming rev tree history refers to revisions Sync Gateway actually has. Note the
+// fabricated revisions are strictly decreasing in generation, so the addRevision generation check would
+// not reject them either.
+//
+// This is reachable despite repair-on-load, which is why repair-on-write exists: the write path
+// unmarshals inside its own WriteUpdateWithXattrs callback rather than going through GetDocumentWithRaw.
+func TestInvalidRevTreePushWithFabricatedHistory(t *testing.T) {
+	// the corrupt tree: a gen 10 leaf on a 3 revision branch, so len(branch) <= gen and this encodes
+	// rather than erroring - the client is told the ancestors are 9-abc and 8-abc
+	corruptTree := map[string]string{"1-abc": "", "10-abc": "1-abc", "10-def": "10-abc"}
+	// what the client replays on push: its own new revision, then the history it was given
+	fabricatedHistory := []string{"11-ghi", "10-def", "9-abc", "8-abc"}
+	// the same tree after the repair renumbers 10-def, which is what all three subtests end at
+	repairedTree := map[string]string{"1-abc": "", "10-abc": "1-abc", "11-def": "10-abc"}
+
+	t.Run("push against a corrupt tree repairs it and is then rejected", func(t *testing.T) {
+		dbCtx, ctx := setupTestDB(t)
+		defer dbCtx.Close(ctx)
+		collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, dbCtx)
+		invalidRevTreeCount := dbCtx.DbStats.Database().InvalidRevTreeCount
+
+		PlantRevTreeForTest(t, ctx, collection, "doc1", Body{"planted": true}, corruptTree, "10-def")
+		currentRev, tree := revTreeState(t, ctx, collection, "doc1")
+		require.Equal(t, "10-def", currentRev)
+		require.Equal(t, corruptTree, tree, "the push must start against the corrupt tree, unread by anything else")
+		require.Equal(t, int64(0), invalidRevTreeCount.Value())
+
+		// the push repairs the document, which renames the very revision its history branches from, so
+		// the push itself is then rejected
+		_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", Body{"pushed": true}, fabricatedHistory, false, ExistingVersionWithUpdateToHLV)
+		assertHTTPError(t, err, 409)
+
+		// the repair is its own write, so it survives the 409 the push got. That is what stops this being
+		// a livelock: the document is fixed even though the write that triggered the fix failed.
+		assert.Equal(t, int64(1), invalidRevTreeCount.Value(), "the push should have triggered a repair")
+		currentRev, tree = revTreeState(t, ctx, collection, "doc1")
+		assert.Equal(t, "11-def", currentRev)
+		assert.Equal(t, repairedTree, tree)
+
+		// the rejected push left nothing behind - neither its own revision nor the ancestors it invented
+		for _, absent := range []string{"11-ghi", "9-abc", "8-abc"} {
+			_, present := tree[absent]
+			assert.False(t, present, "the rejected push left %q in the tree", absent)
+		}
+	})
+
+	t.Run("push after the tree has already been repaired is rejected and changes nothing", func(t *testing.T) {
+		dbCtx, ctx := setupTestDB(t)
+		defer dbCtx.Close(ctx)
+		collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, dbCtx)
+		invalidRevTreeCount := dbCtx.DbStats.Database().InvalidRevTreeCount
+
+		PlantRevTreeForTest(t, ctx, collection, "doc1", Body{"planted": true}, corruptTree, "10-def")
+
+		// repair the way production repairs on read - any load through GetDocumentWithRaw
+		repaired, err := collection.GetDocument(ctx, "doc1", DocUnmarshalAll)
+		require.NoError(t, err)
+		require.Equal(t, "11-def", repaired.GetRevTreeID())
+		require.NoError(t, repaired.History.verifyIncreasingGenerations())
+		require.Equal(t, int64(1), invalidRevTreeCount.Value())
+
+		_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", Body{"pushed": true}, fabricatedHistory, false, ExistingVersionWithUpdateToHLV)
+		assertHTTPError(t, err, 409)
+
+		// no second repair - the tree is already valid, so the write path detects nothing
+		assert.Equal(t, int64(1), invalidRevTreeCount.Value(), "an already-repaired document should not be repaired again")
+		currentRev, tree := revTreeState(t, ctx, collection, "doc1")
+		assert.Equal(t, "11-def", currentRev)
+		assert.Equal(t, repairedTree, tree)
+	})
+
+	t.Run("control - push with no known ancestor and no repair involved", func(t *testing.T) {
+		dbCtx, ctx := setupTestDB(t)
+		defer dbCtx.Close(ctx)
+		collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, dbCtx)
+		invalidRevTreeCount := dbCtx.DbStats.Database().InvalidRevTreeCount
+
+		// a clean document, pushed a history sharing no revision with it - isolates the 409 above as the
+		// ordinary no-common-ancestor case rather than anything the repair introduces
+		cleanTree := map[string]string{"1-abc": "", "2-abc": "1-abc"}
+		PlantRevTreeForTest(t, ctx, collection, "doc1", Body{"planted": true}, cleanTree, "2-abc")
+
+		_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", Body{"pushed": true}, fabricatedHistory, false, ExistingVersionWithUpdateToHLV)
+		assertHTTPError(t, err, 409)
+
+		assert.Equal(t, int64(0), invalidRevTreeCount.Value(), "a clean document should never be reported")
+		currentRev, tree := revTreeState(t, ctx, collection, "doc1")
+		assert.Equal(t, "2-abc", currentRev)
+		assert.Equal(t, cleanTree, tree)
+	})
+}
+
+// TestRepairFailureDoesNotReturnPhantomRev asserts that when a repair fails, the document handed back to
+// the caller matches what is in the bucket - it must not carry the renumbered tree, current revision or
+// sequence that the repair produced in memory and then failed to commit.
+//
+// The failure is a genuine lost CAS race, injected with a leaky bucket: a concurrent write bumps the
+// document's CAS out from under the repair's CAS-guarded write. That is what two Sync Gateway nodes
+// reading the same corrupt document produce, and it is the only repair failure the read path can reach
+// now that it repairs against doc.Cas.
+func TestRepairFailureDoesNotReturnPhantomRev(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD)
+
+	const docID = "corruptRacedRepair"
+	plantedTree := map[string]string{"1-abc": "", "2-abc": "1-abc", "2-def": "2-abc"}
+
+	tb := base.GetTestBucket(t)
+	var raceOnce sync.Once
+	lb := base.NewLeakyBucket(tb, base.LeakyBucketConfig{
+		// fires before the real UpdateXattrs, so the repair's CAS is stale by the time it lands. Written
+		// through the underlying bucket to avoid re-entering this callback.
+		UpdateXattrsCallback: func(key string) {
+			if key != docID {
+				return
+			}
+			raceOnce.Do(func() {
+				ctx := base.TestCtx(t)
+				var body []byte
+				_, err := tb.GetSingleDataStore().Get(ctx, key, &body)
+				require.NoError(t, err)
+				require.NoError(t, tb.GetSingleDataStore().Set(ctx, key, 0, nil, body))
+				t.Logf("concurrent write bumped the CAS of %q out from under the repair", key)
+			})
+		},
+		IgnoreClose: true,
+	})
+
+	defer tb.Close(base.TestCtx(t)) // IgnoreClose means dbCtx.Close leaves the underlying bucket open
+	dbCtx, ctx := setupTestDBForBucket(t, lb)
+	defer dbCtx.Close(ctx)
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, dbCtx)
+
+	PlantRevTreeForTest(t, ctx, collection, docID, Body{"planted": true}, plantedTree, "2-def")
+	dbCtx.FlushRevisionCacheForTest()
+
+	invalidRevTreeCount := dbCtx.DbStats.Database().InvalidRevTreeCount
+
+	doc, err := collection.GetDocument(ctx, docID, DocUnmarshalAll)
+	require.NoError(t, err)
+
+	// what the bucket actually holds, read without going through the repairing path
+	currentRev, tree := revTreeState(t, ctx, collection, docID)
+	syncData, err := collection.GetDocSyncData(ctx, docID)
+	require.NoError(t, err)
+
+	require.Equal(t, int64(1), invalidRevTreeCount.Value(), "precondition: the repair should have been attempted")
+
+	// nothing reached the bucket, so it still holds exactly what was planted
+	assert.Equal(t, "2-def", currentRev, "the failed repair should not have changed the committed revision")
+	assert.Equal(t, plantedTree, tree, "the failed repair should not have changed the committed rev tree")
+
+	// the returned document agrees with the bucket on every revision, not just the current one - a
+	// document renumbered in memory but never written would diverge here
+	assert.Equal(t, currentRev, doc.GetRevTreeID(),
+		"GetDocument returned a revision that is not in the bucket")
+	assert.Equal(t, tree, revTreeParents(doc.History),
+		"GetDocument returned a rev tree that was never committed")
+	assert.Equal(t, syncData.Sequence, doc.Sequence,
+		"GetDocument returned a sequence that was never committed")
+	_, currentInTree := tree[currentRev]
+	assert.True(t, currentInTree, "current revision %q is not in the rev tree", currentRev)
+
+	// the rollback restored the corruption rather than leaving a half-repaired tree behind, so a later
+	// read still detects it and can try again
+	assert.True(t, doc.History.hasNonIncreasingGenerations(ctx, doc.GetRevTreeID()),
+		"the returned document should still be detected as invalid, so a later read retries the repair")
+}
+
+// TestInvalidRevTreeRepairKeepsWinningBranch covers a conflicted document whose losing branch carries
+// more violations than the winning one. Renumbering raises every branch, so the losing leaf can be
+// lifted past the winner - and if the repair let that happen, _sync.rev would name a revision the tree
+// no longer selects, and the next write would silently move the document onto the losing branch.
+func TestInvalidRevTreeRepairKeepsWinningBranch(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD)
+	dbCtx, ctx := setupTestDB(t)
+	defer dbCtx.Close(ctx)
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, dbCtx)
+
+	// winning branch 1-aaa, 2-bbb, 2-zzz - one violation; losing branch 1-aaa, 2-ppp, 2-qqq, 2-ccc - two
+	const docID = "conflictedCorruptDoc"
+	PlantRevTreeForTest(t, ctx, collection, docID, Body{"branch": "winner"}, map[string]string{
+		"1-aaa": "",
+		"2-bbb": "1-aaa", "2-zzz": "2-bbb",
+		"2-ppp": "1-aaa", "2-qqq": "2-ppp", "2-ccc": "2-qqq",
+	}, "2-zzz")
+	// the losing leaf of a conflict keeps its body in the rev tree
+	rewriteSyncDataForTest(t, ctx, collection, docID, 0, func(syncData *SyncData) {
+		syncData.History["2-ccc"].Body = []byte(`{"branch":"loser"}`)
+		syncData.History["2-ccc"].Channels = syncData.getCurrentChannels()
+	})
+	dbCtx.FlushRevisionCacheForTest()
+
+	bodyBefore, err := collection.Get1xRevBody(ctx, docID, "", false, nil)
+	require.NoError(t, err)
+	require.Equal(t, "winner", bodyBefore["branch"], "precondition: the document is on the winning branch")
+
+	repaired, err := collection.GetDocument(ctx, docID, DocUnmarshalAll)
+	require.NoError(t, err)
+	// 2-zzz renumbers to 3-zzz, but the losing branch reaches 4-ccc, so it is raised again to stay ahead
+	assert.Equal(t, "5-zzz", repaired.GetRevTreeID())
+	winner, _, _ := repaired.History.winningRevision(ctx)
+	assert.Equal(t, repaired.GetRevTreeID(), winner, "the repair left the current revision off the winning branch")
+	assert.Equal(t, map[string]string{
+		"1-aaa": "",
+		"2-bbb": "1-aaa", "5-zzz": "2-bbb",
+		"2-ppp": "1-aaa", "3-qqq": "2-ppp", "4-ccc": "3-qqq",
+	}, revTreeParents(repaired.History))
+	require.NoError(t, repaired.History.verifyIncreasingGenerations())
+
+	// the winner is what was committed, not just what was returned
+	dbCtx.FlushRevisionCacheForTest()
+	currentRev, tree := revTreeState(t, ctx, collection, docID)
+	assert.Equal(t, "5-zzz", currentRev)
+	assert.Equal(t, revTreeParents(repaired.History), tree)
+
+	// the next write extends the winning branch, and the document stays on it
+	newRev, _, err := collection.Put(ctx, docID, Body{BodyRev: currentRev, "branch": "winner", "n": 2})
+	require.NoError(t, err)
+	assert.Equal(t, 6, genOfRevID(ctx, newRev))
+
+	dbCtx.FlushRevisionCacheForTest()
+	bodyAfter, err := collection.Get1xRevBody(ctx, docID, "", false, nil)
+	require.NoError(t, err)
+	assert.Equal(t, newRev, bodyAfter[BodyRev].(string))
+	assert.Equal(t, "winner", bodyAfter["branch"], "the document was moved onto the losing branch")
+}
+
+// TestInvalidRevTreeRepairAbandonedWhenCurrentRevIsNotWinner covers the guard behind the branch-raising:
+// a document whose current revision is already off the winning branch is left corrupt rather than being
+// renumbered onto a branch of the repair's choosing.
+func TestInvalidRevTreeRepairAbandonedWhenCurrentRevIsNotWinner(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD)
+	dbCtx, ctx := setupTestDB(t)
+	defer dbCtx.Close(ctx)
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, dbCtx)
+
+	// 3-xxx outranks the current revision before anything is renumbered, and still does after
+	const docID = "currentRevIsNotWinnerDoc"
+	plantedTree := map[string]string{"1-rrr": "", "2-bbb": "1-rrr", "2-aaa": "2-bbb", "3-xxx": "1-rrr"}
+	PlantRevTreeForTest(t, ctx, collection, docID, Body{"planted": true}, plantedTree, "2-aaa")
+	dbCtx.FlushRevisionCacheForTest()
+
+	invalidRevTreeCount := dbCtx.DbStats.Database().InvalidRevTreeCount
+	syncDataBefore, err := collection.GetDocSyncData(ctx, docID)
+	require.NoError(t, err)
+
+	base.AssertLogContains(t, "the repair failed", func() {
+		doc, err := collection.GetDocument(ctx, docID, DocUnmarshalAll)
+		require.NoError(t, err)
+		assert.Equal(t, "2-aaa", doc.GetRevTreeID(), "the abandoned repair should not have moved the current revision")
+		assert.Equal(t, plantedTree, revTreeParents(doc.History))
+		assert.Equal(t, syncDataBefore.Sequence, doc.Sequence, "the abandoned repair should not have consumed a sequence")
+	})
+	require.Equal(t, int64(1), invalidRevTreeCount.Value(), "corrupt rev tree was not reported")
+
+	// nothing reached the bucket either
+	currentRev, tree := revTreeState(t, ctx, collection, docID)
+	assert.Equal(t, "2-aaa", currentRev)
+	assert.Equal(t, plantedTree, tree)
+}
+
+// TestInvalidRevTreeRepairOfTombstonedDoc pins that a tombstone is repaired in place and stays one - the
+// repair is a metadata-only xattr write, so it has to reach a document with no body.
+func TestInvalidRevTreeRepairOfTombstonedDoc(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD)
+	dbCtx, ctx := setupTestDB(t)
+	defer dbCtx.Close(ctx)
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, dbCtx)
+
+	const docID = "tombstonedCorruptDoc"
+	rev, _, err := collection.Put(ctx, docID, Body{"planted": true})
+	require.NoError(t, err)
+	_, _, err = collection.DeleteDoc(ctx, docID, DocVersion{RevTreeID: rev})
+	require.NoError(t, err)
+
+	// plant the corrupt tree through the datastore, so the document stays a tombstone
+	xattrs, cas, err := collection.dataStore.GetXattrs(ctx, docID, []string{base.SyncXattrName})
+	require.NoError(t, err)
+	var syncData SyncData
+	require.NoError(t, base.JSONUnmarshal(xattrs[base.SyncXattrName], &syncData))
+	syncData.History = RevTree{
+		"1-abc": &RevInfo{ID: "1-abc"},
+		"2-abc": &RevInfo{ID: "2-abc", Parent: "1-abc"},
+		"2-def": &RevInfo{ID: "2-def", Parent: "2-abc", Deleted: true, Channels: syncData.getCurrentChannels()},
+	}
+	syncData.SetRevTreeID("2-def")
+	raw, err := base.JSONMarshal(syncData)
+	require.NoError(t, err)
+	_, err = collection.dataStore.UpdateXattrs(ctx, docID, 0, cas, map[string][]byte{base.SyncXattrName: raw},
+		&sgbucket.MutateInOptions{MacroExpansion: []sgbucket.MacroExpansionSpec{
+			sgbucket.NewMacroExpansionSpec(xattrCasPath(base.SyncXattrName), sgbucket.MacroCas)}})
+	require.NoError(t, err)
+	dbCtx.FlushRevisionCacheForTest()
+
+	repaired, err := collection.GetDocument(ctx, docID, DocUnmarshalAll)
+	require.NoError(t, err)
+	require.Equal(t, "3-def", repaired.GetRevTreeID())
+	assert.True(t, repaired.IsDeleted(), "the repaired document is no longer a tombstone")
+	repairedLeaf, err := repaired.History.getInfo("3-def")
+	require.NoError(t, err)
+	assert.True(t, repairedLeaf.Deleted, "the renumbered revision lost its tombstone flag")
+
+	// the repair reached the tombstone in the bucket, and left it a tombstone
+	dbCtx.FlushRevisionCacheForTest()
+	currentRev, tree := revTreeState(t, ctx, collection, docID)
+	assert.Equal(t, "3-def", currentRev)
+	assert.Equal(t, map[string]string{"1-abc": "", "2-abc": "1-abc", "3-def": "2-abc"}, tree)
+	var body []byte
+	_, err = collection.dataStore.Get(ctx, docID, &body)
+	assert.True(t, base.IsDocNotFoundError(err), "the repair resurrected the document body, got %v", err)
 }

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"slices"
 	"strconv"
@@ -703,6 +704,80 @@ func RawDocWithInlineSyncData(_ testing.TB) string {
 `
 }
 
+// PlantRevTreeForTest writes docID, then rewrites its _sync xattr so the document's revision tree is
+// exactly the supplied one, with currentRev as the current revision. revs maps each revision ID to its
+// parent's ID, with "" for a root, so any shape can be planted - a single non-increasing generation, a
+// branched tree, or corruption confined to a losing branch.
+//
+// The rest of the metadata is made to look like a document that really was written len(revs) times: one
+// sequence is allocated per revision, doc.Sequence is the last of them, and recent_sequences holds them
+// all. Only the tree itself is fabricated.
+func PlantRevTreeForTest(t *testing.T, ctx context.Context, collection *DatabaseCollectionWithUser, docID string, body Body, revs map[string]string, currentRev string) {
+	t.Helper()
+	require.Contains(t, slices.Collect(maps.Keys(revs)), currentRev, "currentRev is not in the tree being planted")
+	require.LessOrEqual(t, len(revs), kMaxRecentSequences, "a tree this large would have had its recent_sequences pruned, which this helper does not model")
+
+	// the write allocates the first sequence, so this stands in for the first revision
+	_, _, err := collection.Put(ctx, docID, body)
+	require.NoError(t, err)
+
+	// one sequence per remaining revision, so the document's sequence history is as long as its tree
+	rewriteSyncDataForTest(t, ctx, collection, docID, len(revs)-1, func(syncData *SyncData) {
+		planted := make(RevTree, len(revs))
+		for revID, parentID := range revs {
+			planted[revID] = &RevInfo{ID: revID, Parent: parentID}
+		}
+		// the current revision keeps the document's channels, so the planted document stays readable
+		planted[currentRev].Channels = syncData.getCurrentChannels()
+		syncData.History = planted
+		syncData.SetRevTreeID(currentRev)
+	})
+}
+
+// rewriteSyncDataForTest rewrites a document's _sync xattr, allocating sequenceCount new sequences first
+// and appending them to recent_sequences with the last becoming the document's sequence - so the write
+// leaves the sequence metadata looking like sequenceCount real revisions. mutate is applied to the
+// document's SyncData in between. The document body is left untouched.
+func rewriteSyncDataForTest(t *testing.T, ctx context.Context, collection *DatabaseCollectionWithUser, docID string, sequenceCount int, mutate func(syncData *SyncData)) {
+	t.Helper()
+
+	sequences := make([]uint64, 0, sequenceCount)
+	for range sequenceCount {
+		sequence, seqErr := collection.dbCtx.sequences.nextSequence(ctx)
+		require.NoError(t, seqErr)
+		sequences = append(sequences, sequence)
+	}
+
+	_, err := collection.dataStore.WriteUpdateWithXattrs(ctx, docID, []string{base.SyncXattrName}, 0, nil, nil,
+		func(rawBody []byte, xattrs map[string][]byte, _ uint64) (sgbucket.UpdatedDoc, error) {
+			var syncData SyncData
+			if unmarshalErr := base.JSONUnmarshal(xattrs[base.SyncXattrName], &syncData); unmarshalErr != nil {
+				return sgbucket.UpdatedDoc{}, unmarshalErr
+			}
+
+			mutate(&syncData)
+
+			// append the new sequences and make the highest current, exactly as updateAndReturnDoc would
+			// have left it. Sorted for the same reason assignSequence sorts (db/crud.go) - production
+			// never leaves recent_sequences out of order, so a fixture must not either.
+			syncData.RecentSequences = append(syncData.RecentSequences, sequences...)
+			if len(syncData.RecentSequences) > 1 {
+				base.SortedUint64Slice(syncData.RecentSequences).Sort()
+			}
+			syncData.Sequence = syncData.RecentSequences[len(syncData.RecentSequences)-1]
+
+			updatedXattr, marshalErr := base.JSONMarshal(syncData)
+			if marshalErr != nil {
+				return sgbucket.UpdatedDoc{}, marshalErr
+			}
+			return sgbucket.UpdatedDoc{
+				Doc:    rawBody,
+				Xattrs: map[string][]byte{base.SyncXattrName: updatedXattr},
+			}, nil
+		})
+	require.NoError(t, err)
+}
+
 // WriteDirect will write a document named doc-{sequence} with a given set of channels. This is used to simulate out of order sequence writes by bypassing typical Sync Gateway CRUD functions.
 func WriteDirect(t *testing.T, collection *DatabaseCollection, channelArray []string, sequence uint64) {
 	key := fmt.Sprintf("doc-%v", sequence)
@@ -1170,4 +1245,26 @@ func MigrateSeqCounterForTest(t testing.TB, ctx context.Context, ms *base.Metada
 // usingShardedResync returns true if cbgt based resync will be used for test
 func usingShardedResync(testing.TB) bool {
 	return base.IsEnterpriseEdition() && !sgtest.UnitTestUrlIsWalrus()
+}
+
+// revTreeState reads a document's current revision and rev tree as revID -> parent.
+//
+// It reads through GetDocSyncData rather than GetDocument deliberately: GetDocument goes through
+// GetDocumentWithRaw, which repairs an invalid rev tree on load, so observing a corrupt document that
+// way would repair the very thing being observed. GetDocSyncData unmarshals the xattr directly.
+func revTreeState(t *testing.T, ctx context.Context, collection *DatabaseCollectionWithUser, docID string) (currentRev string, tree map[string]string) {
+	t.Helper()
+	syncData, err := collection.GetDocSyncData(ctx, docID)
+	require.NoError(t, err)
+	return syncData.GetRevTreeID(), revTreeParents(syncData.History)
+}
+
+// revTreeParents renders a rev tree as revID -> parent, for asserting a tree's whole shape in one
+// comparison rather than probing individual revisions.
+func revTreeParents(tree RevTree) map[string]string {
+	parents := make(map[string]string, len(tree))
+	for revID, info := range tree {
+		parents[revID] = info.Parent
+	}
+	return parents
 }

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -4471,3 +4471,55 @@ func TestGetDocChannelHistory(t *testing.T) {
 		assert.Equal(t, expected, apiResult)
 	})
 }
+
+// TestInvalidRevTreeRestGetRepairsAndRenames covers same read-path contract through
+// REST GET handler - the user-visible half.
+// A plain GET repairs the document and returns the renumbered current revision; a GET naming the
+// revision the repair renumbered away gets a 404, because that revision genuinely no longer exists.
+func TestInvalidRevTreeRestGetRepairsAndRenames(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD, base.KeyHTTP)
+
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+
+	docID := SafeDocumentName(t, t.Name())
+	collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
+
+	// 2-def sits at the same generation as its parent, so the repair renumbers it to 3-def
+	db.PlantRevTreeForTest(t, ctx, collection, docID, db.Body{"planted": true},
+		map[string]string{"1-abc": "", "2-abc": "1-abc", "2-def": "2-abc"}, "2-def")
+	rt.GetDatabase().FlushRevisionCacheForTest()
+
+	invalidRevTreeCount := rt.GetDatabase().DbStats.Database().InvalidRevTreeCount
+	require.Equal(t, int64(0), invalidRevTreeCount.Value())
+
+	// a GET naming the pre-repair revision repairs the document, and then cannot find the revision it
+	// was asked for - the repair renumbered it out of existence
+	resp := rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/"+docID+"?rev=2-def", "")
+	RequireStatus(t, resp, http.StatusNotFound)
+	require.Equal(t, int64(1), invalidRevTreeCount.Value(), "the GET should have repaired the document")
+
+	// a plain GET returns the repaired current revision
+	resp = rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/"+docID, "")
+	RequireStatus(t, resp, http.StatusOK)
+	var body db.Body
+	require.NoError(t, base.JSONUnmarshal(resp.BodyBytes(), &body))
+	assert.Equal(t, "3-def", body[db.BodyRev])
+
+	// ...as does a GET naming it explicitly, with a revision history that exists in the tree
+	resp = rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/"+docID+"?rev=3-def&revs=true", "")
+	RequireStatus(t, resp, http.StatusOK)
+	body = db.Body{}
+	require.NoError(t, base.JSONUnmarshal(resp.BodyBytes(), &body))
+	assert.Equal(t, "3-def", body[db.BodyRev])
+	revisions, ok := body[db.BodyRevisions].(map[string]any)
+	require.True(t, ok, "expected _revisions in %v", body)
+	assert.Equal(t, float64(3), revisions[db.RevisionsStart].(float64))
+	assert.Equal(t, []any{"def", "abc", "abc"}, revisions[db.RevisionsIds].([]any))
+
+	// the repair is not applied a second time
+	rt.GetDatabase().FlushRevisionCacheForTest()
+	resp = rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/"+docID, "")
+	RequireStatus(t, resp, http.StatusOK)
+	assert.Equal(t, int64(1), invalidRevTreeCount.Value(), "a repaired document should not be reported again")
+}

--- a/rest/blip_legacy_revid_test.go
+++ b/rest/blip_legacy_revid_test.go
@@ -1434,3 +1434,204 @@ func TestLegacyHistoryPushCreatesDuplicateGenerationRevs(t *testing.T) {
 		}
 	})
 }
+
+func TestInvalidRevTreePullRepairsAndRedelivers(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD, base.KeySync, base.KeySyncMsg)
+
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.Run(func(t *testing.T) {
+		rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
+		defer rt.Close()
+
+		docID := SafeDocumentName(t, t.Name())
+		collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
+
+		// 3 revisions with a leaf at generation 2: encodeRevisions produces a _revisions list that
+		// splitRevisionList rejects, which is what makes this unreplicatable over BLIP v3
+		db.PlantRevTreeForTest(t, ctx, collection, docID, db.Body{"planted": true},
+			map[string]string{"1-abc": "", "2-abc": "1-abc", "2-def": "2-abc"}, "2-def")
+		rt.GetDatabase().FlushRevisionCacheForTest()
+		rt.WaitForPendingChanges()
+
+		invalidRevTreeCount := rt.GetDatabase().DbStats.Database().InvalidRevTreeCount
+		noRevSendCount := rt.GetDatabase().DbStats.CBLReplicationPull().NoRevSendCount
+		require.Equal(t, int64(0), invalidRevTreeCount.Value())
+
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
+		defer client.Close()
+		btcRunner.StartPull(client.id)
+		defer btcRunner.UnsubPullChanges(client.id)
+
+		// either way the document is repaired on load, exactly once, and 2-def is renumbered to 3-def
+		base.RequireWaitForStat(t, invalidRevTreeCount.Value, 1)
+		repaired, err := collection.GetDocument(ctx, docID, db.DocUnmarshalAll)
+		require.NoError(t, err)
+		require.Equal(t, "3-def", repaired.GetRevTreeID())
+
+		// the repair leaves cv untouched, so a 4.0+ client identifies the document by the same version
+		// it always did - only a pre-4.0 client sees the rev ID change
+		repairedVersion := DocVersion{RevTreeID: "3-def"}
+		if client.UseHLV() {
+			repairedVersion = DocVersion{CV: *repaired.HLV.ExtractCurrentVersionFromHLV()}
+		}
+		btcRunner.WaitForVersion(client.id, docID, repairedVersion)
+
+		if client.UseHLV() {
+			// no rev tree history goes on the wire and cv did not change, so there is nothing to skip
+			assert.Equal(t, int64(0), noRevSendCount.Value())
+		} else {
+			// the changes message named 2-def, which the repair renumbered out of existence, so that
+			// revision is skipped - and the repair's new sequence delivers 3-def straight after
+			base.RequireWaitForStat(t, noRevSendCount.Value, 1)
+
+			// the repaired revision carries the tree's real ancestors, not the fabricated ones a
+			// pre-repair send would have produced
+			msg, ok := btcRunner.GetPullRevMessage(client.id, docID, repairedVersion)
+			require.True(t, ok)
+			assert.Equal(t, "2-abc,1-abc", msg.Properties[db.RevMessageHistory])
+		}
+	})
+}
+
+// TestInvalidRevTreeQuietCaseRepairedBeforeSend covers the quiet case: a corrupt document whose leaf
+// generation is high enough relative to its branch length that encodeRevisions succeeds, so pre-repair
+// Sync Gateway would have sent it with no norev and no complaint, under ancestor rev IDs that have never
+// existed. The repair on load means those ancestors are never sent.
+//
+// Tree 1-abc -> 10-abc -> 10-def. Pre-repair the wire history was "9-abc,8-abc" - both fabricated, true
+// ancestors 10-abc and 1-abc. After repair the parent is truthful. The grandparent is still wrong, and
+// deliberately so: the tree has a legitimate generation gap between 1-abc and 10-abc, and _revisions can
+// only express start, start-1, start-2.
+func TestInvalidRevTreeQuietCaseRepairedBeforeSend(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD, base.KeySync, base.KeySyncMsg)
+
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // pre-4.0 clients are the ones sent rev tree history
+
+	btcRunner.Run(func(t *testing.T) {
+		rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
+		defer rt.Close()
+
+		docID := SafeDocumentName(t, t.Name())
+		collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
+
+		// gen 10 leaf on a 3 revision branch: 10 >= 3, so splitRevisionList accepts the encoding and
+		// nothing would have flagged this document before the generation invariant was checked directly
+		db.PlantRevTreeForTest(t, ctx, collection, docID, db.Body{"planted": true},
+			map[string]string{"1-abc": "", "10-abc": "1-abc", "10-def": "10-abc"}, "10-def")
+		rt.GetDatabase().FlushRevisionCacheForTest()
+		rt.WaitForPendingChanges()
+
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
+		defer client.Close()
+		btcRunner.StartPull(client.id)
+		defer btcRunner.UnsubPullChanges(client.id)
+
+		repairedVersion := DocVersion{RevTreeID: "11-def"}
+		btcRunner.WaitForVersion(client.id, docID, repairedVersion)
+		base.RequireWaitForStat(t, rt.GetDatabase().DbStats.Database().InvalidRevTreeCount.Value, 1)
+
+		msg, ok := btcRunner.GetPullRevMessage(client.id, docID, repairedVersion)
+		require.True(t, ok)
+		wireHistory := msg.Properties[db.RevMessageHistory]
+
+		doc, err := collection.GetDocument(ctx, docID, db.DocUnmarshalAll)
+		require.NoError(t, err)
+		require.Equal(t, "11-def", doc.GetRevTreeID())
+
+		// the parent is now a revision that really exists, which is the link a client splices onto
+		wireAncestors := strings.Split(wireHistory, ",")
+		require.NotEmpty(t, wireAncestors)
+		_, parentInTree := doc.History[wireAncestors[0]]
+		assert.True(t, parentInTree, "parent %q on the wire is not in the rev tree", wireAncestors[0])
+		assert.Equal(t, "10-abc", wireAncestors[0])
+
+		// ...whereas pre-repair not even the parent existed
+		assert.Equal(t, "10-abc,9-abc", wireHistory, "9-abc is the pre-existing generation gap lossiness, not the CBG-5713 corruption")
+	})
+}
+
+// TestInvalidRevTreePullRenamedRevReplacementOrNoRev covers what a pre-4.0 client is sent when the
+// revision it asked for is renumbered out of existence by the repair its own request triggered.
+//
+// The changes message names 2-def, taken from the channel cache without reading the document. The client
+// asks for it, sendRevision calls GetRev, that load repairs the tree and renames 2-def to 3-def, and the
+// requested revision is now genuinely missing - so getRevision returns ErrMissing and sendRevision takes
+// its existing IsDocNotFoundError branch. Which of the two things that branch can do depends entirely on
+// whether the client opted into sendReplacementRevs, so both are covered here.
+func TestInvalidRevTreePullRenamedRevReplacementOrNoRev(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD, base.KeySync, base.KeySyncMsg)
+
+	testCases := []struct {
+		name                string
+		sendReplacementRevs bool
+	}{
+		{name: "replacement revs enabled", sendReplacementRevs: true},
+		{name: "replacement revs disabled", sendReplacementRevs: false},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			btcRunner := NewBlipTesterClientRunner(t)
+			// a 4.0+ client is sent the cv, which the repair leaves untouched, so no revision ever goes missing
+			btcRunner.SkipSubtest[VersionVectorSubtestName] = true
+
+			btcRunner.Run(func(t *testing.T) {
+				rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
+				defer rt.Close()
+
+				docID := SafeDocumentName(t, t.Name())
+				collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
+
+				// 2-def sits at the same generation as its parent, so the repair renumbers it to 3-def
+				db.PlantRevTreeForTest(t, ctx, collection, docID, db.Body{"planted": true},
+					map[string]string{"1-abc": "", "2-abc": "1-abc", "2-def": "2-abc"}, "2-def")
+				rt.GetDatabase().FlushRevisionCacheForTest()
+				rt.WaitForPendingChanges()
+
+				invalidRevTreeCount := rt.GetDatabase().DbStats.Database().InvalidRevTreeCount
+				noRevSendCount := rt.GetDatabase().DbStats.CBLReplicationPull().NoRevSendCount
+				require.Equal(t, int64(0), invalidRevTreeCount.Value(), "nothing has read the document yet")
+
+				client := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
+					sendReplacementRevs: testCase.sendReplacementRevs,
+				})
+				defer client.Close()
+				btcRunner.StartPullSince(client.id, BlipTesterPullOptions{Continuous: false})
+
+				repairedVersion := DocVersion{RevTreeID: "3-def"}
+
+				if testCase.sendReplacementRevs {
+					// the client asked for 2-def and is sent 3-def in its place, on the same sequence
+					btcRunner.WaitForVersion(client.id, docID, repairedVersion)
+
+					msg, ok := btcRunner.GetPullRevMessage(client.id, docID, repairedVersion)
+					require.True(t, ok)
+					assert.Equal(t, db.MessageRev, msg.Profile())
+					assert.Equal(t, "3-def", msg.Properties[db.RevMessageRev])
+					assert.Equal(t, "2-def", msg.Properties[db.RevMessageReplacedRev],
+						"3-def should have been sent as a replacement for the revision the repair renamed")
+					assert.Equal(t, int64(0), noRevSendCount.Value(), "a replacement rev was available, so nothing should have been skipped")
+				} else {
+					// no replacement is allowed, so the revision is skipped
+					base.RequireWaitForStat(t, noRevSendCount.Value, 1)
+
+					// ...and because this pull was one-shot, the client ends it holding nothing. The repair
+					// allocated a higher sequence, so the next pull delivers 3-def - which is what makes the
+					// norev a skip rather than data loss.
+					_, found := btcRunner.GetVersion(client.id, docID, repairedVersion)
+					require.False(t, found, "3-def should not have arrived on the pull that skipped 2-def")
+
+					btcRunner.StartPullSince(client.id, BlipTesterPullOptions{Continuous: false})
+					btcRunner.WaitForVersion(client.id, docID, repairedVersion)
+				}
+
+				// the repair was triggered by the client's request for the revision, not by any other read
+				base.RequireWaitForStat(t, invalidRevTreeCount.Value, 1)
+				doc, err := collection.GetDocument(ctx, docID, db.DocUnmarshalAll)
+				require.NoError(t, err)
+				require.Equal(t, "3-def", doc.GetRevTreeID())
+			})
+		})
+	}
+}

--- a/rest/replicatortest/replicator_conflict_test.go
+++ b/rest/replicatortest/replicator_conflict_test.go
@@ -12,7 +12,9 @@ import (
 	"fmt"
 	"maps"
 	"math"
+	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -2227,4 +2229,191 @@ func getRevTreeID(t *testing.T, parentRevID string, body []byte) string {
 	prevGeneration, _ := db.ParseRevID(t.Context(), parentRevID)
 	require.NotEqual(t, -1, prevGeneration, "failed to parse revID %s", parentRevID)
 	return db.CreateRevIDWithBytes(prevGeneration+1, parentRevID, body)
+}
+
+// A pre-4.0.x Sync Gateway held the CBG-5713 corruption and replicated the document
+// to its ISGR peer before anyone knew the tree was invalid, so the two peers start from *different* trees
+// for the same document:
+
+//	active (the corrupt source):  1-abc -> 10-abc -> 10-def
+//	passive (what it was sent):   8-abc ->  9-abc -> 10-def
+//
+// 9-abc and 8-abc never existed anywhere, they are what encodeRevisions produced for 10-abc and 1-abc because it
+// only expresses a contiguous descending run from start. Repairing the active side renames 10-def to 11-def,
+// and that is what turns a difference into a real conflict: the peer already has a 10-def of its own, so when 11-def
+// arrives as a branch off of 9-abc, it's identified as a conflict.
+var (
+	// activeCorruptTree is the CBG-5713 corruption at the source: 10-def does not exceed its parent 10-abc.
+	activeCorruptTree = map[string]string{"1-abc": "", "10-abc": "1-abc", "10-def": "10-abc"}
+	// passiveFabricatedTree is the same document as an older Sync Gateway delivered it to the peer.
+	passiveFabricatedTree = map[string]string{"8-abc": "", "9-abc": "8-abc", "10-def": "9-abc"}
+	// repairedActiveTree is activeCorruptTree once the repair has renumbered the leaf.
+	repairedActiveTree = map[string]string{"1-abc": "", "10-abc": "1-abc", "11-def": "10-abc"}
+)
+
+// plantUpgradeScenario puts the two divergent starting trees on the two peers and empties both revision
+// caches, so the next read of either document comes from the bucket.
+func plantUpgradeScenario(t *testing.T, activeRT, passiveRT *rest.RestTester, docID string) {
+	t.Helper()
+
+	activeCollection, activeCtx := activeRT.GetSingleTestDatabaseCollectionWithUser()
+	db.PlantRevTreeForTest(t, activeCtx, activeCollection, docID,
+		db.Body{"peer": "active", "channels": []string{"alice"}}, activeCorruptTree, "10-def")
+	activeRT.GetDatabase().FlushRevisionCacheForTest()
+
+	passiveCollection, passiveCtx := passiveRT.GetSingleTestDatabaseCollectionWithUser()
+	db.PlantRevTreeForTest(t, passiveCtx, passiveCollection, docID,
+		db.Body{"peer": "passive", "channels": []string{"alice"}}, passiveFabricatedTree, "10-def")
+	passiveRT.GetDatabase().FlushRevisionCacheForTest()
+
+	// both peers believe the current revision is the same, which is what keeps this invisible
+	activeCurrentRev, activeTree, _, err := revTreeState(activeCtx, activeCollection, docID)
+	require.NoError(t, err)
+	require.Equal(t, "10-def", activeCurrentRev)
+	require.Equal(t, activeCorruptTree, activeTree)
+	passiveCurrentRev, passiveTree, _, err := revTreeState(passiveCtx, passiveCollection, docID)
+	require.NoError(t, err)
+	require.Equal(t, "10-def", passiveCurrentRev)
+	require.Equal(t, passiveFabricatedTree, passiveTree)
+}
+
+// TestISGRRepairCausesRevTreeConflictOnPeer covers the repair colliding with a peer that already holds the
+// pre-upgrade copy of the same document.
+func TestISGRRepairCausesRevTreeConflictOnPeer(t *testing.T) {
+	base.RequireNumTestBuckets(t, 2)
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCRUD, base.KeySync, base.KeySyncMsg, base.KeyReplicate)
+
+	// Corrupt revision is sent to passive pre fix for sync data. The passive is sent with fake history so when
+	// corruption is fixed on active the documents sit in conflict. This is a new revision is made for active to pull
+	// from passive.
+	t.Run("repaired revision pushed to peer is rejected until the peer is updated", func(t *testing.T) {
+		sgrRunner := rest.NewSGRTestRunner(t)
+		sgrRunner.RunSubprotocolV3(func(t *testing.T) {
+			activeRT, passiveRT, passiveDBURL := sgrRunner.SetupSGRPeers(t)
+			remoteURL, err := url.Parse(passiveDBURL)
+			require.NoError(t, err)
+			activeCtx := activeRT.Context()
+			docID := rest.SafeDocumentName(t, t.Name())
+
+			plantUpgradeScenario(t, activeRT, passiveRT, docID)
+
+			activeCollection, activeCollectionCtx := activeRT.GetSingleTestDatabaseCollectionWithUser()
+			passiveCollection, passiveCollectionCtx := passiveRT.GetSingleTestDatabaseCollectionWithUser()
+
+			// trigger repair on active
+			rest.RequireStatus(t, activeRT.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/"+docID, ""), http.StatusOK)
+			currentRev, tree, _, err := revTreeState(activeCollectionCtx, activeCollection, docID)
+			require.NoError(t, err)
+			require.Equal(t, "11-def", currentRev)
+			require.Equal(t, repairedActiveTree, tree)
+			require.Equal(t, int64(1), activeRT.GetDatabase().DbStats.Database().InvalidRevTreeCount.Value())
+
+			activeRT.WaitForPendingChanges()
+			passiveRT.WaitForPendingChanges()
+
+			pushOnly, err := db.NewActiveReplicator(activeCtx, &db.ActiveReplicatorConfig{
+				ID:                     rest.SafeDocumentName(t, t.Name()+"push"),
+				Direction:              db.ActiveReplicatorTypePush,
+				RemoteDBURL:            remoteURL,
+				ActiveDB:               &db.Database{DatabaseContext: activeRT.GetDatabase()},
+				ChangesBatchSize:       200,
+				Continuous:             true,
+				ReplicationStatsMap:    dbReplicatorStats(t),
+				CollectionsEnabled:     !activeRT.GetDatabase().OnlyDefaultCollection(),
+				SupportedBLIPProtocols: sgrRunner.SupportedSubprotocols,
+			})
+			require.NoError(t, err)
+			require.NoError(t, pushOnly.Start(activeCtx))
+
+			// Conflict state. Repair ends with rev tree: 1-abc -> 10-abc -> 11-def and this is sent as
+			// 9-abc -> 10-abc -> 11-def. When peer has 8-abc -> 9-abc -> 10-def (from a roundtrip of replication of
+			// corrupt doc before fix).
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				assert.Equal(c, int64(1), pushOnly.GetStatus(activeCtx).DocWriteConflict)
+			}, 30*time.Second, 100*time.Millisecond)
+			assert.Equal(t, int64(0), pushOnly.GetStatus(activeCtx).DocsWritten)
+
+			// the peer is untouched, and the two sides now disagree about the current revision with
+			// nothing in the replication able to settle it
+			passiveCurrentRev, passiveTree, passiveLeaves, err := revTreeState(passiveCollectionCtx, passiveCollection, docID)
+			require.NoError(t, err)
+			assert.Equal(t, "10-def", passiveCurrentRev)
+			assert.Equal(t, passiveFabricatedTree, passiveTree)
+			assert.Len(t, passiveLeaves, 1)
+			require.NoError(t, pushOnly.Stop())
+
+			// A new revision on the peer will unblock the situation and will trigger conflict resolution on active
+			resp := passiveRT.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+docID+"?rev=10-def",
+				`{"peer":"passive","update":1,"channels":["alice"]}`)
+			rest.RequireStatus(t, resp, http.StatusCreated)
+			passiveUpdateRev := rest.DocVersionFromPutResponse(t, resp).RevTreeID
+			require.True(t, strings.HasPrefix(passiveUpdateRev, "11-"), "got %q", passiveUpdateRev)
+			passiveRT.WaitForPendingChanges()
+
+			activeRT.CreateReplication(rest.SafeDocumentName(t, t.Name()), passiveDBURL, db.ActiveReplicatorTypePushAndPull, nil, true, db.ConflictResolverDefault, "")
+			activeRT.WaitForReplicationStatus(rest.SafeDocumentName(t, t.Name()), db.ReplicationStateRunning)
+
+			// passive version wins
+			requireRepairConvergedOnPeerBranch(t, activeRT, passiveRT, docID, passiveUpdateRev)
+		})
+	})
+
+	// Passive peer has corrupt revision replicated to it before fix is applied. When active peer pulls a new revision
+	// from passive into a corrupt local version, the write will fix the rev tree and resolve the resulting conflict.
+	// Then push result back to passive.
+	t.Run("new revision on peer pulled back repairs and resolves in one pass", func(t *testing.T) {
+		sgrRunner := rest.NewSGRTestRunner(t)
+		sgrRunner.RunSubprotocolV3(func(t *testing.T) {
+			activeRT, passiveRT, passiveDBURL := sgrRunner.SetupSGRPeers(t)
+			docID := rest.SafeDocumentName(t, t.Name())
+
+			plantUpgradeScenario(t, activeRT, passiveRT, docID)
+
+			// the peer moves first, and the active is never read, so its tree is still corrupt
+			resp := passiveRT.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+docID+"?rev=10-def",
+				`{"peer":"passive","update":1,"channels":["alice"]}`)
+			rest.RequireStatus(t, resp, http.StatusCreated)
+			passiveUpdateRev := rest.DocVersionFromPutResponse(t, resp).RevTreeID
+			gen, _ := db.ParseRevID(base.TestCtx(t), passiveUpdateRev)
+			require.Equal(t, 11, gen)
+			passiveRT.WaitForPendingChanges()
+			require.Equal(t, int64(0), activeRT.GetDatabase().DbStats.Database().InvalidRevTreeCount.Value())
+
+			activeRT.CreateReplication(rest.SafeDocumentName(t, t.Name()), passiveDBURL, db.ActiveReplicatorTypePushAndPull, nil, true, db.ConflictResolverDefault, "")
+			activeRT.WaitForReplicationStatus(rest.SafeDocumentName(t, t.Name()), db.ReplicationStateRunning)
+
+			// passive version wins
+			requireRepairConvergedOnPeerBranch(t, activeRT, passiveRT, docID, passiveUpdateRev)
+		})
+	})
+}
+
+func requireRepairConvergedOnPeerBranch(t *testing.T, activeRT, passiveRT *rest.RestTester, docID string, passiveUpdateRev string) {
+	t.Helper()
+	convergedRev, perPeer := rest.RequireRevTreeConvergence(t, docID, activeRT, passiveRT)
+	activeSyncData, passiveSyncData := perPeer[0], perPeer[1]
+
+	gen, _ := db.ParseRevID(base.TestCtx(t), convergedRev)
+	require.Equal(t, 12, gen)
+	assert.Equal(t, passiveUpdateRev, activeSyncData.History[convergedRev].Parent, "the winner should extend the peer's update")
+
+	// the repaired branch is closed off with a new tombstone revision rather than left live
+	leaves := activeSyncData.History.GetLeaves()
+	require.Len(t, leaves, 2, "expected the winner plus the tombstoned losing branch, got %v", leaves)
+	var tombstone string
+	for _, leaf := range leaves {
+		if leaf != convergedRev {
+			tombstone = leaf
+		}
+	}
+	require.NotEmpty(t, tombstone)
+	assert.Equal(t, "11-def", activeSyncData.History[tombstone].Parent, "the tombstone should close the repaired branch")
+	assert.True(t, strings.HasPrefix(tombstone, "12-"), "the tombstone should be a new revision, got %q", tombstone)
+
+	// the peer is only ever sent the winner, so it has no losing branch of its own to close
+	assert.Len(t, passiveSyncData.History.GetLeaves(), 1)
+
+	// the corruption was repaired once, on the peer that held it, not once per write that touched it
+	assert.Equal(t, int64(1), activeRT.GetDatabase().DbStats.Database().InvalidRevTreeCount.Value())
+	assert.Equal(t, int64(0), passiveRT.GetDatabase().DbStats.Database().InvalidRevTreeCount.Value())
 }

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -8368,3 +8368,98 @@ func TestActiveReplicatorPullUpdatedDocChannels(t *testing.T) {
 		assert.NotNil(t, removalA, "chanA should be marked removed after the ISGR update, channels=%v", doc.Channels)
 	})
 }
+
+// quietCaseTree is the CBG-5713 corruption in its quiet form: 10-def does not exceed the generation of
+// its parent 10-abc, but the leaf generation is high enough relative to the branch length that
+// encodeRevisions still produces a _revisions list splitRevisionList accepts. Sync Gateway therefore
+// replicated it without complaint, under ancestor rev IDs that never existed - encodeRevisions can only
+// express start, start-1, start-2, so 1-abc went on the wire as 8-abc.
+var quietCaseTree = map[string]string{"1-abc": "", "10-abc": "1-abc", "10-def": "10-abc"}
+
+// repairedTreeAtSource is quietCaseTree after repair.
+var repairedTreeAtSource = map[string]string{"1-abc": "", "10-abc": "1-abc", "11-def": "10-abc"}
+
+// repairedWireTreeOnPeer is what a peer builds from the repaired document, and it is deliberately not
+// equal to repairedTreeAtSource. SGW encodes revisions as a descending run so 1-abc -> 10-abc gap is sent
+// as 9-abc -> 10-abc.
+var repairedWireTreeOnPeer = map[string]string{"9-abc": "", "10-abc": "9-abc", "11-def": "10-abc"}
+
+// revTreeState reads a document's current revision, rev tree and leaves without repairing it.
+func revTreeState(ctx context.Context, collection *db.DatabaseCollectionWithUser, docID string) (currentRev string, tree map[string]string, leaves []string, err error) {
+	syncData, err := collection.GetDocSyncData(ctx, docID)
+	if err != nil {
+		return "", nil, nil, err
+	}
+	tree = make(map[string]string, len(syncData.History))
+	for revID, info := range syncData.History {
+		tree[revID] = info.Parent
+	}
+	return syncData.GetRevTreeID(), tree, syncData.History.GetLeaves(), nil
+}
+
+// requirePostRepairRevTreeState waits for a document to reach an exact rev tree shape on a peer, then asserts it is
+// a single unconflicted branch. Not to be used when conflicts are generated.
+func requirePostRepairRevTreeState(t *testing.T, collection *db.DatabaseCollectionWithUser, ctx context.Context, docID string, expectedCurrentRev string, expectedTree map[string]string) {
+	t.Helper()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		currentRev, tree, _, err := revTreeState(ctx, collection, docID)
+		if !assert.NoError(c, err) {
+			return
+		}
+		assert.Equal(c, expectedCurrentRev, currentRev)
+		assert.Equal(c, expectedTree, tree)
+	}, 20*time.Second, 100*time.Millisecond)
+
+	_, _, leaves, err := revTreeState(ctx, collection, docID)
+	require.NoError(t, err)
+	require.Len(t, leaves, 1, "repair must not leave a conflicting branch behind")
+}
+
+// TestISGRInvalidRevTreeRepairedBeforeSend asserts a corrupt document is repaired on load and never
+// replicated to another Sync Gateway in its corrupt form.
+func TestISGRInvalidRevTreeRepairedBeforeSend(t *testing.T) {
+	base.RequireNumTestBuckets(t, 2)
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD, base.KeySync, base.KeySyncMsg)
+
+	sgrRunner := rest.NewSGRTestRunner(t)
+	sgrRunner.Run(func(t *testing.T) {
+		activeRT, passiveRT, passiveDBURL := sgrRunner.SetupSGRPeers(t)
+		docID := rest.SafeDocumentName(t, t.Name())
+
+		activeCollection, activeCollectionCtx := activeRT.GetSingleTestDatabaseCollectionWithUser()
+		db.PlantRevTreeForTest(t, activeCollectionCtx, activeCollection, docID,
+			db.Body{"planted": true, "channels": []string{"alice"}}, quietCaseTree, "10-def")
+		activeRT.WaitForPendingChanges()
+		activeRT.GetDatabase().FlushRevisionCacheForTest()
+
+		// assert active side has corrupt tree
+		invalidRevTreeCount := activeRT.GetDatabase().DbStats.Database().InvalidRevTreeCount
+		currentRev, tree, _, err := revTreeState(activeCollectionCtx, activeCollection, docID)
+		require.NoError(t, err)
+		require.Equal(t, "10-def", currentRev)
+		require.Equal(t, quietCaseTree, tree)
+		require.Equal(t, int64(0), invalidRevTreeCount.Value())
+
+		activeRT.CreateReplication(rest.SafeDocumentName(t, t.Name()), passiveDBURL, db.ActiveReplicatorTypePush, nil, true, db.ConflictResolverDefault, "")
+		activeRT.WaitForReplicationStatus(rest.SafeDocumentName(t, t.Name()), db.ReplicationStateRunning)
+
+		// passive get repaired version of doc
+		passiveCollection, passiveCollectionCtx := passiveRT.GetSingleTestDatabaseCollectionWithUser()
+		requirePostRepairRevTreeState(t, passiveCollection, passiveCollectionCtx, docID, "11-def", repairedWireTreeOnPeer)
+
+		// active also has repaired version (from reading the doc to send)
+		requirePostRepairRevTreeState(t, activeCollection, activeCollectionCtx, docID, "11-def", repairedTreeAtSource)
+		assert.Equal(t, int64(1), invalidRevTreeCount.Value())
+
+		if sgrRunner.IsV4Protocol() {
+			activeDoc, err := activeCollection.GetDocument(activeCollectionCtx, docID, db.DocUnmarshalAll)
+			require.NoError(t, err)
+			passiveDoc, err := passiveCollection.GetDocument(passiveCollectionCtx, docID, db.DocUnmarshalAll)
+			require.NoError(t, err)
+			assert.Equal(t, activeDoc.HLV.GetCurrentVersionString(), passiveDoc.HLV.GetCurrentVersionString())
+		}
+
+		// the passive peer never saw a corrupt tree, so it had nothing to repair
+		assert.Equal(t, int64(0), passiveRT.GetDatabase().DbStats.Database().InvalidRevTreeCount.Value())
+	})
+}

--- a/rest/utilities_testing_isgr.go
+++ b/rest/utilities_testing_isgr.go
@@ -9,14 +9,17 @@
 package rest
 
 import (
+	"context"
 	"net/http/httptest"
 	"net/url"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -275,4 +278,59 @@ func SetupISGRPeersWithOpts(t *testing.T, opts TestISGRPeerOpts) TestISGRPeers {
 		PassiveRT:    passiveRT,
 		PassiveDBURL: passiveDBURL.String(),
 	}
+}
+
+// RequireRevTreeConvergence waits for two or more peers to agree on a document's current revision, then will
+// assert that any other leaf revision(s) are tombstone revisions. Uses GetDocSyncData to avoid read side
+// repair of corrupt metadata through GetDocumentWithRaw. It will return the converged revID and the per peer sync data
+// for callers to assert on.
+func RequireRevTreeConvergence(t *testing.T, docID string, peers ...*RestTester) (convergedRev string, perPeer []db.SyncData) {
+	t.Helper()
+	require.GreaterOrEqual(t, len(peers), 2, "convergence needs at least two peers")
+
+	collections := make([]*db.DatabaseCollectionWithUser, len(peers))
+	ctxs := make([]context.Context, len(peers))
+	for i, peer := range peers {
+		collections[i], ctxs[i] = peer.GetSingleTestDatabaseCollectionWithUser()
+	}
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		var first string
+		for i := range peers {
+			syncData, err := collections[i].GetDocSyncData(ctxs[i], docID)
+			if !assert.NoError(c, err, "peer %d does not have doc %q yet", i, docID) {
+				return
+			}
+			if i == 0 {
+				first = syncData.GetRevTreeID()
+				continue
+			}
+			assert.Equal(c, first, syncData.GetRevTreeID(), "peer %d has not converged with peer 0", i)
+		}
+	}, 20*time.Second, 100*time.Millisecond)
+
+	perPeer = make([]db.SyncData, len(peers))
+	for i := range peers {
+		syncData, err := collections[i].GetDocSyncData(ctxs[i], docID)
+		require.NoError(t, err)
+		perPeer[i] = syncData
+
+		if i == 0 {
+			convergedRev = syncData.GetRevTreeID()
+		}
+		require.Equal(t, convergedRev, syncData.GetRevTreeID(), "peer %d disagrees on the current revision", i)
+
+		current, ok := syncData.History[convergedRev]
+		require.True(t, ok, "peer %d names %q as current but does not have it in its rev tree", i, convergedRev)
+		assert.False(t, current.Deleted, "peer %d converged on a tombstone, %q", i, convergedRev)
+
+		for _, leaf := range syncData.History.GetLeaves() {
+			if leaf == convergedRev {
+				continue
+			}
+			assert.True(t, syncData.History[leaf].Deleted,
+				"peer %d still holds live conflicting leaf %q alongside converged revision %q", i, leaf, convergedRev)
+		}
+	}
+	return convergedRev, perPeer
 }


### PR DESCRIPTION
CBG-5813

Unclean cherry pick of #8726 to 4.1.2
Changes from main commit:
- `base/stats.go` — `invalid_rev_tree_count` is registered as `StatAddedVersion4dot1dot2` rather than `StatAddedVersion4dot2dot0`, matching the release it ships in
- `rest/replicatortest/replicator_conflict_test.go`, `rest/replicatortest/replicator_test.go` — `SetupSGRPeers` returns three values on 4.1.2 rather than `*TestISGRPeers`, and `dbReplicatorStats` takes only `*testing.T`
- `rest/utilities_testing_isgr.go` — release branch predates the `testing/assert` and `testing/require` wrappers; imports renamed back to `github.com/stretchr/testify`
- `db/revtree_test.go` — testify's `assert.NotContains` is not generic over `iter.Seq` the way the `testing/assert` wrapper is, so `maps.Keys(repaired.History)` is materialised with `slices.Collect`
- `rest/blip_legacy_revid_test.go` — `TestInvalidRevTreePullRepairsAndRedelivers` and `TestInvalidRevTreePullRenamedRevReplacementOrNoRev` lose the client-side assertion that the norev names the pre-repair rev ID `2-def`. `WaitForPullNoRevMessage` comes from CBG-5547 (#8459), which is not on this branch. The `noRevSendCount` stat assertions that followed them are kept, so both tests still verify that a norev was sent
- `db/attachment_test.go`, `db/util_testing.go` — the new functions are appended at end of file; the functions upstream anchored them to do not exist on 4.1.2

🤖 Opened with the `sync-gateway-backport` skill in [Claude Code](https://claude.com/claude-code)
