### PR TITLE
CBG-5837: fix TestInvalidRevTreePullRenamedRevReplacementOrNoRev flake

### DIFF
--- a/rest/blip_legacy_revid_test.go
+++ b/rest/blip_legacy_revid_test.go
@@ -1625,6 +1625,10 @@ func TestInvalidRevTreePullRenamedRevReplacementOrNoRev(t *testing.T) {
 					_, found := btcRunner.GetVersion(client.id, docID, repairedVersion)
 					require.False(t, found, "3-def should not have arrived on the pull that skipped 2-def")
 
+					// the next pull is one-shot too, so it only carries the repair once the change cache
+					// has caught up with the sequence the repair allocated
+					rt.WaitForPendingChanges()
+
 					btcRunner.StartPullSince(client.id, BlipTesterPullOptions{Continuous: false})
 					btcRunner.WaitForVersion(client.id, docID, repairedVersion)
 				}


### PR DESCRIPTION
The `replacement_revs_disabled` case starts its second one-shot pull as soon as the norev for `2-def` arrives. The repair that renames `2-def` to `3-def` allocates a new sequence and writes it, but the test never waited for the change cache to receive that sequence. When the second `subChanges` won the race, the changes feed replayed the pre-repair entry, the client already held `2-def` from the norev and refused it, and the one-shot pull ended without ever sending `3-def`:

```
Repaired invalid rev tree ... Current revision 2-def is now 3-def.
Sending norev ... 2-def due to unavailable revision: 404 missing
#3: Type:subChanges Since:0
Sent 1 changes to client, from seq 3      <-- passing runs send from seq 4
Peer didn't want revision ... 2-def (seq:3)
```

Product behaviour is correct - the repair does allocate the higher sequence, and the next pull does deliver `3-def` once the cache holds it - so this is a missing wait in the test only. `rt.WaitForPendingChanges()` covers it: `sequenceAllocator.lastSequence()` returns the last allocated sequence, so the wait ends as soon as the repair's sequence is cached, with no dependence on the unused-sequence release interval.

`go test -tags cb_sg_enterprise,cb_sg_devmode ./rest/ -run 'TestInvalidRevTreePullRenamedRevReplacementOrNoRev/replacement_revs_disabled' -count=50 -race` with four package runs in parallel reproduced the CI failure once in 200 iterations on `main`. With the wait in place, 1800 iterations under the same load pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)