### PR TITLE
[4.1.2 Backport] CBG-5825: Fix norev handling in BlipTesterCollectionClient (test-only)

### DIFF
--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1964,17 +1964,11 @@ func TestSendReplacementRevision(t *testing.T) {
 					base.RequireWaitForStat(t, rt.GetDatabase().DbStats.CBLReplicationPull().NoRevSendCount.Value, 0)
 				} else {
 					// requested revision (or any alternative) did not get replicated
-					data := btcRunner.SingleCollection(btc.id).WaitForVersion(docID, version1)
-					assert.Nil(t, data)
+					btcRunner.SingleCollection(btc.id).WaitForPullNoRevMessage(docID, version1)
 
 					// no message for rev 2
 					_, ok := btcRunner.SingleCollection(btc.id).GetPullRevMessage(docID, version2)
 					require.False(t, ok)
-
-					// norev message for the requested rev
-					msg, ok := btcRunner.SingleCollection(btc.id).GetPullRevMessage(docID, version1)
-					require.True(t, ok)
-					assert.Equal(t, db.MessageNoRev, msg.Profile())
 
 					base.RequireWaitForStat(t, rt.GetDatabase().DbStats.CBLReplicationPull().NoRevSendCount.Value, 1)
 					base.RequireWaitForStat(t, rt.GetDatabase().DbStats.CBLReplicationPull().ReplacementRevSendCount.Value, 0)
@@ -3080,11 +3074,8 @@ func TestImportInvalidSyncGetsNoRev(t *testing.T) {
 		require.NoError(t, err)
 
 		btcRunner.StartOneshotPull(btc.id)
-		msg := btcRunner.WaitForPullRevMessage(btc.id, docID, version)
-		require.Equal(t, db.MessageNoRev, msg.Profile())
-
-		msg = btcRunner.WaitForPullRevMessage(btc.id, docID2, version2)
-		require.Equal(t, db.MessageNoRev, msg.Profile())
+		btcRunner.WaitForPullNoRevMessage(btc.id, docID, version)
+		btcRunner.WaitForPullNoRevMessage(btc.id, docID2, version2)
 	})
 }
 
@@ -3203,8 +3194,7 @@ func TestOnDemandImportBlipFailure(t *testing.T) {
 
 				btcRunner.StartOneshotPull(btc2.id)
 
-				msg := btcRunner.WaitForPullRevMessage(btc2.id, docID, revID)
-				require.Equal(t, db.MessageNoRev, msg.Profile())
+				btcRunner.WaitForPullNoRevMessage(btc2.id, docID, revID)
 			})
 		}
 	})
@@ -3484,57 +3474,6 @@ func TestBlipPushRevOnResurrection(t *testing.T) {
 	})
 }
 
-func TestBlipPullConflict(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeySync, base.KeySyncMsg, base.KeySGTest)
-	btcRunner := NewBlipTesterClientRunner(t)
-
-	btcRunner.SkipSubtest[RevtreeSubtestName] = true
-
-	btcRunner.Run(func(t *testing.T) {
-		rt := NewRestTesterPersistentConfig(t)
-		defer rt.Close()
-
-		const (
-			alice   = "alice"
-			cblBody = `{"actor": "cbl"}`
-			sgBody  = `{"actor": "sg"}`
-			docID   = "doc1"
-		)
-		rt.CreateUser(alice, []string{"*"})
-		sgVersion := rt.PutDoc(docID, `{"actor": "sg"}`)
-		rt.WaitForPendingChanges()
-
-		opts := &BlipTesterClientOpts{
-			Username: alice,
-		}
-		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
-		defer btc.Close()
-
-		client := btcRunner.SingleCollection(btc.id)
-		preConflictCBLVersion := btcRunner.AddRev(btc.id, docID, EmptyDocVersion(), []byte(cblBody))
-		require.NotEqual(t, sgVersion, preConflictCBLVersion)
-		_, preConflictHLV, _ := client.GetDoc(docID)
-		require.Empty(t, preConflictHLV.PreviousVersions)
-		require.Empty(t, preConflictHLV.MergeVersions)
-
-		btcRunner.StartOneshotPull(btc.id)
-
-		// expect resolution as CBL wins (local wins)
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			body, postConflictHLV, _ := client.GetDoc(docID)
-			assert.Equal(c, db.HybridLogicalVector{
-				CurrentVersionCAS: 0,
-				Version:           preConflictCBLVersion.CV.Value,
-				SourceID:          preConflictCBLVersion.CV.SourceID,
-				PreviousVersions: db.HLVVersions{
-					sgVersion.CV.SourceID: sgVersion.CV.Value,
-				},
-			}, *postConflictHLV)
-			assert.Equal(c, string(body), cblBody)
-		}, time.Second*10, time.Millisecond*10)
-	})
-}
-
 func TestManyChannelsRemovedOnDocUpdate(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeySyncMsg, base.KeyChanges, base.KeyCache, base.KeySGTest)
 
@@ -3749,113 +3688,7 @@ func TestBlipNoRevOnCorruptHistory(t *testing.T) {
 		expectedVersion := DocVersion{RevTreeID: "3-c"}
 
 		btcRunner.StartOneshotPull(btc.id)
-		msg := btcRunner.WaitForPullRevMessage(btc.id, docID, expectedVersion)
-		require.Equal(t, db.MessageNoRev, msg.Profile())
-	})
-}
-
-func TestBlipNoRevOnCorruptHistoryDelta(t *testing.T) {
-	base.TestRequiresDeltaSync(t)
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeySyncMsg, base.KeyCache, base.KeyCRUD, base.KeySGTest)
-	btcRunner := NewBlipTesterClientRunner(t)
-	// a norev message is only sent on delta sync when v2 protocol is used, otherwise the deleted flag on a changes
-	// message is used
-	btcRunner.RunSubprotocolV2(func(t *testing.T) {
-		rt := NewRestTester(t,
-			&RestTesterConfig{
-				PersistentConfig: true,
-				SyncFn:           channels.DocChannelsSyncFunction,
-			},
-		)
-		defer rt.Close()
-
-		dbConfig := rt.NewDbConfig()
-		dbConfig.DeltaSync = &DeltaSyncConfig{Enabled: base.Ptr(true)}
-		dbConfig.AutoImport = false
-		RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
-
-		const user = "user"
-		const channelA = "A"
-		rt.CreateUser(user, []string{channelA})
-		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
-			Username:     user,
-			ClientDeltas: true,
-		})
-		defer btc.Close()
-
-		ctx := rt.Context()
-		docID := SafeDocumentName(t, t.Name())
-		docRev1 := rt.CreateDocNoHLV(docID, db.Body{"delta": true, "channels": []string{channelA}})
-		btcRunner.StartOneshotPull(btc.id)
-		btcRunner.WaitForVersion(btc.id, docID, DocVersion{RevTreeID: docRev1.GetRevTreeID()})
-		seq, err := rt.GetDatabase().NextSequence(ctx)
-		require.NoError(t, err)
-		// document contains an invalid revtree
-		//
-		// 3-c is a child of 3-d, a revision must be one or more generations higher than it its parent, not equal
-		badSyncRaw := `{
-			"cas": "expand",
-			"channel_set":  [
-				{
-					"end": {{.rev3seq}},
-					"name": "A",
-					"start": {{.rev1seq}}
-				}
-			],
-			"channels": {
-				"A": {
-					"rev": "{{.rev1}}",
-					"seq": {{.rev3seq}}
-				}
-			},
-			"channel_set_history": null,
-			"history": {
-				"parents": [
-					3,
-					0,
-					-1,
-					2
-				],
-				"revs": [
-					"3-d",
-					"3-c",
-					"{{.rev1}}",
-					"2-b"
-				]
-			},
-			"rev": "3-c",
-			"sequence": {{.rev3seq}},
-			"value_crc32c": "expand"
-		}`
-		tmpl := template.Must(template.New("badSync").Option("missingkey=error").Parse(badSyncRaw))
-		var badSyncData bytes.Buffer
-		require.NoError(t, tmpl.Execute(&badSyncData, map[string]any{
-			"rev1":    docRev1.GetRevTreeID(),
-			"rev1seq": docRev1.Sequence,
-			"rev3seq": seq,
-		}))
-
-		mutateInOptions := db.DefaultMutateInOpts()
-		_, err = rt.GetSingleDataStore().WriteWithXattrs(
-			ctx,
-			docID,
-			0,
-			docRev1.Cas,
-			[]byte(`{"key":"value"}`),
-			map[string][]byte{
-				base.SyncXattrName: badSyncData.Bytes(),
-			},
-			nil,
-			mutateInOptions,
-		)
-		require.NoError(t, err)
-
-		rt.WaitForPendingChanges()
-		expectedVersion := DocVersion{RevTreeID: "3-c"}
-
-		btcRunner.StartOneshotPull(btc.id)
-		msg := btcRunner.WaitForPullRevMessage(btc.id, docID, expectedVersion)
-		require.Equal(t, db.MessageNoRev, msg.Profile())
+		btcRunner.WaitForPullNoRevMessage(btc.id, docID, expectedVersion)
 	})
 }
 

--- a/rest/cbl_conflict_test.go
+++ b/rest/cbl_conflict_test.go
@@ -1,0 +1,287 @@
+/*
+Copyright 2026-Present Couchbase, Inc.
+
+Use of this software is governed by the Business Source License included in
+the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+file, in accordance with the Business Source License, use of this software will
+be governed by the Apache License, Version 2.0, included in the file
+licenses/APL2.txt.
+*/
+
+package rest
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+	"text/template"
+	"time"
+
+	"github.com/couchbase/gocb/v2"
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/channels"
+	"github.com/couchbase/sync_gateway/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBlipConflictResolution covers CBL-side conflict resolution over BLIP, including the norev-clobber
+// guard (CBG-5547), as subtests sharing one RestTester/database.
+func TestBlipConflictResolution(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeySyncMsg, base.KeyCache, base.KeyCRUD, base.KeySGTest)
+
+	rt := NewRestTester(t, &RestTesterConfig{
+		PersistentConfig:  true,
+		GuestEnabled:      true, // pulled as guest by PullConflictNoRevLosesBody
+		SyncFn:            channels.DocChannelsSyncFunction,
+		LeakyBucketConfig: &base.LeakyBucketConfig{},
+	})
+	defer rt.Close()
+
+	dbConfig := rt.NewDbConfig()
+	dbConfig.DeltaSync = &DeltaSyncConfig{Enabled: base.Ptr(true)}
+	dbConfig.AutoImport = false
+	RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
+
+	testCases := []struct {
+		name string
+		test func(t *testing.T, rt *RestTester)
+	}{
+		{"PullConflict", testBlipPullConflict},
+		{"PullConflictNoRevLosesBody", testBlipPullConflictNoRevLosesBody},
+		{"NoRevOnCorruptHistoryDelta", testBlipNoRevOnCorruptHistoryDelta},
+		{"NoRevIgnoredSingleChangesEntry", testBlipNoRevIgnoredSingleChangesEntry},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) { tc.test(t, rt) })
+	}
+}
+
+func testBlipPullConflict(t *testing.T, rt *RestTester) {
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[RevtreeSubtestName] = true
+
+	btcRunner.Run(func(t *testing.T) {
+		const (
+			alice   = "alice"
+			cblBody = `{"actor": "cbl"}`
+		)
+		docID := SafeDocumentName(t, t.Name())
+		rt.CreateUser(alice, []string{"*"})
+		sgVersion := rt.PutDoc(docID, `{"actor": "sg", "channels": ["shared"]}`)
+		rt.WaitForPendingChanges()
+
+		opts := &BlipTesterClientOpts{
+			Username: alice,
+		}
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer btc.Close()
+
+		client := btcRunner.SingleCollection(btc.id)
+		preConflictCBLVersion := btcRunner.AddRev(btc.id, docID, EmptyDocVersion(), []byte(cblBody))
+		require.NotEqual(t, sgVersion, preConflictCBLVersion)
+		_, preConflictHLV, _ := client.GetDoc(docID)
+		require.Empty(t, preConflictHLV.PreviousVersions)
+		require.Empty(t, preConflictHLV.MergeVersions)
+
+		btcRunner.StartOneshotPull(btc.id)
+
+		// expect resolution as CBL wins (local wins)
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			body, postConflictHLV, _ := client.GetDoc(docID)
+			assert.Equal(c, db.HybridLogicalVector{
+				CurrentVersionCAS: 0,
+				Version:           preConflictCBLVersion.CV.Value,
+				SourceID:          preConflictCBLVersion.CV.SourceID,
+				PreviousVersions: db.HLVVersions{
+					sgVersion.CV.SourceID: sgVersion.CV.Value,
+				},
+			}, *postConflictHLV)
+			assert.Equal(c, string(body), cblBody)
+		}, time.Second*10, time.Millisecond*10)
+	})
+}
+
+// testBlipPullConflictNoRevLosesBody asserts a bodyless norev can't overwrite a client's known-good revision
+// during conflict resolution.
+func testBlipPullConflictNoRevLosesBody(t *testing.T, rt *RestTester) {
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[RevtreeSubtestName] = true // requires HLV-based conflict detection
+
+	btcRunner.Run(func(t *testing.T) {
+		const cblBody = `{"actor": "cbl"}`
+		docID := SafeDocumentName(t, t.Name())
+
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
+		defer btc.Close()
+
+		client := btcRunner.SingleCollection(btc.id)
+		cblVersion := btcRunner.AddRev(btc.id, docID, EmptyDocVersion(), []byte(cblBody))
+
+		// SG writes its own conflicting revision afterwards, so it genuinely wins LWW resolution.
+		sgVersion := rt.PutDoc(docID, `{"actor": "sg", "channels": ["shared"]}`)
+		require.Greater(t, sgVersion.CV.Value, cblVersion.CV.Value)
+		rt.WaitForPendingChanges()
+
+		// Force SG to fail to retrieve its own revision body, so the pull can only deliver a bodyless norev.
+		rt.GetDatabase().FlushRevisionCacheForTest()
+		leakyDataStore, ok := base.AsLeakyDataStore(rt.Bucket().DefaultDataStore(rt.Context()))
+		require.True(t, ok)
+		leakyDataStore.SetGetRawCallback(func(string) error { return gocb.ErrDocumentNotFound })
+		leakyDataStore.SetGetWithXattrCallback(func(string) error { return gocb.ErrDocumentNotFound })
+		t.Cleanup(func() {
+			// reset the leaky callbacks so they don't leak into other subtests sharing this RestTester
+			leakyDataStore.SetGetRawCallback(nil)
+			leakyDataStore.SetGetWithXattrCallback(nil)
+		})
+
+		btcRunner.StartOneshotPull(btc.id)
+
+		btcRunner.WaitForPullNoRevMessage(btc.id, docID, sgVersion)
+
+		body, _, _ := client.GetDoc(docID)
+		require.Equal(t, []byte(cblBody), body, "norev overwrote known-good revision with no body")
+	})
+}
+
+// testBlipNoRevIgnoredSingleChangesEntry asserts that once a bodyless norev is ignored because the client
+// already holds real content for the doc (CBG-5547), the client's push-changes iteration (OneShotChangesSince)
+// still surfaces the document exactly once. A stale second _seqStore entry left behind for the ignored norev's
+// sequence previously caused the same revision to be proposed twice during push replication.
+func testBlipNoRevIgnoredSingleChangesEntry(t *testing.T, rt *RestTester) {
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[RevtreeSubtestName] = true // requires HLV-based conflict detection
+
+	btcRunner.Run(func(t *testing.T) {
+		const cblBody = `{"actor": "cbl"}`
+		docID := SafeDocumentName(t, t.Name())
+
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
+		defer btc.Close()
+
+		client := btcRunner.SingleCollection(btc.id)
+		cblVersion := btcRunner.AddRev(btc.id, docID, EmptyDocVersion(), []byte(cblBody))
+
+		// SG writes its own conflicting revision afterwards, so it genuinely wins LWW resolution.
+		sgVersion := rt.PutDoc(docID, `{"actor": "sg", "channels": ["shared"]}`)
+		require.Greater(t, sgVersion.CV.Value, cblVersion.CV.Value)
+		rt.WaitForPendingChanges()
+
+		// Force SG to fail to retrieve its own revision body, so the pull can only deliver a bodyless norev.
+		rt.GetDatabase().FlushRevisionCacheForTest()
+		leakyDataStore, ok := base.AsLeakyDataStore(rt.Bucket().DefaultDataStore(rt.Context()))
+		require.True(t, ok)
+		leakyDataStore.SetGetRawCallback(func(string) error { return gocb.ErrDocumentNotFound })
+		leakyDataStore.SetGetWithXattrCallback(func(string) error { return gocb.ErrDocumentNotFound })
+		t.Cleanup(func() {
+			// reset the leaky callbacks so they don't leak into other subtests sharing this RestTester
+			leakyDataStore.SetGetRawCallback(nil)
+			leakyDataStore.SetGetWithXattrCallback(nil)
+		})
+
+		btcRunner.StartOneshotPull(btc.id)
+		btcRunner.WaitForPullNoRevMessage(btc.id, docID, sgVersion)
+
+		var matches []proposeChangeBatchEntry
+		for _, change := range client.OneShotChangesSince(rt.Context(), 0) {
+			if change.docID == docID {
+				matches = append(matches, *change)
+			}
+		}
+		require.Len(t, matches, 1, "expected exactly one push-changes entry for docID %q, got %#v", docID, matches)
+	})
+}
+
+// testBlipNoRevOnCorruptHistoryDelta asserts a norev papering over corrupt server-side revision history
+// doesn't clobber a real revision the client already pulled for the same document.
+func testBlipNoRevOnCorruptHistoryDelta(t *testing.T, rt *RestTester) {
+	base.TestRequiresDeltaSync(t)
+	btcRunner := NewBlipTesterClientRunner(t)
+	// a norev message is only sent on delta sync when v2 protocol is used, otherwise the deleted flag on a changes
+	// message is used
+	btcRunner.RunSubprotocolV2(func(t *testing.T) {
+		const (
+			user     = "corruptHistoryUser"
+			channelA = "A"
+		)
+		rt.CreateUser(user, []string{channelA})
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
+			Username:     user,
+			ClientDeltas: true,
+		})
+		defer btc.Close()
+
+		ctx := rt.Context()
+		docID := SafeDocumentName(t, t.Name())
+		docRev1 := rt.CreateDocNoHLV(docID, db.Body{"delta": true, "channels": []string{channelA}})
+		btcRunner.StartOneshotPull(btc.id)
+		btcRunner.WaitForVersion(btc.id, docID, DocVersion{RevTreeID: docRev1.GetRevTreeID()})
+		seq, err := rt.GetDatabase().NextSequence(ctx)
+		require.NoError(t, err)
+		// document contains an invalid revtree
+		//
+		// 3-c is a child of 3-d, a revision must be one or more generations higher than it its parent, not equal
+		badSyncRaw := `{
+			"cas": "expand",
+			"channel_set":  [
+				{
+					"end": {{.rev3seq}},
+					"name": "A",
+					"start": {{.rev1seq}}
+				}
+			],
+			"channels": {
+				"A": {
+					"rev": "{{.rev1}}",
+					"seq": {{.rev3seq}}
+				}
+			},
+			"channel_set_history": null,
+			"history": {
+				"parents": [
+					3,
+					0,
+					-1,
+					2
+				],
+				"revs": [
+					"3-d",
+					"3-c",
+					"{{.rev1}}",
+					"2-b"
+				]
+			},
+			"rev": "3-c",
+			"sequence": {{.rev3seq}},
+			"value_crc32c": "expand"
+		}`
+		tmpl := template.Must(template.New("badSync").Option("missingkey=error").Parse(badSyncRaw))
+		var badSyncData bytes.Buffer
+		require.NoError(t, tmpl.Execute(&badSyncData, map[string]any{
+			"rev1":    docRev1.GetRevTreeID(),
+			"rev1seq": docRev1.Sequence,
+			"rev3seq": seq,
+		}))
+
+		mutateInOptions := db.DefaultMutateInOpts()
+		_, err = rt.GetSingleDataStore().WriteWithXattrs(
+			ctx,
+			docID,
+			0,
+			docRev1.Cas,
+			[]byte(`{"key":"value"}`),
+			map[string][]byte{
+				base.SyncXattrName: badSyncData.Bytes(),
+			},
+			nil,
+			mutateInOptions,
+		)
+		require.NoError(t, err)
+
+		rt.WaitForPendingChanges()
+		expectedVersion := DocVersion{RevTreeID: "3-c"}
+
+		btcRunner.StartOneshotPull(btc.id)
+		btcRunner.WaitForPullNoRevMessage(btc.id, docID, expectedVersion)
+	})
+}

--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -2041,6 +2041,45 @@ func (btcc *BlipTesterCollectionClient) WaitForPullRevMessage(docID string, vers
 	return msg
 }
 
+// WaitForPullNoRevMessage will return the norev message received by the client for the given docID/version as
+// part of a pull replication. This includes norevs that were bodyless and therefore not applied to the client's
+// local document - every message received by the replication is stored regardless of how (or whether) it was
+// subsequently applied to client state.
+// If the message is not found after 10 seconds, the test will fail.
+func (btcc *BlipTesterCollectionClient) WaitForPullNoRevMessage(docID string, version DocVersion) *blip.Message {
+	btcc.TB().Helper()
+	var msg *blip.Message
+	var lookupVersion DocVersion
+	if btcc.UseHLV() && !version.CV.IsEmpty() {
+		lookupVersion = DocVersion{CV: version.CV}
+	} else {
+		lookupVersion = DocVersion{RevTreeID: version.RevTreeID}
+	}
+	require.EventuallyWithT(btcc.TB(), func(c *assert.CollectT) {
+		var matches []*blip.Message
+		for _, m := range btcc.parent.pullReplication.GetMessages() {
+			if m.Profile() != db.MessageNoRev || m.Properties[db.NorevMessageId] != docID {
+				continue
+			}
+			var incomingVersion DocVersion
+			if btcc.UseHLV() {
+				_, incomingVersion = btcc.parent.getVersionsFromRevMessage(m)
+			} else {
+				incomingVersion = DocVersion{RevTreeID: m.Properties[db.NorevMessageRev]}
+			}
+			if incomingVersion == lookupVersion {
+				matches = append(matches, m)
+			}
+		}
+		if !assert.NotEmpty(c, matches, "norev message not found for docID %q version %v in pull replication messages", docID, version) {
+			return
+		}
+		require.Len(btcc.TB(), matches, 1, "expected exactly one norev message for docID %q version %v, got %d", docID, version, len(matches))
+		msg = matches[0]
+	}, 10*time.Second, 5*time.Millisecond, "BlipTesterClient timed out waiting for pull norev message")
+	return msg
+}
+
 // GetPullRevMessage returns the last successful rev message that wrote the given docID/DocVersion on the client.
 func (btcc *BlipTesterCollectionClient) GetPullRevMessage(docID string, version DocVersion) (msg *blip.Message, found bool) {
 	btcc.seqLock.RLock()
@@ -2089,6 +2128,15 @@ func (btcRunner *BlipTestClientRunner) WaitForDoc(clientID uint32, docID string)
 // WaitForPullRevMessage blocks until the given doc ID and rev ID has been stored by the client as part of a pull replication and returns the message when found. If document is not found after 10 seconds, test will fail.
 func (btcRunner *BlipTestClientRunner) WaitForPullRevMessage(clientID uint32, docID string, version DocVersion) *blip.Message {
 	return btcRunner.SingleCollection(clientID).WaitForPullRevMessage(docID, version)
+}
+
+// WaitForPullNoRevMessage blocks until a norev message for the given doc ID and version has been received by the
+// client as part of a pull replication and returns the message when found, even if the norev was ignored to avoid
+// clobbering a known-good revision. If not found after 10 seconds, test will fail.
+func (btcRunner *BlipTestClientRunner) WaitForPullNoRevMessage(clientID uint32, docID string, version DocVersion) *blip.Message {
+	btcc := btcRunner.SingleCollection(clientID)
+	btcc.TB().Helper()
+	return btcc.WaitForPullNoRevMessage(docID, version)
 }
 
 // WaitForPushRevMessage blocks until the given doc ID and rev ID has been stored by the client as part of a push replication and returns the message when found. If document is not found after 10 seconds, test will fail.
@@ -2241,6 +2289,17 @@ func (btcc *BlipTesterCollectionClient) addRev(ctx context.Context, docID string
 			updatedHLV.UpdateWithIncomingHLV(opts.incomingHLV)
 		}
 	}
+	// A bodyless norev must never clobber a document we already have real content for. Leave the doc's active
+	// revision, _seqStore entry, _revisionsBySeq and _seqsByVersions untouched: this norev never applied to
+	// client state, so it must not be discoverable as a revision the client holds (via
+	// getAllRevisions/_proposeChangesEntryForDoc) or as a second, stale-looking _seqStore pointer to the same
+	// doc that would be yielded twice by changes iteration. Waiters use WaitForPullNoRevMessage, which reads
+	// the raw pull replication message log directly.
+	if opts.isNoRev && newBody == nil && hasLocalDoc && doc._latestRev(btcc.TB()).body != nil {
+		require.Equal(btcc.TB(), db.MessageNoRev, opts.msg.Profile(), "only norev messages should hit this bodyless-clobber guard")
+		base.DebugfCtx(ctx, base.KeySGTest, "Ignoring norev body for docID %q: no body for version %#v", docID, opts.incomingVersion)
+		return
+	}
 	newVersion.CV = *updatedHLV.ExtractCurrentVersionFromHLV()
 	// ConflictResolver is currently on BlipTesterClient, but might be per replication in the future.
 	docRev := clientDocRev{
@@ -2255,13 +2314,15 @@ func (btcc *BlipTesterCollectionClient) addRev(ctx context.Context, docID string
 
 	if !hasLocalDoc {
 		doc = newClientDocument(docID, newClientSeq, &docRev)
+		btcc._seqStore[newClientSeq] = doc
+		btcc._seqFromDocID[docID] = newClientSeq
 	} else {
 		// remove existing entry and replace with new seq
 		delete(btcc._seqStore, doc._latestSeq)
 		doc._addNewRev(docRev)
+		btcc._seqStore[newClientSeq] = doc
+		btcc._seqFromDocID[docID] = newClientSeq
 	}
-	btcc._seqStore[newClientSeq] = doc
-	btcc._seqFromDocID[docID] = newClientSeq
 
 	if opts.replacedVersion != nil {
 		// store the new sequence for a replaced rev for tests waiting for this specific rev


### PR DESCRIPTION
CBG-5825

Unclean cherry pick of #8459 to 4.1.2
Changes from main commit:
- `rest/cbl_conflict_test.go` — 4.1.2 predates the `testing/assert` and `testing/require` wrapper packages, so the imports were renamed back to `github.com/stretchr/testify/{assert,require}`. Assertions are unchanged.

Prerequisite for #8757, whose `TestMissingBackupBodyWhenTombstoneBranchPromotedToWinningBranch` calls `WaitForPullNoRevMessage` — added by this commit. CBG-5547 had no backport ticket for 4.1.2, so CBG-5825 was created as its clone.

test-only

🤖 Opened with the `sync-gateway-backport` skill in [Claude Code](https://claude.com/claude-code)
