### PR TITLE
CBG-5764 Keep _mou previous values describing one mutation

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -1271,7 +1271,7 @@ func (db *DatabaseCollectionWithUser) updateHLV(ctx context.Context, d *Document
 
 // MigrateAttachmentMetadata will move any attachment metadata defined in sync data to global sync xattr
 func (c *DatabaseCollectionWithUser) MigrateAttachmentMetadata(ctx context.Context, docID string, cas uint64, syncData *SyncData) error {
-	xattrs, _, err := c.dataStore.GetXattrs(ctx, docID, []string{base.GlobalXattrName, base.VirtualXattrRevSeqNo})
+	xattrs, _, err := c.dataStore.GetXattrs(ctx, docID, []string{base.GlobalXattrName, base.MouXattrName, base.VirtualXattrRevSeqNo})
 	if err != nil && !base.IsXattrNotFoundError(err) {
 		return err
 	}
@@ -1298,11 +1298,16 @@ func (c *DatabaseCollectionWithUser) MigrateAttachmentMetadata(ctx context.Conte
 		base.InfofCtx(ctx, base.KeyCRUD, "Could not determine revSeqNo found when attempting to migrate sync data attachments to global xattr for doc %q. Assuming 0. Error: %v", base.UD(docID), err)
 	}
 
-	metadataOnlyUpdate := &MetadataOnlyUpdate{
-		HexCAS:           expandMacroCASValueString, // when non-empty, this is replaced with cas macro expansion
-		PreviousHexCAS:   syncData.Cas,
-		PreviousRevSeqNo: revSeqNo,
+	var currentMou *MetadataOnlyUpdate
+	if xattrs[base.MouXattrName] != nil {
+		if err := base.JSONUnmarshal(xattrs[base.MouXattrName], &currentMou); err != nil {
+			return base.RedactErrorf("Failed to Unmarshal _mou when attempting to migrate sync data attachments to global xattr with id: %s. Error: %v", base.UD(docID), err)
+		}
 	}
+	// Migrating attachment metadata only changes metadata, so the update has to describe the mutation that
+	// last wrote the document body - carried forward from the current _mou when that was itself a
+	// metadata-only update.
+	metadataOnlyUpdate := computeMetadataOnlyUpdate(cas, revSeqNo, currentMou)
 	rawMouXattr, err := base.JSONMarshal(metadataOnlyUpdate)
 	if err != nil {
 		return base.RedactErrorf("Failed to marshal _mou when attempting to migrate sync data attachments to global xattr with id: %s. Error: %v", base.UD(docID), err)
@@ -3350,7 +3355,7 @@ func (db *DatabaseCollectionWithUser) correctVersionAheadOfCAS(ctx context.Conte
 
 	cas2, err := db.restampVersionCAS(ctx, key, doc, casOut)
 	if err != nil {
-		if base.IsCasMismatch(err) {
+		if isSupersededWriteError(err) {
 			// A concurrent writer beat us to it; it's that writer's responsibility to satisfy the invariant.
 			base.DebugfCtx(ctx, base.KeyVV, "Skipping CAS re-stamp for doc %q due to our generated version %d ahead of CAS %d: concurrent update won ahead of re-stamp", base.UD(doc.ID), doc.HLV.Version, casOut)
 			return doc
@@ -3375,6 +3380,13 @@ func (db *DatabaseCollectionWithUser) correctVersionAheadOfCAS(ctx context.Conte
 	return doc
 }
 
+// isSupersededWriteError reports whether err means the write a correction was asked to apply to has already
+// been superseded by a concurrent write. The correction applies to that one write only, so it is skipped and
+// satisfying the invariant becomes the concurrent writer's responsibility.
+func isSupersededWriteError(err error) bool {
+	return errors.Is(err, base.ErrUpdateCancel) || base.IsCasMismatch(err)
+}
+
 // restampVersionCAS re-persists the document's _sync and _vv xattrs so the server assigns a fresh CAS,
 // leaving the current version (cv.ver) unchanged while macro-expanding _sync.cas and _vv.cvCas to the new
 // CAS. It is a metadata-only update guarded on the supplied CAS: the revision, sequence and body are
@@ -3386,25 +3398,42 @@ func (db *DatabaseCollectionWithUser) restampVersionCAS(ctx context.Context, key
 		return 0, err
 	}
 
-	mou := computeMetadataOnlyUpdate(cas, doc.RevSeqNo, doc.MetadataOnlyUpdate)
-	rawMouXattr, err := base.JSONMarshal(mou)
-	if err != nil {
-		return 0, base.RedactErrorf("failed to marshal _mou when attempting to re-persist %s to correct version and CAS drift. Error: %v", base.UD(doc.ID), err)
-	}
+	opts := &sgbucket.MutateInOptions{PreserveExpiry: true}
+	return db.dataStore.WriteUpdateWithXattrs(ctx, key, db.syncGlobalSyncMouRevSeqNoAndUserXattrKeys(), 0, nil, opts,
+		func(currentValue []byte, currentXattrs map[string][]byte, currentCas uint64) (sgbucket.UpdatedDoc, error) {
+			// Only the write this is correcting may be re-stamped. A concurrent write has already moved the
+			// document on, and satisfying the invariant is that writer's responsibility.
+			if currentCas != cas {
+				return sgbucket.UpdatedDoc{}, base.ErrUpdateCancel
+			}
 
-	opts := &sgbucket.MutateInOptions{
-		MacroExpansion: []sgbucket.MacroExpansionSpec{
-			sgbucket.NewMacroExpansionSpec(xattrCasPath(base.SyncXattrName), sgbucket.MacroCas),
-			sgbucket.NewMacroExpansionSpec(xattrCurrentVersionCASPath(base.VvXattrName), sgbucket.MacroCas),
-			sgbucket.NewMacroExpansionSpec(XattrMouCasPath(), sgbucket.MacroCas),
-		},
-		PreserveExpiry: true,
-	}
-	return db.dataStore.UpdateXattrs(ctx, key, 0, cas, map[string][]byte{
-		base.SyncXattrName: syncXattr,
-		base.VvXattrName:   vvXattr,
-		base.MouXattrName:  rawMouXattr,
-	}, opts)
+			// The write being corrected is the mutation _mou has to point back at, so take the revision
+			// sequence number the server assigned it.
+			revSeqNo, err := unmarshalRevSeqNo(currentXattrs[base.VirtualXattrRevSeqNo])
+			if err != nil {
+				return sgbucket.UpdatedDoc{}, base.RedactErrorf("failed to determine revSeqNo when attempting to re-persist %s to correct version and CAS drift. Error: %v", base.UD(doc.ID), err)
+			}
+			mou := computeMetadataOnlyUpdate(cas, revSeqNo, doc.MetadataOnlyUpdate)
+			rawMouXattr, err := base.JSONMarshal(mou)
+			if err != nil {
+				return sgbucket.UpdatedDoc{}, base.RedactErrorf("failed to marshal _mou when attempting to re-persist %s to correct version and CAS drift. Error: %v", base.UD(doc.ID), err)
+			}
+
+			return sgbucket.UpdatedDoc{
+				Doc: nil, // the body is not being changed
+				Xattrs: map[string][]byte{
+					base.SyncXattrName: syncXattr,
+					base.VvXattrName:   vvXattr,
+					base.MouXattrName:  rawMouXattr,
+				},
+				IsTombstone: len(currentValue) == 0,
+				Spec: []sgbucket.MacroExpansionSpec{
+					sgbucket.NewMacroExpansionSpec(xattrCasPath(base.SyncXattrName), sgbucket.MacroCas),
+					sgbucket.NewMacroExpansionSpec(xattrCurrentVersionCASPath(base.VvXattrName), sgbucket.MacroCas),
+					sgbucket.NewMacroExpansionSpec(XattrMouCasPath(), sgbucket.MacroCas),
+				},
+			}, nil
+		})
 }
 
 // repairInvalidRevTreeForGet repairs a document whose revision tree contains a revision that does not

--- a/db/crud.go
+++ b/db/crud.go
@@ -3355,7 +3355,7 @@ func (db *DatabaseCollectionWithUser) correctVersionAheadOfCAS(ctx context.Conte
 
 	cas2, err := db.restampVersionCAS(ctx, key, doc, casOut)
 	if err != nil {
-		if isSupersededWriteError(err) {
+		if errors.Is(err, base.ErrUpdateCancel) {
 			// A concurrent writer beat us to it; it's that writer's responsibility to satisfy the invariant.
 			base.DebugfCtx(ctx, base.KeyVV, "Skipping CAS re-stamp for doc %q due to our generated version %d ahead of CAS %d: concurrent update won ahead of re-stamp", base.UD(doc.ID), doc.HLV.Version, casOut)
 			return doc
@@ -3378,13 +3378,6 @@ func (db *DatabaseCollectionWithUser) correctVersionAheadOfCAS(ctx context.Conte
 	}
 	base.InfofCtx(ctx, base.KeyVV, "Re-stamped CAS for doc %q from %d to %d so generated version %d <= CAS", base.UD(doc.ID), casOut, cas2, doc.HLV.Version)
 	return doc
-}
-
-// isSupersededWriteError reports whether err means the write a correction was asked to apply to has already
-// been superseded by a concurrent write. The correction applies to that one write only, so it is skipped and
-// satisfying the invariant becomes the concurrent writer's responsibility.
-func isSupersededWriteError(err error) bool {
-	return errors.Is(err, base.ErrUpdateCancel) || base.IsCasMismatch(err)
 }
 
 // restampVersionCAS re-persists the document's _sync and _vv xattrs so the server assigns a fresh CAS,

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -2958,7 +2958,7 @@ func TestWritePathRepairMouChain(t *testing.T) {
 
 	// the SDK write is the last real body mutation
 	require.NoError(t, collection.dataStore.Set(ctx, docID, 0, nil, []byte(`{"sdk":true}`)))
-	_, sdkWriteCas, err := collection.dataStore.GetRaw(ctx, docID)
+	sdkWriteRevSeqNo, sdkWriteCas, err := collection.getRevSeqNo(ctx, docID)
 	require.NoError(t, err)
 	dbCtx.FlushRevisionCacheForTest()
 
@@ -2977,12 +2977,8 @@ func TestWritePathRepairMouChain(t *testing.T) {
 	assert.Equal(t, base.CasToString(sdkWriteCas), mouAfterRepair.PreviousHexCAS,
 		"write-path _mou.pCas should have chained back to the SDK write, not restarted at the import")
 
-	// _mou.pRev is the revSeqNo before the repair's own mutation. The repair is the last write here (the
-	// caller's write was rejected), so that is one less than the document's current revSeqNo - and never
-	// zero, which is what the write path stamped before it stopped discarding the revSeqNo it fetches.
-	revSeqNoAfterRepair, _, err := collection.getRevSeqNo(ctx, docID)
-	require.NoError(t, err)
-	require.NotZero(t, revSeqNoAfterRepair)
-	assert.Equal(t, revSeqNoAfterRepair-1, mouAfterRepair.PreviousRevSeqNo,
-		"write-path _mou.pRev should be the revSeqNo immediately before the repair (current revSeqNo %d)", revSeqNoAfterRepair)
+	// pRev names the same mutation as pCas, so it has to chain back past the import too
+	require.NotZero(t, sdkWriteRevSeqNo)
+	assert.Equal(t, sdkWriteRevSeqNo, mouAfterRepair.PreviousRevSeqNo,
+		"write-path _mou.pRev should name the SDK write like pCas does, not the import between it and the repair")
 }

--- a/db/document.go
+++ b/db/document.go
@@ -1495,9 +1495,14 @@ func (doc *Document) channelsForRevTreeID(revTreeID string) (base.Set, bool) {
 // computeMetadataOnlyUpdate computes a new metadataOnlyUpdate based on the existing document's CAS and metadataOnlyUpdate
 func computeMetadataOnlyUpdate(currentCas uint64, revNo uint64, currentMou *MetadataOnlyUpdate) *MetadataOnlyUpdate {
 	var prevCas string
+	prevRevNo := revNo
 	currentCasString := base.CasToString(currentCas)
 	if currentMou != nil && currentCasString == currentMou.HexCAS {
+		// The mutation being replaced was itself a metadata-only update, so carry its previous values
+		// forward - pCas and pRev have to keep describing the same mutation, the one that last wrote the
+		// document body.
 		prevCas = currentMou.PreviousHexCAS
+		prevRevNo = currentMou.PreviousRevSeqNo
 	} else {
 		prevCas = currentCasString
 	}
@@ -1505,7 +1510,7 @@ func computeMetadataOnlyUpdate(currentCas uint64, revNo uint64, currentMou *Meta
 	metadataOnlyUpdate := &MetadataOnlyUpdate{
 		HexCAS:           expandMacroCASValueString, // when non-empty, this is replaced with cas macro expansion
 		PreviousHexCAS:   prevCas,
-		PreviousRevSeqNo: revNo,
+		PreviousRevSeqNo: prevRevNo,
 	}
 	return metadataOnlyUpdate
 }

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -9,6 +9,7 @@
 package db
 
 import (
+	"context"
 	"maps"
 	"math/rand/v2"
 	"strconv"
@@ -375,10 +376,12 @@ func TestHLVImport(t *testing.T) {
 				require.NoError(t, err)
 			},
 			expectedMou: func(output *outputData) *MetadataOnlyUpdate {
+				// the mutation being imported was itself a metadata-only update, so both previous values are
+				// carried forward from it and keep describing the write that last changed the body
 				return &MetadataOnlyUpdate{
 					HexCAS:           string(base.Uint64CASToLittleEndianHex(output.postImportCas)),
 					PreviousHexCAS:   output.preImportMou.PreviousHexCAS,
-					PreviousRevSeqNo: output.preImportRevSeqNo,
+					PreviousRevSeqNo: output.preImportMou.PreviousRevSeqNo,
 				}
 			},
 			expectedHLV: func(output *outputData) *HybridLogicalVector {
@@ -440,10 +443,12 @@ func TestHLVImport(t *testing.T) {
 				require.NoError(t, err)
 			},
 			expectedMou: func(output *outputData) *MetadataOnlyUpdate {
+				// the mutation being imported was itself a metadata-only update, so both previous values are
+				// carried forward from it and keep describing the write that last changed the body
 				return &MetadataOnlyUpdate{
 					HexCAS:           string(base.Uint64CASToLittleEndianHex(output.postImportCas)),
 					PreviousHexCAS:   output.preImportMou.PreviousHexCAS,
-					PreviousRevSeqNo: output.preImportRevSeqNo,
+					PreviousRevSeqNo: output.preImportMou.PreviousRevSeqNo,
 				}
 			},
 			expectedHLV: func(output *outputData) *HybridLogicalVector {
@@ -556,6 +561,128 @@ func TestHLVVersionAheadOfCASCorrection(t *testing.T) {
 		assert.Greater(t, doc.HLV.Version, doc.Cas, "version beyond the wait bound should be left ahead of CAS")
 		assert.Equal(t, before, retryCount.Value(), "skipped correction should not increment the stat")
 	})
+}
+
+// TestRestampVersionCASSkipsConcurrentWrite covers restampVersionCAS declining to re-stamp a document that
+// has moved on since the write it was asked to correct. The correction applies to that write only, and the
+// concurrent writer is the one that has to satisfy cv.ver <= cas for its own mutation.
+func TestRestampVersionCASSkipsConcurrentWrite(t *testing.T) {
+	dbc, ctx := setupTestDB(t)
+	defer dbc.Close(ctx)
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, dbc)
+
+	docID := t.Name()
+	rev1ID, doc, err := collection.Put(ctx, docID, Body{"value": 1234})
+	require.NoError(t, err)
+	casOfFirstWrite := doc.Cas
+
+	// a second write moves the document on
+	_, concurrentDoc, err := collection.Put(ctx, docID, Body{BodyRev: rev1ID, "value": 5678})
+	require.NoError(t, err)
+
+	_, err = collection.restampVersionCAS(ctx, docID, doc, casOfFirstWrite)
+	require.Error(t, err, "a superseded write must not be re-stamped")
+	require.True(t, isSupersededWriteError(err), "the re-stamp has to fail in a way correctVersionAheadOfCAS skips on, got %v", err)
+
+	_, _, casAfter := getSyncAndMou(t, collection, docID)
+	require.Equal(t, concurrentDoc.Cas, casAfter, "the concurrent write must be left untouched")
+}
+
+// TestRestampVersionCASMou covers _mou for the version-CAS correction. This is the one path that writes a
+// metadata-only update immediately after a body write of its own, rather than over a document some earlier
+// write left behind, so _mou has to name the write being corrected - the other paths are covered by
+// TestMetadataOnlyUpdateWritePaths.
+func TestRestampVersionCASMou(t *testing.T) {
+	testCases := []struct {
+		name string
+		// write makes the body write whose version-CAS correction is under test, over the document left by
+		// setup at revID.
+		write       func(t *testing.T, ctx context.Context, collection *DatabaseCollectionWithUser, docID, revID string) *Document
+		isTombstone bool
+	}{
+		{
+			name: "live document",
+			write: func(t *testing.T, ctx context.Context, collection *DatabaseCollectionWithUser, docID, revID string) *Document {
+				_, doc, err := collection.Put(ctx, docID, Body{BodyRev: revID, "value": 5678, "chan": "B"})
+				require.NoError(t, err)
+				return doc
+			},
+		},
+		{
+			name: "tombstone",
+			write: func(t *testing.T, ctx context.Context, collection *DatabaseCollectionWithUser, docID, revID string) *Document {
+				_, doc, err := collection.DeleteDoc(ctx, docID, DocVersion{RevTreeID: revID})
+				require.NoError(t, err)
+				return doc
+			},
+			isTombstone: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			dbc, ctx := setupTestDB(t)
+			defer dbc.Close(ctx)
+			collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, dbc)
+
+			// move the document between channels, so the ended channel history the carry-forward step below
+			// compacts is there to prune
+			_, err := collection.UpdateSyncFun(ctx, `function(doc){channel(doc.chan);}`)
+			require.NoError(t, err)
+
+			docID := "restampVersionCASDoc"
+			rev1ID, _, err := collection.Put(ctx, docID, Body{"value": 1234, "chan": "A"})
+			require.NoError(t, err)
+			rev2ID, _, err := collection.Put(ctx, docID, Body{BodyRev: rev1ID, "value": 1234, "chan": "B"})
+			require.NoError(t, err)
+
+			// the state before the write under test - _mou must end up naming a mutation after this one
+			_, mou, priorCas := getSyncAndMou(t, collection, docID)
+			require.Nil(t, mou, "a write of the body should not leave a metadata-only update behind")
+			priorRevSeqNo := docRevSeqNo(t, collection, docID)
+
+			retryCount := dbc.DbStats.Database().HLVVersionCASRetryCount
+			before := retryCount.Value()
+
+			// SG clock ahead of the server, so the write's generated version exceeds its CAS and is corrected
+			dbc.hlc.SetClockForTest(func() uint64 { return sgbucket.HLCWallClock() + uint64(100*time.Millisecond) })
+			defer dbc.hlc.SetClockForTest(sgbucket.HLCWallClock)
+
+			doc := testCase.write(t, ctx, collection, docID, rev2ID)
+			require.Equal(t, before+1, retryCount.Value(), "expected a corrective re-stamp for this write")
+			require.LessOrEqual(t, doc.HLV.Version, doc.Cas, "version should be corrected to <= CAS")
+
+			body, xattrs, cas, err := collection.dataStore.GetWithXattrs(ctx, docID, []string{base.MouXattrName, base.VirtualXattrRevSeqNo})
+			require.NoError(t, err)
+			require.Equal(t, testCase.isTombstone, len(body) == 0, "the re-stamp must not change whether the document is a tombstone")
+
+			require.NoError(t, base.JSONUnmarshal(xattrs[base.MouXattrName], &mou))
+			require.NotNil(t, mou, "the re-stamp has to record a metadata-only update")
+			restampRevSeqNo := RetrieveDocRevSeqNo(t, xattrs[base.VirtualXattrRevSeqNo])
+
+			require.Equal(t, base.CasToString(cas), mou.HexCAS, "_mou.cas has to name the re-stamp, so it is not imported as an external write")
+			// the corrected write's own CAS is not observable from outside it, so both previous values are
+			// pinned by sandwiching them between the write before it and the re-stamp that follows it
+			require.Greater(t, mou.PreviousCAS(), priorCas, "pCas has to name the write being corrected, not the one before it")
+			require.Less(t, mou.PreviousCAS(), cas, "pCas has to name a mutation older than the re-stamp itself")
+			require.Greater(t, mou.PreviousRevSeqNo, priorRevSeqNo, "pRev has to name the same mutation as pCas, the write being corrected")
+			require.Less(t, mou.PreviousRevSeqNo, restampRevSeqNo, "pRev has to name a mutation older than the re-stamp itself")
+			bodyWriteHexCas, bodyWriteRevSeqNo := mou.PreviousHexCAS, mou.PreviousRevSeqNo
+
+			// A second metadata-only write, from a different path - channel history compaction, which unlike
+			// resync applies to a tombstone as well as a live document. Both previous values have to be
+			// carried forward, or they stop naming the last write to the body.
+			compacted, err := collection.CompactDocChannelHistory(ctx, docID, 100)
+			require.NoError(t, err)
+			require.NotEmpty(t, compacted, "compaction should have pruned channel history, or no write happens")
+
+			_, mou, cas = getSyncAndMou(t, collection, docID)
+			require.NotNil(t, mou)
+			require.Equal(t, base.CasToString(cas), mou.HexCAS)
+			require.Equal(t, bodyWriteHexCas, mou.PreviousHexCAS, "pCas has to survive a second metadata-only write")
+			require.Equal(t, bodyWriteRevSeqNo, mou.PreviousRevSeqNo, "pRev has to survive a second metadata-only write alongside pCas")
+		})
+	}
 }
 
 // TestHLVMapToCBLString:

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -581,8 +581,7 @@ func TestRestampVersionCASSkipsConcurrentWrite(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = collection.restampVersionCAS(ctx, docID, doc, casOfFirstWrite)
-	require.Error(t, err, "a superseded write must not be re-stamped")
-	require.True(t, isSupersededWriteError(err), "the re-stamp has to fail in a way correctVersionAheadOfCAS skips on, got %v", err)
+	require.ErrorIs(t, err, base.ErrUpdateCancel, "the re-stamp has to fail in a way correctVersionAheadOfCAS skips on")
 
 	_, _, casAfter := getSyncAndMou(t, collection, docID)
 	require.Equal(t, concurrentDoc.Cas, casAfter, "the concurrent write must be left untouched")

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package db
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -1830,4 +1831,231 @@ func attachmentMetaFromGlobalXattr(t *testing.T, rawGlobalSync []byte) Attachmen
 	}
 	require.NoError(t, base.JSONUnmarshal(rawGlobalSync, &globalSyncData))
 	return globalSyncData.Attachments
+}
+
+// docRevSeqNo returns the document's current server revision sequence number.
+func docRevSeqNo(t *testing.T, collection *DatabaseCollectionWithUser, docID string) uint64 {
+	t.Helper()
+	xattrs, _, err := collection.dataStore.GetXattrs(base.TestCtx(t), docID, []string{base.VirtualXattrRevSeqNo})
+	require.NoError(t, err)
+	return RetrieveDocRevSeqNo(t, xattrs[base.VirtualXattrRevSeqNo])
+}
+
+// mouWritePath is one code path that persists a metadata-only update: a mutation that changes a document's
+// metadata without changing its body.
+type mouWritePath struct {
+	name string
+	// setup writes the document and leaves it in the state the path under test expects. The document's CAS
+	// and revision sequence number as of the end of setup are what _mou then has to point back at.
+	setup func(t *testing.T, ctx context.Context, collection *DatabaseCollectionWithUser, docID string) (revID string)
+	// run performs the metadata-only write, and nothing else - the document's body is left as setup wrote
+	// it, so _mou has to point back at the state observed between the two.
+	run func(t *testing.T, ctx context.Context, collection *DatabaseCollectionWithUser, docID, revID string)
+}
+
+// TestMetadataOnlyUpdateWritePaths pins _mou for every code path that writes one.
+//
+// A metadata-only update states that Sync Gateway changed a document's metadata without touching its body.
+// Two properties have to hold for each path: _mou.cas has to name the mutation just made, which is how the
+// import feed tells the mutation is Sync Gateway's own rather than an external write to import, and _mou.pCas
+// has to name the mutation that last changed the body, so a reader can still identify which version of the
+// body the document holds.
+//
+// Each case then performs a second metadata-only write, from a different path, to check that pCas and pRev
+// are both carried forward rather than moved on to the first metadata-only write - they have to keep
+// describing the same mutation as each other.
+func TestMetadataOnlyUpdateWritePaths(t *testing.T) {
+	// sdkBodyWrite writes the document body from outside Sync Gateway, leaving the metadata xattrs in place.
+	// The document then needs importing, and the CAS of this write is the one _mou.pCas has to name.
+	sdkBodyWrite := func(t *testing.T, ctx context.Context, collection *DatabaseCollectionWithUser, docID string) {
+		_, _, cas, err := collection.dataStore.GetWithXattrs(ctx, docID, []string{base.SyncXattrName})
+		require.NoError(t, err)
+		_, err = collection.dataStore.WriteCas(ctx, docID, 0, cas, []byte(`{"value": "written outside Sync Gateway"}`), 0)
+		require.NoError(t, err)
+	}
+
+	putDoc := func(t *testing.T, ctx context.Context, collection *DatabaseCollectionWithUser, docID string) string {
+		revID, _, err := collection.Put(ctx, docID, Body{"value": 1234})
+		require.NoError(t, err)
+		return revID
+	}
+
+	paths := []mouWritePath{
+		{
+			// ImportDocRaw through OnDemandImportForGet
+			name: "on-demand import for get",
+			setup: func(t *testing.T, ctx context.Context, collection *DatabaseCollectionWithUser, docID string) string {
+				revID := putDoc(t, ctx, collection, docID)
+				sdkBodyWrite(t, ctx, collection, docID)
+				return revID
+			},
+			run: func(t *testing.T, ctx context.Context, collection *DatabaseCollectionWithUser, docID, _ string) {
+				_, err := collection.GetDocument(ctx, docID, DocUnmarshalAll)
+				require.NoError(t, err)
+			},
+		},
+		{
+			// ImportDoc through OnDemandImportForWrite. The import creates a revision for the external write,
+			// so the update that triggered it is rejected as a conflict; the import is the write under test.
+			name: "on-demand import for write",
+			setup: func(t *testing.T, ctx context.Context, collection *DatabaseCollectionWithUser, docID string) string {
+				revID := putDoc(t, ctx, collection, docID)
+				sdkBodyWrite(t, ctx, collection, docID)
+				return revID
+			},
+			run: func(t *testing.T, ctx context.Context, collection *DatabaseCollectionWithUser, docID, revID string) {
+				_, _, err := collection.Put(ctx, docID, Body{BodyRev: revID, "value": 5678})
+				require.Error(t, err)
+				status, _ := base.ErrorAsHTTPStatus(err)
+				require.Equal(t, http.StatusConflict, status)
+			},
+		},
+		{
+			// MigrateAttachmentMetadata
+			name: "attachment metadata migration",
+			setup: func(t *testing.T, ctx context.Context, collection *DatabaseCollectionWithUser, docID string) string {
+				revID, _, err := collection.Put(ctx, docID, Body{
+					"value":         1234,
+					BodyAttachments: map[string]any{"myatt": map[string]any{"content_type": "text/plain", "data": "SGVsbG8gV29ybGQh"}},
+				})
+				require.NoError(t, err)
+
+				// put the document into the pre-4.0 layout, with its attachment metadata in the sync xattr
+				value, _, err := collection.dataStore.GetRaw(ctx, docID)
+				require.NoError(t, err)
+				MoveAttachmentXattrFromGlobalToSync(t, collection.GetCollectionDatastore(), docID, value, true)
+				return revID
+			},
+			run: func(t *testing.T, ctx context.Context, collection *DatabaseCollectionWithUser, docID, _ string) {
+				syncData, _, cas := getSyncAndMou(t, collection, docID)
+				require.NotEmpty(t, syncData.AttachmentsPre4dot0)
+				require.NoError(t, collection.MigrateAttachmentMetadata(ctx, docID, cas, syncData))
+			},
+		},
+		{
+			// CompactDocChannelHistory
+			name: "channel history compaction",
+			setup: func(t *testing.T, ctx context.Context, collection *DatabaseCollectionWithUser, docID string) string {
+				// compaction only writes when there is ended channel history to prune, so move the document
+				// from one channel to another. The second put is the last write to the body.
+				_, err := collection.UpdateSyncFun(ctx, `function(doc){channel(doc.chan);}`)
+				require.NoError(t, err)
+
+				rev1ID, _, err := collection.Put(ctx, docID, Body{"value": 1234, "chan": "A"})
+				require.NoError(t, err)
+				rev2ID, _, err := collection.Put(ctx, docID, Body{BodyRev: rev1ID, "value": 5678, "chan": "B"})
+				require.NoError(t, err)
+				return rev2ID
+			},
+			run: func(t *testing.T, ctx context.Context, collection *DatabaseCollectionWithUser, docID, _ string) {
+				compacted, err := collection.CompactDocChannelHistory(ctx, docID, 100)
+				require.NoError(t, err)
+				require.NotEmpty(t, compacted, "compaction should have pruned channel history, or no write happens")
+			},
+		},
+		{
+			// ResyncDocument
+			name:  "resync",
+			setup: putDoc,
+			run: func(t *testing.T, ctx context.Context, collection *DatabaseCollectionWithUser, docID, _ string) {
+				// resync only writes when the sync function changes the document's channels
+				_, err := collection.UpdateSyncFun(ctx, `function(doc){channel("resynced");}`)
+				require.NoError(t, err)
+				require.NoError(t, collection.ResyncDocument(ctx, docID, getBucketDocument(t, collection.DatabaseCollection, docID), false))
+			},
+		},
+	}
+	// The remaining path that writes an _mou, restampVersionCAS, does not fit this table: its metadata-only
+	// write follows a body write it makes itself, so _mou points at that write rather than at the state
+	// setup left behind. It is covered by TestRestampVersionCASMou.
+
+	for _, tc := range paths {
+		t.Run(tc.name, func(t *testing.T) {
+			dbc, ctx := setupTestDB(t)
+			defer dbc.Close(ctx)
+			collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, dbc)
+
+			_, err := collection.UpdateSyncFun(ctx, `function(doc){channel("initial");}`)
+			require.NoError(t, err)
+
+			const docID = "metadataOnlyUpdateDoc"
+			revID := tc.setup(t, ctx, collection, docID)
+
+			syncData, mou, bodyCas := getSyncAndMou(t, collection, docID)
+			require.NotNil(t, syncData)
+			require.Nil(t, mou, "a write of the body should not leave a metadata-only update behind")
+			bodyRevSeqNo := docRevSeqNo(t, collection, docID)
+
+			tc.run(t, ctx, collection, docID, revID)
+
+			_, mou, cas := getSyncAndMou(t, collection, docID)
+			require.NotNil(t, mou, "a metadata-only write has to record a metadata-only update")
+			require.Equal(t, base.CasToString(cas), mou.HexCAS, "_mou.cas has to name this mutation, so it is not imported as an external write")
+			require.Equal(t, base.CasToString(bodyCas), mou.PreviousHexCAS, "_mou.pCas has to name the mutation that last changed the body")
+			require.Equal(t, bodyRevSeqNo, mou.PreviousRevSeqNo, "_mou.pRev has to name the same mutation as pCas")
+			bodyWriteHexCas, bodyWriteRevSeqNo := mou.PreviousHexCAS, mou.PreviousRevSeqNo
+
+			// A second metadata-only write, from a different path than the one under test. Both previous
+			// values have to be carried forward, or they stop naming the last write to the body.
+			_, err = collection.UpdateSyncFun(ctx, `function(doc){channel("chained");}`)
+			require.NoError(t, err)
+			require.NoError(t, collection.ResyncDocument(ctx, docID, getBucketDocument(t, collection.DatabaseCollection, docID), false))
+
+			_, mou, cas = getSyncAndMou(t, collection, docID)
+			require.NotNil(t, mou)
+			require.Equal(t, base.CasToString(cas), mou.HexCAS)
+			require.Equal(t, bodyWriteHexCas, mou.PreviousHexCAS, "pCas has to survive a second metadata-only write")
+			require.Equal(t, bodyWriteRevSeqNo, mou.PreviousRevSeqNo, "pRev has to survive a second metadata-only write alongside pCas")
+		})
+	}
+}
+
+// TestAttachmentMigrationMouCarriedForward covers attachment metadata migration of a document whose previous
+// mutation was already a metadata-only update, as happens to a document replicated by mobile XDCR from a
+// cluster that had not migrated its attachment metadata. The migration has to carry the previous values
+// forward from that update rather than naming it, so they keep describing the last write to the body.
+func TestAttachmentMigrationMouCarriedForward(t *testing.T) {
+	dbc, ctx := setupTestDB(t)
+	defer dbc.Close(ctx)
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, dbc)
+	ds := collection.GetCollectionDatastore()
+
+	docID := "migrationMouCarriedForward"
+	_, _, err := collection.Put(ctx, docID, Body{
+		"value":         1234,
+		BodyAttachments: map[string]any{"myatt": map[string]any{"content_type": "text/plain", "data": "SGVsbG8gV29ybGQh"}},
+	})
+	require.NoError(t, err)
+
+	// put the document into the pre-4.0 layout, with its attachment metadata in the sync xattr. This is the
+	// last write to the body, so _mou has to point at it throughout.
+	value, _, err := ds.GetRaw(ctx, docID)
+	require.NoError(t, err)
+	MoveAttachmentXattrFromGlobalToSync(t, ds, docID, value, true)
+	_, _, bodyCas := getSyncAndMou(t, collection, docID)
+	bodyRevSeqNo := docRevSeqNo(t, collection, docID)
+
+	// stamp a metadata-only update over it, the way mobile XDCR does, so the document's most recent mutation
+	// is one and the migration below has something to carry forward
+	stampedMou := &MetadataOnlyUpdate{
+		PreviousHexCAS:   base.CasToString(bodyCas),
+		PreviousRevSeqNo: bodyRevSeqNo,
+	}
+	opts := &sgbucket.MutateInOptions{
+		MacroExpansion: []sgbucket.MacroExpansionSpec{sgbucket.NewMacroExpansionSpec(XattrMouCasPath(), sgbucket.MacroCas)},
+	}
+	_, err = ds.UpdateXattrs(ctx, docID, 0, bodyCas, map[string][]byte{base.MouXattrName: base.MustJSONMarshal(t, stampedMou)}, opts)
+	require.NoError(t, err)
+
+	syncData, existingMou, preMigrationCas := getSyncAndMou(t, collection, docID)
+	require.NotEmpty(t, syncData.AttachmentsPre4dot0, "the document should still be in the pre-4.0 layout")
+	require.Equal(t, base.CasToString(preMigrationCas), existingMou.HexCAS, "the document's last mutation has to be a metadata-only update")
+
+	require.NoError(t, collection.MigrateAttachmentMetadata(ctx, docID, preMigrationCas, syncData))
+
+	_, mou, migratedCas := getSyncAndMou(t, collection, docID)
+	require.NotNil(t, mou)
+	require.Equal(t, base.CasToString(migratedCas), mou.HexCAS)
+	require.Equal(t, base.CasToString(bodyCas), mou.PreviousHexCAS, "pCas has to be carried forward from the update being replaced")
+	require.Equal(t, bodyRevSeqNo, mou.PreviousRevSeqNo, "pRev has to be carried forward alongside pCas")
 }


### PR DESCRIPTION
_mou records that Sync Gateway changed a document's metadata without touching its body: _mou.cas names the mutation just made, and pCas/pRev name the mutation that last wrote the body. pRev did not keep up with pCas:

- computeMetadataOnlyUpdate carried pCas forward when replacing a metadata-only update but always wrote the document's current revision sequence number, so chained metadata-only updates left pCas naming the body write and pRev naming the update before them.

- restampVersionCAS wrote pRev as 0, because updateAndReturnDoc reads the document without the revSeqNo virtual xattr and so never populates doc.RevSeqNo in the write path. The re-stamp is now a read-modify-write that takes the revision sequence number the server assigned the write it is correcting, declining the correction when the document has moved on since - previously a CAS mismatch, now ErrUpdateCancel. Both mean the write being corrected has been superseded, so both are skipped, behind a shared isSupersededWriteError predicate.

- MigrateAttachmentMetadata hand-built its _mou and never read the existing one, so it could not carry anything forward. It now uses computeMetadataOnlyUpdate like the other metadata-only writers.

Only pRev was ever wrong. Running the tests below against the parent commit places the damage, where a chained update is one landing on a document whose previous mutation was already a metadata-only update:

| metadata-only write path      | pRev, first update | pRev, chained |
|-------------------------------|--------------------|---------------|
| on-demand import for get      | correct            | wrong         |
| on-demand import for write    | correct            | wrong         |
| attachment metadata migration | correct            | wrong         |
| channel history compaction    | correct            | wrong         |
| resync                        | correct            | wrong         |
| version-CAS correction        | wrong, always 0    | wrong         |

Nothing else about these paths was wrong:

| behaviour                              | before this commit |
|----------------------------------------|--------------------|
| _mou.cas naming the mutation just made | correct            |
| pCas, chained updates included         | correct            |
| re-stamping a tombstone                | already worked     |
| declining a superseded re-stamp        | already worked     |

Re-stamping a tombstone already worked because updateXattrs sets SubdocDocFlagAccessDeleted, and WriteTombstoneWithXattrs reaches that same call for an existing tombstone. A re-stamp superseded by a concurrent write was already declined, on a CAS mismatch.

TestMetadataOnlyUpdateWritePaths covers the paths whose metadata-only write lands on a document some earlier write left behind - both on-demand import paths, attachment metadata migration, channel history compaction and resync - asserting that _mou.cas names the mutation just made, that pCas and pRev name the last write to the body, and that both survive a following metadata-only write from a different path.

TestRestampVersionCASMou covers the version-CAS correction separately, over a live document and a tombstone. It is the one path whose metadata-only write follows a body write it makes itself, so _mou names that write rather than anything observable before it, and both previous values are pinned by sandwiching them between the mutation preceding the write under test and the re-stamp that follows it. Channel history compaction stands in for resync as the second metadata-only write there, as resync declines a tombstone.

TestAttachmentMigrationMouCarriedForward covers migration of a document whose previous mutation was already a metadata-only update, as arrives by mobile XDCR from a cluster that had not migrated its attachment metadata. TestRestampVersionCASSkipsConcurrentWrite covers the declined correction, asserting that the re-stamp is refused in a way correctVersionAheadOfCAS skips on and that the concurrent write is left untouched.

TestWritePathRepairMouChain, which covers the rev tree repair on the write path, pinned pRev to the mutation immediately before the repair - the import the repair chains back past. That contradicted its own pCas assertion, which already required the chain to reach the SDK write, so the pRev assertion now names the same write pCas does.

## Pre-review checklist
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/1140/
