### PR TITLE
[3.3.8 Backport] CBG-5782: do not fail write when recalculateSyncFnForActiveRev cannot find body for tombstone rev

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -931,7 +931,11 @@ func (db *DatabaseCollectionWithUser) get1xRevFromDoc(ctx context.Context, doc *
 // Returns the body and rev ID of the asked-for revision or the most recent available ancestor.
 func (db *DatabaseCollectionWithUser) getAvailableRev(ctx context.Context, doc *Document, revid string) ([]byte, string, AttachmentsMeta, error) {
 	for ; revid != ""; revid = doc.History[revid].Parent {
-		if bodyBytes, attachments, _ := db.getRevision(ctx, doc, revid); bodyBytes != nil {
+		bodyBytes, attachments, err := db.getRevision(ctx, doc, revid)
+		if err != nil && !base.IsDocNotFoundError(err) {
+			return nil, "", nil, err
+		}
+		if bodyBytes != nil {
 			return bodyBytes, revid, attachments, nil
 		}
 	}
@@ -1655,7 +1659,7 @@ func (doc *Document) updateWinningRevAndSetDocFlags(ctx context.Context) {
 	}
 }
 
-func (db *DatabaseCollectionWithUser) storeOldBodyInRevTreeAndUpdateCurrent(ctx context.Context, doc *Document, prevCurrentRev string, newRevID string, newDoc *Document, newDocHasAttachments bool) {
+func (db *DatabaseCollectionWithUser) storeOldBodyInRevTreeAndUpdateCurrent(ctx context.Context, doc *Document, prevCurrentRev string, newRevID string, newDoc *Document, newDocHasAttachments bool) error {
 	if doc.HasBody() && doc.CurrentRev != prevCurrentRev && prevCurrentRev != "" {
 		// Store the doc's previous body into the revision tree:
 		oldBodyJson, marshalErr := doc.BodyBytes(ctx)
@@ -1717,11 +1721,14 @@ func (db *DatabaseCollectionWithUser) storeOldBodyInRevTreeAndUpdateCurrent(ctx 
 		doc.NewestRev = newRevID
 		doc.setFlag(channels.Hidden, true)
 		if doc.CurrentRev != prevCurrentRev {
-			doc.promoteNonWinningRevisionBody(ctx, doc.CurrentRev, db.RevisionBodyLoader)
+			if err := doc.promoteNonWinningRevisionBody(ctx, doc.CurrentRev, db.RevisionBodyLoader); err != nil {
+				return err
+			}
 			// If the update resulted in promoting a previous non-winning revision body to winning, this isn't a metadata only update.
 			doc.metadataOnlyUpdate = nil
 		}
 	}
+	return nil
 }
 
 func (db *DatabaseCollectionWithUser) prepareSyncFn(doc *Document, newDoc *Document) (mutableBody Body, metaMap map[string]interface{}, newRevID string, err error) {
@@ -1768,31 +1775,27 @@ func (db *DatabaseCollectionWithUser) recalculateSyncFnForActiveRev(ctx context.
 	// channels & access, for purposes of updating the doc:
 	curBodyBytes, err := db.getAvailable1xRev(ctx, doc, doc.CurrentRev)
 	if err != nil {
-		return
+		// Only a tombstone is safe to leave without channels - fail the write for a live revision
+		// rather than stripping its channels and access.
+		winner := doc.History[doc.CurrentRev]
+		if winner == nil || !winner.Deleted || !base.IsDocNotFoundError(err) {
+			return
+		}
+		// A promoted tombstone can have no body left anywhere - it never had one of its own, and its
+		// ancestors' backups expire after old_rev_expiry_seconds. It needs no channels or access, so
+		// leave it with none rather than failing the write.
+		base.WarnfCtx(ctx, "updateDoc(%q): Rev %q body unavailable, leaving promoted tombstone in no channels: %v", base.UD(doc.ID), doc.CurrentRev, err)
+		return nil, nil, nil, nil, "", nil
 	}
 
 	var curBody Body
-	err = curBody.Unmarshal(curBodyBytes)
-	if err != nil {
+	if err = curBody.Unmarshal(curBodyBytes); err != nil {
 		return
 	}
 
-	if curBody != nil {
-		base.DebugfCtx(ctx, base.KeyCRUD, "updateDoc(%q): Rev %q causes %q to become current again",
-			base.UD(doc.ID), newRevID, doc.CurrentRev)
-		channelSet, access, roles, syncExpiry, oldBodyJSON, err = db.getChannelsAndAccess(ctx, doc, curBody, metaMap, doc.CurrentRev)
-		if err != nil {
-			return
-		}
-	} else {
-		// Shouldn't be possible (CurrentRev is a leaf so won't have been compacted)
-		base.WarnfCtx(ctx, "updateDoc(%q): Rev %q missing, can't call getChannelsAndAccess "+
-			"on it (err=%v)", base.UD(doc.ID), doc.CurrentRev, err)
-		channelSet = nil
-		access = nil
-		roles = nil
-	}
-	return
+	base.DebugfCtx(ctx, base.KeyCRUD, "updateDoc(%q): Rev %q causes %q to become current again",
+		base.UD(doc.ID), newRevID, doc.CurrentRev)
+	return db.getChannelsAndAccess(ctx, doc, curBody, metaMap, doc.CurrentRev)
 }
 
 func (db *DatabaseCollectionWithUser) addAttachments(ctx context.Context, newAttachments updatedAttachments) error {
@@ -2008,7 +2011,10 @@ func (col *DatabaseCollectionWithUser) documentUpdateFunc(ctx context.Context, d
 	prevCurrentRev := doc.CurrentRev
 	doc.updateWinningRevAndSetDocFlags(ctx)
 	newDocHasAttachments := len(newAttachments) > 0
-	col.storeOldBodyInRevTreeAndUpdateCurrent(ctx, doc, prevCurrentRev, newRevID, newDoc, newDocHasAttachments)
+	err = col.storeOldBodyInRevTreeAndUpdateCurrent(ctx, doc, prevCurrentRev, newRevID, newDoc, newDocHasAttachments)
+	if err != nil {
+		return
+	}
 
 	syncExpiry, oldBodyJSON, channelSet, access, roles, err := col.runSyncFn(ctx, doc, mutableBody, metaMap, newRevID)
 	if err != nil {

--- a/db/document.go
+++ b/db/document.go
@@ -636,19 +636,24 @@ func (c *DatabaseCollection) RevisionBodyLoader(key string) ([]byte, error) {
 }
 
 // Retrieves a non-winning revision body.  If not already loaded in the document (either because inline,
-// or was previously requested), loader function is used to retrieve from the bucket.
-func (doc *Document) getNonWinningRevisionBody(ctx context.Context, revid string, loader RevLoaderFunc) Body {
+// or was previously requested), loader function is used to retrieve from the bucket.  A nil body with no
+// error means the body isn't there - a failed read of an externally stored body is returned as an error,
+// because it doesn't tell us whether the body exists.
+func (doc *Document) getNonWinningRevisionBody(ctx context.Context, revid string, loader RevLoaderFunc) (Body, error) {
 	var body Body
-	bodyBytes, found := doc.History.getRevisionBody(revid, loader)
+	bodyBytes, found, err := doc.History.getRevisionBodyWithError(revid, loader)
+	if err != nil && !base.IsDocNotFoundError(err) {
+		return nil, err
+	}
 	if !found || len(bodyBytes) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	if err := body.Unmarshal(bodyBytes); err != nil {
 		base.WarnfCtx(ctx, "Unexpected error parsing body of rev %q: %v", revid, err)
-		return nil
+		return nil, nil
 	}
-	return body
+	return body, nil
 }
 
 // Fetches the body of a revision as JSON, or nil if it's not available.
@@ -677,11 +682,20 @@ func (doc *Document) removeRevisionBody(ctx context.Context, revID string) {
 }
 
 // makeBodyActive moves a previously non-winning revision body from the rev tree to the document body
-func (doc *Document) promoteNonWinningRevisionBody(ctx context.Context, revid string, loader RevLoaderFunc) {
+func (doc *Document) promoteNonWinningRevisionBody(ctx context.Context, revid string, loader RevLoaderFunc) error {
 	// If the new revision is not current, transfer the current revision's
 	// body to the top level doc._body:
-	doc.UpdateBody(doc.getNonWinningRevisionBody(ctx, revid, loader))
+	body, err := doc.getNonWinningRevisionBody(ctx, revid, loader)
+	if err != nil {
+		// The body is in the bucket but couldn't be read.  Clearing it from the rev tree here would
+		// delete the only copy of it once the write commits, and the write would go on to recalculate
+		// the document's channels without it, so fail the write instead - it can be retried.
+		base.WarnfCtx(ctx, "Unable to read the body of rev %q, being promoted to current for doc %q: %v", revid, base.UD(doc.ID), err)
+		return err
+	}
+	doc.UpdateBody(body)
 	doc.removeRevisionBody(ctx, revid)
+	return nil
 }
 
 func (doc *Document) pruneRevisions(ctx context.Context, maxDepth uint32, keepRev string) int {

--- a/db/revtree.go
+++ b/db/revtree.go
@@ -374,23 +374,31 @@ func (tree RevTree) addRevision(docid string, info RevInfo) (err error) {
 }
 
 func (tree RevTree) getRevisionBody(revid string, loader RevLoaderFunc) ([]byte, bool) {
+	bodyBytes, found, _ := tree.getRevisionBodyWithError(revid, loader)
+	return bodyBytes, found
+}
+
+// getRevisionBodyWithError is getRevisionBody, but hands back the error from a failed load of an
+// externally stored body (see RevInfo.BodyKey) instead of reporting it as a body that isn't there.
+// Callers that act destructively on an absent body need to tell those apart: unlike a _sync:rev:
+// backup, a _sync:rb: doc has no expiry and is referenced by the rev tree, so a failed read of one
+// says nothing about whether the body still exists.
+func (tree RevTree) getRevisionBodyWithError(revid string, loader RevLoaderFunc) ([]byte, bool, error) {
 	if revid == "" {
 		// TODO: CBG-1948
 		panic("Illegal empty revision ID")
 	}
 	info, found := tree[revid]
 	if !found {
-		return nil, false
+		return nil, false, nil
 	}
 
 	// If we don't have a Body in memory and there's a BodyKey present, attempt to retrieve using the loader
 	if info.Body == nil && info.BodyKey != "" {
-		if info.BodyKey != "" {
-			var err error
-			info.Body, err = loader(info.BodyKey)
-			if err != nil {
-				return nil, false
-			}
+		var err error
+		info.Body, err = loader(info.BodyKey)
+		if err != nil {
+			return nil, false, err
 		}
 	}
 
@@ -402,9 +410,9 @@ func (tree RevTree) getRevisionBody(revid string, loader RevLoaderFunc) ([]byte,
 	// is a much lower priority than avoiding write errors, and want to avoid introducing additional conflict scenarios.
 	// The invalid rev tree bodies will eventually be pruned through normal revision tree pruning.
 	if len(info.Body) > 0 && info.Body[0] == nonJSONPrefix {
-		return nil, false
+		return nil, false, nil
 	}
-	return info.Body, true
+	return info.Body, true, nil
 }
 
 func (tree RevTree) setRevisionBody(revid string, body []byte, bodyKey string, hasAttachments bool) {

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -3335,3 +3335,183 @@ func TestBlipPullReplicationRolePurge(t *testing.T) {
 		require.False(t, found, "document in the purged role's channel was replicated to the client")
 	})
 }
+
+func TestMissingBackupBodyWhenTombstoneBranchPromotedToWinningBranch(t *testing.T) {
+	// The promoted tombstone is only reached here by an on-demand import of a delete made behind
+	// Sync Gateway's back, which requires xattrs.
+	base.SkipImportTestsIfNotEnabled(t)
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD, base.KeyImport, base.KeyCache, base.KeySyncMsg)
+
+	const (
+		docID                = "testDoc"
+		username             = "alice"
+		localBranchGen       = 16
+		remoteBranchGen      = 9
+		expectedWinnerGen    = remoteBranchGen + 1 // 10 - minted by resolveDocLocalWins
+		expectedTombstoneGen = localBranchGen + 1  // 17 - minted by tombstoneActiveRevision
+	)
+
+	// The pulling client either opts in to replacement revs or it doesn't - the promoted tombstone
+	// reaches it by a different route in each case.
+	testCases := []struct {
+		name                string
+		sendReplacementRevs bool
+	}{
+		{name: "replacement rev off", sendReplacementRevs: false},
+		{name: "replacement rev on", sendReplacementRevs: true},
+	}
+
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		for _, testCase := range testCases {
+			t.Run(testCase.name, func(t *testing.T) {
+				rt := NewRestTester(t, &RestTesterConfig{
+					DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+						AutoImport: false,
+					}},
+					SyncFn: channels.DocChannelsSyncFunction,
+				})
+				defer rt.Close()
+
+				collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
+
+				dataStore := rt.GetSingleDataStore()
+				rt.CreateUser(username, []string{"chanA"})
+				client := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
+					Username: username,
+				})
+				defer client.Close()
+
+				// --- the client builds the local branch and pushes it ---------------------------------------
+				version := btcRunner.AddRev(client.id, docID, EmptyDocVersion(), []byte(`{"channels": ["chanA"], "test":"doc","gen":1}`))
+				for gen := 2; gen <= localBranchGen; gen++ {
+					version = btcRunner.AddRev(client.id, docID, &version,
+						[]byte(fmt.Sprintf(`{"test":"doc","gen":%d, "channels": ["chanA"]}`, gen)))
+				}
+				btcRunner.StartPushWithOpts(client.id, BlipTesterPushOptions{Since: "0", Continuous: false})
+				rt.WaitForVersion(docID, version)
+				localGen, _ := db.ParseRevID(ctx, version.RevID)
+				require.Equal(t, localBranchGen, localGen)
+
+				// --- ISGR pulls a conflicting revision, and the conflict is resolved -------------------------
+				// DefaultConflictResolver sees both sides live and picks
+				// the higher generation, which is the local branch - so resolveDocLocalWins runs
+				//
+				//  1. it rewrites the local body as a child of the REMOTE branch, making the winner at
+				//      remoteGen+1;
+				//   2. it then calls tombstoneActiveRevision, which tombstones the
+				//      original local branch and adds that tombstone to the rev tree - no Body, no BodyKey - so nothing is
+				//      ever persisted for it in the _sync xattr's history.bodymap. The generation-16 body goes to
+				//      a _sync:rev: document with an old_rev_expiry_seconds TTL.
+				//
+				//	Driving PutExistingRevWithConflictResolution directly rather than standing up a second cluster:
+				//  it is the same function an ISGR active pull calls.
+
+				history := make([]string, 0, remoteBranchGen)
+				for gen := remoteBranchGen; gen >= 1; gen-- {
+					history = append(history, fmt.Sprintf("%d-%s", gen, strings.Repeat("a", 32)))
+				}
+				remoteLeaf := history[0]
+				remoteHistory := history
+				remoteDoc := &db.Document{ID: docID, RevID: remoteLeaf}
+				remoteDoc.UpdateBody(db.Body{"branch": "remote", "channels": []string{"chanA"}})
+
+				_, rawBucketDoc, _ := collection.GetDocumentWithRaw(ctx, docID, db.DocUnmarshalSync)
+				_, _, err := collection.PutExistingRevWithConflictResolution(ctx, remoteDoc, remoteHistory,
+					true, db.NewConflictResolver(db.DefaultConflictResolver, nil), false, rawBucketDoc)
+				require.NoError(t, err, "ISGR conflict resolution should succeed")
+
+				// should have one active branch and one tombstone branch
+				doc, err := collection.GetDocument(ctx, docID, db.DocUnmarshalAll)
+				require.NoError(t, err)
+				require.False(t, doc.IsDeleted(), "the live winner should beat the tombstone")
+				require.Len(t, doc.History.GetLeaves(), 2)
+
+				// The winner is created by SGW as a child of the remote branch, not the remote revision itself, so
+				// it is a new revID at remoteGen+1.
+				winnerRev := doc.CurrentRev
+				winnerGen, _ := db.ParseRevID(ctx, winnerRev)
+				require.Equal(t, expectedWinnerGen, winnerGen)
+				require.NotEqual(t, remoteLeaf, winnerRev, "localWins mints a new revision, it does not reuse the remote one")
+				tombstoneLeaf := ""
+				for _, leaf := range doc.History.GetLeaves() {
+					if doc.History[leaf].Deleted {
+						tombstoneLeaf = leaf
+					}
+				}
+				require.NotEmpty(t, tombstoneLeaf, "expected a tombstoned leaf")
+				require.Empty(t, doc.History[tombstoneLeaf].Body, "the tombstone should hold no inline body")
+				require.Empty(t, doc.History[tombstoneLeaf].BodyKey, "the tombstone should hold no body key")
+				require.False(t, doc.History[tombstoneLeaf].HasAttachments)
+
+				tombstoneGen, _ := db.ParseRevID(ctx, tombstoneLeaf)
+				require.Equal(t, expectedTombstoneGen, tombstoneGen)
+
+				// --- old_rev_expiry_seconds elapses ---------------------------------------------------------
+				// manually delete backup revs to simulate this in interest of time
+				deleteBackupRevisionBodies(t, rt, docID)
+
+				importCountBefore := rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value()
+
+				// --- the deletion that only a read will notice ----------------------------------------------
+				require.NoError(t, dataStore.Delete(docID))
+
+				// Evict the revision cache, so serving the document requires a read from the bucket rather than
+				// being answered from cache - the situation for any document that has not been read recently.
+				rt.GetDatabase().FlushRevisionCacheForTest()
+
+				// A second client, which has never seen this document, replicates. The changes feed offers the
+				// pre-delete revision (nothing has imported the deletion), the client asks for it, the read finds a
+				// non-SG write and imports the deletion on demand. That import tombstones the gen-10 winner, which
+				// leaves the gen-17 tombstone branch as the winner - the branch whose body is no longer available.
+				client2 := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
+					Username:            username,
+					sendReplacementRevs: testCase.sendReplacementRevs,
+				})
+				defer client2.Close()
+				// Continuous, so that the tombstone written by the on-demand import is replicated once it reaches
+				// the channel cache, rather than falling outside a one-shot feed that has already caught up.
+				btcRunner.StartPull(client2.id)
+
+				require.EventuallyWithT(t, func(c *assert.CollectT) {
+					assert.Greater(c, rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value(), importCountBefore,
+						"waiting for the on-demand import of the deletion")
+				}, 10*time.Second, 50*time.Millisecond)
+				// The import must not fail on the promoted branch's missing body - recalculateSyncFnForActiveRev
+				// can't run the sync function for it, but that leaves the revision channel-less rather than
+				// aborting the write.
+				assert.Equal(t, int64(0), rt.GetDatabase().DbStats.SharedBucketImport().ImportErrorCount.Value(),
+					"the on-demand import should not fail on the missing body of the promoted tombstone")
+
+				// The sync function couldn't be run for the promoted tombstone, so it holds no channels -
+				// chanA is marked as a removal, flagged as a deletion so the pull below sends a tombstone.
+				importedDoc, err := collection.GetDocument(ctx, docID, db.DocUnmarshalAll)
+				require.NoError(t, err)
+				require.Equal(t, tombstoneLeaf, importedDoc.CurrentRev, "the tombstone branch should have been promoted")
+				require.True(t, importedDoc.IsDeleted())
+				chanARemoval, inChanA := importedDoc.Channels["chanA"]
+				require.True(t, inChanA)
+				require.NotNil(t, chanARemoval, "chanA should be marked as a removal, not left active")
+				assert.True(t, chanARemoval.Deleted)
+
+				client2Collection := btcRunner.SingleCollection(client2.id)
+				tombstoneVersion := DocVersion{RevID: tombstoneLeaf}
+
+				// The requested revision is gone, so the client gets a norev for it. This holds even for a
+				// client opted in to replacement revs: the replacement is the active revision, and a tombstone
+				// carries no channels, so the user is not authorized for it and the lookup fails with
+				// ErrForbidden. That is not specific to the promoted branch - an ordinary Sync Gateway delete
+				// produces the same norev for an unavailable revision.
+				//
+				// 3.3.8's BlipTesterCollectionClient cannot hand back the norev message it received, so
+				// the norev is asserted through the stat rather than by inspecting the message.
+				base.RequireWaitForStat(t, rt.GetDatabase().DbStats.CBLReplicationPull().NoRevSendCount.Value, 1)
+				assert.Equal(t, int64(0), rt.GetDatabase().DbStats.CBLReplicationPull().ReplacementRevSendCount.Value(),
+					"a channel-less tombstone is never sent as a replacement rev")
+
+				// wait for tombstone to reach client
+				client2Collection.WaitForVersion(docID, tombstoneVersion)
+			})
+		}
+	})
+}

--- a/rest/sync_fn_test.go
+++ b/rest/sync_fn_test.go
@@ -13,10 +13,12 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/couchbase/gocb/v2"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"
@@ -284,6 +286,686 @@ func TestSyncFnDocBodyPropertiesSwitchActiveTombstone(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, 1, numErrorsAfter-numErrorsBefore, "expecting to see only only 1 error logged")
+}
+
+// setUpPromotedLiveBranch builds a conflicted document whose losing branch is live and holds a body
+// of its own, externalised to a _sync:rb: doc because it is over db.MaximumInlineBodySize.
+// Tombstoning the winner promotes that branch, and the _sync:rb: doc is the only place a body for it
+// can come from.
+//
+//	1-a                         chan-base
+//	├── 2-a                     chan-a, live, body externalised to a _sync:rb: doc
+//	└── 2-fff... (winner)       chan-b
+//
+// Each revision is in a channel of its own, so that a recalculation that runs the sync function on
+// the wrong revision's body shows up in the document's channels. Returns the three revisions and
+// the key of branch a's externalised body.
+func setUpPromotedLiveBranch(t *testing.T, rt *RestTester, docID string) (version1a, version2a, version2b DocVersion, bodyKey string) {
+	t.Helper()
+
+	const branchB = "2-ffffffffffffffffffffffffffffffff"
+
+	rt.GetDatabase().Options.AllowConflicts = base.Ptr(true)
+
+	// Non-winning bodies are only moved out to a _sync:rb: doc when xattrs are enabled, so without
+	// this the padded bodies below stay inline and the externalised-body path under test is never
+	// exercised on a SG_TEST_USE_XATTRS=false run. Forcing it keeps both modes on the same path.
+	base.TestExternalRevStorage = true
+	t.Cleanup(func() { base.TestExternalRevStorage = false })
+
+	// Bodies need to be over db.MaximumInlineBodySize so that a non-winning body is held in a
+	// _sync:rb: document rather than inline in the rev tree, and so requires a bucket read.
+	padding := strings.Repeat("x", db.MaximumInlineBodySize*2)
+	docBody := func(branch string) string {
+		return fmt.Sprintf(`{"channels":["chan-%s"],"branch":%q,"padding":%q}`, branch, branch, padding)
+	}
+
+	version1a = rt.PutDoc(docID, docBody("base"))
+	version2a = rt.UpdateDoc(docID, version1a, docBody("a"))
+	// branchB beats 2-a in the revid comparison, so branch b becomes the winner and branch a's body is
+	// moved out of the document into a _sync:rb: doc.
+	version2b = *rt.PutNewEditsFalse(docID, NewDocVersionFromFakeRev(branchB), &version1a, docBody("b"))
+
+	collection, ctx := rt.GetSingleTestDatabaseCollection()
+	doc, err := collection.GetDocument(ctx, docID, db.DocUnmarshalAll)
+	require.NoError(t, err)
+	require.Equal(t, version2b.RevID, doc.CurrentRev, "branch b should be the winning revision")
+	require.Empty(t, doc.History[version2a.RevID].Body, "branch a's body should not be inline in the rev tree")
+	bodyKey = doc.History[version2a.RevID].BodyKey
+	require.NotEmpty(t, bodyKey, "branch a's body should have been externalised")
+	return version1a, version2a, version2b, bodyKey
+}
+
+// TestSyncFnLiveBranchPromotedWithUnreadableBody tombstones the winning revision of a conflicted
+// document so that a live branch is promoted, while every read of a backup body fails with a
+// transient bucket error.
+//
+// recalculateSyncFnForActiveRev can't distinguish that failure from a body that has genuinely
+// expired, because getAvailableRev reports both as a 404. Swallowing it would run the promoted live
+// revision through updateChannels(nil), removing the document from every channel it is in and
+// dropping its access grants, so the write must fail and be retried instead.
+func TestSyncFnLiveBranchPromotedWithUnreadableBody(t *testing.T) {
+
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCRUD)
+
+	const testDocID = "testdoc"
+
+	rt := NewRestTester(t, &RestTesterConfig{
+		GuestEnabled:      true,
+		LeakyBucketConfig: &base.LeakyBucketConfig{},
+		SyncFn:            `function(doc){ if (!doc._deleted) { channel(doc.channels); } }`,
+	})
+	defer rt.Close()
+
+	_, version2a, version2b, bodyKey := setUpPromotedLiveBranch(t, rt, testDocID)
+	collection, ctx := rt.GetSingleTestDatabaseCollection()
+
+	// Fail every backup body read for the duration of the tombstoning write.
+	leakyDataStore, ok := base.AsLeakyDataStore(rt.GetSingleDataStore())
+	require.True(t, ok)
+	leakyDataStore.SetGetRawCallback(func(key string) error {
+		if strings.HasPrefix(key, base.RevBodyPrefix) || strings.HasPrefix(key, base.RevPrefix) {
+			return gocb.ErrTimeout
+		}
+		return nil
+	})
+
+	// Tombstone branch b, which promotes branch a to winning revision.
+	response := rt.SendAdminRequest(http.MethodDelete,
+		fmt.Sprintf("/{{.keyspace}}/%s?rev=%s", testDocID, version2b.RevID), "")
+	RequireStatus(t, response, http.StatusServiceUnavailable)
+
+	leakyDataStore.SetGetRawCallback(nil)
+
+	// The refused write must have left the document, and branch a's externalised body, untouched.
+	doc, err := collection.GetDocument(ctx, testDocID, db.DocUnmarshalAll)
+	require.NoError(t, err)
+	assert.Equal(t, version2b.RevID, doc.CurrentRev, "the refused write should not have changed the winning revision")
+	removal, inChannel := doc.Channels["chan-b"]
+	assert.True(t, inChannel && removal == nil, "the live document should still be in chan-b, got %+v", doc.Channels)
+	_, _, err = rt.GetSingleDataStore().GetRaw(bodyKey)
+	assert.NoError(t, err, "branch a's externalised body should not have been deleted")
+
+	// Once the bucket is healthy again the same write succeeds, and branch a keeps its channel.
+	rt.DeleteDoc(testDocID, version2b)
+	doc, err = collection.GetDocument(ctx, testDocID, db.DocUnmarshalAll)
+	require.NoError(t, err)
+	require.Equal(t, version2a.RevID, doc.CurrentRev, "branch a should now be the winning revision")
+	require.False(t, doc.IsDeleted())
+	removal, inChannel = doc.Channels["chan-a"]
+	assert.True(t, inChannel && removal == nil, "the promoted live revision should be in chan-a, got %+v", doc.Channels)
+}
+
+// TestSyncFnLiveBranchPromotedWithUnreadableExternalisedBody is the other half of
+// TestSyncFnLiveBranchPromotedWithUnreadableBody. There every backup read fails, so the failure
+// surfaces from the _sync:rev: lookup in getAvailableRev. Here only the _sync:rb: doc holding the
+// promoted branch's body is unreadable, which is the read promoteNonWinningRevisionBody makes.
+//
+// Unlike a _sync:rev: backup, a _sync:rb: doc has no expiry and is referenced by the rev tree, so a
+// failed read of one says nothing about whether the body exists. Treating it as an absent body has
+// promoteNonWinningRevisionBody put no body in the document and queue the _sync:rb: doc for
+// deletion, and committing that write then deletes the only copy of the promoted revision's body,
+// leaves the previous winner's body in the bucket under the promoted revision's rev ID, and
+// recalculates the document's channels from whichever ancestor backup is still within
+// old_rev_expiry_seconds. The write has to fail and be retried instead.
+func TestSyncFnLiveBranchPromotedWithUnreadableExternalisedBody(t *testing.T) {
+
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCRUD)
+
+	const testDocID = "testdoc"
+
+	rt := NewRestTester(t, &RestTesterConfig{
+		GuestEnabled:      true,
+		LeakyBucketConfig: &base.LeakyBucketConfig{},
+		SyncFn:            `function(doc){ if (!doc._deleted) { channel(doc.channels); } }`,
+	})
+	defer rt.Close()
+
+	_, version2a, version2b, bodyKey := setUpPromotedLiveBranch(t, rt, testDocID)
+	collection, ctx := rt.GetSingleTestDatabaseCollection()
+	dataStore := rt.GetSingleDataStore()
+
+	doc, err := collection.GetDocument(ctx, testDocID, db.DocUnmarshalAll)
+	require.NoError(t, err)
+	channelsBeforeWrite := doc.Channels
+
+	// Fail only the reads of the externalised body - branch a's body is in the bucket and readable in
+	// principle, and a transient bucket error is the only thing standing between the write and it.
+	leakyDataStore, ok := base.AsLeakyDataStore(dataStore)
+	require.True(t, ok)
+	leakyDataStore.SetGetRawCallback(func(key string) error {
+		if strings.HasPrefix(key, base.RevBodyPrefix) {
+			return gocb.ErrTimeout
+		}
+		return nil
+	})
+
+	// Tombstone branch b, which promotes branch a to winning revision.
+	response := rt.SendAdminRequest(http.MethodDelete,
+		fmt.Sprintf("/{{.keyspace}}/%s?rev=%s", testDocID, version2b.RevID), "")
+	RequireStatus(t, response, http.StatusServiceUnavailable)
+
+	// Cleared before the assertions below, which need to read the bucket themselves.
+	leakyDataStore.SetGetRawCallback(nil)
+
+	// The refused write must have left the document, and branch a's body, exactly as they were.
+	doc, err = collection.GetDocument(ctx, testDocID, db.DocUnmarshalAll)
+	require.NoError(t, err)
+	assert.Equal(t, version2b.RevID, doc.CurrentRev, "the refused write should not have changed the winning revision")
+	assert.Equal(t, bodyKey, doc.History[version2a.RevID].BodyKey, "branch a should still reference its externalised body")
+	assert.Equal(t, channelsBeforeWrite, doc.Channels, "the refused write should not have recalculated the document's channels")
+	_, _, err = dataStore.GetRaw(bodyKey)
+	assert.NoError(t, err, "branch a's externalised body should not have been deleted")
+
+	// The document's body must still be the one its rev ID names.
+	response = rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/"+testDocID, "")
+	RequireStatus(t, response, http.StatusOK)
+	var body db.Body
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
+	assert.Equal(t, version2b.RevID, body[db.BodyRev].(string))
+	assert.Equal(t, "b", body["branch"].(string))
+
+	// Nothing about the refused write is sticky - once the bucket is healthy the same tombstone
+	// promotes branch a, with branch a's own body and channel.
+	rt.DeleteDoc(testDocID, version2b)
+
+	doc, err = collection.GetDocument(ctx, testDocID, db.DocUnmarshalAll)
+	require.NoError(t, err)
+	require.Equal(t, version2a.RevID, doc.CurrentRev, "branch a should now be the winning revision")
+	require.False(t, doc.IsDeleted())
+	removal, inChannel := doc.Channels["chan-a"]
+	assert.True(t, inChannel && removal == nil, "the promoted live revision should be in chan-a, got %+v", doc.Channels)
+
+	response = rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/"+testDocID, "")
+	RequireStatus(t, response, http.StatusOK)
+	body = nil
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
+	assert.Equal(t, version2a.RevID, body[db.BodyRev].(string))
+	assert.Equal(t, "a", body["branch"].(string), "the promoted revision's own body should have been promoted into the document")
+}
+
+// TestSyncFnLiveBranchPromotedWithMissingBody promotes a live branch whose body isn't in the bucket
+// at all: its _sync:rb: doc is gone, and so are the transient backups of every ancestor. A read that
+// found nothing is the one failure that does tell us the body isn't there, so it can't be retried -
+// but a live revision still can't be left with no channels the way a tombstone can, so the write has
+// to fail rather than drop the document out of the channels it is in.
+func TestSyncFnLiveBranchPromotedWithMissingBody(t *testing.T) {
+
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCRUD)
+
+	const testDocID = "testdoc"
+
+	rt := NewRestTester(t, &RestTesterConfig{
+		GuestEnabled: true,
+		SyncFn:       `function(doc){ if (!doc._deleted) { channel(doc.channels); access("bob", "grantedChan"); } }`,
+	})
+	defer rt.Close()
+
+	_, _, version2b, bodyKey := setUpPromotedLiveBranch(t, rt, testDocID)
+	collection, ctx := rt.GetSingleTestDatabaseCollection()
+	dataStore := rt.GetSingleDataStore()
+
+	doc, err := collection.GetDocument(ctx, testDocID, db.DocUnmarshalAll)
+	require.NoError(t, err)
+	_, bobGranted := doc.Access["bob"]
+	require.True(t, bobGranted, "the live document should have granted bob access, got %+v", doc.Access)
+	channelsBeforeWrite := doc.Channels
+
+	// Model the loss of branch a's externalised body, and the ageing out of every transient backup,
+	// leaving no body for branch a anywhere in the bucket.
+	require.NoError(t, dataStore.Delete(bodyKey))
+	deleteBackupRevisionBodies(t, rt, testDocID)
+
+	// Tombstoning branch b promotes branch a, which has no body to run the sync function on.
+	response := rt.SendAdminRequest(http.MethodDelete,
+		fmt.Sprintf("/{{.keyspace}}/%s?rev=%s", testDocID, version2b.RevID), "")
+	// getAvailableRev reports the missing body as db.ErrMissing, which is a 404.
+	RequireStatus(t, response, http.StatusNotFound)
+
+	// The refused write must have left the document in its channels, with its grants.
+	doc, err = collection.GetDocument(ctx, testDocID, db.DocUnmarshalAll)
+	require.NoError(t, err)
+	assert.Equal(t, version2b.RevID, doc.CurrentRev, "the refused write should not have changed the winning revision")
+	assert.False(t, doc.IsDeleted())
+	assert.Equal(t, channelsBeforeWrite, doc.Channels, "the refused write should not have recalculated the document's channels")
+	_, bobGranted = doc.Access["bob"]
+	assert.True(t, bobGranted, "bob's access grant should not have been revoked, got %+v", doc.Access)
+}
+
+// setUpPromotedTombstoneBranch builds the rev tree an ISGR pull leaves behind when conflict
+// resolution keeps the local branch: the local body is re-parented onto the remote branch as the
+// live winner, and the original local branch is tombstoned at a higher generation. That tombstone
+// holds no body of its own, so once the winner is tombstoned it is promoted and only its ancestors'
+// backup bodies can supply a body for the sync function.
+//
+//	1-a ... 6-a                     local branch
+//	└── (T) 7-a                     tombstoned by conflict resolution, no body of its own
+//	1-remote ... 3-remote
+//	└── 4-x                         live winner, minted from the local body
+//
+// The document is in chanA. Returns the live winning revision and the tombstoned leaf.
+func setUpPromotedTombstoneBranch(t *testing.T, rt *RestTester, docID string) (winnerRev, tombstoneRev string) {
+	t.Helper()
+
+	const (
+		localBranchGen  = 6
+		remoteBranchGen = 3
+	)
+
+	collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
+
+	version := rt.PutDoc(docID, `{"channels":["chanA"],"gen":1}`)
+	for gen := 2; gen <= localBranchGen; gen++ {
+		version = rt.UpdateDoc(docID, version, fmt.Sprintf(`{"channels":["chanA"],"gen":%d}`, gen))
+	}
+
+	// Drive PutExistingRevWithConflictResolution directly rather than standing up a second cluster -
+	// it is the same function an ISGR active pull calls. The default resolver sees both sides live and
+	// picks the higher generation, which is the local branch, so resolveDocLocalWins runs.
+	remoteHistory := make([]string, 0, remoteBranchGen)
+	for gen := remoteBranchGen; gen >= 1; gen-- {
+		remoteHistory = append(remoteHistory, fmt.Sprintf("%d-%s", gen, strings.Repeat("a", 32)))
+	}
+	remoteDoc := &db.Document{ID: docID, RevID: remoteHistory[0]}
+	remoteDoc.UpdateBody(db.Body{"branch": "remote", "channels": []string{"chanA"}})
+
+	_, rawBucketDoc, err := collection.GetDocumentWithRaw(ctx, docID, db.DocUnmarshalSync)
+	require.NoError(t, err)
+	_, _, err = collection.PutExistingRevWithConflictResolution(ctx, remoteDoc, remoteHistory, true, db.NewConflictResolver(db.DefaultConflictResolver, nil), false, rawBucketDoc)
+	require.NoError(t, err, "ISGR conflict resolution should succeed")
+
+	doc, err := collection.GetDocument(ctx, docID, db.DocUnmarshalAll)
+	require.NoError(t, err)
+	require.False(t, doc.IsDeleted(), "the live winner should beat the tombstone")
+	require.Len(t, doc.History.GetLeaves(), 2)
+
+	winnerRev = doc.CurrentRev
+	for _, leaf := range doc.History.GetLeaves() {
+		if doc.History[leaf].Deleted {
+			tombstoneRev = leaf
+		}
+	}
+	require.NotEmpty(t, tombstoneRev, "expected a tombstoned leaf")
+	require.Empty(t, doc.History[tombstoneRev].Body, "the tombstone should hold no inline body")
+	require.Empty(t, doc.History[tombstoneRev].BodyKey, "the tombstone should hold no body key")
+	return winnerRev, tombstoneRev
+}
+
+// TestSyncFnPromotedTombstoneWithUnreadableBackupBody is the tombstone twin of
+// TestSyncFnLiveBranchPromotedWithUnreadableBody: the promoted branch's backup bodies are still in the
+// bucket, and the only reason the read fails is a transient bucket error.
+//
+// getAvailableRev discards getRevision's error and reports every failure as a 404, so
+// recalculateSyncFnForActiveRev cannot tell that apart from a body that has genuinely expired. The
+// document's channels and access grants must not be dropped on the strength of an error that says
+// nothing about whether the body exists - the write has to fail and be retried instead.
+func TestSyncFnPromotedTombstoneWithUnreadableBackupBody(t *testing.T) {
+
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCRUD)
+
+	const testDocID = "testdoc"
+
+	testCases := []struct {
+		name             string
+		failBackupReads  bool
+		expectedStatus   int
+		expectTombstoned bool
+	}{
+		{
+			// The backup body is readable, so the sync function runs for the promoted tombstone and its
+			// grants are recalculated as normal.
+			name:             "readable backup body",
+			failBackupReads:  false,
+			expectedStatus:   http.StatusOK,
+			expectTombstoned: true,
+		},
+		{
+			// The backup body is present but unreadable, so there is no basis for stripping the grants.
+			name:             "transient backup body read error",
+			failBackupReads:  true,
+			expectedStatus:   http.StatusServiceUnavailable,
+			expectTombstoned: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			rt := NewRestTester(t, &RestTesterConfig{
+				GuestEnabled:      true,
+				LeakyBucketConfig: &base.LeakyBucketConfig{},
+				SyncFn:            `function(doc){ channel(doc.channels); access("bob", "grantedChan"); }`,
+			})
+			defer rt.Close()
+
+			winnerRev, tombstoneRev := setUpPromotedTombstoneBranch(t, rt, testDocID)
+			collection, ctx := rt.GetSingleTestDatabaseCollection()
+
+			doc, err := collection.GetDocument(ctx, testDocID, db.DocUnmarshalAll)
+			require.NoError(t, err)
+			_, bobGranted := doc.Access["bob"]
+			require.True(t, bobGranted, "the live document should have granted bob access, got %+v", doc.Access)
+
+			// Unlike TestSyncFnPromotedTombstoneWithExpiredBackupBody the backup bodies are left in place -
+			// a transient bucket error is the only thing standing between the write and the body.
+			if testCase.failBackupReads {
+				leakyDataStore, ok := base.AsLeakyDataStore(rt.GetSingleDataStore())
+				require.True(t, ok)
+				leakyDataStore.SetGetRawCallback(func(key string) error {
+					if strings.HasPrefix(key, base.RevBodyPrefix) || strings.HasPrefix(key, base.RevPrefix) {
+						return gocb.ErrTimeout
+					}
+					return nil
+				})
+				defer leakyDataStore.SetGetRawCallback(nil)
+			}
+
+			// Tombstoning the winner promotes the tombstone branch, whose body only its ancestors' backups
+			// can supply.
+			response := rt.SendAdminRequest(http.MethodDelete,
+				fmt.Sprintf("/{{.keyspace}}/%s?rev=%s", testDocID, winnerRev), "")
+			AssertStatus(t, response, testCase.expectedStatus)
+
+			doc, err = collection.GetDocument(ctx, testDocID, db.DocUnmarshalAll)
+			require.NoError(t, err)
+			if testCase.expectTombstoned {
+				assert.Equal(t, tombstoneRev, doc.CurrentRev, "the tombstone branch should have been promoted")
+				assert.True(t, doc.IsDeleted())
+			} else {
+				assert.Equal(t, winnerRev, doc.CurrentRev, "the refused write should not have changed the winning revision")
+				assert.False(t, doc.IsDeleted())
+			}
+
+			// Either way the sync function's output for the promoted branch is intact - it either ran, or the
+			// write was refused before anything was recalculated.
+			_, bobGranted = doc.Access["bob"]
+			assert.True(t, bobGranted, "bob's access grant should not have been revoked, got %+v", doc.Access)
+		})
+	}
+}
+
+// TestSyncFnPromotedTombstoneWithExpiredBackupBody pins what recalculateSyncFnForActiveRev does when
+// a promoted tombstone branch has no body left anywhere: the sync function can't be run for it, so
+// the document ends up in no channels and with no access grants, rather than the write failing.
+func TestSyncFnPromotedTombstoneWithExpiredBackupBody(t *testing.T) {
+
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCRUD)
+
+	const testDocID = "testdoc"
+
+	rt := NewRestTester(t, &RestTesterConfig{
+		GuestEnabled: true,
+		SyncFn:       `function(doc){ channel(doc.channels); access("bob", "grantedChan"); }`,
+	})
+	defer rt.Close()
+
+	winnerRev, tombstoneRev := setUpPromotedTombstoneBranch(t, rt, testDocID)
+	collection, ctx := rt.GetSingleTestDatabaseCollection()
+
+	doc, err := collection.GetDocument(ctx, testDocID, db.DocUnmarshalAll)
+	require.NoError(t, err)
+	_, bobGranted := doc.Access["bob"]
+	require.True(t, bobGranted, "the live document should have granted bob access, got %+v", doc.Access)
+
+	// Model the ancestors' backup bodies ageing out after old_rev_expiry_seconds.
+	deleteBackupRevisionBodies(t, rt, testDocID)
+
+	// Tombstoning the winner promotes the tombstone branch, whose body is now unavailable.
+	response := rt.SendAdminRequest(http.MethodDelete,
+		fmt.Sprintf("/{{.keyspace}}/%s?rev=%s", testDocID, winnerRev), "")
+	RequireStatus(t, response, http.StatusOK)
+
+	doc, err = collection.GetDocument(ctx, testDocID, db.DocUnmarshalAll)
+	require.NoError(t, err)
+	require.Equal(t, tombstoneRev, doc.CurrentRev, "the tombstone branch should have been promoted")
+	require.True(t, doc.IsDeleted())
+
+	removal, inChannel := doc.Channels["chanA"]
+	require.True(t, inChannel, "chanA should still be recorded on the document")
+	require.NotNil(t, removal, "chanA should be marked as a removal, not left active")
+	assert.True(t, removal.Deleted, "the removal should be flagged as a deletion so pull replications send a tombstone")
+	assert.Empty(t, doc.Access, "the promoted tombstone's access grants should have been revoked")
+}
+
+// TestSyncFnPromotedTombstoneWithCorruptBackupBody checks that only a genuinely missing body is
+// tolerated when a tombstone branch is promoted. A backup body that is readable but unusable is an
+// error we have no answer for, so it must fail the write rather than quietly dropping the
+// document's channels and access grants.
+func TestSyncFnPromotedTombstoneWithCorruptBackupBody(t *testing.T) {
+
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCRUD)
+
+	const testDocID = "testdoc"
+
+	rt := NewRestTester(t, &RestTesterConfig{
+		GuestEnabled: true,
+		SyncFn:       `function(doc){ channel(doc.channels); }`,
+	})
+	defer rt.Close()
+
+	winnerRev, _ := setUpPromotedTombstoneBranch(t, rt, testDocID)
+	collection, ctx := rt.GetSingleTestDatabaseCollection()
+
+	doc, err := collection.GetDocument(ctx, testDocID, db.DocUnmarshalAll)
+	require.NoError(t, err)
+
+	// Rewrite every backup rev body as a JSON array. getAvailableRev hands it back without complaint,
+	// but it can't be used as a document body. The leading byte is nonJSONPrefixKindRevBody, which
+	// marks the remainder as a plain JSON body.
+	corruptBody := append([]byte{1}, []byte(`[1,2,3]`)...)
+	dataStore := rt.GetSingleDataStore()
+	corrupted := 0
+	for revID := range doc.History {
+		key := fmt.Sprintf("%s%s:%d:%s", base.RevPrefix, testDocID, len(revID), revID)
+		if _, _, getErr := dataStore.GetRaw(key); getErr != nil {
+			require.True(t, base.IsDocNotFoundError(getErr), "unexpected error reading %s: %v", key, getErr)
+			continue
+		}
+		require.NoError(t, dataStore.SetRaw(key, 0, nil, corruptBody))
+		corrupted++
+	}
+	require.NotZero(t, corrupted, "expected at least one backup rev body to corrupt")
+
+	// Tombstoning the winner promotes the tombstone branch, which walks back to a corrupt body.
+	response := rt.SendAdminRequest(http.MethodDelete,
+		fmt.Sprintf("/{{.keyspace}}/%s?rev=%s", testDocID, winnerRev), "")
+	RequireStatus(t, response, http.StatusInternalServerError)
+
+	// The refused write must have left the document alone.
+	doc, err = collection.GetDocument(ctx, testDocID, db.DocUnmarshalAll)
+	require.NoError(t, err)
+	assert.Equal(t, winnerRev, doc.CurrentRev, "the refused write should not have changed the winning revision")
+	assert.False(t, doc.IsDeleted())
+	removal, inChannel := doc.Channels["chanA"]
+	assert.True(t, inChannel && removal == nil, "the live document should still be in chanA, got %+v", doc.Channels)
+}
+
+// setUpPromotedTombstoneWithExternalisedBody builds a document whose tombstoned leaf holds a body of
+// its own, externalised to a _sync:rb: doc because it is over db.MaximumInlineBodySize. Tombstoning
+// the live winner promotes that leaf, and the _sync:rb: doc is the only place a body for it can come
+// from.
+//
+//	1-a
+//	└── 2-a                     live winner
+//	4-x
+//	└── (T) 5-fff...            tombstone leaf, body held in a _sync:rb: doc
+//
+// PutNewEditsFalse derives each generation in a history from "start" downwards, so the tombstone's
+// parent is a bodiless 4-x rather than 1-a - the shape a push of a revs_limit-truncated history
+// leaves behind. That is deliberate here: the branch holds no ancestor bodies for getAvailableRev to
+// fall back on, so the leaf's own externalised body is the only source of one.
+//
+// The document is in chanA and grants bob access. Returns the live winner, the tombstoned leaf, and
+// the key of the leaf's externalised body.
+func setUpPromotedTombstoneWithExternalisedBody(t *testing.T, rt *RestTester, docID string) (winnerRev, tombstoneRev, bodyKey string) {
+	t.Helper()
+
+	tombstoneRev = "5-ffffffffffffffffffffffffffffffff"
+
+	rt.GetDatabase().Options.AllowConflicts = base.Ptr(true)
+
+	// Non-winning bodies are only moved out to a _sync:rb: doc when xattrs are enabled, so without
+	// this the padded bodies below stay inline and the externalised-body path under test is never
+	// exercised on a SG_TEST_USE_XATTRS=false run. Forcing it keeps both modes on the same path.
+	base.TestExternalRevStorage = true
+	t.Cleanup(func() { base.TestExternalRevStorage = false })
+
+	// Bodies need to be over db.MaximumInlineBodySize so that the tombstone leaf's body is held in a
+	// _sync:rb: doc rather than inline in the rev tree, and so requires a bucket read.
+	padding := strings.Repeat("x", db.MaximumInlineBodySize*2)
+	version1a := rt.PutDoc(docID, fmt.Sprintf(`{"channels":["chanA"],"gen":1,"padding":%q}`, padding))
+	rt.PutNewEditsFalse(docID, NewDocVersionFromFakeRev(tombstoneRev), &version1a,
+		fmt.Sprintf(`{"_deleted":true,"channels":["chanA"],"branch":"tombstone","padding":%q}`, padding))
+	// a live revision always beats a tombstone, so 2-a is the winner and the tombstone leaf is not
+	winnerRev = rt.UpdateDoc(docID, version1a, fmt.Sprintf(`{"channels":["chanA"],"gen":2,"padding":%q}`, padding)).RevID
+
+	collection, ctx := rt.GetSingleTestDatabaseCollection()
+	doc, err := collection.GetDocument(ctx, docID, db.DocUnmarshalAll)
+	require.NoError(t, err)
+	require.Equal(t, winnerRev, doc.CurrentRev, "the live revision should be the winning revision")
+	require.True(t, doc.History[tombstoneRev].Deleted)
+	require.Empty(t, doc.History[tombstoneRev].Body, "the tombstone's body should not be inline in the rev tree")
+	bodyKey = doc.History[tombstoneRev].BodyKey
+	require.NotEmpty(t, bodyKey, "the tombstone's body should have been externalised")
+
+	parentRev := doc.History[tombstoneRev].Parent
+	require.NotEmpty(t, parentRev)
+	require.Empty(t, doc.History[parentRev].Body, "the tombstone's parent should hold no body")
+	require.Empty(t, doc.History[parentRev].BodyKey, "the tombstone's parent should hold no body")
+
+	// Model the live branch's transient backups ageing out, leaving the tombstone's externalised body
+	// as the only body in the bucket besides the winner's own.
+	deleteBackupRevisionBodies(t, rt, docID)
+	_, _, err = rt.GetSingleDataStore().GetRaw(bodyKey)
+	require.NoError(t, err, "the externalised body should still be in the bucket")
+	return winnerRev, tombstoneRev, bodyKey
+}
+
+// TestSyncFnPromotedTombstoneWithUnreadableExternalisedBody is the _sync:rb: twin of
+// TestSyncFnPromotedTombstoneWithUnreadableBackupBody: the promoted tombstone has a body of its own
+// rather than relying on an ancestor's backup, and the only reason the read of it fails is a
+// transient bucket error.
+//
+// A tombstone with no body left anywhere is allowed to end up in no channels, so a promoted
+// tombstone is the case where a failed read is most likely to be waved through as an absent body.
+// It must not be: the read says nothing about whether the body exists, and by the time
+// recalculateSyncFnForActiveRev sees a 404 promoteNonWinningRevisionBody has already queued the
+// _sync:rb: doc for deletion, so committing the write revokes the document's grants and destroys the
+// body that would have prevented that.
+func TestSyncFnPromotedTombstoneWithUnreadableExternalisedBody(t *testing.T) {
+
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCRUD)
+
+	const testDocID = "testdoc"
+
+	rt := NewRestTester(t, &RestTesterConfig{
+		GuestEnabled:      true,
+		LeakyBucketConfig: &base.LeakyBucketConfig{},
+		SyncFn:            `function(doc){ channel(doc.channels); access("bob", "grantedChan"); }`,
+	})
+	defer rt.Close()
+
+	winnerRev, tombstoneRev, bodyKey := setUpPromotedTombstoneWithExternalisedBody(t, rt, testDocID)
+	collection, ctx := rt.GetSingleTestDatabaseCollection()
+	dataStore := rt.GetSingleDataStore()
+
+	doc, err := collection.GetDocument(ctx, testDocID, db.DocUnmarshalAll)
+	require.NoError(t, err)
+	_, bobGranted := doc.Access["bob"]
+	require.True(t, bobGranted, "the live document should have granted bob access, got %+v", doc.Access)
+	channelsBeforeWrite := doc.Channels
+
+	// Fail only the reads of the externalised body - it is in the bucket and readable in principle.
+	leakyDataStore, ok := base.AsLeakyDataStore(dataStore)
+	require.True(t, ok)
+	leakyDataStore.SetGetRawCallback(func(key string) error {
+		if strings.HasPrefix(key, base.RevBodyPrefix) {
+			return gocb.ErrTimeout
+		}
+		return nil
+	})
+
+	// Tombstoning the winner promotes the tombstone leaf, whose body only the _sync:rb: doc can supply.
+	response := rt.SendAdminRequest(http.MethodDelete,
+		fmt.Sprintf("/{{.keyspace}}/%s?rev=%s", testDocID, winnerRev), "")
+	RequireStatus(t, response, http.StatusServiceUnavailable)
+
+	// Cleared before the assertions below, which need to read the bucket themselves.
+	leakyDataStore.SetGetRawCallback(nil)
+
+	// The refused write must have left the document, and the tombstone's body, exactly as they were.
+	doc, err = collection.GetDocument(ctx, testDocID, db.DocUnmarshalAll)
+	require.NoError(t, err)
+	assert.Equal(t, winnerRev, doc.CurrentRev, "the refused write should not have changed the winning revision")
+	assert.False(t, doc.IsDeleted())
+	assert.Equal(t, bodyKey, doc.History[tombstoneRev].BodyKey, "the tombstone should still reference its externalised body")
+	assert.Equal(t, channelsBeforeWrite, doc.Channels, "the refused write should not have recalculated the document's channels")
+	_, bobGranted = doc.Access["bob"]
+	assert.True(t, bobGranted, "bob's access grant should not have been revoked, got %+v", doc.Access)
+	_, _, err = dataStore.GetRaw(bodyKey)
+	assert.NoError(t, err, "the externalised body must not be deleted on a failed read")
+
+	// Once the bucket is healthy the same write succeeds: the sync function runs for the promoted
+	// tombstone using its own body, so the document keeps chanA and bob keeps his grant, and the
+	// now-redundant _sync:rb: doc is cleaned up.
+	rt.DeleteDoc(testDocID, NewDocVersionFromFakeRev(winnerRev))
+
+	doc, err = collection.GetDocument(ctx, testDocID, db.DocUnmarshalAll)
+	require.NoError(t, err)
+	require.Equal(t, tombstoneRev, doc.CurrentRev, "the tombstone branch should have been promoted")
+	require.True(t, doc.IsDeleted())
+	removal, inChannel := doc.Channels["chanA"]
+	assert.True(t, inChannel && removal == nil, "the promoted tombstone should still be in chanA, got %+v", doc.Channels)
+	_, bobGranted = doc.Access["bob"]
+	assert.True(t, bobGranted, "bob's access grant should have been recalculated from the tombstone's own body, got %+v", doc.Access)
+	_, _, err = dataStore.GetRaw(bodyKey)
+	assert.True(t, base.IsDocNotFoundError(err),
+		"the externalised body should have been cleaned up once promoted into the document, got %v", err)
+}
+
+// TestSyncFnPromotedTombstoneWithMissingExternalisedBody is the other side of the split that
+// TestSyncFnPromotedTombstoneWithUnreadableExternalisedBody pins. A read that found nothing does
+// tell us the body isn't there, and no retry can bring it back, so - as with an ancestor's expired
+// backup in TestSyncFnPromotedTombstoneWithExpiredBackupBody - the write is allowed to proceed and
+// leave the promoted tombstone in no channels rather than failing every write to the document from
+// here on.
+func TestSyncFnPromotedTombstoneWithMissingExternalisedBody(t *testing.T) {
+
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCRUD)
+
+	const testDocID = "testdoc"
+
+	rt := NewRestTester(t, &RestTesterConfig{
+		GuestEnabled: true,
+		SyncFn:       `function(doc){ channel(doc.channels); access("bob", "grantedChan"); }`,
+	})
+	defer rt.Close()
+
+	winnerRev, tombstoneRev, bodyKey := setUpPromotedTombstoneWithExternalisedBody(t, rt, testDocID)
+	collection, ctx := rt.GetSingleTestDatabaseCollection()
+
+	doc, err := collection.GetDocument(ctx, testDocID, db.DocUnmarshalAll)
+	require.NoError(t, err)
+	_, bobGranted := doc.Access["bob"]
+	require.True(t, bobGranted, "the live document should have granted bob access, got %+v", doc.Access)
+
+	// The rev tree still points at the externalised body, but it is no longer in the bucket.
+	require.NoError(t, rt.GetSingleDataStore().Delete(bodyKey))
+
+	// Tombstoning the winner promotes the tombstone leaf, which now has no body anywhere.
+	response := rt.SendAdminRequest(http.MethodDelete,
+		fmt.Sprintf("/{{.keyspace}}/%s?rev=%s", testDocID, winnerRev), "")
+	RequireStatus(t, response, http.StatusOK)
+
+	doc, err = collection.GetDocument(ctx, testDocID, db.DocUnmarshalAll)
+	require.NoError(t, err)
+	require.Equal(t, tombstoneRev, doc.CurrentRev, "the tombstone branch should have been promoted")
+	require.True(t, doc.IsDeleted())
+
+	removal, inChannel := doc.Channels["chanA"]
+	require.True(t, inChannel, "chanA should still be recorded on the document")
+	require.NotNil(t, removal, "chanA should be marked as a removal, not left active")
+	assert.True(t, removal.Deleted, "the removal should be flagged as a deletion so pull replications send a tombstone")
+	assert.Empty(t, doc.Access, "the promoted tombstone's access grants should have been revoked")
 }
 
 func TestSyncFunctionErrorLogging(t *testing.T) {

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2932,3 +2932,20 @@ func AssertHTTPErrorReason(t testing.TB, response *TestResponse, expectedStatus 
 
 	assert.Equal(t, expectedReason, httpError.Reason)
 }
+
+// deleteBackupRevisionBodies removes the _sync:rev: backup document for every revision currently in the
+// document's rev tree, modelling their expiry after old_rev_expiry_seconds in a long-lived database.
+func deleteBackupRevisionBodies(t *testing.T, rt *RestTester, docID string) {
+	t.Helper()
+	collection, ctx := rt.GetSingleTestDatabaseCollection()
+	doc, err := collection.GetDocument(ctx, docID, db.DocUnmarshalAll)
+	require.NoError(t, err)
+
+	dataStore := rt.GetSingleDataStore()
+	for revID := range doc.History {
+		key := fmt.Sprintf("%s%s:%d:%s", base.RevPrefix, docID, len(revID), revID)
+		if err := dataStore.Delete(key); err != nil {
+			require.True(t, base.IsDocNotFoundError(err), "unexpected error deleting %s: %v", key, err)
+		}
+	}
+}


### PR DESCRIPTION
CBG-5782

Unclean cherry pick of #8712 to 3.3.8

The production fix applies as upstream. 3.3.8 predates the HLV work and still supports non-xattr mode, so the adaptations below are all pre-existing branch differences. Verified in both modes: default, and `SG_TEST_USE_XATTRS=false`.

Changes from main commit:
- `db/revtree.go` — `RevLoaderFunc` takes no context on 3.3.8, so `getRevisionBody` and the new `getRevisionBodyWithError` keep the branch's ctx-free signatures and call `loader(info.BodyKey)`. `nonJSONPrefix` is a byte constant here rather than a function returning a kind, so the invalid-rev-body guard keeps the branch's comparison and only gains the new error return.
- `db/document.go` — same, `getNonWinningRevisionBody` calls `getRevisionBodyWithError(revid, loader)`
- `db/crud.go` — `SyncData.GetRevTreeID()` does not exist pre-HLV, so the new code uses `doc.CurrentRev`. `getRevision` returns three values on 3.3.8 (no channels), so `getAvailableRev` destructures three.
- `rest/utilities_testing.go` — the conflict region also carried `AssertRevTreeAfterHLVConflictResolution`, `RequireStrictlyIncreasingRevTreeGenerations` and `ClearServerContextLoggingGlobals`, which belong to unrelated main commits and are not on 3.3.8; only `deleteBackupRevisionBodies` was taken. The sgbucket `DataStore` methods `Delete`, `GetRaw` and `SetRaw` take no context argument here.
- `rest/sync_fn_test.go` — `DocVersion` has a single `RevID` field on 3.3.8; `PutExistingRevWithConflictResolution` takes positional arguments (no `db.PutDocOptions`); `allow_conflicts` is still a real config option here, so `Options.AllowConflicts` is set directly instead of calling the 4.x `EnableAllowConflicts` test helper. All eight sync-function tests are ported and assert exactly what they do upstream.
- `rest/sync_fn_test.go` — both setup helpers force `base.TestExternalRevStorage` (reset via `t.Cleanup`). On 3.3.8 a non-winning body is only moved out to a `_sync:rb:` doc when xattrs are enabled — `AllowExternalRevBodyStorage` returns `!UseXattrs()` — so on an `SG_TEST_USE_XATTRS=false` run the padded bodies stayed inline and five of the eight tests failed on *"body should not be inline in the rev tree"*. Forcing the branch's existing test hook keeps both modes on the externalised-body path this fix is about.
- `rest/blip_api_crud_test.go` — `TestMissingBackupBodyWhenTombstoneBranchPromotedToWinningBranch` skips via `base.SkipImportTestsIfNotEnabled`. It reaches the promoted tombstone through an on-demand import of a delete made behind Sync Gateway's back, which requires xattrs; without them `DbStats.SharedBucketImport()` is nil, because the import stats are only initialised when import is enabled, and the test panicked on a nil dereference.
- `rest/blip_api_crud_test.go` — that test is also reduced: 3.3.8's `BlipTesterCollectionClient` has no `WaitForPullNoRevMessage`, `GetPullRevMessage` or `IsVersionTombstone`, so it asserts the norev was sent via the `NoRevSendCount` stat and that the client reaches the tombstone version, but no longer inspects the norev/rev messages themselves — it does not check the rev message profile, its deleted flag, or that the client stored the promoted branch as a tombstone. The `ReplacementRevSendCount` assertion is kept. `btcRunner.Run` takes `SupportedBLIPProtocols` on 3.3.8, and there is no version-vector subtest to skip on a rev-tree-only branch.

🤖 Opened with the `sync-gateway-backport` skill in [Claude Code](https://claude.com/claude-code)
