### PR TITLE
CBG-5580 Fix TestWebhookTimeout flake by raising event queue wait time

### DIFF
--- a/db/event_manager_test.go
+++ b/db/event_manager_test.go
@@ -812,13 +812,14 @@ func TestWebhookTimeout(t *testing.T) {
 
 	// Test slow webhook, short timeout, numProcess=1, waitForProcess > webhook timeout.  All events should get processed.
 	// Webhook timeout 1s
-	// WaitForProcess event manager time 1.5s
+	// WaitForProcess event manager time 5s
 	// Webhook should timeout and clear item from queue before another item attempts to be added to the queue
+	// WaitForProcess is well above the webhook timeout, so a slow machine can't push a queued event past the drop deadline
 	log.Println("Test slow webhook, short timeout")
 	wr.Clear()
 	errCount := 0
 	em = NewEventManager(terminator)
-	em.Start(ctx, 1, 1500)
+	em.Start(ctx, 1, 5000)
 	timeout = uint64(1)
 	webhookHandler, _ = NewWebhook(ctx, fmt.Sprintf("%s/slow_2s", url), "", &timeout, nil)
 	em.RegisterEventHandler(ctx, webhookHandler, DocumentChange)
@@ -861,12 +862,14 @@ func TestWebhookTimeout(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, int64(5), em.GetEventsProcessedSuccess())
 
-	// Test slow webhook, no timeout, numProcess=1, waitForProcess=1s.  All events should complete.
+	// Test slow webhook, no timeout, numProcess=1, waitForProcess=5s.  All events should complete.
+	// WaitForProcess is well above the 1s webhook execution time, so a slow machine can't push a queued event past the
+	// drop deadline
 	log.Println("Test slow webhook, no timeout, wait for process ")
 	wr.Clear()
 	errCount = 0
 	em = NewEventManager(terminator)
-	em.Start(ctx, 1, 1500)
+	em.Start(ctx, 1, 5000)
 	timeout = uint64(0)
 	webhookHandler, _ = NewWebhook(ctx, fmt.Sprintf("%s/slow", url), "", &timeout, nil)
 	em.RegisterEventHandler(ctx, webhookHandler, DocumentChange)


### PR DESCRIPTION
CBG-5580 Fix TestWebhookTimeout flake by raising event queue wait time

Queued events waited ~1s for the single processing slot against a 1500ms drop deadline, so a slow machine dropped events and the processed total never reached 10.

There was only a .5s buffer time or the test would fail so if a test sleep ate through this 500ms due to slow machine this would fail.

In go 1.27, we can use `httptest.NewTestServer` and have this test use `synctest` to avoid these timing mishaps in the first place. We can't use synctest with couchbase server, but this test doesn't use any buckets.

