### PR TITLE
CBG-5843: Fix TestBlipPushRevisionInspectChanges flake

### DIFF
--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -145,11 +145,12 @@ func TestBlipPushRevisionInspectChanges(t *testing.T) {
 	subChangesRequest := bt.newRequest()
 	subChangesRequest.SetProfile("subChanges")
 	subChangesRequest.Properties["continuous"] = "true"
+	// Expect two callbacks on the "changes" profile handler: one for the pushed rev, and one empty (body
+	// "null") request that the handler ignores. Count them before sending, since the handler can run as
+	// soon as subChanges is on the wire.
+	receivedChangesRequestWg.Add(2)
 	sent = bt.sender.Send(subChangesRequest)
 	assert.True(t, sent)
-	// Also expect the "changes" profile handler above to be called back again with an empty request that
-	// will be ignored since body will be "null" hence the incrementing for the wait group by 2
-	receivedChangesRequestWg.Add(2)
 	subChangesResponse := subChangesRequest.Response()
 	assert.Equal(t, subChangesRequest.SerialNumber(), subChangesResponse.SerialNumber())
 


### PR DESCRIPTION
The `changes` handler could call `receivedChangesRequestWg.Done()` before the test called `Add(2)`, panicking with `sync: negative WaitGroup counter`. That panic goes to `HandlerPanicHandler`, which calls `Fatalf` from the go-blip dispatch goroutine; the resulting `runtime.Goexit` skips go-blip's deferred `sender.send(response)`, so Sync Gateway waits 5s for the changes response and the test then times out. Both reported errors come from the one race.

Fix is to increment the WaitGroup before sending `subChanges`.

## Testing

`go test -run '^TestBlipPushRevisionInspectChanges$' -count=200 -race ./rest/` passes. Adding a 50ms sleep between the send and the original `Add(2)` reproduces the reported failure exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)