### PR TITLE
CBG-5834: Fix TestUserXattrRevCache flake

### DIFF
--- a/rest/importuserxattrtest/revcache_test.go
+++ b/rest/importuserxattrtest/revcache_test.go
@@ -40,10 +40,14 @@ func TestUserXattrRevCache(t *testing.T) {
 				}
 			}`
 
-	// Sync function to set channel access to a channels UserXattrKey
+	// Sync function to set channel access to a channels UserXattrKey.
+	// Each rest tester needs a distinct database name - the cbgt dest factory registry is
+	// process-global and keyed on database name, so same-named databases in one process would
+	// clobber each other's import listener registration.
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
 		CustomTestBucket: tb.NoCloseClone(),
 		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+			Name:             "rt1",
 			AutoImport:       true,
 			UserXattrKey:     &xattrKey,
 			ImportPartitions: base.Ptr(uint16(2)), // temporarily config to 2 import partitions (default 1 for rest tester) pending CBG-3438 + CBG-3439
@@ -55,6 +59,7 @@ func TestUserXattrRevCache(t *testing.T) {
 	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
 		CustomTestBucket: tb.NoCloseClone(),
 		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+			Name:             "rt2",
 			AutoImport:       true,
 			UserXattrKey:     &xattrKey,
 			ImportPartitions: base.Ptr(uint16(2)), // temporarily config to 2 import partitions (default 1 for rest tester) pending CBG-3438 + CBG-3439
@@ -66,7 +71,7 @@ func TestUserXattrRevCache(t *testing.T) {
 	dataStore := rt2.GetSingleDataStore()
 
 	ctx = rt2.Context()
-	a := rt2.ServerContext().Database(ctx, "db").Authenticator(ctx)
+	a := rt2.ServerContext().Database(ctx, rt2.GetDatabase().Name).Authenticator(ctx)
 	userABC, err := a.NewUser("userABC", "letmein", channels.BaseSetOf(t, "ABC"))
 	require.NoError(t, err)
 	require.NoError(t, a.Save(userABC))


### PR DESCRIPTION
CBG-5834

Fix flaky TestUserXattrRevCache

Both rest testers used the default database name "db", so they computed the same base.DestKey and collided in the process-global cbgtDestFactories map. The second registration replaced the first, and either tester's close removed the entry the other was using. A pindex that then failed to resolve a dest was never created, so its vbuckets were never streamed. A user-xattr-only write is invisible to the caching feed, so the import feed is the only path that can act on it - the doc never gained the channel and the wait ran to the full 20s timeout instead of passing slowly.

Give each rest tester a distinct database name, matching the fix applied to TestUserXattrDeleteWithRevCache in CBG-3399.

Verified against Couchbase Server 7.6.6 EE: 50 iterations of both tests pass with zero collision warnings, where every baseline iteration collided.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/1141/

<!--
Automated review runs on every non-draft PR raised from this repo (forks are not reviewed automatically).
  - Re-run it, or ask a follow-up, by commenting `@droid <question>`
  - Suppress it with the `droid-skip` label, or `WIP`/`DO NOT MERGE` in the title
-->
