### PR TITLE
CBG-5647 Move the weekly integration sweep into a Jenkinsfile

### DIFF
--- a/integration-test/SyncGatewayIntegrationWeekly/Jenkinsfile
+++ b/integration-test/SyncGatewayIntegrationWeekly/Jenkinsfile
@@ -21,10 +21,10 @@ def latestDockerHubTag(String line) {
     return tag
 }
 
-// Every bare 'major.minor.patch' tag on the private cb-vanilla server package, in version order. Each build
-// there is tagged '<version>-<build number>' and the newest build of a line also carries the bare tag, which
-// is the one worth testing. Needs the same credential the child jobs use to pull the images, and five pages
-// of versions to reach past the untagged digests to every active line.
+// Every '<version>-<build number>' tag on the private cb-vanilla server package, in version order. The
+// newest build of a line also carries a bare '<version>' tag, but that one moves from build to build, so the
+// sweep pins the build tag and the record says exactly which image ran. Needs the same credential the child
+// jobs use to pull the images, and five pages of versions to reach past the untagged digests.
 def cbVanillaTags() {
     def tags = sh(returnStdout: true, script: '''#!/bin/bash
         set -euo pipefail
@@ -32,7 +32,7 @@ def cbVanillaTags() {
             curl -sSf -H "Authorization: Bearer $GHCR_TOKEN" -H "Accept: application/vnd.github+json" \\
                 "https://api.github.com/orgs/cb-vanilla/packages/container/server/versions?per_page=100&page=$page"
         done | jq -r '.[] | .metadata.container.tags // [] | .[]' |
-            grep -E '^[0-9]+\\.[0-9]+\\.[0-9]+$' | sort -Vu
+            grep -E '^[0-9]+\\.[0-9]+\\.[0-9]+-[0-9]+$' | sort -Vu
     ''').trim()
     if (!tags) {
         error('Found no cb-vanilla server tags - see the curl output above')
@@ -40,11 +40,11 @@ def cbVanillaTags() {
     return tags.tokenize('\n')
 }
 
-// Highest cb-vanilla image on one line, for example '8.5' -> 'ghcr.io/cb-vanilla/server:8.5.0'.
+// Newest cb-vanilla build on one line, for example '8.5' -> 'ghcr.io/cb-vanilla/server:8.5.0-1109'.
 def latestVanillaImage(List tags, String line) {
     def onLine = tags.findAll { it.startsWith(line + '.') }
     if (!onLine) {
-        error("Found no cb-vanilla tag on line ${line}")
+        error("Found no cb-vanilla build tag on line ${line}")
     }
     return 'ghcr.io/cb-vanilla/server:' + onLine.last()
 }

--- a/integration-test/SyncGatewayIntegrationWeekly/Jenkinsfile
+++ b/integration-test/SyncGatewayIntegrationWeekly/Jenkinsfile
@@ -1,0 +1,137 @@
+// Weekend sweep of the server versions and edition/flag combinations that the adhoc and per-commit runs do
+// not cover. Every combination is a separate SyncGatewayIntegration-Pipeline build and they all run in
+// parallel, so the sweep takes about as long as its slowest child - roughly 2 hours.
+
+// Note for whoever repoints the job at this file: a cron trigger declared in a Jenkinsfile only registers
+// once a build has evaluated it, so start one build by hand afterwards. Until then the job sits waiting on
+// a timer Jenkins does not know about yet.
+
+// Newest Docker Hub tag on a release line, so that 'enterprise-7.6' resolves to 'enterprise-7.6.12'. The
+// name parameter is a substring match, so the grep drops prereleases and longer lines, and sort -V orders
+// by version rather than lexically, which matters as soon as a line reaches patch 10.
+def latestDockerHubTag(String line) {
+    def tag = sh(returnStdout: true, script: '''#!/bin/bash
+        set -eu
+        curl -sSf 'https://hub.docker.com/v2/repositories/couchbase/server/tags?page_size=100&name=LINE.' |
+            grep -o '"name":"[^"]*"' | cut -d'"' -f4 | grep -E "^LINE\\.[0-9]+$" | sort -V | tail -1
+    '''.replace('LINE', line)).trim()
+    if (!tag) {
+        error("Found no Docker Hub tag for Couchbase Server line ${line}")
+    }
+    return tag
+}
+
+// Every bare 'major.minor.patch' tag on the private cb-vanilla server package, in version order. Each build
+// there is tagged '<version>-<build number>' and the newest build of a line also carries the bare tag, which
+// is the one worth testing. Needs the same credential the child jobs use to pull the images, and five pages
+// of versions to reach past the untagged digests to every active line.
+def cbVanillaTags() {
+    def tags = sh(returnStdout: true, script: '''#!/bin/bash
+        set -euo pipefail
+        for page in 1 2 3 4 5; do
+            curl -sSf -H "Authorization: Bearer $GHCR_TOKEN" -H "Accept: application/vnd.github+json" \\
+                "https://api.github.com/orgs/cb-vanilla/packages/container/server/versions?per_page=100&page=$page"
+        done | jq -r '.[] | .metadata.container.tags // [] | .[]' |
+            grep -E '^[0-9]+\\.[0-9]+\\.[0-9]+$' | sort -Vu
+    ''').trim()
+    if (!tags) {
+        error('Found no cb-vanilla server tags - see the curl output above')
+    }
+    return tags.tokenize('\n')
+}
+
+// Highest cb-vanilla image on one line, for example '8.5' -> 'ghcr.io/cb-vanilla/server:8.5.0'.
+def latestVanillaImage(List tags, String line) {
+    def onLine = tags.findAll { it.startsWith(line + '.') }
+    if (!onLine) {
+        error("Found no cb-vanilla tag on line ${line}")
+    }
+    return 'ghcr.io/cb-vanilla/server:' + onLine.last()
+}
+
+// Stage name for a server version: '7.6.4' for a Docker Hub enterprise tag, '7.6.4-CE' for a community one,
+// and the bare version for a cb-vanilla image, whose tag carries no edition.
+def shortServer(String image) {
+    if (image.contains('/')) {
+        return image.tokenize(':').last()
+    }
+    def parts = image.split('-', 2)
+    if (parts.size() < 2) {
+        return image
+    }
+    return parts[1] + (parts[0] == 'community' ? '-CE' : '')
+}
+
+pipeline {
+    agent none
+
+    options {
+        timestamps()
+        timeout(time: 4, unit: 'HOURS')
+        buildDiscarder(logRotator(daysToKeepStr: '30', numToKeepStr: '-1', artifactDaysToKeepStr: '-1', artifactNumToKeepStr: '-1'))
+        // A sweep still running when the next one is due is wedged, so drop it rather than doubling the
+        // load on the integration-test agents.
+        disableConcurrentBuilds(abortPrevious: true)
+    }
+
+    triggers {
+        // Saturday morning Pacific, which leaves the rest of the weekend for a rerun.
+        cron('TZ=America/Los_Angeles\nH 9 * * 6')
+    }
+
+    stages {
+        stage('Integration Tests') {
+            steps {
+                script {
+                    // Resolved on every run so that the sweep follows new patch builds without a commit.
+                    def ga76 = null
+                    def ga80 = null
+                    def tip76 = null
+                    def tip80 = null
+                    def tip85 = null
+                    node('very-lightweight-jobs-only') {
+                        ga76 = latestDockerHubTag('enterprise-7.6')
+                        ga80 = latestDockerHubTag('enterprise-8.0')
+                        withCredentials([usernamePassword(credentialsId: 'github_ghcr_pat', usernameVariable: 'GHCR_USER', passwordVariable: 'GHCR_TOKEN')]) {
+                            def vanillaTags = cbVanillaTags()
+                            tip76 = latestVanillaImage(vanillaTags, '7.6')
+                            tip80 = latestVanillaImage(vanillaTags, '8.0')
+                            tip85 = latestVanillaImage(vanillaTags, '8.5')
+                        }
+                    }
+                    echo("Resolved GA ${ga76}, ${ga80} and tips ${tip76}, ${tip80}, ${tip85}")
+
+                    // Anything not named here takes the child job's own default: EE, rev cache enabled.
+                    def combinations = [
+                        [server: 'enterprise-7.6.4'], // oldest supported
+                        [server: ga76],
+                        [server: ga80],
+                        [server: tip76],
+                        [server: tip80],
+                        [server: tip85],
+                        [server: 'enterprise-7.6.4', sgEdition: 'CE'],
+                        [server: 'enterprise-7.6.4', disableRevCache: true],
+                    ]
+
+                    parallel(combinations.collectEntries { combo ->
+                        def edition = combo.sgEdition ?: 'EE'
+                        def flags = combo.disableRevCache ? "no_revcache_${edition}" : edition
+                        def label = "${shortServer(combo.server)}__${flags}".toString()
+                        [(label): {
+                            node('very-lightweight-jobs-only') {
+                                stage(label) {
+                                    build job: 'SyncGatewayIntegration-Pipeline', parameters: [
+                                        string(name: 'COUCHBASE_SERVER_VERSION', value: combo.server),
+                                        booleanParam(name: 'DISABLE_REV_CACHE', value: combo.disableRevCache as boolean),
+                                        string(name: 'SG_EDITION', value: edition),
+                                        string(name: 'PARENT_JOB_NAME', value: 'WEEKLY: '),
+                                    ]
+                                }
+                            }
+                        }]
+                    })
+                }
+            }
+        }
+    }
+}

--- a/integration-test/SyncGatewayIntegrationWeekly/Jenkinsfile
+++ b/integration-test/SyncGatewayIntegrationWeekly/Jenkinsfile
@@ -118,15 +118,13 @@ pipeline {
                         def flags = combo.disableRevCache ? "no_revcache_${edition}" : edition
                         def label = "${shortServer(combo.server)}__${flags}".toString()
                         [(label): {
-                            node('very-lightweight-jobs-only') {
-                                stage(label) {
-                                    build job: 'SyncGatewayIntegration-Pipeline', parameters: [
-                                        string(name: 'COUCHBASE_SERVER_VERSION', value: combo.server),
-                                        booleanParam(name: 'DISABLE_REV_CACHE', value: combo.disableRevCache as boolean),
-                                        string(name: 'SG_EDITION', value: edition),
-                                        string(name: 'PARENT_JOB_NAME', value: 'WEEKLY: '),
-                                    ]
-                                }
+                            stage(label) {
+                                build job: 'SyncGatewayIntegration-Pipeline', parameters: [
+                                    string(name: 'COUCHBASE_SERVER_VERSION', value: combo.server),
+                                    booleanParam(name: 'DISABLE_REV_CACHE', value: combo.disableRevCache as boolean),
+                                    string(name: 'SG_EDITION', value: edition),
+                                    string(name: 'PARENT_JOB_NAME', value: 'WEEKLY: '),
+                                ]
                             }
                         }]
                     })

--- a/integration-test/SyncGatewayIntegrationWeekly/Jenkinsfile
+++ b/integration-test/SyncGatewayIntegrationWeekly/Jenkinsfile
@@ -11,7 +11,7 @@
 // by version rather than lexically, which matters as soon as a line reaches patch 10.
 def latestDockerHubTag(String line) {
     def tag = sh(returnStdout: true, script: '''#!/bin/bash
-        set -eu
+        set -euo pipefail
         curl -sSf 'https://hub.docker.com/v2/repositories/couchbase/server/tags?page_size=100&name=LINE.' |
             grep -o '"name":"[^"]*"' | cut -d'"' -f4 | grep -E "^LINE\\.[0-9]+$" | sort -V | tail -1
     '''.replace('LINE', line)).trim()


### PR DESCRIPTION
CBG-5647 Move the weekly integration sweep into a Jenkinsfile

Extracted the Jenkinsfile directly in the first commit.

Dynamically resolve the versions to pick up the latest minor versions:

1. ask dockerhub the latest 7.6, 8.0 tags for minor versions (7.6.12, 8.0.3 currently)
2. ask cb-vanilla for latest 7.6, 8.0, 8.5 (resolved to x.y.z-1234 now)

Tested with https://jenkins.sgwdev.com/job/tmp-ghcr-tag-probe/7/console

After this merges, `SyncGatewayIntegration-weekly` will need to be updated to point at this jenkinsfile.
