### PR TITLE
Fix redocly lint failures from @redocly/cli 2.49.0

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -32,9 +32,14 @@ on:
       - 'ci-*'
       - 'api-ci-*'
   pull_request:
-    # Only run when we change an API spec
+    # Also run on linter/config changes, so a version bump is validated before merge
     paths:
       - 'docs/api/**'
+      - '.redocly.yaml'
+      - '.yamllint.yml'
+      - '.github/workflows/openapi.yml'
+      - 'package.json'
+      - 'package-lock.json'
     branches:
       - 'master'
       - 'main'
@@ -66,7 +71,7 @@ jobs:
       - uses: *actions_redocly_problem_matchers_version
       - name: redocly lint
         run: |-
-          npx redocly lint --config=.redocly.yaml --format=stylish
+          npm run lint:openapi
 
   yamllint:
     name: 'yamllint'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,8 +62,8 @@ repos:
         # stale node_modules after a version bump
         entry: >-
           bash -c 'npm ci --no-audit --no-fund --silent &&
-          ./node_modules/.bin/redocly lint --config=.redocly.yaml --format=stylish'
-        files: ^(docs/api/|\.redocly\.yaml$)
+          npm run --silent lint:openapi'
+        files: ^(docs/api/|\.redocly\.yaml$|package(-lock)?\.json$)
         pass_filenames: false
 
       - id: yamllint

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -16,7 +16,7 @@ Validates every API root defined in `.redocly.yaml`:
 
 ```sh
 $ npm ci
-$ npx redocly lint --config=.redocly.yaml --format=stylish
+$ npm run lint:openapi
 ```
 
 Redocly is pinned in `package.json` and `package-lock.json`. `npm ci` installs that exact version.
@@ -29,5 +29,5 @@ over this directory in both places.
 ## Preview
 
 ```sh
-$ npx redocly preview-docs --config=.redocly.yaml
+$ npm run preview:openapi
 ```

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -2507,8 +2507,7 @@ Runtime-config:
   type: object
   properties:
     logging:
-      allOf:
-        - $ref: "#/Logging-config"
+      $ref: "#/Logging-config"
     max_concurrent_replications:
       description: Maximum number of concurrent replication connections allowed. If set to 0 this limit will be ignored.
       type: integer
@@ -2532,8 +2531,7 @@ Logging-config:
         - unset
       readOnly: true
     console:
-      allOf:
-        - $ref: '#/Console-logging-config'
+      $ref: '#/Console-logging-config'
     error:
       type: object
       description: Error logging configuration.
@@ -3011,7 +3009,8 @@ Status:
             description: Indicates whether the database requires resync before it can be brought online.
             type: boolean
           state:
-            allOf: # use allOf to prevent DatabaseState from showing as the type in the display
+            description: The current state of the database.
+            allOf:
               - $ref: '#/DatabaseState'
           replication_status:
             type: array
@@ -3062,8 +3061,7 @@ Status:
         Blank if `api.hide_product_version=true` in the startup configuration.
       type: string
     vendor:
-      allOf:
-        - $ref: '#/Vendor'
+      $ref: '#/Vendor'
     runtime:
       description: |-
         Runtime environment information for this Sync Gateway node. Includes Go runtime
@@ -3116,8 +3114,7 @@ NodeInfo:
       type: string
       example: Welcome
     vendor:
-      allOf:
-        - $ref: '#/Vendor'
+      $ref: '#/Vendor'
     version:
       description: |-
         Product version, including the build number and edition (i.e. `EE` or `CE`)
@@ -3148,8 +3145,7 @@ ResyncScopesMap:
   description: 'scope name with one or more collection names for which resync will be triggered'
   type: object
   additionalProperties:
-    allOf:
-      - $ref: '#/CollectionNames'
+    $ref: '#/CollectionNames'
   example: {"scopeName": ["collection1", "collection2"]}
 CollectionNames:
   description: 'List of collection names'
@@ -3197,7 +3193,8 @@ CollectionNames:
         type: string
         description: The Couchbase Server backing bucket for the database.
       state:
-        allOf: # use allOf to prevent DatabaseState from showing as the type in the display
+        description: The current state of the database.
+        allOf:
           - $ref: '#/DatabaseState'
       require_resync:
         description: Indicates whether the database requires resync before it can be brought online.
@@ -3377,8 +3374,7 @@ IndexInitStatus:
             "ready": All indexes were created.
             "error": The index creation operation has failed.
     settings:
-      allOf:
-        - $ref: '#/IndexSettings'
+      $ref: '#/IndexSettings'
   required:
     - status
     - start_time

--- a/docs/api/paths/admin/db-.yaml
+++ b/docs/api/paths/admin/db-.yaml
@@ -57,7 +57,8 @@ get:
                 type: number
                 default: 0
               state:
-                allOf: # use allOf to prevent DatabaseState from showing as the type in the display
+                description: The current state of the database.
+                allOf:
                   - $ref: ../../components/schemas.yaml#/DatabaseState
               server_uuid:
                 description: Unique server identifier.

--- a/docs/api/paths/admin/db-_config-audit.yaml
+++ b/docs/api/paths/admin/db-_config-audit.yaml
@@ -32,7 +32,7 @@ get:
       content:
         application/json:
           schema:
-            oneOf:
+            anyOf:
               - $ref: ../../components/schemas.yaml#/Database-audit
               - $ref: ../../components/schemas.yaml#/Database-audit-verbose
     '403':
@@ -55,7 +55,7 @@ put:
     content:
       application/json:
         schema:
-          oneOf:
+          anyOf:
             - $ref: ../../components/schemas.yaml#/Database-audit
             - $ref: ../../components/schemas.yaml#/Database-audit-verbose
   responses:
@@ -90,7 +90,7 @@ post:
     content:
       application/json:
         schema:
-          oneOf:
+          anyOf:
             - $ref: ../../components/schemas.yaml#/Database-audit
             - $ref: ../../components/schemas.yaml#/Database-audit-verbose
   responses:

--- a/docs/api/paths/admin/db-_index_init.yaml
+++ b/docs/api/paths/admin/db-_index_init.yaml
@@ -39,8 +39,7 @@ post:
     content:
       application/json:
         schema:
-          allOf:
-            - $ref: ../../components/schemas.yaml#/IndexSettings
+          $ref: ../../components/schemas.yaml#/IndexSettings
   responses:
     '200':
       description: successfully changed the status of the index initialization operation

--- a/docs/api/paths/public/db-.yaml
+++ b/docs/api/paths/public/db-.yaml
@@ -52,7 +52,8 @@ get:
                 type: number
                 default: 0
               state:
-                allOf: # use allOf to prevent DatabaseState from showing as the type in the display
+                description: The current state of the database.
+                allOf:
                   - $ref: ../../components/schemas.yaml#/DatabaseState
               server_uuid:
                 description: Unique server identifier.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "sync-gateway-openapi-tooling",
   "private": true,
   "description": "Tooling-only manifest. Pins the OpenAPI linter used by CI and pre-commit.",
+  "scripts": {
+    "lint:openapi": "redocly lint --config=.redocly.yaml --format=stylish",
+    "preview:openapi": "redocly preview-docs --config=.redocly.yaml"
+  },
   "devDependencies": {
     "@redocly/cli": "2.49.0"
   }


### PR DESCRIPTION
`redocly lint` fails on `main` with 32 errors. `@redocly/cli` 2.49.0 (#8749) added the `no-illogical-composition-keywords` rule, and the `openapi` workflow only ran the linter on pull requests touching `docs/api/**`, so the bump merged unvalidated. 2.47.0 passed.

The 32 errors come from 14 sites in two groups.

### Single-entry `allOf`

The wrapper exists to hold sibling keys next to a `$ref`, which OpenAPI 3.0 ignores (`spec-ref-siblings`). The new rule tolerates all of those. It only fires where `allOf` is the sole key and the wrapper therefore does nothing.

- Seven such wrappers are now a bare `$ref`: `Runtime-config.logging`, `Logging-config.console`, both `vendor` properties, `ResyncScopesMap.additionalProperties`, `IndexInitStatus.settings`, and the `_index_init` request body. Each target schema already carries its own `description`.
- The four `DatabaseState` references get `description: The current state of the database.` in place of the `# use allOf to prevent DatabaseState from showing as the type in the display` comment. That sibling is the legitimate reason for the wrapper, and the rendered docs gain the text the comment was working around.

### `oneOf` in `db-_config-audit.yaml`

Changed to `anyOf`. This was a real spec bug rather than a false positive: `Database-audit` and `Database-audit-verbose` differ only in the type of the `events` values, so `{"enabled": true}` validates against both and `oneOf` rejects it.

### Tooling

- The `pull_request` paths in `.github/workflows/openapi.yml` now match the `push` paths, so a linter or config bump is validated before merge. The `redocly-lint` pre-commit hook fires on the npm manifests too.
- Added `lint:openapi` and `preview:openapi` npm scripts, called from CI, pre-commit, and `docs/api/README.md`. The flags now live in one place, and the documented command always uses the pinned local binary. `npx redocly lint` without `node_modules` present silently fetches an unrelated placeholder package named `redocly` from the registry, which prints "This is not the package you're looking for".

### Testing

- `npm run lint:openapi` passes on the pinned 2.49.0 and on 2.51.2.
- The `redocly-lint` and `yamllint` pre-commit hooks pass.
- `redocly bundle` output for `admin`, `public`, `metric`, and `diagnostic` diffed against `main`: the only changes are the ones described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)